### PR TITLE
[FIX] Composer composer's send icon slowness

### DIFF
--- a/e2e/09-roominfo.spec.js
+++ b/e2e/09-roominfo.spec.js
@@ -311,7 +311,7 @@ describe('Room info screen', () => {
 				await waitFor(element(by.text('Yes, delete it!'))).toBeVisible().withTimeout(5000);
 				await expect(element(by.text('Yes, delete it!'))).toBeVisible();
 				await element(by.text('Yes, delete it!')).tap();
-				await waitFor(element(by.id('rooms-list-view'))).toBeVisible().withTimeout(2000);
+				await waitFor(element(by.id('rooms-list-view'))).toBeVisible().withTimeout(10000);
 				await element(by.id('rooms-list-view-search')).replaceText('');
 				await waitFor(element(by.id(`rooms-list-view-item-${ room }`))).toBeNotVisible().withTimeout(60000);
 				await expect(element(by.id(`rooms-list-view-item-${ room }`))).toBeNotVisible();


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #525 

Before:
Every key entered would re-render entire Messagebox (with `setState`).

After:
Message is not persisted on `state` anymore.
I'm using `this` and native TextInput for display and `setState` only for showing/hiding buttons.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
