### PR TITLE
[FIX] LDAP login

### DIFF
--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -274,7 +274,8 @@ const RocketChat = {
 
 		if (state.settings.LDAP_Enable) {
 			params = {
-				...params,
+				username: user,
+				ldapPass: password,
 				ldap: true,
 				ldapOptions: {}
 			};


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #581 
Closes #571 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Parameters were wrongly passed to the server, resulting in credentials always being rejected. To fix this, I passed the actual correct keys to the server for LDAP authentication.