### PR TITLE
[FIX] Start loop searching for rooms updates only when connection goes down and SDK has userId

### DIFF
--- a/app/lib/methods/subscriptions/rooms.js
+++ b/app/lib/methods/subscriptions/rooms.js
@@ -16,23 +16,21 @@ export default async function subscribeRooms() {
 		timer = setTimeout(() => {
 			clearTimeout(timer);
 			timer = false;
-			if (this.sdk.userId) {
-				store.dispatch(roomsRequest());
-				loop();
-			}
+			store.dispatch(roomsRequest());
+			loop();
 		}, 5000);
 	};
 
 	this.sdk.onStreamData('connected', () => {
-		if (this.sdk.userId) {
-			store.dispatch(roomsRequest());
-		}
+		store.dispatch(roomsRequest());
 		clearTimeout(timer);
 		timer = false;
 	});
 
 	this.sdk.onStreamData('close', () => {
-		loop();
+		if (this.sdk.userId) {
+			loop();
+		}
 	});
 
 	this.sdk.onStreamData('stream-notify-user', protectedFunction((ddpMessage) => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
