### PR TITLE
[CHORE] Remove .debug suffix on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -148,9 +148,6 @@ android {
             setProguardFiles([getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'])
             signingConfig signingConfigs.release
         }
-        debug {
-            applicationIdSuffix ".debug"
-        }
     }
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Debug suffix is useful during development, because with it we can keep debug and release versions of the app on the phone.
The downside is that it doesn't open debug version after running `react-native run-android` causing beginner developers to think something is not right.

I'm removing it for now and keeping the `[DEVELOP]` name and logo.
In future, we can think on having the default as `.debug` suffix, but it would need to be both on Android and iOS and update CircleCI jobs.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
