### PR TITLE
Fix issue #741

### DIFF
--- a/app/containers/message/Reply.js
+++ b/app/containers/message/Reply.js
@@ -26,7 +26,8 @@ const styles = StyleSheet.create({
 	authorContainer: {
 		flex: 1,
 		flexDirection: 'row',
-		alignItems: 'center'
+		alignItems: 'center',
+		paddingBottom: 5
 	},
 	author: {
 		flex: 1,


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #741

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
I have fixed Issue #741 . There is more space in the reply component now.
It looks like this now 

<img width="359" alt="Issue #741" src="https://user-images.githubusercontent.com/32356916/54693845-4b55f400-4b4d-11e9-8c74-5d6acf98c883.png">
