### PR TITLE
[FIX] reply bug fixed

### DIFF
--- a/app/containers/MessageBox/ReplyPreview.js
+++ b/app/containers/MessageBox/ReplyPreview.js
@@ -48,6 +48,7 @@ const styles = StyleSheet.create({
 });
 
 @connect(state => ({
+	message: state.messages.replyMessage,
 	Message_TimeFormat: state.settings.Message_TimeFormat,
 	customEmojis: state.customEmojis,
 	baseUrl: state.settings.Site_Url || state.server ? state.server.server : ''

--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -745,12 +745,12 @@ export default class MessageBox extends Component {
 
 	renderReplyPreview = () => {
 		const {
-			replyMessage, replying, closeReply, user
+			replying, closeReply, user
 		} = this.props;
 		if (!replying) {
 			return null;
 		}
-		return <ReplyPreview key='reply-preview' message={replyMessage} close={closeReply} username={user.username} />;
+		return <ReplyPreview key='reply-preview' close={closeReply} username={user.username} />;
 	};
 
 	renderFilesActions = () => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Fixed a bug related to replyPreview component. If the replyPreview component was rendered already and we click on another message for reply, the props in the replyPreview component did not update. It showed the previous message only. 