### PR TITLE
[FIX] Typing not getting cleared after popping a room

### DIFF
--- a/app/lib/methods/subscriptions/room.js
+++ b/app/lib/methods/subscriptions/room.js
@@ -184,6 +184,10 @@ export default function subscribeRoom({ rid }) {
 				typingTimeouts[key] = null;
 			}
 		});
+		database.memoryDatabase.write(() => {
+			const usersTyping = database.memoryDatabase.objects('usersTyping').filtered('rid == $0', rid);
+			database.memoryDatabase.delete(usersTyping);
+		});
 	};
 
 	connectedListener = this.sdk.onStreamData('connected', handleConnected);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
If someone was typing when the user popped out RoomView, typing state would never be cleared.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
