### PR TITLE
[CHORE] Remove e2e tests from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,9 +266,9 @@ workflows:
   build-and-test:
     jobs:
       - lint-testunit
-      - e2e-test:
-          requires:
-            - lint-testunit
+      # - e2e-test:
+      #     requires:
+      #       - lint-testunit
 
       - ios-build:
           requires:


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
E2E is always failing on CircleCI because of misconfiguration.
We're running all tests locally for a few months already.

Let's comment out and keep running tests locally for now.
This is planned to be fixed soon.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
