### PR TITLE
Fixed Bundler Issue on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
 		android:label="@string/app_name"
 		android:icon="@mipmap/ic_launcher"
 		android:theme="@style/AppTheme"
-		android:resizeableActivity="true">
+		android:resizeableActivity="true"
+		android:usesCleartextTraffic="true">
 		<activity
 			android:name=".MainActivity"
 			android:label="@string/app_name"


### PR DESCRIPTION
…ersions block cleartext traffic by default.

<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/697

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Starting with Android 9.0 (API level 28), cleartext support is disabled by default. We need to enable it.

https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted/50834600#50834600
