### PR TITLE
[FIX]  Profile update

### DIFF
--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -644,9 +644,9 @@ const RocketChat = {
 		// RC 0.55.0
 		return this.sdk.methodCall('saveRoomSettings', rid, params);
 	},
-	saveUserProfile(data) {
+	saveUserProfile(data, customFields) {
 		// RC 0.62.2
-		return this.sdk.post('users.updateOwnBasicInfo', { data });
+		return this.sdk.post('users.updateOwnBasicInfo', { data, customFields });
 	},
 	saveUserPreferences(params) {
 		// RC 0.51.0

--- a/app/views/ProfileView/index.js
+++ b/app/views/ProfileView/index.js
@@ -210,12 +210,13 @@ export default class ProfileView extends React.Component {
 				}
 			}
 
-			params.customFields = customFields;
+			const result = await RocketChat.saveUserProfile(params, customFields);
 
-			const result = await RocketChat.saveUserProfile(params);
 			if (result.success) {
-				if (params.customFields) {
-					setUser({ customFields });
+				if (customFields) {
+					setUser({ customFields, ...params });
+				} else {
+					setUser({ ...params });
 				}
 				this.setState({ saving: false });
 				this.toast.show(I18n.t('Profile_saved_successfully'));


### PR DESCRIPTION
@RocketChat/ReactNative
Closes #953 

This PR aims to fix profile update custom fields (phone, mobile, language, etc.). 

The bug was introduced when all the fields on user profile were sent in one object `{ data }.`
But back-end accepts an object in format: `{ data, customFields }`.