### PR TITLE
[REGRESSION] Get rooms on app restore

### DIFF
--- a/app/views/RoomsListView/index.js
+++ b/app/views/RoomsListView/index.js
@@ -19,8 +19,8 @@ import ServerDropdown from './ServerDropdown';
 import {
 	toggleSortDropdown as toggleSortDropdownAction,
 	openSearchHeader as openSearchHeaderAction,
-	closeSearchHeader as closeSearchHeaderAction
-	// roomsRequest as roomsRequestAction
+	closeSearchHeader as closeSearchHeaderAction,
+	roomsRequest as roomsRequestAction
 } from '../../actions/rooms';
 import { appStart as appStartAction } from '../../actions';
 import debounce from '../../utils/debounce';
@@ -55,8 +55,8 @@ const keyExtractor = item => item.rid;
 	toggleSortDropdown: () => dispatch(toggleSortDropdownAction()),
 	openSearchHeader: () => dispatch(openSearchHeaderAction()),
 	closeSearchHeader: () => dispatch(closeSearchHeaderAction()),
-	appStart: () => dispatch(appStartAction())
-	// roomsRequest: () => dispatch(roomsRequestAction())
+	appStart: () => dispatch(appStartAction()),
+	roomsRequest: () => dispatch(roomsRequestAction())
 }))
 export default class RoomsListView extends React.Component {
 	static navigationOptions = ({ navigation }) => {
@@ -104,12 +104,12 @@ export default class RoomsListView extends React.Component {
 		showUnread: PropTypes.bool,
 		useRealName: PropTypes.bool,
 		StoreLastMessage: PropTypes.bool,
-		// appState: PropTypes.string,
+		appState: PropTypes.string,
 		toggleSortDropdown: PropTypes.func,
 		openSearchHeader: PropTypes.func,
 		closeSearchHeader: PropTypes.func,
-		appStart: PropTypes.func
-		// roomsRequest: PropTypes.func
+		appStart: PropTypes.func,
+		roomsRequest: PropTypes.func
 	}
 
 	constructor(props) {
@@ -185,7 +185,7 @@ export default class RoomsListView extends React.Component {
 
 	componentDidUpdate(prevProps) {
 		const {
-			sortBy, groupByType, showFavorites, showUnread
+			sortBy, groupByType, showFavorites, showUnread, appState, roomsRequest
 		} = this.props;
 
 		if (!(
@@ -195,11 +195,9 @@ export default class RoomsListView extends React.Component {
 			&& (prevProps.showUnread === showUnread)
 		)) {
 			this.getSubscriptions();
+		} else if (appState === 'foreground' && appState !== prevProps.appState) {
+			roomsRequest();
 		}
-		// removed for now... we may not need it anymore
-		// else if (appState === 'foreground' && appState !== prevProps.appState) {
-		// 	// roomsRequest();
-		// }
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
We used to do that, but I commented sometime ago.
It started to delay update rooms too much.

Tests:
- [ ] It should get rooms on app open (app was closed)
- [ ] It should get rooms on app restore (open in background)
- [ ] It should get rooms on app restore after an hour in background (open in background but without usage for 1h)

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Closes #931 