### PR TITLE
[IMPROVEMENT] Lazy fetch server info

### DIFF
--- a/app/sagas/selectServer.js
+++ b/app/sagas/selectServer.js
@@ -11,11 +11,13 @@ import database from '../lib/realm';
 import log from '../utils/log';
 import I18n from '../i18n';
 
-const getServerInfo = function* getServerInfo({ server }) {
+const getServerInfo = function* getServerInfo({ server, raiseError = true }) {
 	try {
 		const serverInfo = yield RocketChat.getServerInfo(server);
 		if (!serverInfo.success) {
-			Alert.alert(I18n.t('Oops'), I18n.t(serverInfo.message, serverInfo.messageOptions));
+			if (raiseError) {
+				Alert.alert(I18n.t('Oops'), I18n.t(serverInfo.message, serverInfo.messageOptions));
+			}
 			yield put(serverFailure());
 			return;
 		}
@@ -32,10 +34,6 @@ const getServerInfo = function* getServerInfo({ server }) {
 
 const handleSelectServer = function* handleSelectServer({ server, version, fetchVersion }) {
 	try {
-		let serverInfo;
-		if (fetchVersion) {
-			serverInfo = yield getServerInfo({ server });
-		}
 		yield AsyncStorage.setItem('currentServer', server);
 		const userStringified = yield AsyncStorage.getItem(`${ RocketChat.TOKEN_KEY }-${ server }`);
 
@@ -52,7 +50,13 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 		const settings = database.objects('settings');
 		yield put(actions.setAllSettings(RocketChat.parseSettings(settings.slice(0, settings.length))));
 
-		yield put(selectServerSuccess(server, fetchVersion ? serverInfo && serverInfo.version : version));
+		let serverInfo;
+		if (fetchVersion) {
+			serverInfo = yield getServerInfo({ server, raiseError: false });
+		}
+
+		// Return server version even when offline
+		yield put(selectServerSuccess(server, (serverInfo && serverInfo.version) || version));
 	} catch (e) {
 		log('err_select_server', e);
 	}
@@ -62,7 +66,6 @@ const handleServerRequest = function* handleServerRequest({ server }) {
 	try {
 		const serverInfo = yield getServerInfo({ server });
 
-		// TODO: cai aqui O.o
 		const loginServicesLength = yield RocketChat.getLoginServices(server);
 		if (loginServicesLength === 0) {
 			Navigation.navigate('LoginView');


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Check if user is logged to hide splash screen first and fetch server info later.
Also, stop alerting "Wrong url" in case of server is down.
The user is logged in, so the url is correct.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
