### PR TITLE
[FIX] Draft message do not go away when whole message is removed

### DIFF
--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -227,7 +227,7 @@ export default class RoomView extends React.Component {
 	componentWillUnmount() {
 		this.mounted = false;
 		const { editing, replying } = this.props;
-		if (!editing && this.messagebox && this.messagebox.current && this.messagebox.current.text) {
+		if (!editing && this.messagebox && this.messagebox.current) {
 			const { text } = this.messagebox.current;
 			let obj;
 			if (this.tmid) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

**Acceptance Criteria**

In one room, after typing "test", and go back, then enter the room, remove "test" message and go back. Then enter the room, it will be empty inputfiled

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #923

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
