### PR TITLE
[FIX] Broadcast channel is not readonly

### DIFF
--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -450,7 +450,7 @@ export default class RoomView extends React.Component {
 
 	isOwner = () => {
 		const { room } = this.state;
-		return room && room.roles && Array.from(Object.keys(room.roles), i => room.roles[i].value).includes('owner');
+		return room && room.roles && room.roles.length && !!room.roles.find(role => role === 'owner');
 	}
 
 	isMuted = () => {
@@ -461,7 +461,10 @@ export default class RoomView extends React.Component {
 
 	isReadOnly = () => {
 		const { room } = this.state;
-		return (room.ro && !room.broadcast) || this.isMuted() || room.archived;
+		if (this.isOwner()) {
+			return false;
+		}
+		return (room && room.ro) || this.isMuted();
 	}
 
 	isBlocked = () => {


### PR DESCRIPTION
@RocketChat/ReactNative
Closes #988 

Fixes bug. Now users with access to broadcast room can post messages and user without access don't have messagebox and have text 'This room is read only' displayed.

https://drive.google.com/file/d/1S9XjrIy5PuBZO9gb9t095PwkqUn5ThOG/view?usp=sharing