### PR TITLE
[CI] create job with e2e-build and save workspace for e2e-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,36 +331,33 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - e2e-build
-# TODO UNCOMMMENT
-#          requires:
-#            - e2e-hold
+      - lint-testunit
+
+      - ios-build:
+          requires:
+            - lint-testunit
+      - ios-hold-testflight:
+          type: approval
+          requires:
+            - ios-build
+      - ios-testflight:
+          requires:
+            - ios-hold-testflight
+
+      - android-build:
+          requires:
+            - lint-testunit
+
+      - e2e-hold:
+          type: approval
+          requires:
+            - lint-testunit
+      - e2e-build:
+          requires:
+            - e2e-hold
       - e2e-test-iPhone-7:
           requires:
             - e2e-build
-
       - e2e-test-iPhone-Xʀ:
           requires:
             - e2e-build
-# TODO UNCOMMMENT
-#      - lint-testunit
-#      - e2e-hold:
-#          type: approval
-#          requires:
-#            - lint-testunit
-
-# TODO UNCOMMMENT
-#      - ios-build:
-#          requires:
-#            - lint-testunit
-#      - ios-hold-testflight:
-#          type: approval
-#          requires:
-#            - ios-build
-#      - ios-testflight:
-#          requires:
-#            - ios-hold-testflight
-#
-#      - android-build:
-#          requires:
-#            - lint-testunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ios/build
+            - ios/build/Build/Products
 
 
   e2e-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,30 +269,30 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - lint-testunit
-
-      - e2e-hold:
-          type: approval
-          requires:
-            - lint-testunit
+# TODO UNCOMMMENT
+#      - lint-testunit
+#      - e2e-hold:
+#          type: approval
+#          requires:
+#            - lint-testunit
       - e2e-build:
           requires:
             - e2e-hold
       - e2e-test:
           requires:
             - e2e-build
-
-      - ios-build:
-          requires:
-            - lint-testunit
-      - ios-hold-testflight:
-          type: approval
-          requires:
-            - ios-build
-      - ios-testflight:
-          requires:
-            - ios-hold-testflight
-
-      - android-build:
-          requires:
-            - lint-testunit
+# TODO UNCOMMMENT
+#      - ios-build:
+#          requires:
+#            - lint-testunit
+#      - ios-hold-testflight:
+#          type: approval
+#          requires:
+#            - ios-build
+#      - ios-testflight:
+#          requires:
+#            - ios-hold-testflight
+#
+#      - android-build:
+#          requires:
+#            - lint-testunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             detox build --configuration ios.sim.release
 
       - persist_to_workspace:
-          root: .
+          root: /tmp/iosDetoxBuild
           paths:
             - ios/build/Build/Products/Release-iphonesimulator/*
 
@@ -106,14 +106,24 @@ jobs:
             brew install wix/brew/applesimutils
 
       - attach_workspace:
-          at: ios
+          at: /tmp/iosDetoxBuild
 
       - run:
           name: Install Detox CLI
           command: |
             yarn global add detox-cli
             yarn
-            cd ios/build/Build/Products/Release-iphonesimulator
+            ls
+            cd ios
+            ls
+            cd -
+            cd ios/build
+            ls
+            cd -
+            cd ios/build/Build
+            ls
+            cd -
+            cd ios/build/Build/Products
             ls
             cd -
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,37 +51,37 @@ jobs:
       BASH_ENV: "~/.nvm/nvm.sh"
 
     steps:
-      - checkout
-
-      - run:
-          name: Install Node 8
-          command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-            source ~/.nvm/nvm.sh
-            # https://github.com/creationix/nvm/issues/1394
-            set +e
-            nvm install 8
-
-      - run:
-          name: Install NPM modules
-          command: |
-            yarn global add detox-cli
-            yarn
-
-      - run:
-          name: Build
-          command: |
-            detox build --configuration ios.sim.release
-
+#      - checkout
+#
 #      - run:
-#          name: Create fake folder to persist
+#          name: Install Node 8
 #          command: |
-#            mkdir -p ios/build/Build/Products/Release-iphonesimulator
-#            cd ios/build/Build/Products/Release-iphonesimulator
-#            touch file.txt
-#            pw
-#            ls
-#            cd -
+#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+#            source ~/.nvm/nvm.sh
+#            # https://github.com/creationix/nvm/issues/1394
+#            set +e
+#            nvm install 8
+#
+#      - run:
+#          name: Install NPM modules
+#          command: |
+#            yarn global add detox-cli
+#            yarn
+#
+#      - run:
+#          name: Build
+#          command: |
+#            detox build --configuration ios.sim.release
+
+      - run:
+          name: Create fake folder to persist
+          command: |
+            mkdir -p ios/build/Build/Products/Release-iphonesimulator
+            cd ios/build/Build/Products/Release-iphonesimulator
+            touch file.txt
+            pw
+            ls
+            cd -
 
       - persist_to_workspace:
           root: .
@@ -97,26 +97,26 @@ jobs:
       BASH_ENV: "~/.nvm/nvm.sh"
 
     steps:
-      - checkout
-
-      - run:
-          name: Install Node 8
-          command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-            source ~/.nvm/nvm.sh
-            # https://github.com/creationix/nvm/issues/1394
-            set +e
-            nvm install 8
-
-      - run:
-          name: Install appleSimUtils
-          command: |
-            brew update
-            brew tap wix/brew
-            brew install wix/brew/applesimutils
+#      - checkout
+#
+#      - run:
+#          name: Install Node 8
+#          command: |
+#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+#            source ~/.nvm/nvm.sh
+#            # https://github.com/creationix/nvm/issues/1394
+#            set +e
+#            nvm install 8
+#
+#      - run:
+#          name: Install appleSimUtils
+#          command: |
+#            brew update
+#            brew tap wix/brew
+#            brew install wix/brew/applesimutils
 
       - attach_workspace:
-          at: ios/build/Build/Products/Release-iphonesimulator
+          at: ios/build/Build/Products/Release-iphonesimulator/*
 
       - run:
           name: Install Detox CLI
@@ -136,13 +136,16 @@ jobs:
             cd ios/build/Build/Products
             ls
             cd -
-            yarn global add detox-cli
-            yarn
+            cd ios/build/Build/Products/Release-iphonesimulator
+            ls
+            cd -
+#            yarn global add detox-cli
+#            yarn
 
-      - run:
-          name: Test
-          command: |
-            detox test --configuration ios.sim.release --cleanup --loglevel verbose
+#      - run:
+#          name: Test
+#          command: |
+#            detox test --configuration ios.sim.release --cleanup --loglevel verbose
 
       - store_artifacts:
           path: /tmp/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,6 @@ jobs:
       - run:
           name: Install Detox CLI
           command: |
-#            yarn global add detox-cli
-#            yarn
             ls
             cd ios
             ls
@@ -134,6 +132,8 @@ jobs:
             cd ios/build/Build/Products
             ls
             cd -
+#            yarn global add detox-cli
+#            yarn
 
 #      - run:
 #          name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
     macos:
       xcode: "10.2.1"
 
+    environment:
+      BASH_ENV: "~/.nvm/nvm.sh"
+
     steps:
       - attach_workspace:
           at: ios
@@ -107,6 +110,7 @@ jobs:
           name: Install Detox CLI
           command: |
             yarn global add detox-cli
+            yarn
 
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,22 +85,23 @@ jobs:
           root: .
           paths: .
 
+
   e2e-test:
     macos:
       xcode: "10.2.1"
 
-      steps:
-        - attach_workspace:
-            at: .
+    steps:
+      - attach_workspace:
+          at: .
 
-        - run:
-            name: Test
-            command: |
-              ls
-              detox test --configuration ios.sim.release --cleanup --loglevel verbose
+      - run:
+          name: Test
+          command: |
+            ls
+            detox test --configuration ios.sim.release --cleanup --loglevel verbose
 
-        - store_artifacts:
-            path: /tmp/screenshots
+      - store_artifacts:
+          path: /tmp/screenshots
 
 
   android-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,9 @@ jobs:
           command: |
             yarn global add detox-cli
             yarn
-            cd ios
+            cd ios/build/Build/Products/Release-iphonesimulator
             ls
-            cd ..
+            cd -
 
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             mkdir -p ios/build/Build/Products/Release-iphonesimulator
             cd ios/build/Build/Products/Release-iphonesimulator
             touch file.txt
-            pw
+            pwd
             ls
             cd -
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
           paths:
             - ./node_modules
 
-  e2e-test:
+
+  e2e-build:
     macos:
       xcode: "10.2.1"
 
@@ -78,14 +79,28 @@ jobs:
           name: Build
           command: |
             detox build --configuration ios.sim.release
+            ls
 
-      - run:
-          name: Test
-          command: |
-            detox test --configuration ios.sim.release --cleanup --loglevel verbose
+      - persist_to_workspace
+          root: .
+          paths: .
 
-      - store_artifacts:
-          path: /tmp/screenshots
+  e2e-test:
+    macos:
+      xcode: "10.2.1"
+      steps:
+        - attach_workspace:
+            at: .
+
+        - run:
+            name: Test
+            command: |
+              ls
+              detox test --configuration ios.sim.release --cleanup --loglevel verbose
+
+        - store_artifacts:
+            path: /tmp/screenshots
+
 
   android-build:
     <<: *defaults
@@ -258,9 +273,12 @@ workflows:
           type: approval
           requires:
             - lint-testunit
-      - e2e-test:
+      - e2e-build:
           requires:
             - e2e-hold
+      - e2e-test:
+          requires:
+            - e2e-build
 
       - ios-build:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ios/build/Build/Products/*
+            - ios/build/Build/Products/Release-iphonesimulator/*
 
 
   e2e-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,19 +269,21 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-# TODO UNCOMMMENT
-#      - lint-testunit
-#      - e2e-hold:
-#          type: approval
-#          requires:
-#            - lint-testunit
-      - e2e-build:
+      - e2e-build
 # TODO UNCOMMMENT
 #          requires:
 #            - e2e-hold
       - e2e-test:
           requires:
             - e2e-build
+# TODO UNCOMMMENT
+#      - lint-testunit
+#      - e2e-hold:
+#          type: approval
+#          requires:
+#            - lint-testunit
+
+
 # TODO UNCOMMMENT
 #      - ios-build:
 #          requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,8 @@ jobs:
 #            brew install wix/brew/applesimutils
 
       - attach_workspace:
-          at: ios/build/Build/Products/Release-iphonesimulator/
+          at: .
+#          at: ios/build/Build/Products/Release-iphonesimulator/
 
       - run:
           name: Install Detox CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,37 +51,37 @@ jobs:
       BASH_ENV: "~/.nvm/nvm.sh"
 
     steps:
-#      - checkout
-#
-#      - run:
-#          name: Install Node 8
-#          command: |
-#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-#            source ~/.nvm/nvm.sh
-#            # https://github.com/creationix/nvm/issues/1394
-#            set +e
-#            nvm install 8
-#
-#      - run:
-#          name: Install NPM modules
-#          command: |
-#            yarn global add detox-cli
-#            yarn
-#
-#      - run:
-#          name: Build
-#          command: |
-#            detox build --configuration ios.sim.release
+      - checkout
 
       - run:
-          name: Create fake folder to persist
+          name: Install Node 8
           command: |
-            mkdir -p ios/build/Build/Products/Release-iphonesimulator
-            cd ios/build/Build/Products/Release-iphonesimulator
-            touch file.txt
-            pwd
-            ls
-            cd -
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
+
+      - run:
+          name: Install NPM modules
+          command: |
+            yarn global add detox-cli
+            yarn
+
+      - run:
+          name: Build
+          command: |
+            detox build --configuration ios.sim.release
+
+#      - run:
+#          name: Create fake folder to persist
+#          command: |
+#            mkdir -p ios/build/Build/Products/Release-iphonesimulator
+#            cd ios/build/Build/Products/Release-iphonesimulator
+#            touch file.txt
+#            pwd
+#            ls
+#            cd -
 
       - persist_to_workspace:
           root: .
@@ -97,23 +97,23 @@ jobs:
       BASH_ENV: "~/.nvm/nvm.sh"
 
     steps:
-#      - checkout
-#
-#      - run:
-#          name: Install Node 8
-#          command: |
-#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-#            source ~/.nvm/nvm.sh
-#            # https://github.com/creationix/nvm/issues/1394
-#            set +e
-#            nvm install 8
-#
-#      - run:
-#          name: Install appleSimUtils
-#          command: |
-#            brew update
-#            brew tap wix/brew
-#            brew install wix/brew/applesimutils
+      - checkout
+
+      - run:
+          name: Install Node 8
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
+
+      - run:
+          name: Install appleSimUtils
+          command: |
+            brew update
+            brew tap wix/brew
+            brew install wix/brew/applesimutils
 
       - attach_workspace:
           at: .
@@ -140,13 +140,13 @@ jobs:
             cd ios/build/Build/Products/Release-iphonesimulator
             ls
             cd -
-#            yarn global add detox-cli
-#            yarn
+            yarn global add detox-cli
+            yarn
 
-#      - run:
-#          name: Test
-#          command: |
-#            detox test --configuration ios.sim.release --cleanup --loglevel verbose
+      - run:
+          name: Test
+          command: |
+            detox test --configuration ios.sim.release --cleanup --loglevel verbose
 
       - store_artifacts:
           path: /tmp/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,28 +53,36 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Install Node 8
-          command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-            source ~/.nvm/nvm.sh
-            # https://github.com/creationix/nvm/issues/1394
-            set +e
-            nvm install 8
+#      - run:
+#          name: Install Node 8
+#          command: |
+#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+#            source ~/.nvm/nvm.sh
+#            # https://github.com/creationix/nvm/issues/1394
+#            set +e
+#            nvm install 8
+#
+#      - run:
+#          name: Install NPM modules
+#          command: |
+#            yarn global add detox-cli
+#            yarn
+#
+#      - run:
+#          name: Build
+#          command: |
+#            detox build --configuration ios.sim.release
 
       - run:
-          name: Install NPM modules
+          name: Create fake folder to persist
           command: |
-            yarn global add detox-cli
-            yarn
-
-      - run:
-          name: Build
-          command: |
-            detox build --configuration ios.sim.release
+            mkdir -p ios/build/Build/Products/Release-iphonesimulator
+            cd ios/build/Build/Products/Release-iphonesimulator
+            touch file.txt
+            cd -
 
       - persist_to_workspace:
-          root: /tmp/iosDetoxBuild
+          root: .
           paths:
             - ios/build/Build/Products/Release-iphonesimulator/*
 
@@ -89,30 +97,30 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Install Node 8
-          command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-            source ~/.nvm/nvm.sh
-            # https://github.com/creationix/nvm/issues/1394
-            set +e
-            nvm install 8
-
-      - run:
-          name: Install appleSimUtils
-          command: |
-            brew update
-            brew tap wix/brew
-            brew install wix/brew/applesimutils
+#      - run:
+#          name: Install Node 8
+#          command: |
+#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+#            source ~/.nvm/nvm.sh
+#            # https://github.com/creationix/nvm/issues/1394
+#            set +e
+#            nvm install 8
+#
+#      - run:
+#          name: Install appleSimUtils
+#          command: |
+#            brew update
+#            brew tap wix/brew
+#            brew install wix/brew/applesimutils
 
       - attach_workspace:
-          at: /tmp/iosDetoxBuild
+          at: /tmp/ios
 
       - run:
           name: Install Detox CLI
           command: |
-            yarn global add detox-cli
-            yarn
+#            yarn global add detox-cli
+#            yarn
             ls
             cd ios
             ls
@@ -127,10 +135,10 @@ jobs:
             ls
             cd -
 
-      - run:
-          name: Test
-          command: |
-            detox test --configuration ios.sim.release --cleanup --loglevel verbose
+#      - run:
+#          name: Test
+#          command: |
+#            detox test --configuration ios.sim.release --cleanup --loglevel verbose
 
       - store_artifacts:
           path: /tmp/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ios/build/Build/Products
+            - ios/build/Build/Products/Release-iphonesimulator/*
 
 
   e2e-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,8 +276,9 @@ workflows:
 #          requires:
 #            - lint-testunit
       - e2e-build:
-          requires:
-            - e2e-hold
+# TODO UNCOMMMENT
+#          requires:
+#            - e2e-hold
       - e2e-test:
           requires:
             - e2e-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
 
       - persist_to_workspace:
           root: .
-          paths: .
+          paths:
+            - ios/build
 
 
   e2e-test:
@@ -92,7 +93,7 @@ jobs:
 
     steps:
       - attach_workspace:
-          at: .
+          at: ios
 
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,13 +63,6 @@ jobs:
             nvm install 8
 
       - run:
-          name: Install appleSimUtils
-          command: |
-            brew update
-            brew tap wix/brew
-            brew install wix/brew/applesimutils
-
-      - run:
           name: Install NPM modules
           command: |
             yarn global add detox-cli
@@ -79,7 +72,6 @@ jobs:
           name: Build
           command: |
             detox build --configuration ios.sim.release
-            ls
 
       - persist_to_workspace:
           root: .
@@ -96,9 +88,29 @@ jobs:
           at: ios
 
       - run:
+          name: Install Node 8
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
+
+      - run:
+          name: Install appleSimUtils
+          command: |
+            brew update
+            brew tap wix/brew
+            brew install wix/brew/applesimutils
+
+      - run:
+          name: Install Detox CLI
+          command: |
+            yarn global add detox-cli
+
+      - run:
           name: Test
           command: |
-            ls
             detox test --configuration ios.sim.release --cleanup --loglevel verbose
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       BASH_ENV: "~/.nvm/nvm.sh"
 
     steps:
-      - checkout
+#      - checkout
 
 #      - run:
 #          name: Install Node 8
@@ -114,7 +114,7 @@ jobs:
 #            brew install wix/brew/applesimutils
 
       - attach_workspace:
-          at: /tmp/ios
+          at: ios
 
       - run:
           name: Install Detox CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
 #            brew install wix/brew/applesimutils
 
       - attach_workspace:
-          at: ios/build/Build/Products/Release-iphonesimulator/*
+          at: ios/build/Build/Products/Release-iphonesimulator/
 
       - run:
           name: Install Detox CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,14 @@ jobs:
             detox build --configuration ios.sim.release
             ls
 
-      - persist_to_workspace
+      - persist_to_workspace:
           root: .
           paths: .
 
   e2e-test:
     macos:
       xcode: "10.2.1"
+
       steps:
         - attach_workspace:
             at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ios/build/Build/Products/Release-iphonesimulator/*
+            - ios/build/Build/Products/*
 
 
   e2e-test:
@@ -88,8 +88,6 @@ jobs:
 
     steps:
       - checkout
-      - attach_workspace:
-          at: ios
 
       - run:
           name: Install Node 8
@@ -107,11 +105,17 @@ jobs:
             brew tap wix/brew
             brew install wix/brew/applesimutils
 
+      - attach_workspace:
+          at: ios
+
       - run:
           name: Install Detox CLI
           command: |
             yarn global add detox-cli
             yarn
+            cd ios
+            ls
+            cd ..
 
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,33 +53,35 @@ jobs:
     steps:
       - checkout
 
-#      - run:
-#          name: Install Node 8
-#          command: |
-#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-#            source ~/.nvm/nvm.sh
-#            # https://github.com/creationix/nvm/issues/1394
-#            set +e
-#            nvm install 8
-#
-#      - run:
-#          name: Install NPM modules
-#          command: |
-#            yarn global add detox-cli
-#            yarn
-#
-#      - run:
-#          name: Build
-#          command: |
-#            detox build --configuration ios.sim.release
+      - run:
+          name: Install Node 8
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
 
       - run:
-          name: Create fake folder to persist
+          name: Install NPM modules
           command: |
-            mkdir -p ios/build/Build/Products/Release-iphonesimulator
-            cd ios/build/Build/Products/Release-iphonesimulator
-            touch file.txt
-            cd -
+            yarn global add detox-cli
+            yarn
+
+      - run:
+          name: Build
+          command: |
+            detox build --configuration ios.sim.release
+
+#      - run:
+#          name: Create fake folder to persist
+#          command: |
+#            mkdir -p ios/build/Build/Products/Release-iphonesimulator
+#            cd ios/build/Build/Products/Release-iphonesimulator
+#            touch file.txt
+#            pw
+#            ls
+#            cd -
 
       - persist_to_workspace:
           root: .
@@ -95,23 +97,23 @@ jobs:
       BASH_ENV: "~/.nvm/nvm.sh"
 
     steps:
-#      - checkout
+      - checkout
 
-#      - run:
-#          name: Install Node 8
-#          command: |
-#            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-#            source ~/.nvm/nvm.sh
-#            # https://github.com/creationix/nvm/issues/1394
-#            set +e
-#            nvm install 8
-#
-#      - run:
-#          name: Install appleSimUtils
-#          command: |
-#            brew update
-#            brew tap wix/brew
-#            brew install wix/brew/applesimutils
+      - run:
+          name: Install Node 8
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
+
+      - run:
+          name: Install appleSimUtils
+          command: |
+            brew update
+            brew tap wix/brew
+            brew install wix/brew/applesimutils
 
       - attach_workspace:
           at: ios/build/Build/Products/Release-iphonesimulator
@@ -134,13 +136,13 @@ jobs:
             cd ios/build/Build/Products
             ls
             cd -
-#            yarn global add detox-cli
-#            yarn
+            yarn global add detox-cli
+            yarn
 
-#      - run:
-#          name: Test
-#          command: |
-#            detox test --configuration ios.sim.release --cleanup --loglevel verbose
+      - run:
+          name: Test
+          command: |
+            detox test --configuration ios.sim.release --cleanup --loglevel verbose
 
       - store_artifacts:
           path: /tmp/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,16 +114,18 @@ jobs:
 #            brew install wix/brew/applesimutils
 
       - attach_workspace:
-          at: ios
+          at: ios/build/Build/Products/Release-iphonesimulator
 
       - run:
           name: Install Detox CLI
           command: |
             ls
             cd ios
+            echo "IOS FOLDER"
             ls
             cd -
             cd ios/build
+            echo "IOS/BUILD FOLDER"
             ls
             cd -
             cd ios/build/Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,23 +73,13 @@ jobs:
           command: |
             detox build --configuration ios.sim.release
 
-#      - run:
-#          name: Create fake folder to persist
-#          command: |
-#            mkdir -p ios/build/Build/Products/Release-iphonesimulator
-#            cd ios/build/Build/Products/Release-iphonesimulator
-#            touch file.txt
-#            pwd
-#            ls
-#            cd -
-
       - persist_to_workspace:
           root: .
           paths:
             - ios/build/Build/Products/Release-iphonesimulator/*
 
 
-  e2e-test:
+  e2e-test-iPhone-7:
     macos:
       xcode: "10.2.1"
 
@@ -117,40 +107,64 @@ jobs:
 
       - attach_workspace:
           at: .
-#          at: ios/build/Build/Products/Release-iphonesimulator/
 
       - run:
           name: Install Detox CLI
           command: |
-            ls
-            cd ios
-            echo "IOS FOLDER"
-            ls
-            cd -
-            cd ios/build
-            echo "IOS/BUILD FOLDER"
-            ls
-            cd -
-            cd ios/build/Build
-            ls
-            cd -
-            cd ios/build/Build/Products
-            ls
-            cd -
-            cd ios/build/Build/Products/Release-iphonesimulator
-            ls
-            cd -
             yarn global add detox-cli
             yarn
 
       - run:
           name: Test
           command: |
-            detox test --configuration ios.sim.release --cleanup --loglevel verbose
+            detox test --configuration ios.sim.release-iPhone7 --cleanup --loglevel verbose
 
       - store_artifacts:
           path: /tmp/screenshots
 
+
+  e2e-test-iPhone-Xʀ:
+    macos:
+      xcode: "10.2.1"
+
+    environment:
+      BASH_ENV: "~/.nvm/nvm.sh"
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node 8
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
+
+      - run:
+          name: Install appleSimUtils
+          command: |
+            brew update
+            brew tap wix/brew
+            brew install wix/brew/applesimutils
+
+      - attach_workspace:
+          at: .
+
+      - run:
+          name: Install Detox CLI
+          command: |
+            yarn global add detox-cli
+            yarn
+
+      - run:
+          name: Test
+          command: |
+            detox test --configuration ios.sim.release-iPhoneXʀ --cleanup --loglevel verbose
+
+      - store_artifacts:
+          path: /tmp/screenshots
 
   android-build:
     <<: *defaults
@@ -321,7 +335,11 @@ workflows:
 # TODO UNCOMMMENT
 #          requires:
 #            - e2e-hold
-      - e2e-test:
+      - e2e-test-iPhone-7:
+          requires:
+            - e2e-build
+
+      - e2e-test-iPhone-Xʀ:
           requires:
             - e2e-build
 # TODO UNCOMMMENT
@@ -330,7 +348,6 @@ workflows:
 #          type: approval
 #          requires:
 #            - lint-testunit
-
 
 # TODO UNCOMMMENT
 #      - ios-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
       BASH_ENV: "~/.nvm/nvm.sh"
 
     steps:
+      - checkout
       - attach_workspace:
           at: ios
 

--- a/e2e/00-onboarding.spec.js
+++ b/e2e/00-onboarding.spec.js
@@ -4,7 +4,7 @@ const {
 const { takeScreenshot } = require('./helpers/screenshot');
 const data = require('./data');
 
-describe.only('Onboarding', () => {
+describe('Onboarding', () => {
 	before(async() => {
 		await waitFor(element(by.id('onboarding-view'))).toBeVisible().withTimeout(2000);
 	});

--- a/e2e/00-onboarding.spec.js
+++ b/e2e/00-onboarding.spec.js
@@ -4,7 +4,7 @@ const {
 const { takeScreenshot } = require('./helpers/screenshot');
 const data = require('./data');
 
-describe('Onboarding', () => {
+describe.only('Onboarding', () => {
 	before(async() => {
 		await waitFor(element(by.id('onboarding-view'))).toBeVisible().withTimeout(2000);
 	});
@@ -35,7 +35,7 @@ describe('Onboarding', () => {
 		it('should navigate to create new workspace', async() => {
 			// webviews are not supported by detox: https://github.com/wix/detox/issues/136#issuecomment-306591554
 		});
-	
+
 		it('should navigate to join community', async() => {
 			await element(by.id('join-community-button')).tap();
 			await waitFor(element(by.id('welcome-view'))).toBeVisible().withTimeout(60000);

--- a/package.json
+++ b/package.json
@@ -151,6 +151,18 @@
         "type": "ios.simulator",
         "name": "iPhone 7"
       },
+      "ios.sim.release-iPhone7": {
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/RocketChatRN.app",
+        "build": "xcodebuild -workspace ios/RocketChatRN.xcworkspace -scheme RocketChatRN -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "name": "iPhone 7"
+      },
+      "ios.sim.release-iPhoneXʀ": {
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/RocketChatRN.app",
+        "build": "xcodebuild -workspace ios/RocketChatRN.xcworkspace -scheme RocketChatRN -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "name": "iPhone Xʀ"
+      },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",


### PR DESCRIPTION
@RocketChat/ReactNative

The old e2e-test job was doing detox ios build and test on simulator iphone 7. 

In order to make it possible to create one detox ios build and run it on iPhone 7 and iPhone Xr the old job was divided into three:
* e2e-build - makes detox ios e2e build and persists the build at workspace.
* e2e-test-ios-iphone7 - ataches workspace from job e2e-build and then runs tests on iPhone7
* e2e-test-ios-iphoneXr - ataches workspace from job e2e-build and then runs tests on iPhoneXr