### PR TITLE
[CI] create job with e2e-build and save workspace for e2e-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,44 @@ jobs:
           paths:
             - ./node_modules
 
-  e2e-test:
+
+  e2e-build:
+    macos:
+      xcode: "10.2.1"
+
+    environment:
+      BASH_ENV: "~/.nvm/nvm.sh"
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node 8
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
+
+      - run:
+          name: Install NPM modules
+          command: |
+            yarn global add detox-cli
+            yarn
+
+      - run:
+          name: Build
+          command: |
+            detox build --configuration ios.sim.release
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ios/build/Build/Products/Release-iphonesimulator/*
+
+
+  e2e-test-iPhone-7:
     macos:
       xcode: "10.2.1"
 
@@ -68,21 +105,63 @@ jobs:
             brew tap wix/brew
             brew install wix/brew/applesimutils
 
+      - attach_workspace:
+          at: .
+
       - run:
-          name: Install NPM modules
+          name: Install Detox CLI
           command: |
             yarn global add detox-cli
             yarn
 
       - run:
-          name: Build
+          name: Test
           command: |
-            detox build --configuration ios.sim.release
+            detox test --configuration ios.sim.release-iPhone7 --cleanup --loglevel verbose
+
+      - store_artifacts:
+          path: /tmp/screenshots
+
+
+  e2e-test-iPhone-Xʀ:
+    macos:
+      xcode: "10.2.1"
+
+    environment:
+      BASH_ENV: "~/.nvm/nvm.sh"
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Node 8
+          command: |
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+            source ~/.nvm/nvm.sh
+            # https://github.com/creationix/nvm/issues/1394
+            set +e
+            nvm install 8
+
+      - run:
+          name: Install appleSimUtils
+          command: |
+            brew update
+            brew tap wix/brew
+            brew install wix/brew/applesimutils
+
+      - attach_workspace:
+          at: .
+
+      - run:
+          name: Install Detox CLI
+          command: |
+            yarn global add detox-cli
+            yarn
 
       - run:
           name: Test
           command: |
-            detox test --configuration ios.sim.release --cleanup
+            detox test --configuration ios.sim.release-iPhoneXʀ --cleanup --loglevel verbose
 
       - store_artifacts:
           path: /tmp/screenshots
@@ -254,14 +333,6 @@ workflows:
     jobs:
       - lint-testunit
 
-      - e2e-hold:
-          type: approval
-          requires:
-            - lint-testunit
-      - e2e-test:
-          requires:
-            - e2e-hold
-
       - ios-build:
           requires:
             - lint-testunit
@@ -276,3 +347,17 @@ workflows:
       - android-build:
           requires:
             - lint-testunit
+
+      - e2e-hold:
+          type: approval
+          requires:
+            - lint-testunit
+      - e2e-build:
+          requires:
+            - e2e-hold
+      - e2e-test-iPhone-7:
+          requires:
+            - e2e-build
+      - e2e-test-iPhone-Xʀ:
+          requires:
+            - e2e-build

--- a/package.json
+++ b/package.json
@@ -146,11 +146,17 @@
         "type": "ios.simulator",
         "name": "iPhone 7"
       },
-      "ios.sim.release": {
+      "ios.sim.release-iPhone7": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/RocketChatRN.app",
         "build": "xcodebuild -workspace ios/RocketChatRN.xcworkspace -scheme RocketChatRN -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "name": "iPhone 7"
+      },
+      "ios.sim.release-iPhoneXʀ": {
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/RocketChatRN.app",
+        "build": "xcodebuild -workspace ios/RocketChatRN.xcworkspace -scheme RocketChatRN -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "name": "iPhone Xʀ"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@rocket.chat/sdk": "1.0.0-alpha.28",
     "deep-equal": "^1.0.1",
+    "detox": "^12.11.2",
     "ejson": "^2.1.2",
     "expo-web-browser": "^5.0.3",
     "js-base64": "^2.5.1",
@@ -97,7 +98,6 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-runtime": "^6.26.0",
     "codecov": "3.3.0",
-    "detox": "12.8.0",
     "eslint": "^5.6.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,12 @@
         "type": "ios.simulator",
         "name": "iPhone 7"
       },
+      "ios.sim.release": {
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/RocketChatRN.app",
+        "build": "xcodebuild -workspace ios/RocketChatRN.xcworkspace -scheme RocketChatRN -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "name": "iPhone 7"
+      },
       "ios.sim.release-iPhone7": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/RocketChatRN.app",
         "build": "xcodebuild -workspace ios/RocketChatRN.xcworkspace -scheme RocketChatRN -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
+  integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helpers" "^7.4.4"
+    "@babel/parser" "^7.4.5"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.5"
+    "@babel/types" "^7.4.4"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.2.2":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.0.tgz#f663838cd7b542366de3aa608a657b8ccb2a99eb"
@@ -288,6 +308,11 @@
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
   integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
+
+"@babel/parser@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
+  integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
 
 "@babel/plugin-external-helpers@^7.0.0":
   version "7.2.0"
@@ -882,6 +907,21 @@
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.4.4"
     "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
+"@babel/traverse@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
+  integrity sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.5"
     "@babel/types" "^7.4.4"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -4906,16 +4946,18 @@ detect-port@^1.2.3:
     address "^1.0.1"
     debug "^2.6.0"
 
-detox@12.8.0:
-  version "12.8.0"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-12.8.0.tgz#68cf92ff02fcdb896f05c67b2b40a8c94d09b24b"
-  integrity sha512-mDe4HcrfUePokhgv6gZADzqqgE6BxYnHXNm4qi5WrwgPJJQMjTLeJOsD7Z6t02SoK5G5Uvq3rx9Z7eI+Xgb3iQ==
+detox@^12.11.2:
+  version "12.11.2"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-12.11.2.tgz#ec4fe2076589895aeaf1ba073ba605e3d43a274a"
+  integrity sha512-WmKth9B0/fsJPrM8sTZgMtN/zrFIKgSGD4hVcXVCTrtTQqHBQB2SqhLDuQrPpkyEXVGTl3O9viCJG7d651ZGIg==
   dependencies:
+    "@babel/core" "^7.4.5"
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"
     chalk "^2.4.2"
     child-process-promise "^2.2.0"
     fs-extra "^4.0.2"
+    funpermaproxy "^1.0.1"
     get-port "^2.1.0"
     ini "^1.3.4"
     lodash "^4.17.5"
@@ -4926,7 +4968,7 @@ detox@12.8.0:
     tail "^2.0.0"
     telnet-client "0.15.3"
     tempfile "^2.0.0"
-    ws "^1.1.1"
+    ws "^3.3.1"
     yargs "^13.0.0"
     yargs-parser "^13.0.0"
 
@@ -6355,6 +6397,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+funpermaproxy@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/funpermaproxy/-/funpermaproxy-1.0.1.tgz#4650e69b7c334d9717c06beba9b339cc08ac3335"
+  integrity sha512-9pEzs5vnNtR7ZGihly98w/mQ7blsvl68Wj30ZCDAXy7qDN4CWLLjdfjtH/P2m6whsnaJkw15hysCNHMXue+wdA==
 
 fuse.js@^3.0.1, fuse.js@^3.3.0:
   version "3.3.0"
@@ -14781,7 +14828,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^1.1.0, ws@^1.1.1, ws@^1.1.5:
+ws@^1.1.0, ws@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
   integrity sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==


### PR DESCRIPTION
@RocketChat/ReactNative

The old e2e-test job was doing detox ios build and test on simulator iphone 7. 

In order to make it possible to create one detox ios build and run it on iPhone 7 and iPhone Xr the old job was divided into three:
* e2e-build - makes detox ios e2e build and persists the build at workspace.
* e2e-test-ios-iphone7 - ataches workspace from job e2e-build and then runs tests on iPhone7
* e2e-test-ios-iphoneXr - ataches workspace from job e2e-build and then runs tests on iPhoneXr