### PR TITLE
[IMPROVEMENT] Code of regex empty space on quote

### DIFF
--- a/app/containers/message/Markdown.js
+++ b/app/containers/message/Markdown.js
@@ -57,7 +57,7 @@ const Markdown = React.memo(({
 	if (m) {
 		m = emojify(m, { output: 'unicode' });
 	}
-	m = m.replace(/\[\s\]\(.*?\).*?\s/, '').trim(); // remove empty space on quote
+	m = m.replace(/^\[([^\]]*)\]\(([^)]*)\)\s/, '').trim();
 	if (numberOfLines > 0) {
 		m = m.replace(/[\n]+/g, '\n').trim();
 	}

--- a/app/containers/message/Markdown.js
+++ b/app/containers/message/Markdown.js
@@ -57,10 +57,7 @@ const Markdown = React.memo(({
 	if (m) {
 		m = emojify(m, { output: 'unicode' });
 	}
-	const matched = m.match(/^\[([^\]]*)\]\(([^)]*)\)\1/);
-	if (matched && matched[0] !== msg) {
-		m = m.replace(/^\[([^\]]*)\]\(([^)]*)\)/, '').trim();
-	}
+	m = m.replace(/\[\s\]\(.*?\).*?\s/, '').trim(); // remove empty space on quote
 	if (numberOfLines > 0) {
 		m = m.replace(/[\n]+/g, '\n').trim();
 	}


### PR DESCRIPTION
Improve code to regex empty spaces on quote and works with message with only a md link like a:
```[name](link)```

## Screenshot

![](https://i.imgur.com/8N1uOTv.png)
