### PR TITLE
[Chore] [CI] [TESTS] update detox to make ci pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,28 +252,27 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-#      - lint-testunit
-#
-#      - e2e-hold:
-#          type: approval
-#          requires:
-#            - lint-testunit
-      - e2e-test
+      - lint-testunit
 
-#          requires:
-#            - e2e-hold
+      - e2e-hold:
+          type: approval
+          requires:
+            - lint-testunit
+      - e2e-test:
+          requires:
+            - e2e-hold
 
-#      - ios-build:
-#          requires:
-#            - lint-testunit
-#      - ios-hold-testflight:
-#          type: approval
-#          requires:
-#            - ios-build
-#      - ios-testflight:
-#          requires:
-#            - ios-hold-testflight
-#
-#      - android-build:
-#          requires:
-#            - lint-testunit
+      - ios-build:
+          requires:
+            - lint-testunit
+      - ios-hold-testflight:
+          type: approval
+          requires:
+            - ios-build
+      - ios-testflight:
+          requires:
+            - ios-hold-testflight
+
+      - android-build:
+          requires:
+            - lint-testunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,7 @@ workflows:
 #          requires:
 #            - lint-testunit
       - e2e-test
+
 #          requires:
 #            - e2e-hold
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,27 +252,27 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - lint-testunit
+#      - lint-testunit
+#
+#      - e2e-hold:
+#          type: approval
+#          requires:
+#            - lint-testunit
+      - e2e-test
+#          requires:
+#            - e2e-hold
 
-      - e2e-hold:
-          type: approval
-          requires:
-            - lint-testunit
-      - e2e-test:
-          requires:
-            - e2e-hold
-
-      - ios-build:
-          requires:
-            - lint-testunit
-      - ios-hold-testflight:
-          type: approval
-          requires:
-            - ios-build
-      - ios-testflight:
-          requires:
-            - ios-hold-testflight
-
-      - android-build:
-          requires:
-            - lint-testunit
+#      - ios-build:
+#          requires:
+#            - lint-testunit
+#      - ios-hold-testflight:
+#          type: approval
+#          requires:
+#            - ios-build
+#      - ios-testflight:
+#          requires:
+#            - ios-hold-testflight
+#
+#      - android-build:
+#          requires:
+#            - lint-testunit

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "babel-plugin-transform-remove-console": "^6.9.4",
     "babel-runtime": "^6.26.0",
     "codecov": "3.3.0",
-    "detox": "12.8.0",
+    "detox": "12.11.3",
     "eslint": "^5.6.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
@RocketChat/ReactNative

This PR updates Detox to 12.11.3 from 12.8.0 in order to make CI pass.

