### PR TITLE
[FIX] Append server URL on avatar if necessary

### DIFF
--- a/app/containers/Avatar.js
+++ b/app/containers/Avatar.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 
+const formatUrl = (url, baseUrl, uriSize, avatarAuthURLFragment) => (
+	`${ baseUrl }${ url }?format=png&width=${ uriSize }&height=${ uriSize }${ avatarAuthURLFragment }`
+);
+
 const Avatar = React.memo(({
 	text, size, baseUrl, borderRadius, style, avatar, type, children, userId, token
 }) => {
@@ -26,7 +30,14 @@ const Avatar = React.memo(({
 		avatarAuthURLFragment = `&rc_token=${ token }&rc_uid=${ userId }`;
 	}
 
-	const uri = avatar || `${ baseUrl }/avatar/${ room }?format=png&width=${ uriSize }&height=${ uriSize }${ avatarAuthURLFragment }`;
+
+	let uri;
+	if (avatar) {
+		uri = avatar.includes('http') ? avatar : formatUrl(avatar, baseUrl, uriSize, avatarAuthURLFragment);
+	} else {
+		uri = formatUrl(`/avatar/${ room }`, baseUrl, uriSize, avatarAuthURLFragment);
+	}
+
 
 	const image = (
 		<FastImage


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
If avatar is a local image (like `/avatar/room.png`), browser is going to convert to `${ serverUrl }/avatar/room.png` automatically.
It doesn't happen by default on RN.
It crashes on Android and returns an empty space on iOS.

This PR fixes this issue by checking if `http` is present and append server URL if it's not.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
