### PR TITLE
[FIX] Endless "connecting" on notification tap on iOS

### DIFF
--- a/app/notifications/push/push.ios.js
+++ b/app/notifications/push/push.ios.js
@@ -1,5 +1,7 @@
 import NotificationsIOS from 'react-native-notifications';
 
+import reduxStore from '../../lib/createStore';
+
 class PushNotification {
 	constructor() {
 		this.onRegister = null;
@@ -11,7 +13,10 @@ class PushNotification {
 		});
 
 		NotificationsIOS.addEventListener('notificationOpened', (notification, completion) => {
-			this.onNotification(notification);
+			const { background } = reduxStore.getState().app;
+			if (background) {
+				this.onNotification(notification);
+			}
 			completion();
 		});
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Turns out react-native-notifications v2 fires `notificationOpened` event even on cold start.
It was dispatching `deepLinkingOpen` twice causing `selectServerRequest` to never finish.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
