### PR TITLE
[FIX] Handle disconnect and reconnect properly

### DIFF
--- a/app/lib/methods/subscriptions/room.js
+++ b/app/lib/methods/subscriptions/room.js
@@ -11,38 +11,14 @@ const removeListener = listener => listener.stop();
 
 export default function subscribeRoom({ rid }) {
 	let promises;
-	let timer = null;
 	let connectedListener;
 	let disconnectedListener;
 	let notifyRoomListener;
 	let messageReceivedListener;
 	const typingTimeouts = {};
-	const loop = () => {
-		if (timer) {
-			return;
-		}
-		timer = setTimeout(() => {
-			try {
-				clearTimeout(timer);
-				timer = false;
-				this.loadMissedMessages({ rid });
-				loop();
-			} catch (e) {
-				loop();
-			}
-		}, 5000);
-	};
 
-	const handleConnected = () => {
+	const handleConnection = () => {
 		this.loadMissedMessages({ rid });
-		clearTimeout(timer);
-		timer = false;
-	};
-
-	const handleDisconnected = () => {
-		if (this.sdk.userId) {
-			loop();
-		}
 	};
 
 	const getUserTyping = username => (
@@ -176,8 +152,6 @@ export default function subscribeRoom({ rid }) {
 			messageReceivedListener.then(removeListener);
 			messageReceivedListener = false;
 		}
-		clearTimeout(timer);
-		timer = false;
 		Object.keys(typingTimeouts).forEach((key) => {
 			if (typingTimeouts[key]) {
 				clearTimeout(typingTimeouts[key]);
@@ -190,8 +164,8 @@ export default function subscribeRoom({ rid }) {
 		});
 	};
 
-	connectedListener = this.sdk.onStreamData('connected', handleConnected);
-	disconnectedListener = this.sdk.onStreamData('close', handleDisconnected);
+	connectedListener = this.sdk.onStreamData('connected', handleConnection);
+	disconnectedListener = this.sdk.onStreamData('close', handleConnection);
 	notifyRoomListener = this.sdk.onStreamData('stream-notify-room', handleNotifyRoomReceived);
 	messageReceivedListener = this.sdk.onStreamData('stream-room-messages', handleMessageReceived);
 

--- a/app/lib/methods/subscriptions/rooms.js
+++ b/app/lib/methods/subscriptions/rooms.js
@@ -16,29 +16,8 @@ let streamListener;
 let subServer;
 
 export default function subscribeRooms() {
-	let timer = null;
-	const loop = () => {
-		if (timer) {
-			return;
-		}
-		timer = setTimeout(() => {
-			clearTimeout(timer);
-			timer = false;
-			store.dispatch(roomsRequest());
-			loop();
-		}, 5000);
-	};
-
-	const handleConnected = () => {
+	const handleConnection = () => {
 		store.dispatch(roomsRequest());
-		clearTimeout(timer);
-		timer = false;
-	};
-
-	const handleDisconnected = () => {
-		if (this.sdk.userId) {
-			loop();
-		}
 	};
 
 	const handleStreamMessageReceived = protectedFunction((ddpMessage) => {
@@ -145,12 +124,10 @@ export default function subscribeRooms() {
 			streamListener.then(removeListener);
 			streamListener = false;
 		}
-		clearTimeout(timer);
-		timer = false;
 	};
 
-	connectedListener = this.sdk.onStreamData('connected', handleConnected);
-	disconnectedListener = this.sdk.onStreamData('close', handleDisconnected);
+	connectedListener = this.sdk.onStreamData('connected', handleConnection);
+	disconnectedListener = this.sdk.onStreamData('close', handleConnection);
 	streamListener = this.sdk.onStreamData('stream-notify-user', handleStreamMessageReceived);
 
 	try {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@rocket.chat/sdk": "1.0.0-alpha.28",
+    "@rocket.chat/sdk": "1.0.0-alpha.30",
     "deep-equal": "^1.0.1",
     "ejson": "2.2.0",
     "expo-haptics": "^6.0.0",

--- a/patches/react-native+0.60.4.patch
+++ b/patches/react-native+0.60.4.patch
@@ -1,3 +1,15 @@
+diff --git a/node_modules/react-native/Libraries/WebSocket/RCTSRWebSocket.m b/node_modules/react-native/Libraries/WebSocket/RCTSRWebSocket.m
+index 6f1e5e8..b835657 100644
+--- a/node_modules/react-native/Libraries/WebSocket/RCTSRWebSocket.m
++++ b/node_modules/react-native/Libraries/WebSocket/RCTSRWebSocket.m
+@@ -595,6 +595,7 @@ - (void)closeWithCode:(NSInteger)code reason:(NSString *)reason;
+       }
+     }
+ 
++    [self.delegate webSocket:self didCloseWithCode:code reason:reason wasClean:YES];
+     [self _sendFrameWithOpcode:RCTSROpCodeConnectionClose data:payload];
+   });
+ }
 diff --git a/node_modules/react-native/React/Modules/RCTRedBox.m b/node_modules/react-native/React/Modules/RCTRedBox.m
 index 7ed4900..bb85402 100644
 --- a/node_modules/react-native/React/Modules/RCTRedBox.m

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,10 +1347,10 @@
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.0.2.tgz#1d94f02800b094753f9271c206a26c2a06ca14ee"
   integrity sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw==
 
-"@rocket.chat/sdk@1.0.0-alpha.28":
-  version "1.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/@rocket.chat/sdk/-/sdk-1.0.0-alpha.28.tgz#569f3c578c5c12ed54a9317d36fa8413208ce021"
-  integrity sha512-tQ+tIIX5R931cxIlTTn2ftCfiIo372vCG3omzDwzSfw6Kq24f7giUxVEpWfsI4GtuTU4caoren7wuGYwnST/+A==
+"@rocket.chat/sdk@1.0.0-alpha.30":
+  version "1.0.0-alpha.30"
+  resolved "https://registry.yarnpkg.com/@rocket.chat/sdk/-/sdk-1.0.0-alpha.30.tgz#fabfab601892bde9c9277a8aae92e88da770d64e"
+  integrity sha512-beKIoCw0XLjN8dcusqwBiS1hCVKE+y1IzpRYHUtNciS5LhOPujLUwrzF+pys2xkia5TohbRlsbNYlXPehvSHLQ==
   dependencies:
     "@types/event-emitter" "^0.3.2"
     "@types/eventemitter3" "^2.0.2"
@@ -8754,9 +8754,9 @@ pad-component@0.0.1:
   resolved "https://registry.yarnpkg.com/pad-component/-/pad-component-0.0.1.tgz#ad1f22ce1bf0fdc0d6ddd908af17f351a404b8ac"
   integrity sha1-rR8izhvw/cDW3dkIrxfzUaQEuKw=
 
-paho-mqtt@eclipse/paho.mqtt.javascript#master:
+"paho-mqtt@github:eclipse/paho.mqtt.javascript#master":
   version "1.1.0"
-  resolved "https://codeload.github.com/eclipse/paho.mqtt.javascript/tar.gz/9b761defeeb4a627db31d92ae1b0ca91b44b226e"
+  resolved "https://codeload.github.com/eclipse/paho.mqtt.javascript/tar.gz/f5859463aba9a9b7c19f99ab7c4849a723f8d832"
 
 pako@~1.0.2:
   version "1.0.8"


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
There are some issues on our socket connection handle that this PR fixes.

- When user changes servers, we don't close sockets correctly leaving some sessions hanging until the app is closed.
  - There was an issue on our JS SDK fixed here: https://github.com/RocketChat/Rocket.Chat.js.SDK/pull/91
  - There was an issue on React Native for iOS fixed here: https://github.com/facebook/react-native/pull/26052
- When user goes offline, reopen socket does a loop requesting data from Rest API
  - JS SDK already sends messages to the app, so we are reusing them to fetch data from Rest API instead of maintaining another loop.

I created a local patch for RN (it can take longer to get released), but we can wait for JS SDK to be bumped.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
