### PR TITLE
[FIX] Unsubscribe rooms listeners immediately on server change

### DIFF
--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -53,7 +53,12 @@ const STATUSES = ['offline', 'online', 'away', 'busy'];
 
 const RocketChat = {
 	TOKEN_KEY,
-	subscribeRooms,
+	async subscribeRooms() {
+		if (this.roomsSub) {
+			this.roomsSub.stop();
+		}
+		this.roomsSub = await subscribeRooms.call(this);
+	},
 	subscribeRoom,
 	canOpenRoom,
 	createChannel({

--- a/app/sagas/rooms.js
+++ b/app/sagas/rooms.js
@@ -1,5 +1,5 @@
 import {
-	put, select, race, take, fork, cancel, takeLatest, delay
+	put, select, race, take, fork, cancel, delay
 } from 'redux-saga/effects';
 import { BACKGROUND, INACTIVE } from 'redux-enhancer-react-native-appstate';
 
@@ -10,18 +10,9 @@ import log from '../utils/log';
 import mergeSubscriptionsRooms from '../lib/methods/helpers/mergeSubscriptionsRooms';
 import RocketChat from '../lib/rocketchat';
 
-let roomsSub;
-
-const removeSub = function removeSub() {
-	if (roomsSub && roomsSub.stop) {
-		roomsSub.stop();
-	}
-};
-
 const handleRoomsRequest = function* handleRoomsRequest() {
 	try {
-		removeSub();
-		roomsSub = yield RocketChat.subscribeRooms();
+		yield RocketChat.subscribeRooms();
 		const newRoomsUpdatedAt = new Date();
 		const server = yield select(state => state.server.server);
 		const [serverRecord] = database.databases.serversDB.objects('servers').filtered('id = $0', server);
@@ -53,12 +44,7 @@ const handleRoomsRequest = function* handleRoomsRequest() {
 	}
 };
 
-const handleLogout = function handleLogout() {
-	removeSub();
-};
-
 const root = function* root() {
-	yield takeLatest(types.LOGOUT, handleLogout);
 	while (true) {
 		const params = yield take(types.ROOMS.REQUEST);
 		const isAuthenticated = yield select(state => state.login.isAuthenticated);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
On #987, I fixed a few race conditions, but I left listeners created by `RocketChat.subscribeRooms` to be closed on the next `roomsRequest` action.
Although it works in most cases, if the user changes from one server to another, it keeps connect and disconnect listeners opened and it runs `roomsRequest` before setting next server.

This PR fixes it by moving `this.roomsSub` back to `RocketChat`.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
### Test plan

- [x] Login must request and subscribe to rooms changes
- [x] Changing server must request and subscribe to rooms changes
- [x] With two servers logged in: Logging out from one server must request and subscribe to rooms changes for the other
- [x] Notifications must request and subscribe to rooms changes
- [x] Adding a new server must request and subscribe to rooms changes

**Note**: 
- `Request` is a `/GET` Rest API for `subscriptions.get` and `rooms.get`
- `Subscribe` is listening for changes via socket