### PR TITLE
[FIX] Crashing when last message is pin

### DIFF
--- a/app/presentation/RoomItem/LastMessage.js
+++ b/app/presentation/RoomItem/LastMessage.js
@@ -13,7 +13,7 @@ const formatMsg = ({
 	if (!showLastMessage) {
 		return '';
 	}
-	if (!lastMessage) {
+	if (!lastMessage || lastMessage.pinned) {
 		return I18n.t('No_Message');
 	}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
When the last message is a pin, it's crashing the app.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
