### PR TITLE
[FIX] Block code on thread preview

### DIFF
--- a/app/containers/message/Content.js
+++ b/app/containers/message/Content.js
@@ -27,7 +27,7 @@ const Content = React.memo((props) => {
 				numberOfLines={props.tmid ? 1 : 0}
 				channels={props.channels}
 				mentions={props.mentions}
-				useMarkdown={props.useMarkdown}
+				useMarkdown={props.useMarkdown && !props.tmid}
 				navToRoomInfo={props.navToRoomInfo}
 				tmid={props.tmid}
 			/>


### PR DESCRIPTION
@RocketChat/ReactNative

We need to disable markdown when it is a Thread Reply Preview because it causes weird behaviors.

### Before
![](https://i.imgur.com/8bnxG3t.png)

### After
![](https://i.imgur.com/0NSOXAB.png)