### PR TITLE
[FIX] Bugsnag notify only accept Error

### DIFF
--- a/app/utils/log.js
+++ b/app/utils/log.js
@@ -8,4 +8,10 @@ export const { analytics } = firebase;
 export const loggerConfig = bugsnag.config;
 export const { leaveBreadcrumb } = bugsnag;
 
-export default bugsnag.notify;
+export default (e) => {
+	if (e instanceof Error) {
+		bugsnag.notify(e);
+	} else {
+		console.log(e);
+	}
+};


### PR DESCRIPTION
@RocketChat/ReactNative

`Bugsnag.notify` only accept `Errors`, we need to create a condition because sometimes `RocketChatJS SDK` return an `Object` instead of `Error` on `reject`.

More info:
[Bugsnag notify docs](https://docs.bugsnag.com/platforms/javascript/reporting-handled-errors/#sending-custom-errors)