### PR TITLE
[FIX] Unnecessary rooms list render on focus

### DIFF
--- a/app/views/RoomsListView/index.js
+++ b/app/views/RoomsListView/index.js
@@ -164,18 +164,19 @@ class RoomsListView extends React.Component {
 			width
 		};
 		Orientation.unlockAllOrientations();
-		this.didFocusListener = props.navigation.addListener('didFocus', () => {
-			BackHandler.addEventListener(
-				'hardwareBackPress',
-				this.handleBackPress
-			);
-		});
 		this.willFocusListener = props.navigation.addListener('willFocus', () => {
+			// Check if there were changes while not focused (it's set on sCU)
 			if (this.shouldUpdate) {
 				animateNextTransition();
 				this.forceUpdate();
 				this.shouldUpdate = false;
 			}
+		});
+		this.didFocusListener = props.navigation.addListener('didFocus', () => {
+			BackHandler.addEventListener(
+				'hardwareBackPress',
+				this.handleBackPress
+			);
 		});
 		this.willBlurListener = props.navigation.addListener('willBlur', () => BackHandler.addEventListener(
 			'hardwareBackPress',
@@ -217,12 +218,15 @@ class RoomsListView extends React.Component {
 			return true;
 		}
 
+		// Compare changes only once
 		const chatsNotEqual = !isEqual(nextState.allChats, allChats);
 
+		// If they aren't equal, set to update if focused
 		if (chatsNotEqual) {
 			this.shouldUpdate = true;
 		}
 
+		// Abort if it's not focused
 		if (!nextProps.navigation.isFocused()) {
 			return false;
 		}
@@ -245,6 +249,7 @@ class RoomsListView extends React.Component {
 		if (!isEqual(nextState.search, search)) {
 			return true;
 		}
+		// If it's focused and there are changes, update
 		if (chatsNotEqual) {
 			this.shouldUpdate = false;
 			return true;
@@ -288,14 +293,14 @@ class RoomsListView extends React.Component {
 		if (this.querySubscription && this.querySubscription.unsubscribe) {
 			this.querySubscription.unsubscribe();
 		}
+		if (this.willFocusListener && this.willFocusListener.remove) {
+			this.willFocusListener.remove();
+		}
 		if (this.didFocusListener && this.didFocusListener.remove) {
 			this.didFocusListener.remove();
 		}
 		if (this.willBlurListener && this.willBlurListener.remove) {
 			this.willBlurListener.remove();
-		}
-		if (this.willFocusListener && this.willFocusListener.remove) {
-			this.willFocusListener.remove();
 		}
 		Dimensions.removeEventListener('change', this.onDimensionsChange);
 		console.countReset(`${ this.constructor.name }.render calls`);

--- a/app/views/RoomsListView/index.js
+++ b/app/views/RoomsListView/index.js
@@ -169,7 +169,13 @@ class RoomsListView extends React.Component {
 				'hardwareBackPress',
 				this.handleBackPress
 			);
-			this.forceUpdate();
+		});
+		this.willFocusListener = props.navigation.addListener('willFocus', () => {
+			if (this.shouldUpdate) {
+				animateNextTransition();
+				this.forceUpdate();
+				this.shouldUpdate = false;
+			}
 		});
 		this.willBlurListener = props.navigation.addListener('willBlur', () => BackHandler.addEventListener(
 			'hardwareBackPress',
@@ -204,10 +210,17 @@ class RoomsListView extends React.Component {
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {
+		const { allChats } = this.state;
 		// eslint-disable-next-line react/destructuring-assignment
 		const propsUpdated = shouldUpdateProps.some(key => nextProps[key] !== this.props[key]);
 		if (propsUpdated) {
 			return true;
+		}
+
+		const chatsNotEqual = !isEqual(nextState.allChats, allChats);
+
+		if (chatsNotEqual) {
+			this.shouldUpdate = true;
 		}
 
 		if (!nextProps.navigation.isFocused()) {
@@ -218,7 +231,6 @@ class RoomsListView extends React.Component {
 			loading,
 			searching,
 			width,
-			allChats,
 			search
 		} = this.state;
 		if (nextState.loading !== loading) {
@@ -233,7 +245,8 @@ class RoomsListView extends React.Component {
 		if (!isEqual(nextState.search, search)) {
 			return true;
 		}
-		if (!isEqual(nextState.allChats, allChats)) {
+		if (chatsNotEqual) {
+			this.shouldUpdate = false;
 			return true;
 		}
 		return false;
@@ -280,6 +293,9 @@ class RoomsListView extends React.Component {
 		}
 		if (this.willBlurListener && this.willBlurListener.remove) {
 			this.willBlurListener.remove();
+		}
+		if (this.willFocusListener && this.willFocusListener.remove) {
+			this.willFocusListener.remove();
 		}
 		Dimensions.removeEventListener('change', this.onDimensionsChange);
 		console.countReset(`${ this.constructor.name }.render calls`);


### PR DESCRIPTION
@RocketChat/ReactNative

We can use `willFocus` instead `didFocus` to check if `RoomsListView` needs a re-render.
To check it we can use a instance variable and set it when chats are not equal, when `RoomsListView` receive focus we forceUpdate if it is `true`, when it re-render we can set to `false`.
