### PR TITLE
[FIX] Dispatch roomsRequest on app foreground event even if not connected

### DIFF
--- a/app/views/RoomsListView/index.js
+++ b/app/views/RoomsListView/index.js
@@ -57,8 +57,7 @@ const shouldUpdateProps = [
 	'showUnread',
 	'useRealName',
 	'StoreLastMessage',
-	'appState',
-	'isAuthenticated'
+	'appState'
 ];
 const getItemLayout = (data, index) => ({
 	length: ROW_HEIGHT,
@@ -139,8 +138,7 @@ class RoomsListView extends React.Component {
 		openSearchHeader: PropTypes.func,
 		closeSearchHeader: PropTypes.func,
 		appStart: PropTypes.func,
-		roomsRequest: PropTypes.func,
-		isAuthenticated: PropTypes.bool
+		roomsRequest: PropTypes.func
 	};
 
 	constructor(props) {
@@ -264,8 +262,7 @@ class RoomsListView extends React.Component {
 			showFavorites,
 			showUnread,
 			appState,
-			roomsRequest,
-			isAuthenticated
+			roomsRequest
 		} = this.props;
 
 		if (
@@ -280,7 +277,6 @@ class RoomsListView extends React.Component {
 		} else if (
 			appState === 'foreground'
 			&& appState !== prevProps.appState
-			&& isAuthenticated
 		) {
 			roomsRequest();
 		}
@@ -801,7 +797,6 @@ const mapStateToProps = state => ({
 	userId: state.login.user && state.login.user.id,
 	username: state.login.user && state.login.user.username,
 	token: state.login.user && state.login.user.token,
-	isAuthenticated: state.login.isAuthenticated,
 	server: state.server.server,
 	baseUrl: state.settings.baseUrl || state.server ? state.server.server : '',
 	searchText: state.rooms.searchText,


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
We weren't dispatching `roomsRequest` action if not connected.
`roomsRequest` saga already waits for `isAuthenticated` state: https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/app/sagas/rooms.js#L81
This PR may fix some foreground events not fetching rooms updates.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
