### PR TITLE
[FIX] End Jitsi call on unmount

### DIFF
--- a/app/views/JitsiMeetView.js
+++ b/app/views/JitsiMeetView.js
@@ -33,6 +33,13 @@ class JitsiMeetView extends React.Component {
 		}, 1000);
 	}
 
+	componentWillUnmount() {
+		if (this.jitsiTimeout) {
+			BackgroundTimer.clearInterval(this.jitsiTimeout);
+		}
+		JitsiMeet.endCall();
+	}
+
 	// Jitsi Update Timeout needs to be called every 10 seconds to make sure
 	// call is not ended and is available to web users.
 	onConferenceJoined = () => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
It usually happens when the user taps Android back button.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
