### PR TITLE
[FIX] Invalid version

### DIFF
--- a/app/lib/methods/getSettings.js
+++ b/app/lib/methods/getSettings.js
@@ -2,6 +2,7 @@ import { InteractionManager } from 'react-native';
 import { sanitizedRaw } from '@nozbe/watermelondb/RawRecord';
 import { Q } from '@nozbe/watermelondb';
 
+import RocketChat from '../rocketchat';
 import reduxStore from '../createStore';
 import * as actions from '../../actions';
 import settings from '../../constants/settings';
@@ -50,6 +51,20 @@ const serverInfoUpdate = async(serverInfo, iconSetting) => {
 		}
 	});
 };
+
+export async function setSettings() {
+	const db = database.active;
+	const settingsCollection = db.collections.get('settings');
+	const settingsRecords = await settingsCollection.query().fetch();
+	const parsed = Object.values(settingsRecords).map(item => ({
+		_id: item.id,
+		valueAsString: item.valueAsString,
+		valueAsBoolean: item.valueAsBoolean,
+		valueAsNumber: item.valueAsNumber,
+		_updatedAt: item._updatedAt
+	}));
+	reduxStore.dispatch(actions.setAllSettings(RocketChat.parseSettings(parsed.slice(0, parsed.length))));
+}
 
 export default async function() {
 	try {

--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -27,7 +27,7 @@ import subscribeRoom from './methods/subscriptions/room';
 
 import protectedFunction from './methods/helpers/protectedFunction';
 import readMessages from './methods/readMessages';
-import getSettings from './methods/getSettings';
+import getSettings, { setSettings } from './methods/getSettings';
 
 import getRooms from './methods/getRooms';
 import getPermissions from './methods/getPermissions';
@@ -532,6 +532,7 @@ const RocketChat = {
 	cancelUpload,
 	isUploadActive,
 	getSettings,
+	setSettings,
 	getPermissions,
 	getCustomEmojis,
 	setCustomEmojis,

--- a/app/sagas/selectServer.js
+++ b/app/sagas/selectServer.js
@@ -81,22 +81,6 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 			}
 		}
 
-		database.setActiveDB(server);
-
-		const db = database.active;
-		const serversCollection = db.collections.get('settings');
-		const settingsRecords = yield serversCollection.query().fetch();
-		const settings = Object.values(settingsRecords).map(item => ({
-			_id: item.id,
-			valueAsString: item.valueAsString,
-			valueAsBoolean: item.valueAsBoolean,
-			valueAsNumber: item.valueAsNumber,
-			_updatedAt: item._updatedAt
-		}));
-		yield put(actions.setAllSettings(RocketChat.parseSettings(settings.slice(0, settings.length))));
-
-		yield RocketChat.setCustomEmojis();
-
 		if (user) {
 			yield RocketChat.connect({ server, user });
 			yield put(setUser(user));
@@ -105,6 +89,11 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 			yield RocketChat.connect({ server });
 			yield put(actions.appStart('outside'));
 		}
+
+		// We can't use yield here because fetch of Settings & Custom Emojis is slower
+		// and block the selectServerSuccess raising multiples errors
+		RocketChat.setSettings();
+		RocketChat.setCustomEmojis();
 
 		let serverInfo;
 		if (fetchVersion) {

--- a/app/sagas/selectServer.js
+++ b/app/sagas/selectServer.js
@@ -81,14 +81,7 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 			}
 		}
 
-		if (user) {
-			yield RocketChat.connect({ server, user });
-			yield put(setUser(user));
-			yield put(actions.appStart('inside'));
-		} else {
-			yield RocketChat.connect({ server });
-			yield put(actions.appStart('outside'));
-		}
+		database.setActiveDB(server);
 
 		const db = database.active;
 		const serversCollection = db.collections.get('settings');
@@ -103,6 +96,15 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 		yield put(actions.setAllSettings(RocketChat.parseSettings(settings.slice(0, settings.length))));
 
 		yield RocketChat.setCustomEmojis();
+
+		if (user) {
+			yield RocketChat.connect({ server, user });
+			yield put(setUser(user));
+			yield put(actions.appStart('inside'));
+		} else {
+			yield RocketChat.connect({ server });
+			yield put(actions.appStart('outside'));
+		}
 
 		let serverInfo;
 		if (fetchVersion) {


### PR DESCRIPTION
@RocketChat/reactnative 

After we start `serverSelectRequest` the `RocketChat.connect` is started and call `login`, when login success we call `fetchCustomEmojis`, `fetchPermissions` and this access `redux.getState().server.version`, but if we get this before `serverSelectSuccess` we have a null version.. it can occur when `/api/info` is slower than `/login`..

Other possible approach is create a action `setVersion` and call it when `getServerInfo` 🤔 ...
What do you think?

