### PR TITLE
[FIX] Server with backslash

### DIFF
--- a/app/views/NewServerView.js
+++ b/app/views/NewServerView.js
@@ -190,7 +190,7 @@ class NewServerView extends React.Component {
 			}
 		}
 
-		return url.replace(/\/+$/, '');
+		return url.replace(/\/+$/, '').replace(/\\/g, '/');
 	}
 
 	uriToPath = uri => uri.replace('file://', '');


### PR DESCRIPTION
@RocketChat/ReactNative

If users put `https:\\open.rocket.chat` it raises an error, but it work's how expected on google chrome and can cause a bit confusing on users..
We can replace all `\` with `/`.