### PR TITLE
[FIX] Server with subpath

### DIFF
--- a/app/lib/database/index.js
+++ b/app/lib/database/index.js
@@ -52,7 +52,7 @@ class DB {
 	}
 
 	setActiveDB(database = '') {
-		const path = database.replace(/(^\w+:|^)\/\//, '');
+		const path = database.replace(/(^\w+:|^)\/\//, '').replace(/\//, '.');
 		const dbName = `${ appGroupPath }${ path }.db`;
 
 		const adapter = new SQLiteAdapter({


### PR DESCRIPTION
@RocketChat/ReactNative

When we have a server with `https://open.rocket.chat/rocketchat` [subpath] it raises an error because we try to create and read a database file with name `open.rocket.chat/rocketchat`.
To fix it after remove `http://` or `https://` I replace all `/` with `.`, it will create `open.rocket.chat.rocketchat` and you can use multiples servers with differents `subpaths.