### PR TITLE
[IMPROVEMENT] Save last message as message when subscription changes

### DIFF
--- a/app/sagas/rooms.js
+++ b/app/sagas/rooms.js
@@ -11,6 +11,7 @@ import database from '../lib/database';
 import log from '../utils/log';
 import mergeSubscriptionsRooms from '../lib/methods/helpers/mergeSubscriptionsRooms';
 import RocketChat from '../lib/rocketchat';
+import buildMessage from '../lib/methods/helpers/buildMessage';
 
 const handleRoomsRequest = function* handleRoomsRequest() {
 	try {
@@ -26,16 +27,26 @@ const handleRoomsRequest = function* handleRoomsRequest() {
 
 		const db = database.active;
 		yield db.action(async() => {
-			const subCollection = db.collections.get('subscriptions');
 			if (!subscriptions.length) {
 				return;
 			}
+
+			const subCollection = db.collections.get('subscriptions');
+			const messagesCollection = db.collections.get('messages');
 
 			const subsIds = subscriptions.map(sub => sub.rid);
 			const existingSubs = await subCollection.query(Q.where('id', Q.oneOf(subsIds))).fetch();
 			const subsToUpdate = existingSubs.filter(i1 => subscriptions.find(i2 => i1._id === i2._id));
 			const subsToCreate = subscriptions.filter(i1 => !existingSubs.find(i2 => i1._id === i2._id));
 			// TODO: subsToDelete?
+
+			const lastMessages = subscriptions
+				.map(sub => sub.lastMessage && buildMessage(sub.lastMessage))
+				.filter(lm => lm);
+			const lastMessagesIds = lastMessages.map(lm => lm._id);
+			const existingMessages = await messagesCollection.query(Q.where('id', Q.oneOf(lastMessagesIds))).fetch();
+			const messagesToUpdate = existingMessages.filter(i1 => lastMessages.find(i2 => i1.id === i2._id));
+			const messagesToCreate = lastMessages.filter(i1 => !existingMessages.find(i2 => i1._id === i2.id));
 
 			const allRecords = [
 				...subsToCreate.map(subscription => subCollection.prepareCreate((s) => {
@@ -46,6 +57,17 @@ const handleRoomsRequest = function* handleRoomsRequest() {
 					const newSub = subscriptions.find(s => s._id === subscription._id);
 					return subscription.prepareUpdate(() => {
 						Object.assign(subscription, newSub);
+					});
+				}),
+				...messagesToCreate.map(message => messagesCollection.prepareCreate((m) => {
+					m._raw = sanitizedRaw({ id: message._id }, messagesCollection.schema);
+					m.subscription.id = message.rid;
+					return Object.assign(m, message);
+				})),
+				...messagesToUpdate.map((message) => {
+					const newMessage = lastMessages.find(m => m._id === message.id);
+					return message.prepareUpdate(() => {
+						Object.assign(message, newMessage);
 					});
 				})
 			];


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Save subscription.lastMessage on messages collection without entering the room.

**Important:** use a database browser (like DB Browser for SQLite) to make sure all DMLs happened outside RoomView.

### Test plan 1 (rest api test)
- Logout (just to clear the database)
- Login
- All last messages should have been inserted on messages collection 

### Test plan 2 (rest api test)
- With app closed, receive a new message
- Restore the app
- Check if the message was inserted on db

### Test plan 3 (rest api test)
- With app closed, receive an update to an existing last message
- Restore the app
- Check if the message was updated on db

### Test plan 4 (stream test)
- With app opened, receive a new message
- Check if the message was inserted on db

### Test plan 5 (stream test)
- With app opened, receive an update to an existing last message
- Check if the message was updated on db

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
