### PR TITLE
[FIX] Parse Urls

### DIFF
--- a/app/lib/methods/helpers/parseUrls.js
+++ b/app/lib/methods/helpers/parseUrls.js
@@ -9,6 +9,11 @@ export default urls => urls.filter(url => url.meta && !url.ignoreParse).map((url
 		decodedOgImage = meta.ogImage.replace(/&amp;/g, '&');
 	}
 	tmp.image = decodedOgImage || meta.twitterImage || meta.oembedThumbnailUrl;
+	if (tmp.image.indexOf('//') === 0) {
+		tmp.image = `${ url.parsedUrl.protocol }${ tmp.image }`;
+	} else if (tmp.image.indexOf('/') === 0 && (url.parsedUrl && url.parsedUrl.host)) {
+		tmp.image = `${ url.parsedUrl.protocol }//${ url.parsedUrl.host }${ tmp.image }`;
+	}
 	tmp.url = url.url;
 	return tmp;
 });


### PR DESCRIPTION
@RocketChat/ReactNative

Implement a case of `image` from `url` that not have host, following web client:
https://github.com/RocketChat/Rocket.Chat/blob/d53e264b83ccc971236123853e4b68c9eb6beeb4/app/oembed/client/oembedUrlWidget.js