### PR TITLE
[FIX] Prevent server with whitespace

### DIFF
--- a/app/views/NewServerView.js
+++ b/app/views/NewServerView.js
@@ -175,7 +175,7 @@ class NewServerView extends React.Component {
 	}
 
 	completeUrl = (url) => {
-		url = url && url.trim();
+		url = url && url.replace(/\s/g, '');
 
 		if (/^(\w|[0-9-_]){3,}$/.test(url)
 			&& /^(htt(ps?)?)|(loca((l)?|(lh)?|(lho)?|(lhos)?|(lhost:?\d*)?)$)/.test(url) === false) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
This PR fixes a crash happening on Android only in case of the user entered a whitespace on server URL, like `https:// open. rocket. chat`.
It wouldn't just raise an error on iOS.
Now we're removing whitespaces and it would submit the correct URL even with the typo.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
