### PR TITLE
[IMPROVEMENT] Authentication via deep linking

### DIFF
--- a/app/actions/login.js
+++ b/app/actions/login.js
@@ -1,9 +1,10 @@
 import * as types from './actionsTypes';
 
-export function loginRequest(credentials) {
+export function loginRequest(credentials, logoutOnError) {
 	return {
 		type: types.LOGIN.REQUEST,
-		credentials
+		credentials,
+		logoutOnError
 	};
 }
 

--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -14,9 +14,7 @@ import { isIOS, getBundleId } from '../utils/deviceInfo';
 import { extractHostname } from '../utils/server';
 import fetch, { headers } from '../utils/fetch';
 
-import {
-	setUser, setLoginServices, loginRequest, loginFailure, logout
-} from '../actions/login';
+import { setUser, setLoginServices, loginRequest } from '../actions/login';
 import { disconnect, connectSuccess, connectRequest } from '../actions/connect';
 import {
 	shareSelectServer, shareSetUser
@@ -163,7 +161,7 @@ const RocketChat = {
 	stopListener(listener) {
 		return listener && listener.stop();
 	},
-	connect({ server, user }) {
+	connect({ server, user, logoutOnError = false }) {
 		return new Promise((resolve) => {
 			if (!this.sdk || this.sdk.client.host !== server) {
 				database.setActiveDB(server);
@@ -208,7 +206,7 @@ const RocketChat = {
 			this.sdk.connect()
 				.then(() => {
 					if (user && user.token) {
-						reduxStore.dispatch(loginRequest({ resume: user.token }));
+						reduxStore.dispatch(loginRequest({ resume: user.token }, logoutOnError));
 					}
 				})
 				.catch((err) => {
@@ -380,11 +378,6 @@ const RocketChat = {
 			};
 			return user;
 		} catch (e) {
-			if (e.data && e.data.message && /you've been logged out by the server/i.test(e.data.message)) {
-				reduxStore.dispatch(logout({ server: this.sdk.client.host }));
-			} else {
-				reduxStore.dispatch(loginFailure(e));
-			}
 			throw e;
 		}
 	},

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -6,7 +6,6 @@ import RNUserDefaults from 'rn-user-defaults';
 import Navigation from '../lib/Navigation';
 import * as types from '../actions/actionsTypes';
 import { selectServerRequest } from '../actions/server';
-import { loginRequest } from '../actions/login';
 import database from '../lib/database';
 import RocketChat from '../lib/rocketchat';
 import EventEmitter from '../utils/events';

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -6,6 +6,7 @@ import RNUserDefaults from 'rn-user-defaults';
 import Navigation from '../lib/Navigation';
 import * as types from '../actions/actionsTypes';
 import { selectServerRequest } from '../actions/server';
+import { loginRequest } from '../actions/login';
 import database from '../lib/database';
 import RocketChat from '../lib/rocketchat';
 import EventEmitter from '../utils/events';
@@ -53,17 +54,13 @@ const handleOpen = function* handleOpen({ params }) {
 
 	// TODO: needs better test
 	// if deep link is from same server
-	if (server === host) {
-		if (user) {
-			const connected = yield select(state => state.server.connected);
-			if (!connected) {
-				yield put(selectServerRequest(host));
-				yield take(types.SERVER.SELECT_SUCCESS);
-			}
-			yield navigate({ params });
-		} else {
-			yield put(appStart('outside'));
+	if (server === host && user) {
+		const connected = yield select(state => state.server.connected);
+		if (!connected) {
+			yield put(selectServerRequest(host));
+			yield take(types.SERVER.SELECT_SUCCESS);
 		}
+		yield navigate({ params });
 	} else {
 		// search if deep link's server already exists
 		const serversDB = database.servers;
@@ -80,13 +77,18 @@ const handleOpen = function* handleOpen({ params }) {
 			// do nothing?
 		}
 		// if deep link is from a different server
-		const result = yield RocketChat.getServerInfo(server);
+		const result = yield RocketChat.getServerInfo(host);
 		if (!result.success) {
 			return;
 		}
 		Navigation.navigate('OnboardingView', { previousServer: server });
 		yield delay(1000);
 		EventEmitter.emit('NewServer', { server: host });
+
+		if (params.token) {
+			yield take(types.SERVER.SELECT_SUCCESS);
+			yield RocketChat.connect({ server: host, user: { token: params.token } });
+		}
 	}
 };
 

--- a/app/sagas/login.js
+++ b/app/sagas/login.js
@@ -9,7 +9,7 @@ import 'moment/min/locales';
 import * as types from '../actions/actionsTypes';
 import { appStart } from '../actions';
 import { serverFinishAdd, selectServerRequest } from '../actions/server';
-import { loginFailure, loginSuccess, setUser } from '../actions/login';
+import { loginFailure, loginSuccess, setUser, logout } from '../actions/login';
 import { roomsRequest } from '../actions/rooms';
 import { toMomentLocale } from '../utils/moment';
 import RocketChat from '../lib/rocketchat';
@@ -24,7 +24,7 @@ const loginWithPasswordCall = args => RocketChat.loginWithPassword(args);
 const loginCall = args => RocketChat.login(args);
 const logoutCall = args => RocketChat.logout(args);
 
-const handleLoginRequest = function* handleLoginRequest({ credentials }) {
+const handleLoginRequest = function* handleLoginRequest({ credentials, logoutOnError = false }) {
 	try {
 		let result;
 		if (credentials.resume) {
@@ -34,7 +34,11 @@ const handleLoginRequest = function* handleLoginRequest({ credentials }) {
 		}
 		return yield put(loginSuccess(result));
 	} catch (error) {
-		yield put(loginFailure(error));
+		if (logoutOnError) {
+			yield put(logout());
+		} else {
+			yield put(loginFailure(error));
+		}
 	}
 };
 

--- a/app/sagas/login.js
+++ b/app/sagas/login.js
@@ -9,7 +9,9 @@ import 'moment/min/locales';
 import * as types from '../actions/actionsTypes';
 import { appStart } from '../actions';
 import { serverFinishAdd, selectServerRequest } from '../actions/server';
-import { loginFailure, loginSuccess, setUser, logout } from '../actions/login';
+import {
+	loginFailure, loginSuccess, setUser, logout
+} from '../actions/login';
 import { roomsRequest } from '../actions/rooms';
 import { toMomentLocale } from '../utils/moment';
 import RocketChat from '../lib/rocketchat';

--- a/app/sagas/selectServer.js
+++ b/app/sagas/selectServer.js
@@ -87,7 +87,7 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 		}
 
 		if (user) {
-			yield RocketChat.connect({ server, user });
+			yield RocketChat.connect({ server, user, logoutOnError: true });
 			yield put(setUser(user));
 			yield put(actions.appStart('inside'));
 		} else {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This PR adds the capability of logging in via deep linking.
Docs: https://rocket.chat/docs/developer-guides/deeplink/#deeplink

The logic is really simple: it's just call `RocketChat.connect` with resume token, but I had to change the code a little, because the server response when login fails is hard to track down on the app and we have so many ways to login that makes even worse.
We can login via:
- Password
- Register
- OAuth/SSO
- Resume the app
- Deep linking

In all of them, we have to tell the user if the login was succeeded or not, but when resuming the app we have to make sure the user is logged out automatically.
Because of this I've created `logoutOnError` prop, that is default `false` and it's `true` only when the app is resumed.
