### PR TITLE
[FIX] Prevent multiple tap on send (Share Extension)

### DIFF
--- a/app/views/ShareView/index.js
+++ b/app/views/ShareView/index.js
@@ -97,8 +97,8 @@ class ShareView extends React.Component {
 		} else {
 			await this.sendTextMessage();
 		}
-		this.setState({ loading: false });
 
+		this.setState({ loading: false });
 		ShareExtension.close();
 	}
 

--- a/app/views/ShareView/index.js
+++ b/app/views/ShareView/index.js
@@ -86,16 +86,19 @@ class ShareView extends React.Component {
 	bytesToSize = bytes => `${ (bytes / 1048576).toFixed(2) }MB`;
 
 	_sendMessage = async() => {
-		const { isMedia } = this.state;
-		this.setState({ loading: true });
+		const { isMedia, loading } = this.state;
+		if (loading) {
+			return;
+		}
 
+		this.setState({ loading: true });
 		if (isMedia) {
 			await this.sendMediaMessage();
 		} else {
 			await this.sendTextMessage();
 		}
-
 		this.setState({ loading: false });
+
 		ShareExtension.close();
 	}
 


### PR DESCRIPTION
@RocketChat/ReactNative

While content is posted to server you could tap "send", this causes multiple repeated messages.
This PR prevent clicks while send is loading.