### PR TITLE
[FIX] Join Room Button doesn't disappear

### DIFF
--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -179,11 +179,13 @@ class RoomView extends React.Component {
 		}
 
 		this.beginAnimating = false;
-		this.didFocusListener = props.navigation.addListener('didFocus', () => this.beginAnimating = true);
+		this.didFocusListener = props.navigation.addListener('didFocus', () => {
+			this.mounted = true;
+			this.beginAnimating = true;
+		});
 		this.messagebox = React.createRef();
 		this.list = React.createRef();
 		this.willBlurListener = props.navigation.addListener('willBlur', () => this.mounted = false);
-		this.willFocusListener = props.navigation.addListener('willFocus', () => this.mounted = true);
 		this.mounted = false;
 		console.timeEnd(`${ this.constructor.name } init`);
 	}
@@ -299,9 +301,6 @@ class RoomView extends React.Component {
 		}
 		if (this.willBlurListener && this.willBlurListener.remove) {
 			this.willBlurListener.remove();
-		}
-		if (this.willFocusListener && this.willFocusListener.remove) {
-			this.willFocusListener.remove();
 		}
 		if (this.subSubscription && this.subSubscription.unsubscribe) {
 			this.subSubscription.unsubscribe();

--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -183,6 +183,7 @@ class RoomView extends React.Component {
 		this.messagebox = React.createRef();
 		this.list = React.createRef();
 		this.willBlurListener = props.navigation.addListener('willBlur', () => this.mounted = false);
+		this.willFocusListener = props.navigation.addListener('willFocus', () => this.mounted = true);
 		this.mounted = false;
 		console.timeEnd(`${ this.constructor.name } init`);
 	}
@@ -298,6 +299,9 @@ class RoomView extends React.Component {
 		}
 		if (this.willBlurListener && this.willBlurListener.remove) {
 			this.willBlurListener.remove();
+		}
+		if (this.willFocusListener && this.willFocusListener.remove) {
+			this.willFocusListener.remove();
 		}
 		if (this.subSubscription && this.subSubscription.unsubscribe) {
 			this.subSubscription.unsubscribe();


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #901

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This PR fixes the join room buton issue. When we move from room view to room action view, the `willBlur` event handler on navigation object is called ,setting `this.mount`  to false. Hence I added 'willFocus' event handler to make `this.mount` true again.
![ezgif com-crop (1)](https://user-images.githubusercontent.com/44807945/71524418-78f97600-28f3-11ea-963c-c281b572466e.gif)
