### PR TITLE
[CHORE] Update to new server response

### DIFF
--- a/app/sagas/selectServer.js
+++ b/app/sagas/selectServer.js
@@ -4,6 +4,7 @@ import {
 import { Alert } from 'react-native';
 import RNUserDefaults from 'rn-user-defaults';
 import { sanitizedRaw } from '@nozbe/watermelondb/RawRecord';
+import semver from 'semver';
 
 import Navigation from '../lib/Navigation';
 import { SERVER } from '../actions/actionsTypes';
@@ -35,18 +36,20 @@ const getServerInfo = function* getServerInfo({ server, raiseError = true }) {
 			return;
 		}
 
+		const validVersion = semver.coerce(serverInfo.version);
+
 		const serversDB = database.servers;
 		const serversCollection = serversDB.collections.get('servers');
 		yield serversDB.action(async() => {
 			try {
 				const serverRecord = await serversCollection.find(server);
 				await serverRecord.update((record) => {
-					record.version = serverInfo.version;
+					record.version = validVersion;
 				});
 			} catch (e) {
 				await serversCollection.create((record) => {
 					record._raw = sanitizedRaw({ id: server }, serversCollection.schema);
-					record.version = serverInfo.version;
+					record.version = validVersion;
 				});
 			}
 		});


### PR DESCRIPTION
@RocketChat/ReactNative

We'll remove the patch version from `/api/info`, so it will return only `2.4` for example, instead of `2.4.0`.
Semver needs a valid version, with `coerce` the version will be fixed.