### PR TITLE
[FIX] Dropdown does not closes automatically

### DIFF
--- a/app/views/DirectoryView/index.js
+++ b/app/views/DirectoryView/index.js
@@ -112,7 +112,7 @@ class DirectoryView extends React.Component {
 	}
 
 	changeType = (type) => {
-		this.setState({ type, data: [] }, () => this.search());
+		this.setState({ type, data: [], showOptionsDropdown: false }, () => this.search());
 	}
 
 	toggleWorkspace = () => {


### PR DESCRIPTION
@RocketChat/ReactNative

Closes #1514 

When the user select the option from the dropdown menu, it just update the state and close the dropdown automatically.


