### PR TITLE
[FIX] Go to direct message from members list

### DIFF
--- a/app/views/RoomMembersView/index.js
+++ b/app/views/RoomMembersView/index.js
@@ -122,7 +122,6 @@ class RoomMembersView extends React.Component {
 			if (query.length) {
 				const [room] = query;
 				this.goRoom({ rid: room.rid, name: item.username, room });
-				this.goRoom({ rid: room.rid, name: item.username, room });
 			} else {
 				const result = await RocketChat.createDirectMessage(item.username);
 				if (result.success) {

--- a/app/views/RoomMembersView/index.js
+++ b/app/views/RoomMembersView/index.js
@@ -119,8 +119,9 @@ class RoomMembersView extends React.Component {
 			const db = database.active;
 			const subsCollection = db.collections.get('subscriptions');
 			const query = await subsCollection.query(Q.where('name', item.username)).fetch();
-			if (query) {
+			if (query.length) {
 				const [room] = query;
+				this.goRoom({ rid: room.rid, name: item.username, room });
 				this.goRoom({ rid: room.rid, name: item.username, room });
 			} else {
 				const result = await RocketChat.createDirectMessage(item.username);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1517

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This Pr fixes the issue. Actually the issue was around the code `if(query)` . When no previous conversation data was present, `query` would be an empty array and not `undefined`. Hence the `if` block was always getting executed even if there was no data. SO i changed it to `query.length` which gives 0 when there is nothing inside `query` so that the `else` block gets executed. 