### PR TITLE
[FIX] Draft messages not working with themed Messagebox

### DIFF
--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -42,7 +42,6 @@ import {
 	MENTIONS_TRACKING_TYPE_USERS
 } from './constants';
 import CommandsPreview from './CommandsPreview';
-import { withTheme } from '../../theme';
 
 const imagePickerConfig = {
 	cropping: true,
@@ -888,4 +887,4 @@ const dispatchToProps = ({
 	typing: (rid, status) => userTypingAction(rid, status)
 });
 
-export default connect(mapStateToProps, dispatchToProps, null, { forwardRef: true })(withTheme(MessageBox));
+export default connect(mapStateToProps, dispatchToProps, null, { forwardRef: true })(MessageBox);

--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -813,6 +813,7 @@ class RoomView extends React.Component {
 				tmid={this.tmid}
 				roomType={room.t}
 				isFocused={navigation.isFocused}
+				theme={theme}
 				message={selectedMessage}
 				editing={editing}
 				editRequest={this.onEditRequest}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1524 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
`withTheme` don't forward refs.
Instead of modifying it to do so, I just forwarded `theme` to `Messagebox`.
I think it was wrong anyway.
Passing `theme` as prop to `Messagebox` helps writing tests :)