### PR TITLE
[FIX] Make SAML wait for idp token instead of creating it on client

### DIFF
--- a/app/views/AuthenticationWebView.js
+++ b/app/views/AuthenticationWebView.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { WebView } from 'react-native-webview';
 import { connect } from 'react-redux';
+import parse from 'url-parse';
 
 import RocketChat from '../lib/rocketchat';
 import { isIOS } from '../utils/deviceInfo';
@@ -10,6 +11,7 @@ import StatusBar from '../containers/StatusBar';
 import ActivityIndicator from '../containers/ActivityIndicator';
 import { withTheme } from '../theme';
 import { themedHeader } from '../utils/navigation';
+import log from '../utils/log';
 
 const userAgent = isIOS
 	? 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1'
@@ -64,32 +66,43 @@ class AuthenticationWebView extends React.PureComponent {
 	}
 
 	onNavigationStateChange = (webViewState) => {
-		const url = decodeURIComponent(webViewState.url);
-		if (this.authType === 'saml' || this.authType === 'cas') {
-			const { navigation } = this.props;
-			const ssoToken = navigation.getParam('ssoToken');
-			if (url.includes('ticket') || url.includes('validate')) {
-				let payload;
-				const credentialToken = { credentialToken: ssoToken };
-				if (this.authType === 'saml') {
-					payload = { ...credentialToken, saml: true };
-				} else {
-					payload = { cas: credentialToken };
-				}
-				// We need to set a timeout when the login is done with SSO in order to make it work on our side.
-				// It is actually due to the SSO server processing the response.
-				setTimeout(() => {
-					this.login(payload);
-				}, 3000);
-			}
-		}
+		try {
+			const url = decodeURIComponent(webViewState.url);
 
-		if (this.authType === 'oauth') {
-			if (this.redirectRegex.test(url)) {
-				const parts = url.split('#');
-				const credentials = JSON.parse(parts[1]);
-				this.login({ oauth: { ...credentials } });
+			if (this.authType === 'cas') {
+				const { navigation } = this.props;
+				const ssoToken = navigation.getParam('ssoToken');
+				if (url.includes('ticket') || url.includes('validate')) {
+					const payload = { cas: ssoToken };
+					// We need to set a timeout when the login is done with SSO in order to make it work on our side.
+					// It is actually due to the SSO server processing the response.
+					setTimeout(() => {
+						this.login(payload);
+					}, 3000);
+				}
 			}
+
+			if (this.authType === 'saml') {
+				const parsedUrl = parse(url, true);
+				if (parsedUrl.query && parsedUrl.query.saml_idp_credentialToken) {
+					const payload = { credentialToken: parsedUrl.query.saml_idp_credentialToken, saml: true };
+					// We need to set a timeout when the login is done with SSO in order to make it work on our side.
+					// It is actually due to the SSO server processing the response.
+					setTimeout(() => {
+						this.login(payload);
+					}, 3000);
+				}
+			}
+
+			if (this.authType === 'oauth') {
+				if (this.redirectRegex.test(url)) {
+					const parts = url.split('#');
+					const credentials = JSON.parse(parts[1]);
+					this.login({ oauth: { ...credentials } });
+				}
+			}
+		} catch (e) {
+			log(e);
 		}
 	}
 

--- a/app/views/LoginSignupView.js
+++ b/app/views/LoginSignupView.js
@@ -250,9 +250,8 @@ class LoginSignupView extends React.Component {
 		const { server } = this.props;
 		const {	clientConfig } = loginService;
 		const {	provider } = clientConfig;
-		const ssoToken = random(17);
-		const url = `${ server }/_saml/authorize/${ provider }/${ ssoToken }`;
-		this.openOAuth({ url, ssoToken, authType: 'saml' });
+		const url = `${ server }/_saml/authorize/${ provider }/`;
+		this.openOAuth({ url, authType: 'saml' });
 	}
 
 	onPressCas = () => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Instead of creating a token, sending it to idp and waiting for a validation, we're just opening idp and waiting for a token.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
