### PR TITLE
[FIX] Insert messages with blank users

### DIFF
--- a/app/lib/methods/helpers/normalizeMessage.js
+++ b/app/lib/methods/helpers/normalizeMessage.js
@@ -18,12 +18,6 @@ function normalizeAttachments(msg) {
 }
 
 export default (msg) => {
-	/**
-	 * 2019-03-29: Realm object properties are *always* optional, but `u.username` is required
-	 * https://realm.io/docs/javascript/latest/#to-one-relationships
-	 */
-	if (!msg || !msg.u || !msg.u.username) { return; }
-
 	msg = normalizeAttachments(msg);
 	msg.reactions = msg.reactions || [];
 	msg.unread = msg.unread || false;


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1521 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
#### Context
An earlier workaround was preventing Realm from inserting users without a username.
That was ages ago and now we're using WatermelonDB.

#### Issue
If we prevent blank users from appearing, it'll cause messages to stop loading because of the error.

#### Fix
Let the blank users show on the app and the behaviour stays the same as web (the real issue is the blank users).
We're already working on a fix for that.

In the meantime, let's fix the app.