### PR TITLE
[FIX] Added navigation from Register to Room List

### DIFF
--- a/app/views/RegisterView.js
+++ b/app/views/RegisterView.js
@@ -126,12 +126,12 @@ class RegisterView extends React.Component {
 				name, email, pass: password, username, ...customFields
 			});
 			await loginRequest({ user: email, password });
+			const { navigation } = this.props;
+			navigation.navigate('RoomsListView');
 		} catch (e) {
 			Alert.alert(I18n.t('Oops'), e.data.error);
 		}
 		this.setState({ saving: false });
-		const { navigation } = this.props;
-		navigation.navigate('RoomsListView');
 	}
 
 	renderCustomFields = () => {

--- a/app/views/RegisterView.js
+++ b/app/views/RegisterView.js
@@ -130,6 +130,8 @@ class RegisterView extends React.Component {
 			Alert.alert(I18n.t('Oops'), e.data.error);
 		}
 		this.setState({ saving: false });
+		const { navigation } = this.props;
+		navigation.navigate('RoomsListView');
 	}
 
 	renderCustomFields = () => {

--- a/app/views/RegisterView.js
+++ b/app/views/RegisterView.js
@@ -119,15 +119,13 @@ class RegisterView extends React.Component {
 		const {
 			name, email, password, username, customFields
 		} = this.state;
-		const { loginRequest } = this.props;
 
 		try {
 			await RocketChat.register({
 				name, email, pass: password, username, ...customFields
 			});
-			await loginRequest({ user: email, password });
 			const { navigation } = this.props;
-			navigation.navigate('RoomsListView');
+			navigation.navigate('LoginView');
 		} catch (e) {
 			Alert.alert(I18n.t('Oops'), e.data.error);
 		}

--- a/app/views/SetUsernameView.js
+++ b/app/views/SetUsernameView.js
@@ -94,12 +94,12 @@ class SetUsernameView extends React.Component {
 		try {
 			await RocketChat.setUsername(username);
 			await loginRequest({ resume: token });
+			const { navigation } = this.props;
+			navigation.navigate('RoomsListView');
 		} catch (e) {
 			log(e);
 		}
 		this.setState({ saving: false });
-		const { navigation } = this.props;
-		navigation.navigate('RoomsListView');
 	}
 
 	render() {

--- a/app/views/SetUsernameView.js
+++ b/app/views/SetUsernameView.js
@@ -98,6 +98,8 @@ class SetUsernameView extends React.Component {
 			log(e);
 		}
 		this.setState({ saving: false });
+		const { navigation } = this.props;
+		navigation.navigate('RoomsListView');
 	}
 
 	render() {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1544 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
I added just 2 line code into the RegisterView.js and SetUsername.js , first line extracted the navigation from the props and then in the second line I navigated from above two mentioned screens to the RoomsListView. So earlier when we click on Register button , nothing happens which can be seen on screen. Now on pressing the Register Button , we will be directed to the RoomsListView.

Here is view of that :

![vSUosn](https://user-images.githubusercontent.com/39923784/72226297-b88fb580-35b5-11ea-8148-f24490c307e0.gif)
