### PR TITLE
When we listen to any audio message then it will be good if the time is displayed

### DIFF
--- a/app/containers/message/Audio.js
+++ b/app/containers/message/Audio.js
@@ -197,7 +197,9 @@ class Audio extends React.Component {
 						onValueChange={this.onValueChange}
 						thumbImage={isIOS && { uri: 'audio_thumb', scale: Dimensions.get('window').scale }}
 					/>
-					<Text style={[styles.duration, { color: themes[theme].auxiliaryText }]}>{this.duration}</Text>
+					{paused ? <Text style={[styles.duration, { color: themes[theme].auxiliaryText }]}>{this.duration}</Text>
+			        :<Text style={[styles.duration, { color: themes[theme].auxiliaryText }]}>{formatTime(currentTime)}</Text>
+		            }
 				</View>
 				<Markdown msg={description} baseUrl={baseUrl} username={user.username} getCustomEmoji={getCustomEmoji} useMarkdown={useMarkdown} theme={theme} />
 			</>


### PR DESCRIPTION
Earlier it was showing only the duration of the audio now it can show current time till audio ends so that we can know how much audio we have listened
@RocketChat/ReactNative


Closes #1557
![Peek 2020-01-14 01-36](https://user-images.githubusercontent.com/52153085/72288359-e5ec6a00-366e-11ea-8776-80a755964be2.gif)


