### PR TITLE
Disable Dark level options when light theme is selected

### DIFF
--- a/app/views/ThemeView.js
+++ b/app/views/ThemeView.js
@@ -102,6 +102,14 @@ class ThemeView extends React.Component {
 		return false;
 	}
 
+	showDisabled = (header) => {
+		const lightTheme = THEMES[0];
+		if (header === I18n.t('Dark_level') && this.isSelected(lightTheme)) {
+			return true;
+		}
+		return false;
+	}
+
 	onClick = (item) => {
 		const { themePreferences } = this.props;
 		const { darkLevel, currentTheme } = themePreferences;
@@ -154,10 +162,11 @@ class ThemeView extends React.Component {
 
 	renderSectionHeader = (header = I18n.t('Theme')) => {
 		const { theme } = this.props;
+
 		return (
 			<>
 				<View style={styles.info}>
-					<Text style={[styles.infoText, { color: themes[theme].infoText }]}>{header}</Text>
+					<Text style={[styles.infoText, { color: themes[theme].infoText }]}>{this.showDisabled(header) ? `${ header } (Disabled)` : `${ header }` }</Text>
 				</View>
 				{this.renderSeparator()}
 			</>

--- a/app/views/ThemeView.js
+++ b/app/views/ThemeView.js
@@ -18,6 +18,7 @@ import { CustomIcon } from '../lib/Icons';
 import { THEME_PREFERENCES_KEY } from '../lib/rocketchat';
 import { supportSystemTheme } from '../utils/deviceInfo';
 
+
 const THEME_GROUP = 'THEME_GROUP';
 const DARK_GROUP = 'DARK_GROUP';
 
@@ -92,6 +93,15 @@ class ThemeView extends React.Component {
 		}
 	}
 
+	isDisabled = (item) => {
+		const { group } = item;
+		const lightTheme = THEMES[0];
+		if (group === DARK_GROUP && this.isSelected(lightTheme)) {
+			return true;
+		}
+		return false;
+	}
+
 	onClick = (item) => {
 		const { themePreferences } = this.props;
 		const { darkLevel, currentTheme } = themePreferences;
@@ -127,14 +137,15 @@ class ThemeView extends React.Component {
 		const { theme } = this.props;
 		const { label, value } = item;
 		const isFirst = index === 0;
+
 		return (
 			<>
 				{item.separator || isFirst ? this.renderSectionHeader(item.header) : null}
 				<ListItem
 					title={label}
-					onPress={() => this.onClick(item)}
+					onPress={this.isDisabled(item) ? null : () => this.onClick(item)}
 					testID={`theme-view-${ value }`}
-					right={this.isSelected(item) ? this.renderIcon : null}
+					right={!this.isDisabled(item) && this.isSelected(item) ? this.renderIcon : null}
 					theme={theme}
 				/>
 			</>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1578

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This Pr solves the issue, the Dark level options are disbled with a 'Disabled' message beside the `Dark Level`.
![ezgif com-crop(7)](https://user-images.githubusercontent.com/44807945/72343255-6d2ff100-36f4-11ea-83b2-a776ce9d100b.gif)
