### PR TITLE
[FIX] Add username block condition to prevent error

### DIFF
--- a/app/presentation/RoomItem/LastMessage.js
+++ b/app/presentation/RoomItem/LastMessage.js
@@ -14,7 +14,7 @@ const formatMsg = ({
 	if (!showLastMessage) {
 		return '';
 	}
-	if (!lastMessage || lastMessage.pinned) {
+	if (!lastMessage || !lastMessage.u || lastMessage.pinned) {
 		return I18n.t('No_Message');
 	}
 	if (lastMessage.t === 'jitsi_call_started') {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Attempt to fix an annoying error caused by empty `u` object on `lastMessage`.

Closes #1582 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
