### PR TITLE
fixed minimum length for new Password field of Profile View to minimum six characters

### DIFF
--- a/app/views/ProfileView/index.js
+++ b/app/views/ProfileView/index.js
@@ -118,6 +118,12 @@ class ProfileView extends React.Component {
 		});
 	}
 
+	validPassword = (password) => {
+		if ((password.length < 7) || (/(.)\1/.test(password)) || !((/[a-z]/).test(password)) || !((/^(?!.*(.).*\1.*\1.*\1).*/).test(password))) {
+			return true;
+		}
+	}
+
 	formIsChanged = () => {
 		const {
 			name, username, email, newPassword, avatar, customFields
@@ -125,7 +131,7 @@ class ProfileView extends React.Component {
 		const { user } = this.props;
 		let customFieldsChanged = false;
 
-		if (newPassword === null || newPassword.length < 6) {
+		if (this.validPassword(newPassword) || newPassword === null) {
 			return false;
 		}
 		const customFieldsKeys = Object.keys(customFields);

--- a/app/views/ProfileView/index.js
+++ b/app/views/ProfileView/index.js
@@ -131,7 +131,7 @@ class ProfileView extends React.Component {
 		const { user } = this.props;
 		let customFieldsChanged = false;
 
-		if (this.validPassword(newPassword) || newPassword === null) {
+		if (newPassword === null || this.validPassword(newPassword)) {
 			return false;
 		}
 		const customFieldsKeys = Object.keys(customFields);

--- a/app/views/ProfileView/index.js
+++ b/app/views/ProfileView/index.js
@@ -125,6 +125,9 @@ class ProfileView extends React.Component {
 		const { user } = this.props;
 		let customFieldsChanged = false;
 
+		if (newPassword === null || newPassword.length < 6) {
+			return false;
+		}
 		const customFieldsKeys = Object.keys(customFields);
 		if (customFieldsKeys.length) {
 			customFieldsKeys.forEach((key) => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1597 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Now minimum 6 characters will be required to make the ```Save Changes``` button active.

Earlier it was like this : 
![choe-K](https://user-images.githubusercontent.com/39923784/72540885-95ac1c80-38a7-11ea-8e63-e2637ec56076.gif)

Now it is like this : 

![Y7nfzo](https://user-images.githubusercontent.com/39923784/72556415-92735980-38c4-11ea-8bbe-aa8e0e8a2f59.gif)



