### PR TITLE
When some option is clicked in sorting by activity dropdown menu it should close automatically #1550

### DIFF
--- a/app/views/RoomsListView/SortDropdown/index.js
+++ b/app/views/RoomsListView/SortDropdown/index.js
@@ -78,16 +78,19 @@ class Sort extends PureComponent {
 	toggleGroupByType = () => {
 		const { groupByType } = this.props;
 		this.setSortPreference({ groupByType: !groupByType });
+		this.close();
 	}
 
 	toggleGroupByFavorites = () => {
 		const { showFavorites } = this.props;
 		this.setSortPreference({ showFavorites: !showFavorites });
+		this.close();
 	}
 
 	toggleUnread = () => {
 		const { showUnread } = this.props;
 		this.setSortPreference({ showUnread: !showUnread });
+		this.close();
 	}
 
 	close = () => {


### PR DESCRIPTION


Earlier after  clicking on any of the last three options in "sorting by activity " dropdown menu we have to close it manually. Now it will get automatically closed when we click on any option
@RocketChat/ReactNative


Closes #1550


![Peek 2020-01-21 20-51](https://user-images.githubusercontent.com/52153085/72817972-b6ea7f80-3c90-11ea-866f-fd65ea4a72c0.gif)

