### PR TITLE
[FIX] Message Actions not opening

### DIFF
--- a/app/containers/MessageActions.js
+++ b/app/containers/MessageActions.js
@@ -394,7 +394,7 @@ class MessageActions extends React.Component {
 			}
 		}
 		const { actionsHide } = this.props;
-		actionsHide();
+		actionsHide(true);
 	}
 
 	render() {

--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -412,9 +412,9 @@ class RoomView extends React.Component {
 		this.setState({ selectedMessage: message, showErrorActions: true });
 	}
 
-	onActionsHide = () => {
+	onActionsHide = (hideAction = false) => {
 		const { editing, replying, reacting } = this.state;
-		if (editing || replying || reacting) {
+		if ((editing || replying || reacting) && !hideAction) {
 			return;
 		}
 		this.setState({ selectedMessage: {}, showActions: false });
@@ -845,7 +845,7 @@ class RoomView extends React.Component {
 							room={room}
 							user={user}
 							message={selectedMessage}
-							actionsHide={this.onActionsHide}
+							actionsHide={hideAction => this.onActionsHide(hideAction)}
 							editInit={this.onEditInit}
 							replyInit={this.onReplyInit}
 							reactionInit={this.onReactionInit}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes  #1612

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
This Pr fixes the issue. Actually the issue was with the logical error. When replying or editing, the `showAction` is set to true. Now when we  press `Permalink` without closing reply or edit box, the `editing` or `replying` booleans are set to `true`. So the `onActionsHide` function returns without setting `showActions` to false. Hence after that, when we try to longPress any message, since `showActions` is still set to true, the state does not update. So I added the logic as given in the code, however I am not sure if its the best way to solve this logic error.
![ezgif com-crop(17)](https://user-images.githubusercontent.com/44807945/72899068-47859600-3d4b-11ea-9fbc-aa0e77fdaf5f.gif)
