### PR TITLE
[FIX] Unsubscribe from room

### DIFF
--- a/app/lib/methods/subscriptions/room.js
+++ b/app/lib/methods/subscriptions/room.js
@@ -10,8 +10,22 @@ import reduxStore from '../../createStore';
 import { addUserTyping, removeUserTyping, clearUserTyping } from '../../../actions/usersTyping';
 import debounce from '../../../utils/debounce';
 
-const unsubscribe = (subscriptions = []) => Promise.all(subscriptions.map(sub => sub.unsubscribe));
-const removeListener = listener => listener.stop();
+const unsubscribe = async(promise) => {
+	try {
+		const subscriptions = await promise || [];
+		await Promise.all(subscriptions.map(sub => sub.unsubscribe));
+	} catch (e) {
+		// do nothing
+	}
+};
+const removeListener = async(promise) => {
+	try {
+		const listener = await promise;
+		listener.stop();
+	} catch (e) {
+		// do nothing
+	}
+};
 
 let promises;
 let connectedListener;
@@ -199,34 +213,24 @@ export default function subscribeRoom({ rid }) {
 	});
 
 	const stop = async() => {
-		let params;
 		if (promises) {
-			try {
-				params = await promises;
-				await unsubscribe(params);
-			} catch (error) {
-				// Do nothing
-			}
+			await unsubscribe(promises);
 			promises = false;
 		}
 		if (connectedListener) {
-			params = await connectedListener;
-			removeListener(params);
+			await removeListener(connectedListener);
 			connectedListener = false;
 		}
 		if (disconnectedListener) {
-			params = await disconnectedListener;
-			removeListener(params);
+			await removeListener(disconnectedListener);
 			disconnectedListener = false;
 		}
 		if (notifyRoomListener) {
-			params = await notifyRoomListener;
-			removeListener(params);
+			await removeListener(notifyRoomListener);
 			notifyRoomListener = false;
 		}
 		if (messageReceivedListener) {
-			params = await messageReceivedListener;
-			removeListener(params);
+			await removeListener(messageReceivedListener);
 			messageReceivedListener = false;
 		}
 		reduxStore.dispatch(clearUserTyping());

--- a/app/lib/methods/subscriptions/room.js
+++ b/app/lib/methods/subscriptions/room.js
@@ -9,40 +9,66 @@ import database from '../../database';
 import reduxStore from '../../createStore';
 import { addUserTyping, removeUserTyping, clearUserTyping } from '../../../actions/usersTyping';
 import debounce from '../../../utils/debounce';
+import RocketChat from '../../rocketchat';
 
-const unsubscribe = async(promise) => {
-	try {
-		const subscriptions = await promise || [];
-		await Promise.all(subscriptions.map(sub => sub.unsubscribe()));
-	} catch (e) {
-		// do nothing
+export default class RoomSubscription {
+	constructor(rid) {
+		this.rid = rid;
+		this.isAlive = true;
 	}
-};
-const removeListener = async(promise) => {
-	try {
-		const listener = await promise;
-		listener.stop();
-	} catch (e) {
-		// do nothing
+
+	subscribe = async() => {
+		console.log(`[RCRN] Subscribing to room ${ this.rid }`);
+		if (this.promises) {
+			await this.unsubscribe();
+		}
+		this.promises = RocketChat.subscribeRoom(this.rid);
+
+		this.connectedListener = RocketChat.onStreamData('connected', this.handleConnection);
+		this.disconnectedListener = RocketChat.onStreamData('close', this.handleConnection);
+		this.notifyRoomListener = RocketChat.onStreamData('stream-notify-room', this.handleNotifyRoomReceived);
+		this.messageReceivedListener = RocketChat.onStreamData('stream-room-messages', this.handleMessageReceived);
+		if (!this.isAlive) {
+			this.unsubscribe();
+		}
 	}
-};
 
-let promises;
-let connectedListener;
-let disconnectedListener;
-let notifyRoomListener;
-let messageReceivedListener;
+	unsubscribe = async() => {
+		console.log(`[RCRN] Unsubscribing from room ${ this.rid }`);
+		this.isAlive = false;
+		if (this.promises) {
+			try {
+				const subscriptions = await this.promises || [];
+				subscriptions.map(sub => sub.unsubscribe());
+			} catch (e) {
+				// do nothing
+			}
+		}
+		this.removeListener(this.connectedListener);
+		this.removeListener(this.disconnectedListener);
+		this.removeListener(this.notifyRoomListener);
+		this.removeListener(this.messageReceivedListener);
+		reduxStore.dispatch(clearUserTyping());
+	}
 
-export default function subscribeRoom({ rid }) {
-	console.log(`[RCRN] Subscribed to room ${ rid }`);
-
-	const handleConnection = () => {
-		this.loadMissedMessages({ rid }).catch(e => console.log(e));
+	removeListener = async(promise) => {
+		if (promise) {
+			try {
+				const listener = await promise;
+				listener.stop();
+			} catch (e) {
+				// do nothing
+			}
+		}
 	};
 
-	const handleNotifyRoomReceived = protectedFunction((ddpMessage) => {
+	handleConnection = () => {
+		RocketChat.loadMissedMessages({ rid: this.rid }).catch(e => console.log(e));
+	};
+
+	handleNotifyRoomReceived = protectedFunction((ddpMessage) => {
 		const [_rid, ev] = ddpMessage.fields.eventName.split('/');
-		if (rid !== _rid) {
+		if (this.rid !== _rid) {
 			return;
 		}
 		if (ev === 'typing') {
@@ -101,14 +127,14 @@ export default function subscribeRoom({ rid }) {
 		}
 	});
 
-	const read = debounce((lastOpen) => {
-		this.readMessages(rid, lastOpen);
+	read = debounce((lastOpen) => {
+		this.readMessages(this.rid, lastOpen);
 	}, 300);
 
-	const handleMessageReceived = protectedFunction((ddpMessage) => {
+	handleMessageReceived = protectedFunction((ddpMessage) => {
 		const message = buildMessage(EJSON.fromJSONValue(ddpMessage.fields.args[0]));
 		const lastOpen = new Date();
-		if (rid !== message.rid) {
+		if (this.rid !== message.rid) {
 			return;
 		}
 		InteractionManager.runAfterInteractions(async() => {
@@ -140,7 +166,7 @@ export default function subscribeRoom({ rid }) {
 				batch.push(
 					msgCollection.prepareCreate(protectedFunction((m) => {
 						m._raw = sanitizedRaw({ id: message._id }, msgCollection.schema);
-						m.subscription.id = rid;
+						m.subscription.id = this.rid;
 						Object.assign(m, message);
 					}))
 				);
@@ -164,7 +190,7 @@ export default function subscribeRoom({ rid }) {
 					batch.push(
 						threadsCollection.prepareCreate(protectedFunction((t) => {
 							t._raw = sanitizedRaw({ id: message._id }, threadsCollection.schema);
-							t.subscription.id = rid;
+							t.subscription.id = this.rid;
 							Object.assign(t, message);
 						}))
 					);
@@ -192,7 +218,7 @@ export default function subscribeRoom({ rid }) {
 						threadMessagesCollection.prepareCreate(protectedFunction((tm) => {
 							tm._raw = sanitizedRaw({ id: message._id }, threadMessagesCollection.schema);
 							Object.assign(tm, message);
-							tm.subscription.id = rid;
+							tm.subscription.id = this.rid;
 							tm.rid = message.tmid;
 							delete tm.tmid;
 						}))
@@ -200,7 +226,7 @@ export default function subscribeRoom({ rid }) {
 				}
 			}
 
-			read(lastOpen);
+			this.read(lastOpen);
 
 			try {
 				await db.action(async() => {
@@ -211,39 +237,4 @@ export default function subscribeRoom({ rid }) {
 			}
 		});
 	});
-
-	const stop = async() => {
-		if (promises) {
-			await unsubscribe(promises);
-			promises = false;
-		}
-		if (connectedListener) {
-			await removeListener(connectedListener);
-			connectedListener = false;
-		}
-		if (disconnectedListener) {
-			await removeListener(disconnectedListener);
-			disconnectedListener = false;
-		}
-		if (notifyRoomListener) {
-			await removeListener(notifyRoomListener);
-			notifyRoomListener = false;
-		}
-		if (messageReceivedListener) {
-			await removeListener(messageReceivedListener);
-			messageReceivedListener = false;
-		}
-		reduxStore.dispatch(clearUserTyping());
-	};
-
-	connectedListener = this.sdk.onStreamData('connected', handleConnection);
-	disconnectedListener = this.sdk.onStreamData('close', handleConnection);
-	notifyRoomListener = this.sdk.onStreamData('stream-notify-room', handleNotifyRoomReceived);
-	messageReceivedListener = this.sdk.onStreamData('stream-room-messages', handleMessageReceived);
-
-	promises = this.sdk.subscribeRoom(rid);
-
-	return {
-		stop: () => stop()
-	};
 }

--- a/app/lib/methods/subscriptions/room.js
+++ b/app/lib/methods/subscriptions/room.js
@@ -13,7 +13,7 @@ import debounce from '../../../utils/debounce';
 const unsubscribe = async(promise) => {
 	try {
 		const subscriptions = await promise || [];
-		await Promise.all(subscriptions.map(sub => sub.unsubscribe));
+		await Promise.all(subscriptions.map(sub => sub.unsubscribe()));
 	} catch (e) {
 		// do nothing
 	}

--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -21,7 +21,6 @@ import {
 } from '../actions/share';
 
 import subscribeRooms from './methods/subscriptions/rooms';
-import subscribeRoom from './methods/subscriptions/room';
 
 import protectedFunction from './methods/helpers/protectedFunction';
 import readMessages from './methods/readMessages';
@@ -73,7 +72,6 @@ const RocketChat = {
 			log(e);
 		}
 	},
-	subscribeRoom,
 	canOpenRoom,
 	createChannel({
 		name, users, type, readOnly, broadcast
@@ -668,6 +666,9 @@ const RocketChat = {
 	},
 	subscribe(...args) {
 		return this.sdk.subscribe(...args);
+	},
+	subscribeRoom(...args) {
+		return this.sdk.subscribeRoom(...args);
 	},
 	unsubscribe(subscription) {
 		return this.sdk.unsubscribe(subscription);

--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -48,6 +48,7 @@ import {
 } from '../../commands';
 import ModalNavigation from '../../lib/ModalNavigation';
 import { Review } from '../../utils/review';
+import RoomClass from '../../lib/methods/subscriptions/room';
 
 const stateAttrsUpdate = [
 	'joined',
@@ -185,6 +186,7 @@ class RoomView extends React.Component {
 		this.list = React.createRef();
 		this.willBlurListener = props.navigation.addListener('willBlur', () => this.mounted = false);
 		this.mounted = false;
+		this.sub = new RoomClass(this.rid);
 		console.timeEnd(`${ this.constructor.name } init`);
 	}
 
@@ -284,7 +286,8 @@ class RoomView extends React.Component {
 				}
 			}
 		}
-		await this.unsubscribe();
+		this.unsubscribe();
+		delete this.sub;
 		if (this.didFocusListener && this.didFocusListener.remove) {
 			this.didFocusListener.remove();
 		}
@@ -336,8 +339,7 @@ class RoomView extends React.Component {
 						this.setLastOpen(null);
 					}
 					RocketChat.readMessages(room.rid, newLastOpen).catch(e => console.log(e));
-					await this.unsubscribe();
-					this.sub = RocketChat.subscribeRoom(room);
+					this.sub.subscribe();
 				}
 			}
 
@@ -384,9 +386,10 @@ class RoomView extends React.Component {
 	}
 
 	unsubscribe = async() => {
-		if (this.sub && this.sub.stop) {
-			await this.sub.stop();
+		if (this.sub && this.sub.unsubscribe) {
+			await this.sub.unsubscribe();
 		}
+		delete this.sub;
 	}
 
 	observeRoom = (room) => {

--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -287,7 +287,6 @@ class RoomView extends React.Component {
 			}
 		}
 		this.unsubscribe();
-		delete this.sub;
 		if (this.didFocusListener && this.didFocusListener.remove) {
 			this.didFocusListener.remove();
 		}

--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -294,9 +294,6 @@ class RoomView extends React.Component {
 		if (this.onForegroundInteraction && this.onForegroundInteraction.cancel) {
 			this.onForegroundInteraction.cancel();
 		}
-		if (this.initInteraction && this.initInteraction.cancel) {
-			this.initInteraction.cancel();
-		}
 		if (this.willBlurListener && this.willBlurListener.remove) {
 			this.willBlurListener.remove();
 		}


### PR DESCRIPTION
@RocketChat/ReactNative

In bad internet connections, some unsubscribe calls used to fail.
This PR refactors `subscribeRoom` to use a class, so it's easier to manage across rooms.

Example:
If the phone loses the internet connection, SDK takes some time before acting as disconnected state.
In the meantime, the user can make DDP calls and the SDK will queue them and execute when internet is up again.

#### Test Plan (easier to test on iOS Simulator):
- Focus on RoomsListView
- Disconnect from internet
- Go to DM A
- Go back to rooms list
- Go to DM B
- Connect to internet
- Wait for SDK to get connection again
- Only streams from DM B should be open