### PR TITLE
[FIX] Disallow empty sharing

### DIFF
--- a/app/containers/MessageActions.js
+++ b/app/containers/MessageActions.js
@@ -262,6 +262,9 @@ class MessageActions extends React.Component {
 	handleShare = async() => {
 		const { message } = this.props;
 		const permalink = await this.getPermalink(message);
+		if (!permalink) {
+			return;
+		}
 		Share.share({
 			message: permalink
 		});

--- a/app/views/InviteUsersView/index.js
+++ b/app/views/InviteUsersView/index.js
@@ -52,7 +52,7 @@ class InviteUsersView extends React.Component {
 
 	share = () => {
 		const { invite } = this.props;
-		if (!invite) {
+		if (!invite || !invite.url) {
 			return;
 		}
 		Share.share({ message: invite.url });

--- a/app/views/RoomActionsView/index.js
+++ b/app/views/RoomActionsView/index.js
@@ -389,6 +389,9 @@ class RoomActionsView extends React.Component {
 	handleShare = () => {
 		const { room } = this.state;
 		const permalink = RocketChat.getPermalinkChannel(room);
+		if (!permalink) {
+			return;
+		}
 		Share.share({
 			message: permalink
 		});


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
App crashes with `At least one of URL and message is required` in case of empty url.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
