### PR TITLE
[BUG-FIX] Mentions Bug fixed

### DIFF
--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -292,17 +292,16 @@ class MessageBox extends Component {
 				const { start, end } = this.component._lastNativeSelection;
 				const cursor = Math.max(start, end);
 				const lastNativeText = this.component._lastNativeText || '';
-				// matches if text either starts with '/' or have (@,#,:) then it groups whatever comes next of mention type
 				const regexp = /(#|@|:|^\/)([a-z0-9._-]+)$/im;
-				const result = lastNativeText.substr(0, cursor).match(regexp);
-				if (!result) {
-					const slash = lastNativeText.match(/^\/$/); // matches only '/' in input
-					if (slash) {
-						return this.identifyMentionKeyword('', MENTIONS_TRACKING_TYPE_COMMANDS);
+				const mentionWithSearch = lastNativeText.substr(0, cursor).match(regexp);
+				if (!mentionWithSearch) {
+					const mentionWithOutSearch = lastNativeText.match(/(#|@|:|^\/)$/);
+					if (mentionWithOutSearch) {
+						return this.identifyMentionKeyword('a', mentionWithOutSearch[0]);
 					}
 					return this.stopTrackingMention();
 				}
-				const [, lastChar, name] = result;
+				const [, lastChar, name] = mentionWithSearch;
 				this.identifyMentionKeyword(name, lastChar);
 			} catch (e) {
 				log(e);


### PR DESCRIPTION
1. Updated the regex to look for other mention categories too.
2. gave new meaningful names to the variables
3. Updated the params passed to identifyMentionKeyword()

@RocketChat/ReactNative
Closes #1580 

What was the bug?
In the web site, whenever we used "@" a list of possible mentions would appear whereas this wasn't the case in the mobile app. We had to enter one extra character after "@", "#" and ":" to give the possible mentions.

Is the bug fixed?
YES, now all the symbols "@", "#", ":" and "/" have the expected behavior. Showcased in the below screenshots.

![3](https://user-images.githubusercontent.com/41206172/73969660-da285680-4941-11ea-8e67-c87174113a37.jpg)
![2](https://user-images.githubusercontent.com/41206172/73969662-dc8ab080-4941-11ea-84a3-fd3dbcc7182d.jpg)
![1](https://user-images.githubusercontent.com/41206172/73969671-ddbbdd80-4941-11ea-92a9-3b8372b814f7.jpg)

