### PR TITLE
[NEW] Confirm logout/clear cache

### DIFF
--- a/app/containers/MessageActions.js
+++ b/app/containers/MessageActions.js
@@ -224,19 +224,18 @@ class MessageActions extends React.Component {
 	}
 
 	handleDelete = () => {
-		const { message } = this.props;
-		showConfirmationAlert(
-			I18n.t('You_will_not_be_able_to_recover_this_message'),
-			I18n.t('Are_you_sure_question_mark'),
-			I18n.t('Delete'),
-			async() => {
+		showConfirmationAlert({
+			message: I18n.t('You_will_not_be_able_to_recover_this_message'),
+			callToAction: I18n.t('Delete'),
+			onPress: async() => {
+				const { message } = this.props;
 				try {
 					await RocketChat.deleteMessage(message.id, message.subscription.id);
 				} catch (e) {
 					log(e);
 				}
 			}
-		);
+		});
 	}
 
 	handleEdit = () => {

--- a/app/containers/MessageActions.js
+++ b/app/containers/MessageActions.js
@@ -14,6 +14,7 @@ import Navigation from '../lib/Navigation';
 import { getMessageTranslation } from './message/utils';
 import { LISTENER } from './Toast';
 import EventEmitter from '../utils/events';
+import { showConfirmationAlert } from '../utils/info';
 
 class MessageActions extends React.Component {
 	static propTypes = {
@@ -224,27 +225,17 @@ class MessageActions extends React.Component {
 
 	handleDelete = () => {
 		const { message } = this.props;
-		Alert.alert(
-			I18n.t('Are_you_sure_question_mark'),
+		showConfirmationAlert(
 			I18n.t('You_will_not_be_able_to_recover_this_message'),
-			[
-				{
-					text: I18n.t('Cancel'),
-					style: 'cancel'
-				},
-				{
-					text: I18n.t('Yes_action_it', { action: 'delete' }),
-					style: 'destructive',
-					onPress: async() => {
-						try {
-							await RocketChat.deleteMessage(message.id, message.subscription.id);
-						} catch (e) {
-							log(e);
-						}
-					}
+			I18n.t('Are_you_sure_question_mark'),
+			I18n.t('Delete'),
+			async() => {
+				try {
+					await RocketChat.deleteMessage(message.id, message.subscription.id);
+				} catch (e) {
+					log(e);
 				}
-			],
-			{ cancelable: false }
+			}
 		);
 	}
 

--- a/app/i18n/locales/en.js
+++ b/app/i18n/locales/en.js
@@ -491,5 +491,8 @@ export default {
 	Server_selection: 'Server selection',
 	Server_selection_numbers: 'Server selection 1...9',
 	Add_server: 'Add server',
-	New_line: 'New line'
+	New_line: 'New line',
+	You_will_be_logged_out_of_this_application: 'You will be logged out of this application.',
+	Clear: 'Clear',
+	This_will_clear_all_your_offline_data: 'This will clear all your offline data.'
 };

--- a/app/i18n/locales/pt-BR.js
+++ b/app/i18n/locales/pt-BR.js
@@ -440,5 +440,8 @@ export default {
 	Server_selection: 'Seleção de servidor',
 	Server_selection_numbers: 'Selecionar servidor 1...9',
 	Add_server: 'Adicionar servidor',
-	New_line: 'Nova linha'
+	New_line: 'Nova linha',
+	You_will_be_logged_out_of_this_application: 'Você sairá deste aplicativo.',
+	Clear: 'Limpar',
+	This_will_clear_all_your_offline_data: 'Isto limpará todos os seus dados offline.'
 };

--- a/app/utils/info.js
+++ b/app/utils/info.js
@@ -3,9 +3,9 @@ import I18n from '../i18n';
 
 export const showErrorAlert = (message, title, onPress = () => {}) => Alert.alert(title, message, [{ text: 'OK', onPress }], { cancelable: true });
 
-export const showConfirmationAlert = (message, title, CTA, onPress = () => {}) => (
+export const showConfirmationAlert = ({ message, callToAction, onPress }) => (
 	Alert.alert(
-		title,
+		I18n.t('Are_you_sure_question_mark'),
 		message,
 		[
 			{
@@ -13,11 +13,11 @@ export const showConfirmationAlert = (message, title, CTA, onPress = () => {}) =
 				style: 'cancel'
 			},
 			{
-				text: CTA,
+				text: callToAction,
 				style: 'destructive',
 				onPress
 			}
 		],
-		{ cancelable: true }
+		{ cancelable: false }
 	)
 );

--- a/app/utils/info.js
+++ b/app/utils/info.js
@@ -1,3 +1,23 @@
 import { Alert } from 'react-native';
+import I18n from '../i18n';
 
 export const showErrorAlert = (message, title, onPress = () => {}) => Alert.alert(title, message, [{ text: 'OK', onPress }], { cancelable: true });
+
+export const showConfirmationAlert = (message, title, CTA, onPress = () => {}) => (
+	Alert.alert(
+		title,
+		message,
+		[
+			{
+				text: I18n.t('Cancel'),
+				style: 'cancel'
+			},
+			{
+				text: CTA,
+				style: 'destructive',
+				onPress
+			}
+		],
+		{ cancelable: true }
+	)
+);

--- a/app/views/SettingsView/index.js
+++ b/app/views/SettingsView/index.js
@@ -22,7 +22,7 @@ import {
 } from '../../utils/deviceInfo';
 import openLink from '../../utils/openLink';
 import scrollPersistTaps from '../../utils/scrollPersistTaps';
-import { showErrorAlert } from '../../utils/info';
+import { showErrorAlert, showConfirmationAlert } from '../../utils/info';
 import styles from './styles';
 import sharedStyles from '../Styles';
 import { loggerConfig, analytics } from '../../utils/log';
@@ -88,21 +88,35 @@ class SettingsView extends React.Component {
 		appStart: PropTypes.func
 	}
 
-	logout = () => {
-		const { logout, split } = this.props;
-		if (split) {
-			Navigation.navigate('RoomView');
-		}
-		logout();
+	handleLogout = () => {
+		showConfirmationAlert(
+			I18n.t('You_will_be_logged_out_of_this_application'),
+			I18n.t('Are_you_sure_question_mark'),
+			I18n.t('Logout'),
+			() => {
+				const { logout, split } = this.props;
+				if (split) {
+					Navigation.navigate('RoomView');
+				}
+				logout();
+			}
+		);
 	}
 
-	clearCache = async() => {
-		const {
-			server: { server }, loginRequest, token, appStart
-		} = this.props;
-		await appStart('loading');
-		await RocketChat.clearCache({ server });
-		await loginRequest({ resume: token }, true);
+	handleClearCache = () => {
+		showConfirmationAlert(
+			I18n.t('This_will_clear_all_your_offline_data'),
+			I18n.t('Are_you_sure_question_mark'),
+			I18n.t('Clear'),
+			async() => {
+				const {
+					server: { server }, loginRequest, token, appStart
+				} = this.props;
+				await appStart('loading');
+				await RocketChat.clearCache({ server });
+				await loginRequest({ resume: token }, true);
+			}
+		);
 	}
 
 	toggleMarkdown = (value) => {
@@ -329,7 +343,7 @@ class SettingsView extends React.Component {
 					<ListItem
 						title={I18n.t('Clear_cache')}
 						testID='settings-clear-cache'
-						onPress={this.clearCache}
+						onPress={this.handleClearCache}
 						right={this.renderDisclosure}
 						color={themes[theme].dangerColor}
 						theme={theme}
@@ -338,7 +352,7 @@ class SettingsView extends React.Component {
 					<ListItem
 						title={I18n.t('Logout')}
 						testID='settings-logout'
-						onPress={this.logout}
+						onPress={this.handleLogout}
 						right={this.renderDisclosure}
 						color={themes[theme].dangerColor}
 						theme={theme}

--- a/app/views/SettingsView/index.js
+++ b/app/views/SettingsView/index.js
@@ -89,26 +89,24 @@ class SettingsView extends React.Component {
 	}
 
 	handleLogout = () => {
-		showConfirmationAlert(
-			I18n.t('You_will_be_logged_out_of_this_application'),
-			I18n.t('Are_you_sure_question_mark'),
-			I18n.t('Logout'),
-			() => {
+		showConfirmationAlert({
+			message: I18n.t('You_will_be_logged_out_of_this_application'),
+			callToAction: I18n.t('Logout'),
+			onPress: () => {
 				const { logout, split } = this.props;
 				if (split) {
 					Navigation.navigate('RoomView');
 				}
 				logout();
 			}
-		);
+		});
 	}
 
 	handleClearCache = () => {
-		showConfirmationAlert(
-			I18n.t('This_will_clear_all_your_offline_data'),
-			I18n.t('Are_you_sure_question_mark'),
-			I18n.t('Clear'),
-			async() => {
+		showConfirmationAlert({
+			message: I18n.t('This_will_clear_all_your_offline_data'),
+			callToAction: I18n.t('Clear'),
+			onPress: async() => {
 				const {
 					server: { server }, loginRequest, token, appStart
 				} = this.props;
@@ -116,7 +114,7 @@ class SettingsView extends React.Component {
 				await RocketChat.clearCache({ server });
 				await loginRequest({ resume: token }, true);
 			}
-		);
+		});
 	}
 
 	toggleMarkdown = (value) => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
In this PR was done:

* Exported delete message Alert into `showConfirmationAlert(message, title, CTA, onPress)`method in `/utils/info.js`

* Used this in "Logout" and "Clear local server cache".

* Added ptBR Intl for the new messages.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/29265857/74108280-6e1f3b80-4b57-11ea-879f-c7954249cccf.gif)
