### PR TITLE
Re-enable react-native-screens

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -209,6 +209,8 @@ dependencies {
     implementation('com.crashlytics.sdk.android:crashlytics:2.9.9@aar') {
         transitive = true
     }
+    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
 
     if (enableHermes) {
       def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/app/index.js
+++ b/app/index.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import RNUserDefaults from 'rn-user-defaults';
 import Modal from 'react-native-modal';
 import KeyCommands, { KeyCommandsEmitter } from 'react-native-keycommands';
+import { enableScreens } from 'react-native-screens';
 
 import {
 	defaultTheme,
@@ -41,10 +42,7 @@ import Tablet, { initTabletNav } from './tablet';
 import sharedStyles from './views/Styles';
 import { SplitContext } from './split';
 
-if (isIOS) {
-	const RNScreens = require('react-native-screens');
-	RNScreens.useScreens();
-}
+enableScreens();
 
 const parseDeepLinking = (url) => {
 	if (url) {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-native-progress": "^4.0.3",
     "react-native-reanimated": "1.4.0",
     "react-native-responsive-ui": "^1.1.1",
-    "react-native-screens": "^2.0.0-alpha.3",
+    "react-native-screens": "kmagiera/react-native-screens#master",
     "react-native-scrollable-tab-view": "^1.0.0",
     "react-native-slowlog": "^1.0.2",
     "react-native-unimodules": "0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9518,10 +9518,9 @@ react-native-safe-area-view@^0.14.1, react-native-safe-area-view@^0.14.6:
   dependencies:
     debounce "^1.2.0"
 
-react-native-screens@^2.0.0-alpha.3:
-  version "2.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.3.tgz#af86f265b2fb4293b626cf4396db7743de5a54af"
-  integrity sha512-SA3uGrc3UM1V9y6gfVU1UPf1a3dMyQCj3p5J7y6g81Of8rV5Pc34s6fWzOKNAWgOiviAktZB1z7Jngdl7+acZg==
+react-native-screens@kmagiera/react-native-screens#master:
+  version "2.0.0-beta.2"
+  resolved "https://codeload.github.com/kmagiera/react-native-screens/tar.gz/24b70abd64aa37e5289298ef232adc6203bb21c7"
   dependencies:
     debounce "^1.2.0"
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
We disabled react-native-screens on [this commit](https://github.com/RocketChat/Rocket.Chat.ReactNative/commit/682ac6b4a5fe692b3161fa80ab63ebfd85645615) because paste wasn't working on Android.
They fixed paste [here](https://github.com/kmagiera/react-native-screens/commit/10a0badee22c4f5eec822914b4a4f92398fe6bf5).
Let's enable it again :)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
