### PR TITLE
​​[FIX]Makes consective soft line breaks compatible

### DIFF
--- a/app/containers/markdown/index.js
+++ b/app/containers/markdown/index.js
@@ -21,8 +21,7 @@ import MarkdownTableCell from './TableCell';
 
 import styles from './styles';
 
-const formatText = text => {
-
+const formatText = (text) => {
 	// Support <http://link|Text>
 	text = text.replace(
 		new RegExp('(?:<|<)((?:https|http):\\/\\/[^\\|]+)\\|(.+?)(?=>|>)(?:>|>)', 'gm'),
@@ -30,10 +29,10 @@ const formatText = text => {
 	);
 
 	// Convert consecutive \n breaks to commonmark-compatible line breaks to be rendered.
-	text = text.replace(/\n(?=\n)/g, "\n&nbsp;");
+	text = text.replace(/\n(?=\n)/g, '\n&nbsp;');
 
 	return text;
-}
+};
 
 const emojiRanges = [
 	'\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]', // unicode emoji from https://www.regextester.com/106421

--- a/app/containers/markdown/index.js
+++ b/app/containers/markdown/index.js
@@ -21,11 +21,19 @@ import MarkdownTableCell from './TableCell';
 
 import styles from './styles';
 
-// Support <http://link|Text>
-const formatText = text => text.replace(
-	new RegExp('(?:<|<)((?:https|http):\\/\\/[^\\|]+)\\|(.+?)(?=>|>)(?:>|>)', 'gm'),
-	(match, url, title) => `[${ title }](${ url })`
-);
+const formatText = text => {
+
+	// Support <http://link|Text>
+	text = text.replace(
+		new RegExp('(?:<|<)((?:https|http):\\/\\/[^\\|]+)\\|(.+?)(?=>|>)(?:>|>)', 'gm'),
+		(match, url, title) => `[${ title }](${ url })`
+	);
+
+	// Convert consecutive \n breaks to commonmark-compatible line breaks to be rendered.
+	text = text.replace(/\n(?=\n)/g, "\n&nbsp;");
+
+	return text;
+}
 
 const emojiRanges = [
 	'\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]', // unicode emoji from https://www.regextester.com/106421


### PR DESCRIPTION
@RocketChat/ReactNative

Closes #1513 

Write a message like this

> hijk
> 
> jk

Browser Render:
![](https://user-images.githubusercontent.com/38764067/71772426-beabe380-2f70-11ea-9047-451b190b5973.png)

Current app render:
![](https://user-images.githubusercontent.com/38764067/71772533-8d341780-2f72-11ea-9656-074e71054f3f.jpg)

FIXED app render:
![](https://user-images.githubusercontent.com/38764067/71772540-9e7d2400-2f72-11ea-997b-da70ec254bd4.jpg)

The commonmark library has a policy to format new line characters to be rendered. Added that in the **formatText** function where link tags were already being processed, instead of how I did this in the render function before(was wrong to put it there).