### PR TITLE
[FIX]Add empty space before custom emoji if needed

### DIFF
--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -367,17 +367,17 @@ class MessageBox extends Component {
 		const { text } = this;
 		const { emoji } = params;
 		let newText = '';
-		// Add space if not before emoji if not already there
+		// Add space before custom emoji if not already there
 		let addSpace = '';
 
 		// if messagebox has an active cursor
 		if (this.component && this.component._lastNativeSelection) {
 			const { start, end } = this.component._lastNativeSelection;
 			const cursor = Math.max(start, end);
-			addSpace = text.charAt(cursor - 1) === ' ' ? '' : ' ';
+			addSpace = emoji.charAt(0) === ':' && text.charAt(cursor - 1) !== ' ' ? ' ' : '';
 			newText = `${ text.substr(0, cursor) }${ addSpace }${ emoji }${ text.substr(cursor) }`;
 		} else {
-			addSpace = text.charAt(text.length - 1) === ' ' ? '' : ' ';
+			addSpace = emoji.charAt(0) === ':' && text.charAt(text.length - 1) !== ' ' ? ' ' : '';
 			// if messagebox doesn't have a cursor, just append selected emoji
 			newText = `${ text }${ addSpace }${ emoji }`;
 		}

--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -367,15 +367,19 @@ class MessageBox extends Component {
 		const { text } = this;
 		const { emoji } = params;
 		let newText = '';
+		// Add space if not before emoji if not already there
+		let addSpace = '';
 
 		// if messagebox has an active cursor
 		if (this.component && this.component._lastNativeSelection) {
 			const { start, end } = this.component._lastNativeSelection;
 			const cursor = Math.max(start, end);
-			newText = `${ text.substr(0, cursor) }${ emoji }${ text.substr(cursor) }`;
+			addSpace = text.charAt(cursor - 1) === ' ' ? '' : ' ';
+			newText = `${ text.substr(0, cursor) }${ addSpace }${ emoji }${ text.substr(cursor) }`;
 		} else {
+			addSpace = text.charAt(text.length - 1) === ' ' ? '' : ' ';
 			// if messagebox doesn't have a cursor, just append selected emoji
-			newText = `${ text }${ emoji }`;
+			newText = `${ text }${ addSpace }${ emoji }`;
 		}
 		this.setInput(newText);
 		this.setShowSend(true);


### PR DESCRIPTION
@RocketChat/ReactNative

Closes #1717 

If there is no space before custom emojis, then that does not get rendered. Therefore, changed the default keyboard action for adding custom emojis to add a space right before, if it wasn't there already. This ensures the custom emoji, when added through the keyboard, is always rendered by default.

Before FIX:
![](https://im3.ezgif.com/tmp/ezgif-3-3c53bd8f2f63.gif)

After FIX:
![](https://im3.ezgif.com/tmp/ezgif-3-73ef05165876.gif)
