### PR TITLE
[FIX] Add missing calls to user info

### DIFF
--- a/app/containers/message/MessageAvatar.js
+++ b/app/containers/message/MessageAvatar.js
@@ -8,7 +8,7 @@ import styles from './styles';
 const MessageAvatar = React.memo(({
 	isHeader, avatar, author, baseUrl, user, small, navToRoomInfo
 }) => {
-	if (isHeader) {
+	if (isHeader && author) {
 		const navParam = {
 			t: 'd',
 			rid: author._id

--- a/app/containers/message/index.js
+++ b/app/containers/message/index.js
@@ -50,7 +50,20 @@ class MessageContainer extends React.Component {
 	}
 
 	static defaultProps = {
+		getCustomEmoji: () => {},
 		onLongPress: () => {},
+		onReactionPress: () => {},
+		onDiscussionPress: () => {},
+		onThreadPress: () => {},
+		errorActionsShow: () => {},
+		replyBroadcast: () => {},
+		reactionInit: () => {},
+		fetchThreadName: () => {},
+		showAttachment: () => {},
+		onReactionLongPress: () => {},
+		navToRoomInfo: () => {},
+		callJitsi: () => {},
+		blockAction: () => {},
 		archived: false,
 		broadcast: false,
 		theme: 'light'

--- a/app/views/MessagesView/index.js
+++ b/app/views/MessagesView/index.js
@@ -74,6 +74,14 @@ class MessagesView extends React.Component {
 		return false;
 	}
 
+	navToRoomInfo = (navParam) => {
+		const { navigation, user } = this.props;
+		if (navParam.rid === user.id) {
+			return;
+		}
+		navigation.navigate('RoomInfoView', navParam);
+	}
+
 	defineMessagesViewContent = (name) => {
 		const { messages } = this.state;
 		const { user, baseUrl, theme } = this.props;
@@ -88,7 +96,8 @@ class MessagesView extends React.Component {
 			isHeader: true,
 			attachments: item.attachments || [],
 			showAttachment: this.showAttachment,
-			getCustomEmoji: this.getCustomEmoji
+			getCustomEmoji: this.getCustomEmoji,
+			navToRoomInfo: this.navToRoomInfo
 		});
 
 		return ({

--- a/app/views/SearchMessagesView/index.js
+++ b/app/views/SearchMessagesView/index.js
@@ -94,6 +94,14 @@ class SearchMessagesView extends React.Component {
 		return null;
 	}
 
+	navToRoomInfo = (navParam) => {
+		const { navigation, user } = this.props;
+		if (navParam.rid === user.id) {
+			return;
+		}
+		navigation.navigate('RoomInfoView', navParam);
+	}
+
 	renderEmpty = () => {
 		const { theme } = this.props;
 		return (
@@ -118,6 +126,7 @@ class SearchMessagesView extends React.Component {
 				isHeader
 				showAttachment={() => {}}
 				getCustomEmoji={this.getCustomEmoji}
+				navToRoomInfo={this.navToRoomInfo}
 				theme={theme}
 			/>
 		);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
After clicking on MessageAvatar from MessagesView or SearchMessagesView, the app would crash.
I added the missing calls and missing default props for every Message function.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
