### PR TITLE
[FIX] Prevent reaction map error

### DIFF
--- a/app/containers/message/Reactions.js
+++ b/app/containers/message/Reactions.js
@@ -56,7 +56,7 @@ const Reaction = React.memo(({
 const Reactions = React.memo(({
 	reactions, user, baseUrl, onReactionPress, reactionInit, onReactionLongPress, getCustomEmoji, theme
 }) => {
-	if (!reactions || reactions.length === 0) {
+	if (!Array.isArray(reactions) || reactions.length === 0) {
 		return null;
 	}
 	return (


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
There's a weird case when `reactions` is not an array.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
