### PR TITLE
[FIX] Stop logging react-native-image-crop-picker

### DIFF
--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -530,7 +530,7 @@ class MessageBox extends Component {
 				this.showUploadModal(image);
 			}
 		} catch (e) {
-			log(e);
+			// Do nothing
 		}
 	}
 
@@ -541,7 +541,7 @@ class MessageBox extends Component {
 				this.showUploadModal(video);
 			}
 		} catch (e) {
-			log(e);
+			// Do nothing
 		}
 	}
 
@@ -552,7 +552,7 @@ class MessageBox extends Component {
 				this.showUploadModal(image);
 			}
 		} catch (e) {
-			log(e);
+			// Do nothing
 		}
 	}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
react-native-image-crop-picker throws an error when user cancelled the event, like `User cancelled image selection`.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
