### PR TITLE
[FIX] Accept all media types using *

### DIFF
--- a/app/utils/media.js
+++ b/app/utils/media.js
@@ -7,7 +7,7 @@ export const canUploadFile = (file, serverInfo) => {
 		return { success: false, error: 'error-file-too-large' };
 	}
 	// if white list is empty, all media types are enabled
-	if (!FileUpload_MediaTypeWhiteList) {
+	if (!FileUpload_MediaTypeWhiteList || FileUpload_MediaTypeWhiteList === '*') {
 		return { success: true };
 	}
 	const allowedMime = FileUpload_MediaTypeWhiteList.split(',');


### PR DESCRIPTION
@RocketChat/ReactNative

We have a description on server configuration about `Accepted Media Types`, to keep it blank to accept all media types, but sometimes administrators are confused because put a `*` and it not works, so, now we'll accept `*` as `all media types`.
