### PR TITLE
[IMPROVEMENT] Honor "FileUpload_Enabled"

### DIFF
--- a/app/constants/settings.js
+++ b/app/constants/settings.js
@@ -146,6 +146,9 @@ export default {
 	Threads_enabled: {
 		type: 'valueAsBoolean'
 	},
+	FileUpload_Enabled: {
+		type: 'valueAsBoolean'
+	},
 	FileUpload_MediaTypeWhiteList: {
 		type: 'valueAsString'
 	},

--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -116,14 +116,6 @@ class MessageBox extends Component {
 		};
 		this.text = '';
 		this.focused = false;
-		this.messageBoxActions = [
-			I18n.t('Cancel'),
-			I18n.t('Take_a_photo'),
-			I18n.t('Take_a_video'),
-			I18n.t('Choose_from_library'),
-			I18n.t('Choose_file'),
-			I18n.t('Create_Discussion')
-		];
 		const libPickerLabels = {
 			cropperChooseText: I18n.t('Choose'),
 			cropperCancelText: I18n.t('Cancel'),
@@ -509,11 +501,7 @@ class MessageBox extends Component {
 	canUploadFile = (file) => {
 		const { FileUpload_Enabled, FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize } = this.props;
 		const result = canUploadFile(file, { FileUpload_Enabled, FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize });
-		if (result.success) {
-			return true;
-		}
-		Alert.alert(I18n.t('Error_uploading'), I18n.t(result.error));
-		return false;
+		return result.success;
 	}
 
 	sendMediaMessage = async(file) => {
@@ -602,13 +590,14 @@ class MessageBox extends Component {
 
 	showMessageBoxActions = () => {
 		ActionSheet.showActionSheetWithOptions({
-			options: this.messageBoxActions,
+			options: this.createListOfMessageBoxActions(),
 			cancelButtonIndex: FILE_CANCEL_INDEX
 		}, (actionIndex) => {
 			this.handleMessageBoxActions(actionIndex);
 		});
-	
-    showFileActions = () => {
+	}
+
+	showFileActions = () => {
 		const { FileUpload_Enabled } = this.props;
 		if (FileUpload_Enabled) {
 			ActionSheet.showActionSheetWithOptions({
@@ -620,6 +609,15 @@ class MessageBox extends Component {
 		} else {
 			Alert.alert(I18n.t('Error_uploading'), I18n.t('error-message-file-upload-not-allowed'));
 		}
+	}
+
+	createListOfMessageBoxActions = () => {
+		const actions = [I18n.t('Cancel'), I18n.t('Create_Discussion')];
+		const { FileUpload_Enabled } = this.props;
+		if (FileUpload_Enabled) {
+			actions.push(I18n.t('Take_a_photo'), I18n.t('Take_a_video'), I18n.t('Choose_from_library'), I18n.t('Choose_file'));
+		}
+		return actions;
 	}
 
 	handleMessageBoxActions = (actionIndex) => {

--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -85,6 +85,7 @@ class MessageBox extends Component {
 		roomType: PropTypes.string,
 		tmid: PropTypes.string,
 		replyWithMention: PropTypes.bool,
+		FileUpload_Enabled: PropTypes.bool,
 		FileUpload_MediaTypeWhiteList: PropTypes.string,
 		FileUpload_MaxFileSize: PropTypes.number,
 		Message_AudioRecorderEnabled: PropTypes.bool,
@@ -506,8 +507,8 @@ class MessageBox extends Component {
 	}
 
 	canUploadFile = (file) => {
-		const { FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize } = this.props;
-		const result = canUploadFile(file, { FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize });
+		const { FileUpload_Enabled, FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize } = this.props;
+		const result = canUploadFile(file, { FileUpload_Enabled, FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize });
 		if (result.success) {
 			return true;
 		}
@@ -606,6 +607,19 @@ class MessageBox extends Component {
 		}, (actionIndex) => {
 			this.handleMessageBoxActions(actionIndex);
 		});
+	
+    showFileActions = () => {
+		const { FileUpload_Enabled } = this.props;
+		if (FileUpload_Enabled) {
+			ActionSheet.showActionSheetWithOptions({
+				options: this.fileOptions,
+				cancelButtonIndex: FILE_CANCEL_INDEX
+			}, (actionIndex) => {
+				this.handleFileActionPress(actionIndex);
+			});
+		} else {
+			Alert.alert(I18n.t('Error_uploading'), I18n.t('error-message-file-upload-not-allowed'));
+		}
 	}
 
 	handleMessageBoxActions = (actionIndex) => {
@@ -913,6 +927,7 @@ const mapStateToProps = state => ({
 	baseUrl: state.server.server,
 	threadsEnabled: state.settings.Threads_enabled,
 	user: getUserSelector(state),
+	FileUpload_Enabled: state.settings.FileUpload_Enabled,
 	FileUpload_MediaTypeWhiteList: state.settings.FileUpload_MediaTypeWhiteList,
 	FileUpload_MaxFileSize: state.settings.FileUpload_MaxFileSize,
 	Message_AudioRecorderEnabled: state.settings.Message_AudioRecorderEnabled

--- a/app/i18n/locales/en.js
+++ b/app/i18n/locales/en.js
@@ -14,6 +14,7 @@ export default {
 	'error-delete-protected-role': 'Cannot delete a protected role',
 	'error-department-not-found': 'Department not found',
 	'error-direct-message-file-upload-not-allowed': 'File sharing not allowed in direct messages',
+	'error-message-file-upload-not-allowed': 'File uploads have been turned off',
 	'error-duplicate-channel-name': 'A channel with name {{channel_name}} exists',
 	'error-email-domain-blacklisted': 'The email domain is blacklisted',
 	'error-email-send-failed': 'Error trying to send email: {{message}}',

--- a/app/lib/database/model/Server.js
+++ b/app/lib/database/model/Server.js
@@ -10,6 +10,8 @@ export default class Server extends Model {
 
 	@field('use_real_name') useRealName;
 
+	@field('file_upload_enabled') FileUpload_Enabled;
+
 	@field('file_upload_media_type_white_list') FileUpload_MediaTypeWhiteList;
 
 	@field('file_upload_max_file_size') FileUpload_MaxFileSize;

--- a/app/lib/methods/getSettings.js
+++ b/app/lib/methods/getSettings.js
@@ -43,6 +43,9 @@ const serverInfoUpdate = async(serverInfo, iconSetting) => {
 		if (setting._id === 'UI_Use_Real_Name') {
 			return { ...allSettings, useRealName: setting.valueAsBoolean };
 		}
+		if (setting._id === 'FileUpload_Enabled') {
+			return { ...allSettings, FileUpload_Enabled: setting.valueAsBoolean };
+		}
 		if (setting._id === 'FileUpload_MediaTypeWhiteList') {
 			return { ...allSettings, FileUpload_MediaTypeWhiteList: setting.valueAsString };
 		}

--- a/app/utils/media.js
+++ b/app/utils/media.js
@@ -1,5 +1,8 @@
 export const canUploadFile = (file, serverInfo) => {
-	const { FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize } = serverInfo;
+	const { FileUpload_Enabled, FileUpload_MediaTypeWhiteList, FileUpload_MaxFileSize } = serverInfo;
+	if (!FileUpload_Enabled) {
+		return { success: false, error: 'error-message-file-upload-not-allowed' };
+	}
 	if (!(file && file.path)) {
 		return { success: true };
 	}


### PR DESCRIPTION
Fix for honouring file uploads enabled or disabled.

Specific error message upon pressing the upload file button when file uploads are disabled by server settings.

Screenshots below.
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1779 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

![off](https://user-images.githubusercontent.com/1571527/75177855-dc0a5c00-572e-11ea-9436-1e14cb782c2a.gif)

![on](https://user-images.githubusercontent.com/1571527/75178114-5dfa8500-572f-11ea-93b8-f92efce191d4.gif)


