### PR TITLE
[FIX] Markdown Line Break

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3331,7 +3331,7 @@ commondir@^1.0.1:
 
 "commonmark@git+https://github.com/RocketChat/commonmark.js.git":
   version "0.29.0"
-  resolved "git+https://github.com/RocketChat/commonmark.js.git#e50f039d1189372853f0731fbfca2d1d3efc04f8"
+  resolved "git+https://github.com/RocketChat/commonmark.js.git#fe037b1c97ca5bc7d329ef312bf9a374ab8f3d4a"
   dependencies:
     entities "~ 1.1.1"
     mdurl "~ 1.0.1"


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

Commonmark use a regex like `/ \n/` to split lines before parse it, but when it does this, all blank lines disappear, to fix this I create our own split function, that not will ignore blank lines.
Before:
`'a\n\n\na' => ['a', '', '', 'a'];` 
After:
`'a\n\n\na' => ['a\n\n', 'a'];`

![Screen Shot 2020-02-26 at 11 50 46](https://user-images.githubusercontent.com/29778115/75356806-31f61580-588f-11ea-877d-0cc5a53126f3.png)

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1513.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
