### PR TITLE
[FIX] Invalid URL Port

### DIFF
--- a/app/views/NewServerView.js
+++ b/app/views/NewServerView.js
@@ -201,6 +201,11 @@ class NewServerView extends React.Component {
 			url = parsedUrl.host;
 		}
 
+		// host never can contain a ':'
+		if (parsedUrl.host.includes(':')) {
+			return '';
+		}
+
 		url = url && url.replace(/\s/g, '');
 
 		if (/^(\w|[0-9-_]){3,}$/.test(url)


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Sometimes we're receiving some crashes like `Invalid URL Port: chat.domain.com`, maybe it's caused by some mistake about Basic Auth, to handle this case I added a condition that will check if have some `:` on the host, if yes, this url is invalid.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
