### PR TITLE
Random discussion room name when opened from push notification

### DIFF
--- a/app/notifications/inApp/index.js
+++ b/app/notifications/inApp/index.js
@@ -159,17 +159,17 @@ class NotificationBadge extends React.Component {
 
 	goToRoom = async() => {
 		const { notification, navigation, baseUrl } = this.props;
-		const { payload } = notification;
+		const { payload, title } = notification;
 		const { rid, type, prid } = payload;
 		if (!rid) {
 			return;
 		}
-		const name = type === 'd' ? payload.sender.username : payload.name;
+		const name = type === 'd' ? payload.sender.username : title;
 		// if sub is not on local database, title will be null, so we use payload from notification
-		const { title = name } = notification;
+		// const { title = name } = notification;
 		await navigation.navigate('RoomsListView');
 		navigation.navigate('RoomView', {
-			rid, name: title, t: type, prid, baseUrl
+			rid, name, t: type, prid, baseUrl
 		});
 		this.hide();
 	}

--- a/app/notifications/push/index.js
+++ b/app/notifications/push/index.js
@@ -10,13 +10,13 @@ export const onNotification = (notification) => {
 		if (data) {
 			try {
 				const {
-					rid, name, sender, type, host
+					rid, title, sender, type, host
 				} = EJSON.parse(data.ejson);
 
 				const types = {
 					c: 'channel', d: 'direct', p: 'group', l: 'channels'
 				};
-				let roomName = type === 'd' ? sender.username : name;
+				let roomName = type === 'd' ? sender.username : title;
 				if (type === 'l') {
 					roomName = sender.name;
 				}


### PR DESCRIPTION
@RocketChat/ReactNative
I was not able to test this. Because I am not getting push notification on [develop]rocket.chat.ReactNative . But on logging "notification prop" to the console I found that "payload.name" field is having a random string in case of "dissussions" rather than having name of the discussion.And "title" field is having the required name of the discussion.So, I think we should use "title" in place of "payload.name"
![Peek 2020-03-09 12-15](https://user-images.githubusercontent.com/52153085/76189700-5c39c280-6201-11ea-984b-aa7c4fccd237.gif)


Closes #1671 


