### PR TITLE
Show confirmationAlert before blocking and unblocking a user

### DIFF
--- a/app/i18n/locales/en.js
+++ b/app/i18n/locales/en.js
@@ -469,7 +469,7 @@ export default {
 	User_sent_an_attachment: '{{user}} sent an attachment',
 	User_unmuted_by: 'User {{userUnmuted}} unmuted by {{userBy}}',
 	User_was_set_role_by_: '{{user}} was set {{role}} by {{userBy}}',
-    User_will_be_blocked: 'User will be blocked',
+	User_will_be_blocked: 'User will be blocked',
 	User_will_be_unblocked: 'User will be unblocked',
 	Username_is_empty: 'Username is empty',
 	Username: 'Username',

--- a/app/i18n/locales/en.js
+++ b/app/i18n/locales/en.js
@@ -469,7 +469,7 @@ export default {
 	User_sent_an_attachment: '{{user}} sent an attachment',
 	User_unmuted_by: 'User {{userUnmuted}} unmuted by {{userBy}}',
 	User_was_set_role_by_: '{{user}} was set {{role}} by {{userBy}}',
-	User_will_be_blocked: 'Block {{user}}? Blocked contacts will no longer able to call you or send you messages.',
+	User_will_be_blocked: 'Block {{user}} ? Blocked users will no longer able to call you or send you messages.',
 	User_will_be_unblocked: 'User will be unblocked',
 	Username_is_empty: 'Username is empty',
 	Username: 'Username',

--- a/app/i18n/locales/en.js
+++ b/app/i18n/locales/en.js
@@ -469,6 +469,8 @@ export default {
 	User_sent_an_attachment: '{{user}} sent an attachment',
 	User_unmuted_by: 'User {{userUnmuted}} unmuted by {{userBy}}',
 	User_was_set_role_by_: '{{user}} was set {{role}} by {{userBy}}',
+    User_will_be_blocked: 'User will be blocked',
+	User_will_be_unblocked: 'User will be unblocked',
 	Username_is_empty: 'Username is empty',
 	Username: 'Username',
 	Username_or_email: 'Username or email',

--- a/app/i18n/locales/en.js
+++ b/app/i18n/locales/en.js
@@ -469,7 +469,7 @@ export default {
 	User_sent_an_attachment: '{{user}} sent an attachment',
 	User_unmuted_by: 'User {{userUnmuted}} unmuted by {{userBy}}',
 	User_was_set_role_by_: '{{user}} was set {{role}} by {{userBy}}',
-	User_will_be_blocked: 'User will be blocked',
+	User_will_be_blocked: 'Block {{user}}? Blocked contacts will no longer able to call you or send you messages.',
 	User_will_be_unblocked: 'User will be unblocked',
 	Username_is_empty: 'Username is empty',
 	Username: 'Username',

--- a/app/views/RoomActionsView/index.js
+++ b/app/views/RoomActionsView/index.js
@@ -381,8 +381,7 @@ class RoomActionsView extends React.Component {
 	}
 
 	toggleBlockUser = () => {
-		const { room } = this.state;
-		const { member } = this.state;
+		const { room, member } = this.state;
 		const { rid, blocker } = room;
 		let message = I18n.t('User_will_be_unblocked');
 		let callToAction = I18n.t('Unblock_user');

--- a/app/views/RoomActionsView/index.js
+++ b/app/views/RoomActionsView/index.js
@@ -387,7 +387,7 @@ class RoomActionsView extends React.Component {
 		let message = I18n.t('User_will_be_unblocked');
 		let callToAction = I18n.t('Unblock_user');
 		if (!blocker) {
-			message = I18n.t('User_will_be_blocked');
+			message = I18n.t('User_will_be_blocked', { user: member.username });
 			callToAction = I18n.t('Block_user');
 		}
 		showConfirmationAlert({

--- a/app/views/RoomActionsView/index.js
+++ b/app/views/RoomActionsView/index.js
@@ -25,6 +25,7 @@ import { withTheme } from '../../theme';
 import { themedHeader } from '../../utils/navigation';
 import { CloseModalButton } from '../../containers/HeaderButton';
 import { getUserSelector } from '../../selectors/login';
+import { showConfirmationAlert } from '../../utils/info';
 
 class RoomActionsView extends React.Component {
 	static navigationOptions = ({ navigation, screenProps }) => {
@@ -381,13 +382,25 @@ class RoomActionsView extends React.Component {
 
 	toggleBlockUser = () => {
 		const { room } = this.state;
-		const { rid, blocker } = room;
 		const { member } = this.state;
-		try {
-			RocketChat.toggleBlockUser(rid, member._id, !blocker);
-		} catch (e) {
-			log(e);
+		const { rid, blocker } = room;
+		let message = I18n.t('User_will_be_unblocked');
+		let callToAction = I18n.t('Unblock_user');
+		if (!blocker) {
+			message = I18n.t('User_will_be_blocked');
+			callToAction = I18n.t('Block_user');
 		}
+		showConfirmationAlert({
+			message,
+			callToAction,
+			onPress: () => {
+				try {
+					RocketChat.toggleBlockUser(rid, member._id, !blocker);
+				} catch (e) {
+					log(e);
+				}
+			}
+		});
 	}
 
 	handleShare = () => {


### PR DESCRIPTION
Now: Before we block someone, we don't get a confirmation Alert

After Fix: We will get confirmation Alert before blocking a user

![GIF-200323_113513](https://user-images.githubusercontent.com/52153085/77341083-327db100-6d54-11ea-9ae2-7b537443a57c.gif)


@RocketChat/ReactNative
Closes #1917 




> You issue has no description and your PR has a broken link.
> Can you fix it?
> Thanks.

Sorry @diegolmello due to network issues the gif could not be uploaded