### PR TITLE
[FIX] Respect protocol in HTTP Auth IPs

### DIFF
--- a/app/views/NewServerView.js
+++ b/app/views/NewServerView.js
@@ -198,7 +198,7 @@ class NewServerView extends React.Component {
 	completeUrl = (url) => {
 		const parsedUrl = parse(url, true);
 		if (parsedUrl.auth.length) {
-			url = parsedUrl.host;
+			url = parsedUrl.origin;
 		}
 
 		url = url && url.replace(/\s/g, '');


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@djorkaeffalexandre 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #1928 

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
Passing `host` rather than `origin` doesn't give the `url` any idea about the protocol being `http` or `https`

`origin` gives us a url with a protocol.