### PR TITLE
[FIX] Use new LinkedIn OAuth url

### DIFF
--- a/app/views/LoginSignupView.js
+++ b/app/views/LoginSignupView.js
@@ -224,7 +224,7 @@ class LoginSignupView extends React.Component {
 	onPressLinkedin = () => {
 		const { services, server } = this.props;
 		const { clientId } = services.linkedin;
-		const endpoint = 'https://www.linkedin.com/uas/oauth2/authorization';
+		const endpoint = 'https://www.linkedin.com/oauth/v2/authorization';
 		const redirect_uri = `${ server }/_oauth/linkedin?close`;
 		const scope = 'r_liteprofile,r_emailaddress';
 		const state = this.getOAuthState();


### PR DESCRIPTION
@RocketChat/ReactNative

LinkedIn updated his OAuth2 link, how we can see [here](https://developer.linkedin.com/blog/posts/2018/redirecting-oauth-uas), we need to use the new link.