### PR TITLE
[FIX] Logout when token expires

### DIFF
--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -14,7 +14,9 @@ import { isIOS, getBundleId } from '../utils/deviceInfo';
 import { extractHostname } from '../utils/server';
 import fetch, { BASIC_AUTH_KEY } from '../utils/fetch';
 
-import { setUser, setLoginServices, loginRequest } from '../actions/login';
+import {
+	setUser, setLoginServices, loginRequest, logout
+} from '../actions/login';
 import { disconnect, connectSuccess, connectRequest } from '../actions/connect';
 import {
 	shareSelectServer, shareSetUser
@@ -178,6 +180,10 @@ const RocketChat = {
 				this.closeListener.then(this.stopListener);
 			}
 
+			if (this.unauthorizedListener) {
+				this.unauthorizedListener.then(this.unauthorizedListener);
+			}
+
 			if (this.usersListener) {
 				this.usersListener.then(this.stopListener);
 			}
@@ -222,6 +228,10 @@ const RocketChat = {
 
 			this.closeListener = this.sdk.onStreamData('close', () => {
 				reduxStore.dispatch(disconnect());
+			});
+
+			this.unauthorizedListener = this.sdk.onStreamData('unauthorized', () => {
+				reduxStore.dispatch(logout(true));
 			});
 
 			this.usersListener = this.sdk.onStreamData('users', protectedFunction(ddpMessage => RocketChat._setUser(ddpMessage)));

--- a/patches/@rocket.chat+sdk+1.0.0-alpha.41.patch
+++ b/patches/@rocket.chat+sdk+1.0.0-alpha.41.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@rocket.chat/sdk/lib/api/api.js b/node_modules/@rocket.chat/sdk/lib/api/api.js
-index 5b7dc21..49f1af5 100644
+index 5b7dc21..b57b497 100644
 --- a/node_modules/@rocket.chat/sdk/lib/api/api.js
 +++ b/node_modules/@rocket.chat/sdk/lib/api/api.js
 @@ -62,6 +62,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
@@ -19,8 +19,32 @@ index 5b7dc21..49f1af5 100644
          },
          set: function (obj) {
              this._headers = obj;
+@@ -209,6 +210,9 @@ var Api = /** @class */ (function (_super) {
+                         case 11:
+                             err_1 = _b.sent();
+                             this.logger && this.logger.error("[API] POST error(" + endpoint + "): " + JSON.stringify(err_1));
++                            if (err_1.status === 401) {
++                                this.emit('unauthorized');
++                            }
+                             throw err_1;
+                         case 12: return [2 /*return*/];
+                     }
+diff --git a/node_modules/@rocket.chat/sdk/lib/clients/Rocketchat.js b/node_modules/@rocket.chat/sdk/lib/clients/Rocketchat.js
+index fbbd519..4cbf949 100644
+--- a/node_modules/@rocket.chat/sdk/lib/clients/Rocketchat.js
++++ b/node_modules/@rocket.chat/sdk/lib/clients/Rocketchat.js
+@@ -122,6 +122,9 @@ var RocketChatClient = /** @class */ (function (_super) {
+             default:
+                 throw new Error("Invalid Protocol: " + protocol + ", valids: " + Object.keys(drivers_1.Protocols).join());
+         }
++
++        this.once('unauthorized', async() => (await _this.socket).ddp.emit('unauthorized')); // echo event to sdk
++
+         return _this;
+     }
+     RocketChatClient.prototype.resume = function (_a) {
 diff --git a/node_modules/@rocket.chat/sdk/lib/drivers/ddp.js b/node_modules/@rocket.chat/sdk/lib/drivers/ddp.js
-index e3510c7..e3216cc 100644
+index 8f04ff1..e3216cc 100644
 --- a/node_modules/@rocket.chat/sdk/lib/drivers/ddp.js
 +++ b/node_modules/@rocket.chat/sdk/lib/drivers/ddp.js
 @@ -110,6 +110,7 @@ tiny_events_1.EventEmitter.prototype.removeAllListeners = function (event) {


### PR DESCRIPTION
@RocketChat/ReactNative

Closes #1944 .

We have a problem when token expires and app is opened, if you don't close and reopen the app you don't will logged out.
I created a new stream on our sdk to emit a `unauthorized` when some request fails with status 401, we can use it to handle on our app and logout the user when this was emitted.
If it makes sense, I'll merge this changes on our sdk soon.
