### PR TITLE
[FIX] Add server and hide login

### DIFF
--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -965,11 +965,12 @@ const RocketChat = {
 					return ret;
 				}, {});
 				reduxStore.dispatch(setLoginServices(loginServicesReducer));
+			} else {
+				reduxStore.dispatch(setLoginServices({}));
 			}
-			return Promise.resolve(loginServices.length);
 		} catch (error) {
-			console.warn(error);
-			return Promise.reject();
+			console.log(error);
+			reduxStore.dispatch(setLoginServices({}));
 		}
 	},
 	_determineAuthType(services) {

--- a/app/selectors/login.js
+++ b/app/selectors/login.js
@@ -1,8 +1,15 @@
 import { createSelector } from 'reselect';
 
 const getUser = state => state.login.user || {};
+const getLoginServices = state => state.login.services || {};
+const getShowFormLoginSetting = state => state.settings.Accounts_ShowFormLogin || false;
 
 export const getUserSelector = createSelector(
 	[getUser],
 	user => user
+);
+
+export const getShowLoginButton = createSelector(
+	[getLoginServices, getShowFormLoginSetting],
+	(loginServices, showFormLogin) => showFormLogin || Object.values(loginServices).length
 );

--- a/app/views/RegisterView.js
+++ b/app/views/RegisterView.js
@@ -22,6 +22,7 @@ import RocketChat from '../lib/rocketchat';
 import { loginRequest as loginRequestAction } from '../actions/login';
 import openLink from '../utils/openLink';
 import LoginServices from '../containers/LoginServices';
+import { getShowLoginButton } from '../selectors/login';
 
 const styles = StyleSheet.create({
 	title: {
@@ -217,7 +218,7 @@ class RegisterView extends React.Component {
 
 	render() {
 		const { saving } = this.state;
-		const { theme } = this.props;
+		const { theme, showLoginButton } = this.props;
 		return (
 			<FormContainer theme={theme}>
 				<FormContainerInner>
@@ -298,14 +299,17 @@ class RegisterView extends React.Component {
 						</Text>
 					</View>
 
-					<View style={styles.bottomContainer}>
-						<Text style={[styles.bottomContainerText, { color: themes[theme].auxiliaryText }]}>{I18n.t('Do_you_have_an_account')}</Text>
-						<Text
-							style={[styles.bottomContainerTextBold, { color: themes[theme].actionTintColor }]}
-							onPress={this.login}
-						>{I18n.t('Login')}
-						</Text>
-					</View>
+					{showLoginButton
+						? (
+							<View style={styles.bottomContainer}>
+								<Text style={[styles.bottomContainerText, { color: themes[theme].auxiliaryText }]}>{I18n.t('Do_you_have_an_account')}</Text>
+								<Text
+									style={[styles.bottomContainerTextBold, { color: themes[theme].actionTintColor }]}
+									onPress={this.login}
+								>{I18n.t('Login')}
+								</Text>
+							</View>
+						) : null}
 				</FormContainerInner>
 			</FormContainer>
 		);
@@ -319,7 +323,8 @@ const mapStateToProps = state => ({
 	CAS_enabled: state.settings.CAS_enabled,
 	CAS_login_url: state.settings.CAS_login_url,
 	Accounts_CustomFields: state.settings.Accounts_CustomFields,
-	Accounts_EmailVerification: state.settings.Accounts_EmailVerification
+	Accounts_EmailVerification: state.settings.Accounts_EmailVerification,
+	showLoginButton: getShowLoginButton(state)
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/views/RegisterView.js
+++ b/app/views/RegisterView.js
@@ -69,7 +69,8 @@ class RegisterView extends React.Component {
 		Accounts_EmailVerification: PropTypes.bool,
 		theme: PropTypes.string,
 		Site_Name: PropTypes.string,
-		loginRequest: PropTypes.func
+		loginRequest: PropTypes.func,
+		showLoginButton: PropTypes.bool
 	}
 
 	constructor(props) {

--- a/app/views/RoomsListView/ServerDropdown.js
+++ b/app/views/RoomsListView/ServerDropdown.js
@@ -10,7 +10,6 @@ import RNUserDefaults from 'rn-user-defaults';
 
 import { toggleServerDropdown as toggleServerDropdownAction } from '../../actions/rooms';
 import { selectServerRequest as selectServerRequestAction } from '../../actions/server';
-import { appStart as appStartAction } from '../../actions';
 import styles from './styles';
 import Touch from '../../utils/touch';
 import RocketChat from '../../lib/rocketchat';
@@ -35,8 +34,7 @@ class ServerDropdown extends Component {
 		server: PropTypes.string,
 		theme: PropTypes.string,
 		toggleServerDropdown: PropTypes.func,
-		selectServerRequest: PropTypes.func,
-		appStart: PropTypes.func
+		selectServerRequest: PropTypes.func
 	}
 
 	constructor(props) {
@@ -132,7 +130,7 @@ class ServerDropdown extends Component {
 
 	select = async(server) => {
 		const {
-			server: currentServer, selectServerRequest, appStart, navigation, split
+			server: currentServer, selectServerRequest, navigation, split
 		} = this.props;
 
 		this.close();
@@ -142,10 +140,12 @@ class ServerDropdown extends Component {
 				navigation.navigate('RoomView');
 			}
 			if (!userId) {
-				appStart();
-				this.newServerTimeout = setTimeout(() => {
-					EventEmitter.emit('NewServer', { server });
-				}, 1000);
+				setTimeout(() => {
+					navigation.navigate('NewServerView', { previousServer: currentServer });
+					this.newServerTimeout = setTimeout(() => {
+						EventEmitter.emit('NewServer', { server });
+					}, ANIMATION_DURATION);
+				}, ANIMATION_DURATION);
 			} else {
 				selectServerRequest(server);
 			}
@@ -267,8 +267,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
 	toggleServerDropdown: () => dispatch(toggleServerDropdownAction()),
-	selectServerRequest: server => dispatch(selectServerRequestAction(server)),
-	appStart: () => dispatch(appStartAction('outside'))
+	selectServerRequest: server => dispatch(selectServerRequestAction(server))
 });
 
 export default withNavigation(connect(mapStateToProps, mapDispatchToProps)(withTheme(withSplit(ServerDropdown))));

--- a/app/views/WorkspaceView/index.js
+++ b/app/views/WorkspaceView/index.js
@@ -11,6 +11,7 @@ import { withTheme } from '../../theme';
 import FormContainer, { FormContainerInner } from '../../containers/FormContainer';
 import { themedHeader } from '../../utils/navigation';
 import ServerAvatar from './ServerAvatar';
+import { getShowLoginButton } from '../../selectors/login';
 
 class WorkspaceView extends React.Component {
 	static navigationOptions = ({ screenProps }) => ({
@@ -26,7 +27,8 @@ class WorkspaceView extends React.Component {
 		server: PropTypes.string,
 		Assets_favicon_512: PropTypes.object,
 		registrationEnabled: PropTypes.bool,
-		registrationText: PropTypes.string
+		registrationText: PropTypes.string,
+		showLoginButton: PropTypes.bool
 	}
 
 	login = () => {
@@ -41,7 +43,7 @@ class WorkspaceView extends React.Component {
 
 	render() {
 		const {
-			theme, Site_Name, Site_Url, Assets_favicon_512, server, registrationEnabled, registrationText
+			theme, Site_Name, Site_Url, Assets_favicon_512, server, registrationEnabled, registrationText, showLoginButton
 		} = this.props;
 		return (
 			<FormContainer theme={theme}>
@@ -51,12 +53,15 @@ class WorkspaceView extends React.Component {
 						<Text style={[styles.serverName, { color: themes[theme].titleText }]}>{Site_Name}</Text>
 						<Text style={[styles.serverUrl, { color: themes[theme].auxiliaryText }]}>{Site_Url}</Text>
 					</View>
-					<Button
-						title={I18n.t('Login')}
-						type='primary'
-						onPress={this.login}
-						theme={theme}
-					/>
+					{showLoginButton
+						? (
+							<Button
+								title={I18n.t('Login')}
+								type='primary'
+								onPress={this.login}
+								theme={theme}
+							/>
+						) : null}
 					{
 						registrationEnabled ? (
 							<Button
@@ -83,7 +88,8 @@ const mapStateToProps = state => ({
 	Site_Url: state.settings.Site_Url,
 	Assets_favicon_512: state.settings.Assets_favicon_512,
 	registrationEnabled: state.settings.Accounts_RegistrationForm === 'Public',
-	registrationText: state.settings.Accounts_RegistrationForm_LinkReplacementText
+	registrationText: state.settings.Accounts_RegistrationForm_LinkReplacementText,
+	showLoginButton: getShowLoginButton(state)
 });
 
 export default connect(mapStateToProps)(withTheme(WorkspaceView));


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
- [x] Navigate to new server's workspace from ServerDropdown if there's no token
- [x] Hide login button instead of showing a blank LoginView

### Test plan 1
- Log in any server
- Add a server but don't log in
- Open ServerDropdown and tap the unlogged server
- The app should navigate to that server's Workspace
- The app should enable to go back to previous server (via close button on NewServerView)

### Test plan 2
- The app should show login button on WorkspaceView and RegisterView only if `Accounts_ShowFormLogin` is enabled or it there's any login service (OAuth or SSO) available.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
