### PR TITLE
[FIX] Single message thread inserting thread without rid

### DIFF
--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -670,7 +670,6 @@ class RoomView extends React.Component {
 	// eslint-disable-next-line react/sort-comp
 	fetchThreadName = async(tmid, messageId) => {
 		try {
-			const { room } = this.state;
 			const db = database.active;
 			const threadCollection = db.collections.get('threads');
 			const messageCollection = db.collections.get('messages');
@@ -693,7 +692,7 @@ class RoomView extends React.Component {
 					await db.batch(
 						threadCollection.prepareCreate((t) => {
 							t._raw = sanitizedRaw({ id: thread._id }, threadCollection.schema);
-							t.subscription.set(room);
+							t.subscription.id = this.rid;
 							Object.assign(t, thread);
 						}),
 						messageRecord.prepareUpdate((m) => {
@@ -703,7 +702,7 @@ class RoomView extends React.Component {
 				});
 			}
 		} catch (e) {
-			log(e);
+			// log(e);
 		}
 	}
 


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
This PR fixes the app inserting thread message without rid, which was causing `UNIQUE constraint failed`.

How to reproduce:
- Make sure you didn't join `#dev`
- Go to `#dev`
- Scroll until February

Without this PR, the app would fail loading all messages.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
