### PR TITLE
[FIX] Login TOTP Compatibility to older servers

### DIFF
--- a/app/containers/TwoFactor/index.js
+++ b/app/containers/TwoFactor/index.js
@@ -48,6 +48,7 @@ const TwoFactor = React.memo(({ theme, split }) => {
 
 	useDeepCompareEffect(() => {
 		if (!_.isEmpty(data)) {
+			setCode('');
 			setVisible(true);
 		} else {
 			setVisible(false);
@@ -94,7 +95,7 @@ const TwoFactor = React.memo(({ theme, split }) => {
 			<View style={styles.container}>
 				<View style={[styles.content, split && [sharedStyles.modal, sharedStyles.modalFormSheet], { backgroundColor: themes[theme].backgroundColor }]}>
 					<Text style={[styles.title, { color }]}>{I18n.t(method?.title || 'Two_Factor_Authentication')}</Text>
-					<Text style={[styles.subtitle, { color }]}>{I18n.t(method?.text)}</Text>
+					{!!method?.text && <Text style={[styles.subtitle, { color }]}>{I18n.t(method.text)}</Text>}
 					<TextInput
 						value={code}
 						theme={theme}

--- a/app/containers/TwoFactor/index.js
+++ b/app/containers/TwoFactor/index.js
@@ -95,7 +95,7 @@ const TwoFactor = React.memo(({ theme, split }) => {
 			<View style={styles.container}>
 				<View style={[styles.content, split && [sharedStyles.modal, sharedStyles.modalFormSheet], { backgroundColor: themes[theme].backgroundColor }]}>
 					<Text style={[styles.title, { color }]}>{I18n.t(method?.title || 'Two_Factor_Authentication')}</Text>
-					{!!method?.text && <Text style={[styles.subtitle, { color }]}>{I18n.t(method.text)}</Text>}
+					{method?.text ? <Text style={[styles.subtitle, { color }]}>{I18n.t(method.text)}</Text> : null}
 					<TextInput
 						value={code}
 						theme={theme}

--- a/app/containers/TwoFactor/styles.js
+++ b/app/containers/TwoFactor/styles.js
@@ -15,11 +15,12 @@ export default StyleSheet.create({
 	},
 	title: {
 		fontSize: 14,
+		paddingBottom: 8,
 		...sharedStyles.textBold
 	},
 	subtitle: {
 		fontSize: 14,
-		paddingVertical: 8,
+		paddingBottom: 8,
 		...sharedStyles.textRegular,
 		...sharedStyles.textAlignCenter
 	},

--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -338,8 +338,8 @@ const RocketChat = {
 				if (e.data?.error && (e.data.error === 'totp-required' || e.data.error === 'totp-invalid')) {
 					const { details } = e.data;
 					try {
-						await twoFactor({ method: details?.method, invalid: e.data.error === 'totp-invalid' });
-						return resolve(this.loginTOTP(params));
+						const code = await twoFactor({ method: details?.method || 'totp', invalid: e.data.error === 'totp-invalid' });
+						return resolve(this.loginTOTP({ ...params, code: code?.twoFactorCode }));
 					} catch {
 						// twoFactor was canceled
 						return reject();


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
We need to support older totp method on login.
It's not using totp headers on older servers.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
