### PR TITLE
[IMPROVEMENT] Stop inserting last message as message object from rooms stream if room is focused

### DIFF
--- a/app/actions/actionsTypes.js
+++ b/app/actions/actionsTypes.js
@@ -31,7 +31,7 @@ export const ROOMS = createRequestTypes('ROOMS', [
 	'OPEN_SEARCH_HEADER',
 	'CLOSE_SEARCH_HEADER'
 ]);
-export const ROOM = createRequestTypes('ROOM', ['LEAVE', 'DELETE', 'REMOVED', 'USER_TYPING']);
+export const ROOM = createRequestTypes('ROOM', ['SUBSCRIBE', 'UNSUBSCRIBE', 'LEAVE', 'DELETE', 'REMOVED', 'USER_TYPING']);
 export const APP = createRequestTypes('APP', ['START', 'READY', 'INIT', 'INIT_LOCAL_SETTINGS']);
 export const MESSAGES = createRequestTypes('MESSAGES', ['REPLY_BROADCAST']);
 export const CREATE_CHANNEL = createRequestTypes('CREATE_CHANNEL', [...defaultTypes]);

--- a/app/actions/room.js
+++ b/app/actions/room.js
@@ -7,9 +7,10 @@ export function subscribeRoom(rid) {
 	};
 }
 
-export function unsubscribeRoom() {
+export function unsubscribeRoom(rid) {
 	return {
-		type: types.ROOM.UNSUBSCRIBE
+		type: types.ROOM.UNSUBSCRIBE,
+		rid
 	};
 }
 

--- a/app/actions/room.js
+++ b/app/actions/room.js
@@ -1,5 +1,18 @@
 import * as types from './actionsTypes';
 
+export function subscribeRoom(rid) {
+	return {
+		type: types.ROOM.SUBSCRIBE,
+		rid
+	};
+}
+
+export function unsubscribeRoom() {
+	return {
+		type: types.ROOM.UNSUBSCRIBE
+	};
+}
+
 export function leaveRoom(rid, t) {
 	return {
 		type: types.ROOM.LEAVE,

--- a/app/lib/methods/subscriptions/room.js
+++ b/app/lib/methods/subscriptions/room.js
@@ -10,6 +10,7 @@ import reduxStore from '../../createStore';
 import { addUserTyping, removeUserTyping, clearUserTyping } from '../../../actions/usersTyping';
 import debounce from '../../../utils/debounce';
 import RocketChat from '../../rocketchat';
+import { subscribeRoom, unsubscribeRoom } from '../../../actions/room';
 
 const WINDOW_TIME = 1000;
 
@@ -38,6 +39,8 @@ export default class RoomSubscription {
 		if (!this.isAlive) {
 			this.unsubscribe();
 		}
+
+		reduxStore.dispatch(subscribeRoom(this.rid));
 	}
 
 	unsubscribe = async() => {
@@ -59,6 +62,8 @@ export default class RoomSubscription {
 		if (this.timer) {
 			clearTimeout(this.timer);
 		}
+
+		reduxStore.dispatch(unsubscribeRoom());
 	}
 
 	removeListener = async(promise) => {

--- a/app/lib/methods/subscriptions/room.js
+++ b/app/lib/methods/subscriptions/room.js
@@ -63,7 +63,7 @@ export default class RoomSubscription {
 			clearTimeout(this.timer);
 		}
 
-		reduxStore.dispatch(unsubscribeRoom());
+		reduxStore.dispatch(unsubscribeRoom(this.rid));
 	}
 
 	removeListener = async(promise) => {

--- a/app/lib/methods/subscriptions/rooms.js
+++ b/app/lib/methods/subscriptions/rooms.js
@@ -141,7 +141,8 @@ const createOrUpdateSubscription = async(subscription, room) => {
 				}
 			}
 
-			if (tmp.lastMessage) {
+			const roomState = store.getState().room;
+			if (tmp.lastMessage && roomState.rid !== tmp.rid) {
 				const lastMessage = buildMessage(tmp.lastMessage);
 				const messagesCollection = db.collections.get('messages');
 				let messageRecord;

--- a/app/lib/methods/subscriptions/rooms.js
+++ b/app/lib/methods/subscriptions/rooms.js
@@ -141,8 +141,8 @@ const createOrUpdateSubscription = async(subscription, room) => {
 				}
 			}
 
-			const roomState = store.getState().room;
-			if (tmp.lastMessage && roomState.rid !== tmp.rid) {
+			const { rooms } = store.getState().room;
+			if (tmp.lastMessage && !rooms.includes(tmp.rid)) {
 				const lastMessage = buildMessage(tmp.lastMessage);
 				const messagesCollection = db.collections.get('messages');
 				let messageRecord;

--- a/app/reducers/room.js
+++ b/app/reducers/room.js
@@ -2,7 +2,8 @@ import { ROOM } from '../actions/actionsTypes';
 
 const initialState = {
 	rid: null,
-	isDeleting: false
+	isDeleting: false,
+	rooms: []
 };
 
 export default function(state = initialState, action) {
@@ -10,12 +11,13 @@ export default function(state = initialState, action) {
 		case ROOM.SUBSCRIBE:
 			return {
 				...state,
-				rid: action.rid
+				rooms: [action.rid, ...state.rooms]
 			};
 		case ROOM.UNSUBSCRIBE:
 			return {
 				...state,
-				rid: null
+				rooms: state.rooms
+					.filter(room => room.rid === action.rid)
 			};
 		case ROOM.LEAVE:
 			return {

--- a/app/reducers/room.js
+++ b/app/reducers/room.js
@@ -7,6 +7,16 @@ const initialState = {
 
 export default function(state = initialState, action) {
 	switch (action.type) {
+		case ROOM.SUBSCRIBE:
+			return {
+				...state,
+				rid: action.rid
+			};
+		case ROOM.UNSUBSCRIBE:
+			return {
+				...state,
+				rid: null
+			};
 		case ROOM.LEAVE:
 			return {
 				...state,


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
`rooms` stream returns `subscription.lastMessage` info.
`room` stream returns all messages.
Both streams inserts it as a Message record on database.

Let's stop inserting it on `rooms` stream if the room is focused, so we have less tasks to do.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
