### PR TITLE
[FIX] RoomsList update sometimes isn't fired

### DIFF
--- a/app/views/RoomsListView/index.js
+++ b/app/views/RoomsListView/index.js
@@ -212,13 +212,17 @@ class RoomsListView extends React.Component {
 		this.willFocusListener = navigation.addListener('willFocus', () => {
 			// Check if there were changes while not focused (it's set on sCU)
 			if (this.shouldUpdate) {
-				// animateNextTransition();
 				this.forceUpdate();
 				this.shouldUpdate = false;
 			}
 		});
 		this.didFocusListener = navigation.addListener('didFocus', () => {
 			this.animated = true;
+			// Check if there were changes while not focused (it's set on sCU)
+			if (this.shouldUpdate) {
+				this.forceUpdate();
+				this.shouldUpdate = false;
+			}
 			this.backHandler = BackHandler.addEventListener('hardwareBackPress', this.handleBackPress);
 		});
 		this.willBlurListener = navigation.addListener('willBlur', () => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
It's not the best solution, but react-navigation v4 had a problem with navigation lifecycle, some events aren't fired sometimes, refer to [this issue](https://github.com/react-navigation/react-navigation/issues/4867), while we wait to upgrade to react-navigation-v5, this will fix the problem.

Steps to reproduce:
* RoomsList
* Open directory
* Select Users
* Select some user
* Send a message
* Go back to RoomsList
-> WillFocus is not fired

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
