### PR TITLE
[FIX] Prevent double click

### DIFF
--- a/app/views/RoomsListView/index.js
+++ b/app/views/RoomsListView/index.js
@@ -549,6 +549,10 @@ class RoomsListView extends React.Component {
 	}
 
 	_onPressItem = async(item = {}) => {
+		const { navigation } = this.props;
+		if (!navigation.isFocused()) {
+			return;
+		}
 		if (!item.search) {
 			return this.goRoom(item);
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

Pay attention at the header of RoomView.
Before this PR, we're able to click on another roomItem while navigating, so, the header receives new navigation params and be incorrect.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
### Before
![](https://media.giphy.com/media/S8BJhQ7N5rq0UBe6lJ/giphy.gif)

### After
![](https://media.giphy.com/media/Y4axEqGczYm157ddsS/giphy.gif)
<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
