### PR TITLE
[FIX] Prevent crash when thread is not found

### DIFF
--- a/app/views/RoomView/List.js
+++ b/app/views/RoomView/List.js
@@ -96,7 +96,7 @@ class List extends React.Component {
 			this.messagesSubscription = this.messagesObservable
 				.subscribe((data) => {
 					this.interaction = InteractionManager.runAfterInteractions(() => {
-						if (tmid) {
+						if (tmid && this.thread) {
 							data = [this.thread, ...data];
 						}
 						const messages = orderBy(data, ['ts'], ['desc']);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
I faced a problem while ago, some messages aren't threads and was considered as thread, then, when I tried to click on one of this messages, the app crashed.
On this PR I fixed this error, preventing this crash, it's hard to reproduce, so, I followed these steps:
* Open your database
* Add `tmid` to some message
* Try to click on this message

If you have some reproducible test for this, please comment here.
Thanks.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
