### PR TITLE
[FIX] Wait attach activity before changeNavigationBarColor

### DIFF
--- a/app/utils/theme.js
+++ b/app/utils/theme.js
@@ -35,14 +35,18 @@ export const newThemeState = (prevState, newTheme) => {
 	return { themePreferences, theme: getTheme(themePreferences) };
 };
 
-export const setNativeTheme = themePreferences => setTimeout(async() => {
+export const setNativeTheme = async(themePreferences) => {
 	const theme = getTheme(themePreferences);
 	if (isAndroid) {
 		const iconsLight = theme === 'light';
-		await changeNavigationBarColor(themes[theme].navbarBackground, iconsLight);
+		try {
+			await changeNavigationBarColor(themes[theme].navbarBackground, iconsLight);
+		} catch (error) {
+			// Do nothing
+		}
 	}
 	setRootViewColor(themes[theme].backgroundColor);
-}, 500);
+};
 
 export const unsubscribeTheme = () => {
 	if (themeListener && themeListener.remove) {

--- a/app/utils/theme.js
+++ b/app/utils/theme.js
@@ -35,14 +35,14 @@ export const newThemeState = (prevState, newTheme) => {
 	return { themePreferences, theme: getTheme(themePreferences) };
 };
 
-export const setNativeTheme = (themePreferences) => {
+export const setNativeTheme = themePreferences => setTimeout(async() => {
 	const theme = getTheme(themePreferences);
 	if (isAndroid) {
 		const iconsLight = theme === 'light';
-		changeNavigationBarColor(themes[theme].navbarBackground, iconsLight);
+		await changeNavigationBarColor(themes[theme].navbarBackground, iconsLight);
 	}
 	setRootViewColor(themes[theme].backgroundColor);
-};
+}, 500);
 
 export const unsubscribeTheme = () => {
 	if (themeListener && themeListener.remove) {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Sometimes `changeNavigationBarColor` throws an error saying that hasn't have an activity attached, so, we'll do the same thing of #1649, and wait to the activity be attached.
<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
