### PR TITLE
[IMPROVEMENT] Enable navigating to a room from auth deep linking

### DIFF
--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -106,6 +106,8 @@ const handleOpen = function* handleOpen({ params }) {
 		if (params.token) {
 			yield take(types.SERVER.SELECT_SUCCESS);
 			yield RocketChat.connect({ server: host, user: { token: params.token } });
+			yield take(types.LOGIN.SUCCESS);
+			yield navigate({ params });
 		} else {
 			yield handleInviteLink({ params, requireLogin: true });
 		}

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -75,7 +75,7 @@ const handleOpen = function* handleOpen({ params }) {
 		if (!connected) {
 			yield localAuthenticate(host);
 			yield put(selectServerRequest(host));
-			yield take(types.SERVER.SELECT_SUCCESS);
+			yield take(types.LOGIN.SUCCESS);
 		}
 		yield navigate({ params });
 	} else {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Enables room params on auth deep linking.
```
https://go.rocket.chat/auth?host=${ HOST }&token=${ TOKEN }&userId=${ USERID }&path=${ PATH }
rocketchat://auth?host=${ HOST }&token=${ TOKEN }&userId=${ USERID }&path=${ PATH }
```

### Test plan

#### Room
- [ ] channel navigation
- [ ] group navigation
- [ ] dm navigation
- [ ] with and without `rid`
- [ ] push notification

#### Auth
- [ ] authenticate
- [ ] authenticate and navigate to a room

#### Invite links
- [ ] test if it works

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
