### PR TITLE
[FIX] Screen Lock options i18n

### DIFF
--- a/app/constants/localAuthentication.js
+++ b/app/constants/localAuthentication.js
@@ -1,5 +1,3 @@
-import I18n from '../i18n';
-
 export const PASSCODE_KEY = 'kPasscode';
 export const LOCKED_OUT_TIMER_KEY = 'kLockedOutTimer';
 export const ATTEMPTS_KEY = 'kAttempts';
@@ -12,26 +10,3 @@ export const MAX_ATTEMPTS = 6;
 export const TIME_TO_LOCK = 30000;
 
 export const DEFAULT_AUTO_LOCK = 1800;
-
-export const DEFAULT_AUTO_LOCK_OPTIONS = [
-	{
-		title: I18n.t('Local_authentication_auto_lock_60'),
-		value: 60
-	},
-	{
-		title: I18n.t('Local_authentication_auto_lock_300'),
-		value: 300
-	},
-	{
-		title: I18n.t('Local_authentication_auto_lock_900'),
-		value: 900
-	},
-	{
-		title: I18n.t('Local_authentication_auto_lock_1800'),
-		value: 1800
-	},
-	{
-		title: I18n.t('Local_authentication_auto_lock_3600'),
-		value: 3600
-	}
-];

--- a/app/lib/methods/getSettings.js
+++ b/app/lib/methods/getSettings.js
@@ -10,7 +10,7 @@ import log from '../../utils/log';
 import database from '../database';
 import protectedFunction from './helpers/protectedFunction';
 import fetch from '../../utils/fetch';
-import { DEFAULT_AUTO_LOCK, DEFAULT_AUTO_LOCK_OPTIONS } from '../../constants/localAuthentication';
+import { DEFAULT_AUTO_LOCK } from '../../constants/localAuthentication';
 
 const serverInfoKeys = ['Site_Name', 'UI_Use_Real_Name', 'FileUpload_MediaTypeWhiteList', 'FileUpload_MaxFileSize', 'Force_Screen_Lock', 'Force_Screen_Lock_After'];
 
@@ -55,19 +55,6 @@ const serverInfoUpdate = async(serverInfo, iconSetting) => {
 			return { ...allSettings, autoLock };
 		}
 		if (setting._id === 'Force_Screen_Lock_After') {
-			// Force_Screen_Lock from server
-			const forceScreenLock = serverInfo.find(item => item._id === 'Force_Screen_Lock')?.valueAsBoolean;
-
-			// if Force_Screen_Lock is disabled on server and Screen Lock is enabled on app
-			if (!forceScreenLock && server.autoLock) {
-				// if the current autoLockTime is one of our default options, we'll keep this value
-				if (DEFAULT_AUTO_LOCK_OPTIONS.find(option => option.value === server.autoLockTime)) {
-					return { ...allSettings, autoLockTime: server.autoLockTime };
-				}
-				// if the current autoLockTime is a value that isn't in our default options, we'll reset
-				return { ...allSettings, autoLockTime: DEFAULT_AUTO_LOCK };
-			}
-
 			// if Force_Screen_Lock_After === 0 and autoLockTime is null, set app's default value
 			if (setting.valueAsNumber === 0 && !server.autoLockTime) {
 				return { ...allSettings, autoLockTime: DEFAULT_AUTO_LOCK };

--- a/app/views/ScreenLockConfigView.js
+++ b/app/views/ScreenLockConfigView.js
@@ -17,7 +17,7 @@ import { CustomIcon } from '../lib/Icons';
 import database from '../lib/database';
 import { supportedBiometryLabel, changePasscode, checkHasPasscode } from '../utils/localAuthentication';
 import { DisclosureImage } from '../containers/DisclosureIndicator';
-import { DEFAULT_AUTO_LOCK_OPTIONS, DEFAULT_AUTO_LOCK } from '../constants/localAuthentication';
+import { DEFAULT_AUTO_LOCK } from '../constants/localAuthentication';
 
 const styles = StyleSheet.create({
 	listPadding: {
@@ -53,6 +53,29 @@ class ScreenLockConfigView extends React.Component {
 		};
 		this.init();
 	}
+
+	defaultAutoLockOptions = [
+		{
+			title: I18n.t('Local_authentication_auto_lock_60'),
+			value: 60
+		},
+		{
+			title: I18n.t('Local_authentication_auto_lock_300'),
+			value: 300
+		},
+		{
+			title: I18n.t('Local_authentication_auto_lock_900'),
+			value: 900
+		},
+		{
+			title: I18n.t('Local_authentication_auto_lock_1800'),
+			value: 1800
+		},
+		{
+			title: I18n.t('Local_authentication_auto_lock_3600'),
+			value: 3600
+		}
+	];
 
 	init = async() => {
 		const { server } = this.props;
@@ -168,18 +191,24 @@ class ScreenLockConfigView extends React.Component {
 	}
 
 	renderAutoLockItems = () => {
-		const { autoLock } = this.state;
+		const { autoLock, autoLockTime } = this.state;
 		const { theme, Force_Screen_Lock_After, Force_Screen_Lock } = this.props;
 		if (!autoLock) {
 			return null;
 		}
-		let items = DEFAULT_AUTO_LOCK_OPTIONS;
+		let items = this.defaultAutoLockOptions;
 		if (Force_Screen_Lock && Force_Screen_Lock_After > 0) {
 			items = [{
 				title: I18n.t('After_seconds_set_by_admin', { seconds: Force_Screen_Lock_After }),
 				value: Force_Screen_Lock_After,
 				disabled: true
 			}];
+		// if Force_Screen_Lock is disabled and autoLockTime is a value that isn't on our defaultOptions we'll show it
+		} else if (Force_Screen_Lock_After === autoLockTime && !items.find(item => item.value === autoLockTime)) {
+			items.push({
+				title: I18n.t('After_seconds_set_by_admin', { seconds: Force_Screen_Lock_After }),
+				value: Force_Screen_Lock_After
+			});
 		}
 		return (
 			<>


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
I've changed the logic about enable/disable by admin on server settings, now, when the admin disable the `Force_Screen_Lock`, we'll check if the current value of autoLockTime is one of our default values, if yes, we'll show this option as selected, but, if not, we'll show the current option of time, until the user change to some default option, then the older admin option will just be hide.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
