### PR TITLE
[FIX] Handle no attached activity when try biometry

### DIFF
--- a/app/containers/Passcode/PasscodeEnter.js
+++ b/app/containers/Passcode/PasscodeEnter.js
@@ -32,9 +32,13 @@ const PasscodeEnter = ({ theme, hasBiometry, finishProcess }) => {
 
 	const biometry = async() => {
 		if (hasBiometry && status === TYPE.ENTER) {
-			const result = await biometryAuth();
-			if (result?.success) {
-				finishProcess();
+			try {
+				const result = await biometryAuth();
+				if (result?.success) {
+					finishProcess();
+				}
+			} catch {
+				// Do nothing
 			}
 		}
 	};

--- a/app/utils/localAuthentication.js
+++ b/app/utils/localAuthentication.js
@@ -65,16 +65,16 @@ export const biometryAuth = force => LocalAuthentication.authenticateAsync({
 const checkBiometry = async(serverRecord) => {
 	const serversDB = database.servers;
 
-	const result = await biometryAuth(true);
-	await serversDB.action(async() => {
-		try {
+	try {
+		const result = await biometryAuth(true);
+		await serversDB.action(async() => {
 			await serverRecord.update((record) => {
 				record.biometry = !!result?.success;
 			});
-		} catch {
-			// Do nothing
-		}
-	});
+		});
+	} catch {
+		// Do nothing
+	}
 };
 
 export const checkHasPasscode = async({ force = true, serverRecord }) => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Apparently, activities on Android has an extra time to be attached when the app is resumed, this causes some errors because the JS code is loaded before this be attached and some functions are called before the activity be attached, so some native modules are sending Errors like "The app needs to be at foreground", for now I'm doing only a handle of this errors, but I'll try to study how we can wait the activity be attached before try to do native things that needs a activity attached.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
