### PR TITLE
[FIX] No send data to bugsnag if it's an aborted request

### DIFF
--- a/app/utils/log.js
+++ b/app/utils/log.js
@@ -17,7 +17,7 @@ export const logServerVersion = (serverVersion) => {
 };
 
 export default (e) => {
-	if (e instanceof Error && !__DEV__) {
+	if (e instanceof Error && e.message !== 'Aborted' && !__DEV__) {
 		bugsnag.notify(e, (report) => {
 			report.metadata = {
 				details: {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
When you change between servers while it's connecting, all pending API requests will be rejected with ABORTED status, so, it sometimes take the error to bugsnag, we don't want this logs, so I'm just ignoring these logs.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
