### PR TITLE
Revert "[FIX] Autocomplete position on Android"

### DIFF
--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -487,20 +487,10 @@ class MessageBox extends Component {
 	}
 
 	setInput = (text) => {
-		if (this.component && this.component.setNativeProps) {
-			const props = { text };
-
-			if (isAndroid) {
-				const diff = text.length - this.text?.length;
-				const selection = this.component?.lastNativeSelection;
-				const start = selection?.start + diff >= 0 ? selection?.start + diff : text.length;
-				const end = selection?.end + diff >= 0 ? selection?.start + diff : text.length;
-				props.selection = { start, end };
-			}
-
-			this.component.setNativeProps(props);
-		}
 		this.text = text;
+		if (this.component && this.component.setNativeProps) {
+			this.component.setNativeProps({ text });
+		}
 	}
 
 	setShowSend = (showSend) => {


### PR DESCRIPTION
Reverts RocketChat/Rocket.Chat.ReactNative#2106

Unfortunately it's generating some errors on our Bugsnag like:
```
java.lang.IndexOutOfBoundsExceptionMainActivity
setSpan (-11 ... -11) starts before 0
```
So, we'll revert it.