### PR TITLE
[FIX] Here and all mentions shouldn't refer to users

### DIFF
--- a/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -666,16 +666,18 @@ exports[`Storyshots Markdown list Markdown 1`] = `
            
         </Text>
         <Text
-          onPress={[Function]}
           style={
             Array [
               Object {
-                "backgroundColor": "#FF5B5A",
+                "backgroundColor": "#E8F2FF",
                 "color": "#ffffff",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "500",
                 "padding": 5,
+              },
+              Object {
+                "backgroundColor": "#FF5B5A",
               },
             ]
           }
@@ -709,16 +711,18 @@ exports[`Storyshots Markdown list Markdown 1`] = `
            
         </Text>
         <Text
-          onPress={[Function]}
           style={
             Array [
               Object {
-                "backgroundColor": "#FF5B5A",
+                "backgroundColor": "#E8F2FF",
                 "color": "#ffffff",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "500",
                 "padding": 5,
+              },
+              Object {
+                "backgroundColor": "#FF5B5A",
               },
             ]
           }
@@ -896,16 +900,18 @@ exports[`Storyshots Markdown list Markdown 1`] = `
            
         </Text>
         <Text
-          onPress={[Function]}
           style={
             Array [
               Object {
-                "backgroundColor": "#FF5B5A",
+                "backgroundColor": "#E8F2FF",
                 "color": "#ffffff",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "500",
                 "padding": 5,
+              },
+              Object {
+                "backgroundColor": "#FF5B5A",
               },
             ]
           }
@@ -939,16 +945,18 @@ exports[`Storyshots Markdown list Markdown 1`] = `
            
         </Text>
         <Text
-          onPress={[Function]}
           style={
             Array [
               Object {
-                "backgroundColor": "#FF5B5A",
+                "backgroundColor": "#E8F2FF",
                 "color": "#ffffff",
                 "fontFamily": "System",
                 "fontSize": 16,
                 "fontWeight": "500",
                 "padding": 5,
+              },
+              Object {
+                "backgroundColor": "#FF5B5A",
               },
             ]
           }

--- a/app/containers/markdown/AtMention.js
+++ b/app/containers/markdown/AtMention.js
@@ -11,11 +11,10 @@ const AtMention = React.memo(({
 }) => {
 	let mentionStyle = { ...styles.mention, color: themes[theme].buttonText };
 	if (mention === 'all' || mention === 'here') {
-		mentionStyle = {
-			...mentionStyle,
-			...styles.mentionAll
-		};
-	} else if (mention === username) {
+		return <Text style={[mentionStyle, styles.mentionAll, ...style]}>{mention}</Text>;
+	}
+
+	if (mention === username) {
 		mentionStyle = {
 			...mentionStyle,
 			backgroundColor: themes[theme].actionTintColor


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Stop looking for `user.name` when mention is `all` or `here`.
Now it always shows `all/here`.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
