### PR TITLE
[FIX] Screen Lock Time respect local value

### DIFF
--- a/app/lib/methods/getSettings.js
+++ b/app/lib/methods/getSettings.js
@@ -55,12 +55,14 @@ const serverInfoUpdate = async(serverInfo, iconSetting) => {
 			return { ...allSettings, autoLock };
 		}
 		if (setting._id === 'Force_Screen_Lock_After') {
+			const forceScreenLock = serverInfo.find(s => s._id === 'Force_Screen_Lock')?.valueAsBoolean;
+
 			// if Force_Screen_Lock_After === 0 and autoLockTime is null, set app's default value
 			if (setting.valueAsNumber === 0 && !server.autoLockTime) {
 				return { ...allSettings, autoLockTime: DEFAULT_AUTO_LOCK };
 			}
-			// if Force_Screen_Lock_After > 0, use it
-			if (setting.valueAsNumber > 0) {
+			// if Force_Screen_Lock_After > 0 and forceScreenLock is enabled, use it
+			if (setting.valueAsNumber > 0 && forceScreenLock) {
 				return { ...allSettings, autoLockTime: setting.valueAsNumber };
 			}
 		}

--- a/app/views/ScreenLockConfigView.js
+++ b/app/views/ScreenLockConfigView.js
@@ -54,6 +54,12 @@ class ScreenLockConfigView extends React.Component {
 		this.init();
 	}
 
+	componentWillUnmount() {
+		if (this.observable && this.observable.unsubscribe) {
+			this.observable.unsubscribe();
+		}
+	}
+
 	defaultAutoLockOptions = [
 		{
 			title: I18n.t('Local_authentication_auto_lock_60'),
@@ -94,6 +100,19 @@ class ScreenLockConfigView extends React.Component {
 
 		const biometryLabel = await supportedBiometryLabel();
 		this.setState({ biometryLabel });
+
+		this.observe();
+	}
+
+	/*
+	 * We should observe biometry value
+	 * because it can be changed by PasscodeChange
+	 * when the user set his first passcode
+	*/
+	observe = () => {
+		this.observable = this.serverRecord?.observe()?.subscribe(({ biometry }) => {
+			this.setState({ biometry });
+		});
 	}
 
 	save = async() => {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
We'll set the `autoLockTime` with the value that came from server, just if the setting is enabled.

* If the autoLockTime is disabled at server, and you enabled screenLock at your device, it'll be enabled with the default value of `autoLockTime`, and if you change this, the device should respect the value that you've set.
* if the server enable the autoLock, and you have it enabled before locally at your phone, it should must keep enabled and the autoLockTime should change to the value of the server, and respect this always while it's enabled.
* if the server disable the autoLock, your device should keep this enabled with the autoLockTime as the latest value set by an admin, while you not change this.
* if it's disabled at your phone, and was enabled at the server side, it should be enabled at your phone.

* Test plan to latest commit:
 - Login into some server with autoLock disabled
 - Go to settings -> screen lock
 - Enable this and provide a TouchID/FaceID
 - Biometry should show as enabled

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
