### PR TITLE
Removed server toggle dropdown if showServerDropdown is false

### DIFF
--- a/app/views/RoomsListView/Header/Header.android.js
+++ b/app/views/RoomsListView/Header/Header.android.js
@@ -59,29 +59,41 @@ const Header = React.memo(({
 			</View>
 		);
 	}
-	return (
-		<View style={styles.container}>
-			<TouchableOpacity
-				onPress={onPress}
-				testID='rooms-list-header-server-dropdown-button'
-				disabled={connecting || isFetching}
-			>
-				{connecting ? <Text style={[styles.updating, titleColorStyle]}>{I18n.t('Connecting')}</Text> : null}
-				{isFetching ? <Text style={[styles.updating, titleColorStyle]}>{I18n.t('Updating')}</Text> : null}
-				<View style={styles.button}>
-					<Text style={[styles.server, isFetching && styles.serverSmall, titleColorStyle]} numberOfLines={1}>{serverName}</Text>
-					<Image
-						style={[
-							styles.disclosure,
-							showServerDropdown && styles.upsideDown,
-							{ tintColor: themes[theme].headerTitleColor }
-						]}
-						source={{ uri: 'disclosure_indicator_server' }}
-					/>
-				</View>
-			</TouchableOpacity>
-		</View>
-	);
+        if (showServerDropdown) {
+                return (
+                    <View style={styles.container}>
+                            <TouchableOpacity
+                                    onPress={onPress}
+                                    testID='rooms-list-header-server-dropdown-button'
+                                    disabled={connecting || isFetching}
+                            >
+                                    {connecting ? <Text style={[styles.updating, titleColorStyle]}>{I18n.t('Connecting')}</Text> : null}
+                                    {isFetching ? <Text style={[styles.updating, titleColorStyle]}>{I18n.t('Updating')}</Text> : null}
+                                    <View style={styles.button}>
+                                            <Text style={[styles.server, isFetching && styles.serverSmall, titleColorStyle]} numberOfLines={1}>{serverName}</Text>
+                                            <Image
+                                                    style={[
+                                                            styles.disclosure,
+                                                            showServerDropdown && styles.upsideDown,
+                                                            { tintColor: themes[theme].headerTitleColor }
+                                                    ]}
+                                                    source={{ uri: 'disclosure_indicator_server' }}
+                                            />
+                                    </View>
+                            </TouchableOpacity>
+                    </View>
+                );
+        } else {
+                return (
+                    <View style={styles.container}>
+                            {connecting ? <Text style={[styles.updating, titleColorStyle]}>{I18n.t('Connecting')}</Text> : null}
+                            {isFetching ? <Text style={[styles.updating, titleColorStyle]}>{I18n.t('Updating')}</Text> : null}
+                            <View style={styles.button}>
+                                    <Text style={[styles.server, isFetching && styles.serverSmall, titleColorStyle]} numberOfLines={1}>{serverName}</Text>
+                            </View>
+                    </View>
+                );  
+        }
 });
 
 Header.propTypes = {


### PR DESCRIPTION
@RocketChat/ReactNative

I am using the single server branch and noticed that server drop-down in the android header is still toggling. I added an IF statement that will check if **showServerDropdown** is true, if so it will act normally, if it's false I removed the toggle functionality along with the toggle image from the header. 

NOTE: I did not adjust the iOS header but I imagine the same problem exists there and I will get around to it eventually.