### PR TITLE
[FIX] Handle TypeErrors on navigationRef and draftMessage due to null properties 

### DIFF
--- a/app/AppContainer.js
+++ b/app/AppContainer.js
@@ -44,7 +44,7 @@ const App = React.memo(({ root, isMasterDetail }) => {
 	const navTheme = navigationTheme(theme);
 
 	React.useEffect(() => {
-		const state = Navigation.navigationRef.current.getRootState();
+		const state = Navigation.navigationRef.current?.getRootState();
 		const currentRouteName = getActiveRouteName(state);
 		Navigation.routeNameRef.current = currentRouteName;
 		setCurrentScreen(currentRouteName);

--- a/app/containers/InAppNotification/index.js
+++ b/app/containers/InAppNotification/index.js
@@ -11,7 +11,7 @@ export const INAPP_NOTIFICATION_EMITTER = 'NotificationInApp';
 const InAppNotification = memo(() => {
 	const show = (notification) => {
 		const { payload } = notification;
-		const state = Navigation.navigationRef.current.getRootState();
+		const state = Navigation.navigationRef.current?.getRootState();
 		const route = getActiveRoute(state);
 		if (payload.rid) {
 			if (route?.name === 'RoomView' && route.params?.rid === payload.rid) {

--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -196,7 +196,7 @@ class MessageBox extends Component {
 					console.log('Messagebox.didMount: Thread not found');
 				}
 			} else if (!sharing) {
-				msg = this.room.draftMessage;
+				msg = this.room?.draftMessage;
 			}
 		} catch (e) {
 			log(e);

--- a/app/share.js
+++ b/app/share.js
@@ -150,7 +150,7 @@ class Root extends React.Component {
 			this.setState({ root: 'outside' });
 		}
 
-		const state = Navigation.navigationRef.current.getRootState();
+		const state = Navigation.navigationRef.current?.getRootState();
 		const currentRouteName = getActiveRouteName(state);
 		Navigation.routeNameRef.current = currentRouteName;
 		setCurrentScreen(currentRouteName);


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

Check for null before using `navigationRef` and `draftMessage`.
<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
