### PR TITLE
[FIX] Android crashing when restoring from background

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/MainActivity.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/MainActivity.java
@@ -13,7 +13,8 @@ public class MainActivity extends ReactFragmentActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+        // https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067
+        super.onCreate(null);
         RNBootSplash.init(R.drawable.launch_screen, MainActivity.this);
     }
 

--- a/app/views/RoomsListView/index.js
+++ b/app/views/RoomsListView/index.js
@@ -151,8 +151,22 @@ class RoomsListView extends React.Component {
 	}
 
 	componentDidMount() {
-		this.getSubscriptions();
-		const { navigation, closeServerDropdown } = this.props;
+		const {
+			navigation, closeServerDropdown, appState
+		} = this.props;
+
+		/**
+		 * - When didMount is triggered and appState is foreground,
+		 * it means the user is logging in and selectServer has ran, so we can getSubscriptions
+		 *
+		 * - When didMount is triggered and appState is background,
+		 * it means the user has resumed the app, so selectServer needs to be triggered,
+		 * which is going to change server and getSubscriptions will be triggered by componentWillReceiveProps
+		 */
+		if (appState === 'foreground') {
+			this.getSubscriptions();
+		}
+
 		if (isTablet) {
 			EventEmitter.addEventListener(KEY_COMMAND, this.handleCommands);
 		}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Fixes this issue:
> Unable to start activity ComponentInfo{chat.rocket.android/chat.rocket.reactnative.MainActivity}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.swmansion.rnscreens.ScreenFragment: calling Fragment constructor caused an exception

It was fixed by https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067
It also fixes a collateral bug where RoomsListView would remain in loading state.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
### How to reproduce the error
- Enable "Don't keep activities" on Android Developer Options
- Open the app on a server
- Minimize the app (test both normal and back button)
- Restore
- App crashes (or keep in loading state without the RoomsListView changes)

### Test Plan
- Enable "Don't keep activities" on Android Developer Options
- Open the app on a server
- Minimize the app (test both normal and back button)
- Restore
- App should load the server properly
