### PR TITLE
[FIX] Emoji keyboard not showing custom and frequently used emojis on Share Extension

### DIFF
--- a/app/containers/MessageBox/EmojiKeyboard.js
+++ b/app/containers/MessageBox/EmojiKeyboard.js
@@ -17,7 +17,7 @@ export default class EmojiKeyboard extends React.PureComponent {
 	constructor(props) {
 		super(props);
 		const state = store.getState();
-		this.baseUrl = state.server.server;
+		this.baseUrl = state.share.server || state.server.server;
 	}
 
 	onEmojiSelected = (emoji) => {

--- a/app/lib/database/index.js
+++ b/app/lib/database/index.js
@@ -110,7 +110,9 @@ class DB {
 				Thread,
 				ThreadMessage,
 				Upload,
-				Permission
+				Permission,
+				CustomEmoji,
+				FrequentlyUsedEmoji
 			],
 			actionsEnabled: true
 		});

--- a/app/lib/rocketchat.js
+++ b/app/lib/rocketchat.js
@@ -288,6 +288,8 @@ const RocketChat = {
 		const serversDB = database.servers;
 		reduxStore.dispatch(shareSelectServer(server));
 
+		RocketChat.setCustomEmojis();
+
 		// set User info
 		try {
 			const userId = await RNUserDefaults.get(`${ RocketChat.TOKEN_KEY }-${ server }`);


### PR DESCRIPTION
@RocketChat/ReactNative

* Show frequently used emojis at emoji keyboard on Share Extension
* Show custom emojis at emoji keyboard on Share Extension

![Screen Shot 2020-07-08 at 11 40 30](https://user-images.githubusercontent.com/29778115/86932632-ff4b0c00-c10f-11ea-8419-e3777ae07065.png)
![Screen Shot 2020-07-08 at 11 40 27](https://user-images.githubusercontent.com/29778115/86932638-0245fc80-c110-11ea-8a1e-49fa3d90a529.png)


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
