### PR TITLE
[FIX] AttachmentView crashing during title decode

### DIFF
--- a/app/views/AttachmentView.js
+++ b/app/views/AttachmentView.js
@@ -70,10 +70,15 @@ class AttachmentView extends React.Component {
 	setHeader = () => {
 		const { route, navigation, theme } = this.props;
 		const attachment = route.params?.attachment;
-		const { title } = attachment;
+		let { title } = attachment;
+		try {
+			title = decodeURI(title);
+		} catch {
+			// Do nothing
+		}
 		const options = {
+			title,
 			headerLeft: () => <CloseModalButton testID='close-attachment-view' navigation={navigation} buttonStyle={{ color: themes[theme].previewTintColor }} />,
-			title: decodeURI(title),
 			headerRight: () => <SaveButton testID='save-image' onPress={this.handleSave} buttonStyle={{ color: themes[theme].previewTintColor }} />,
 			headerBackground: () => <View style={{ flex: 1, backgroundColor: themes[theme].previewBackground }} />,
 			headerTintColor: themes[theme].previewTintColor,


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
`decodeURI` can throw an error while try to decode filename, so, we'll use the original title at these cases.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
