### PR TITLE
[FIX] ThreadMessagesView throwing error when subscription wasn't found

### DIFF
--- a/app/views/ThreadMessagesView/index.js
+++ b/app/views/ThreadMessagesView/index.js
@@ -127,7 +127,7 @@ class ThreadMessagesView extends React.Component {
 	// eslint-disable-next-line react/sort-comp
 	init = () => {
 		if (!this.subscription) {
-			this.load();
+			return this.load();
 		}
 		try {
 			const lastThreadSync = new Date();


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

## Test Plan
* Go to directory
* Open a room that you don't have joined yet
* Open thread messages view
<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
