### PR TITLE
[FIX] Navigation object undefined when tapping sidebar's user header on tablet

### DIFF
--- a/app/views/SidebarView/index.js
+++ b/app/views/SidebarView/index.js
@@ -144,6 +144,14 @@ class Sidebar extends Component {
 		return state?.routeNames[state?.index];
 	}
 
+	onPressUser = () => {
+		const { navigation, isMasterDetail } = this.props;
+		if (isMasterDetail) {
+			return;
+		}
+		navigation.closeDrawer();
+	}
+
 	renderAdmin = () => {
 		const { isAdmin } = this.state;
 		const { theme, isMasterDetail } = this.props;
@@ -210,7 +218,7 @@ class Sidebar extends Component {
 
 	render() {
 		const {
-			user, Site_Name, baseUrl, useRealName, allowStatusMessage, isMasterDetail, theme, navigation
+			user, Site_Name, baseUrl, useRealName, allowStatusMessage, isMasterDetail, theme
 		} = this.props;
 
 		if (!user) {
@@ -229,7 +237,7 @@ class Sidebar extends Component {
 					]}
 					{...scrollPersistTaps}
 				>
-					<TouchableWithoutFeedback onPress={() => navigation.closeDrawer()} testID='sidebar-close-drawer'>
+					<TouchableWithoutFeedback onPress={this.onPressUser} testID='sidebar-close-drawer'>
 						<View style={styles.header} theme={theme}>
 							<Avatar
 								text={user.username}


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

It was trying to close a nonexistent drawer on `isMasterDetail` layout.
I removed the functionality, because there's a close modal button for that.

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
### Test plan

#### Mobile
- Open drawer
- Tap user header
- It should close the drawer

#### Tablet
- Open drawer (which is a modal on this case)
- Tap user header
- It shouldn't do anything


<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
