### PR TITLE
[FIX] Android stack animation throwing illegal node ID

### DIFF
--- a/app/utils/navigation/animations.js
+++ b/app/utils/navigation/animations.js
@@ -54,8 +54,7 @@ export const FadeFromCenterModal = {
 const forStackAndroid = ({
 	current,
 	inverted,
-	layouts: { screen },
-	closing
+	layouts: { screen }
 }) => {
 	const translateX = multiply(
 		current.progress.interpolate({
@@ -65,13 +64,12 @@ const forStackAndroid = ({
 		inverted
 	);
 
-	const opacity = conditional(
-		closing,
-		current.progress,
+	const opacity = multiply(
 		current.progress.interpolate({
 			inputRange: [0, 1],
 			outputRange: [0, 1]
-		})
+		}),
+		inverted
 	);
 
 	return {


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
This is an attempt to fix the following error:
> com.facebook.react.bridge.JSApplicationCausedNativeException: Illegal node ID set as an input for Animated.multiply node

I kept the animation, but I removed a React Navigation's `conditional` call, which makes some other `multiply` calls.

### Test Plan
Play with the navigation app on Android.

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
