### PR TITLE
[FIX] Avatar caching

### DIFF
--- a/app/containers/Avatar.js
+++ b/app/containers/Avatar.js
@@ -39,7 +39,8 @@ const Avatar = React.memo(({
 			source={{
 				uri,
 				headers: RocketChatSettings.customHeaders,
-				priority: FastImage.priority.high
+				priority: FastImage.priority.high,
+				cache: FastImage.cacheControl.web
 			}}
 		/>
 	);


### PR DESCRIPTION
@RocketChat/ReactNative

Closes #441 

Fixes the bug where the avatar is never refreshed. The default behaviour of FastImage only updates the image if the url changes. But since the avatar url stays the same after changing the image, it gets never refreshed. 

> `FastImage.cacheControl.immutable` - (**Default**) - Only updates if url changes.
> `FastImage.cacheControl.web` - Use headers and follow normal caching procedures.
> `FastImage.cacheControl.cacheOnly` - Only show images from cache, do not make any network requests.
