### PR TITLE
[FIX] Focusing Text Input for writing description in ShareView after uploading an attachment causes chat messages to be hidden under MessageBox in RoomView

### DIFF
--- a/app/containers/MessageBox/styles.js
+++ b/app/containers/MessageBox/styles.js
@@ -15,7 +15,7 @@ export default StyleSheet.create({
 	},
 	composer: {
 		flexDirection: 'column',
-		borderTopWidth: StyleSheet.hairlineWidth
+		borderTopWidth: 1
 	},
 	textArea: {
 		flexDirection: 'row',


### PR DESCRIPTION


<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #2276

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
As long as we tap on the Text Input of MessageBox in ShareView after we have uploaded an attachment, no matter we send the attachment or not, the chat messages in RoomView will become hidden under the MessageBox component on iOS irregularly on different devices. On my devices, it seems to happen every time. 

This problem was traced all the way to the module "react-native-keyboard-tracking-view".
Please see Issue https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/2276.

![IMG_2089](https://user-images.githubusercontent.com/3071383/87243855-a65adb00-c463-11ea-90e4-fdb4f688d7ae.jpg)

