### PR TITLE
Allow send files with '#'

### DIFF
--- a/app/lib/methods/sendFileMessage.js
+++ b/app/lib/methods/sendFileMessage.js
@@ -62,7 +62,7 @@ export function sendFileMessage(rid, fileInfo, tmid, server, user) {
 			formData.append('file', {
 				uri: fileInfo.path,
 				type: fileInfo.type,
-				name: encodeURI(fileInfo.name) || 'fileMessage'
+				name: encodeURIComponent(fileInfo.name) || 'fileMessage'
 			});
 
 			if (fileInfo.description) {

--- a/app/views/AttachmentView.js
+++ b/app/views/AttachmentView.js
@@ -72,7 +72,7 @@ class AttachmentView extends React.Component {
 		const attachment = route.params?.attachment;
 		let { title } = attachment;
 		try {
-			title = decodeURI(title);
+			title = decodeURIComponent(title);
 		} catch {
 			// Do nothing
 		}

--- a/app/views/ShareView/index.js
+++ b/app/views/ShareView/index.js
@@ -132,6 +132,12 @@ class ShareView extends Component {
 				}
 			}
 
+			// encode files with # in the name
+			if (item.path.includes('#')) {
+				const lastPath = item.path.split('/').slice(-1);
+				item.path = item.path.replace(lastPath, encodeURIComponent(lastPath));
+			}
+
 			// Set a filename, if there isn't any
 			if (!item.filename) {
 				item.filename = new Date().toISOString();


### PR DESCRIPTION
This PR make allow to send files with '#' in the name. this problem is because '#' is a especial character to pass fragments. to encode this, is necessary to use encodeURIComponent. With this in mind I make allowable in the preview and share of files from gallery.

![ezgif com-video-to-gif(25)](https://user-images.githubusercontent.com/37127457/88448430-66590800-ce14-11ea-85b6-42069912498c.gif)

I found this pr #2020  with a similar proposal but without the encodeURIComponent this is the result when the name contains '#'

![ezgif com-video-to-gif(26)](https://user-images.githubusercontent.com/37127457/88448544-64dc0f80-ce15-11ea-8b06-2975301345b9.gif)

This problem was fixed too.

![ezgif com-video-to-gif(27)](https://user-images.githubusercontent.com/37127457/88448623-12e7b980-ce16-11ea-94b0-d90154dfa5e2.gif)

This PR closes #2182 



