### PR TITLE
[CHORE] Only run Flipper in debug via MainApplication is debug

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="chat.rocket.reactnative">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <application
+        android:name=".MainDebugApplication"
+        tools:ignore="GoogleAppIndexingWarning"
+        tools:replace="android:name"
+        tools:targetApi="28" />
 
-    <application tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 </manifest>

--- a/android/app/src/debug/java/chat/rocket/reactnative/MainDebugApplication.java
+++ b/android/app/src/debug/java/chat/rocket/reactnative/MainDebugApplication.java
@@ -8,7 +8,6 @@ public class MainDebugApplication extends MainApplication  {
 
   @Override
   public void onCreate() {
-
     super.onCreate();
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
@@ -21,6 +20,6 @@ public class MainDebugApplication extends MainApplication  {
    * @param reactInstanceManager
    */
   private static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
-    com.rndiffapp.ReactNativeFlipper.initializeFlipper(context, reactInstanceManager);
+    ReactNativeFlipper.initializeFlipper(context, reactInstanceManager);
   }
 }

--- a/android/app/src/debug/java/chat/rocket/reactnative/MainDebugApplication.java
+++ b/android/app/src/debug/java/chat/rocket/reactnative/MainDebugApplication.java
@@ -1,0 +1,26 @@
+package chat.rocket.reactnative;
+
+import android.content.Context;
+
+import com.facebook.react.ReactInstanceManager;
+
+public class MainDebugApplication extends MainApplication  {
+
+  @Override
+  public void onCreate() {
+
+    super.onCreate();
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+  }
+
+  /**
+   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
+   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+   *
+   * @param context
+   * @param reactInstanceManager
+   */
+  private static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
+    com.rndiffapp.ReactNativeFlipper.initializeFlipper(context, reactInstanceManager);
+  }
+}

--- a/android/app/src/debug/java/chat/rocket/reactnative/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/chat/rocket/reactnative/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.rndiffapp;
+package chat.rocket.reactnative;
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;
 import com.facebook.flipper.android.utils.FlipperUtils;

--- a/android/app/src/main/java/chat/rocket/reactnative/MainApplication.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/MainApplication.java
@@ -81,38 +81,6 @@ public class MainApplication extends Application implements ReactApplication, IN
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
-    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-  }
-
-  /**
-   * Loads Flipper in React Native templates. Call this in the onCreate method with something like
-   * initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-   *
-   * @param context
-   * @param reactInstanceManager
-   */
-  private static void initializeFlipper(
-      Context context, ReactInstanceManager reactInstanceManager) {
-    if (BuildConfig.DEBUG) {
-      try {
-        /*
-         We use reflection here to pick up the class that initializes Flipper,
-        since Flipper library is not available in release mode
-        */
-        Class<?> aClass = Class.forName("chat.rocket.reactnative");
-        aClass
-            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
-            .invoke(null, context, reactInstanceManager);
-      } catch (ClassNotFoundException e) {
-        e.printStackTrace();
-      } catch (NoSuchMethodException e) {
-        e.printStackTrace();
-      } catch (IllegalAccessException e) {
-        e.printStackTrace();
-      } catch (InvocationTargetException e) {
-        e.printStackTrace();
-      }
-    }
   }
 
   @Override

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
These changes remove the need for reflection to load Flipper. They also fix the need to hard code the package name, which is not helpful when white labelling the RC App. 

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
No UI/UX changes and no dev flow changes. Flipper should work how it did previously.

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x ] Bugfix (non-breaking change which fixes an issue)
- [x ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ x] Lint and unit tests pass locally with my changes
- [x ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x ] I have added necessary documentation (if applicable)
- [x ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
