### PR TITLE
fix: error  'root' is defined but never used  no-unused-vars

### DIFF
--- a/app/stacks/OutsideStack.js
+++ b/app/stacks/OutsideStack.js
@@ -21,7 +21,7 @@ import AuthenticationWebView from '../views/AuthenticationWebView';
 
 // Outside
 const Outside = createStackNavigator();
-const _OutsideStack = ({ root }) => {
+const _OutsideStack = (/*{ root }*/) => {
 	const { theme } = React.useContext(ThemeContext);
 
 	return (


### PR DESCRIPTION
/workspace/Rocket.Chat.ReactNative/app/stacks/OutsideStack.js
  24:26  error  'root' is defined but never used  no-unused-vars

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
