### PR TITLE
[FIX] SanitizeLikeString util crashes for empty strings

### DIFF
--- a/app/lib/database/utils.js
+++ b/app/lib/database/utils.js
@@ -2,6 +2,6 @@ import XRegExp from 'xregexp';
 
 // Matches letters from any alphabet and numbers
 const likeStringRegex = new XRegExp('[^\\p{L}\\p{Nd}]', 'g');
-export const sanitizeLikeString = str => str.replace(likeStringRegex, '_');
+export const sanitizeLikeString = str => str?.replace(likeStringRegex, '_');
 
 export const sanitizer = r => r;

--- a/app/lib/database/utils.test.js
+++ b/app/lib/database/utils.test.js
@@ -4,8 +4,13 @@ import * as utils from './utils';
 describe('sanitizeLikeStringTester', () => {
 	// example chars that shouldn't return
 	const disallowedChars = ',./;[]!@#$%^&*()_-=+~';
-
 	const sanitizeLikeStringTester = str => expect(utils.sanitizeLikeString(`${ str }${ disallowedChars }`)).toBe(`${ str }${ '_'.repeat(disallowedChars.length) }`);
+
+	test('render empty', () => {
+		expect(utils.sanitizeLikeString(null)).toBe(undefined);
+		expect(utils.sanitizeLikeString('')).toBe('');
+		expect(utils.sanitizeLikeString(undefined)).toBe(undefined);
+	});
 
 	// Testing a couple of different alphabets
 	test('render test (latin)', () => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Login and logout from any server just to populate servers history
- Focus on NewServerView's input
- Nothing happens, because it trigger an error

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
