### PR TITLE
fix: Android push notification should appear as a heads-up notification

### DIFF
--- a/android/app/src/play/java/chat/rocket/reactnative/CustomPushNotification.java
+++ b/android/app/src/play/java/chat/rocket/reactnative/CustomPushNotification.java
@@ -213,9 +213,11 @@ public class CustomPushNotification extends PushNotification {
             String CHANNEL_ID = "rocketchatrn_channel_01";
             String CHANNEL_NAME = "All";
 
+            // User-visible importance level: Urgent - Makes a sound and appears as a heads-up notification
+            // https://developer.android.com/training/notify-user/channels#importance
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
                     CHANNEL_NAME,
-                    NotificationManager.IMPORTANCE_DEFAULT);
+                    NotificationManager.IMPORTANCE_HIGH);
 
             final NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
             notificationManager.createNotificationChannel(channel);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Android push notification should appear as a heads-up notification

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

As of 4.10.0, Rocket.Chat.ReactNative sets User-visible importance level to "Makes a sound", but does not show notification bubble. This should be changed to "Makes a sound and appears as a heads-up notification" as user expected with  instant messaging apps (including WhatsApp, Telegram, Slack, etc.).

Related to (has the same problem as) #1451. Also as the Android client-side of server-side https://github.com/RocketChat/push/pull/2 and https://github.com/RocketChat/Rocket.Chat/pull/19061

Note that this is only the default when first install, user still has freedom to change this level to their preference in Android per-app notification settings.

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Receive push notification
2. Observe there is no notification bubble

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
