### PR TITLE
[IMPROVEMENT] pinned and starred state messages is updated before API call and reverted if error occurs

### DIFF
--- a/app/containers/MessageActions/index.js
+++ b/app/containers/MessageActions/index.js
@@ -199,15 +199,15 @@ const MessageActions = React.memo(forwardRef(({
 					m.starred = !m.starred;
 				});
 			});
-			let result = await RocketChat.toggleStarMessage(message.id, !message.starred);
-			if(result.success == true){
-			EventEmitter.emit(LISTENER, { message: !message.starred ? I18n.t('Message_unstarred') : I18n.t('Message_starred') });
-			}else{
-					await db.action(async() => {
-						await message.update((m) => {
-							m.starred = !m.starred;
-						});
+			const result = await RocketChat.toggleStarMessage(message.id, !message.starred);
+			if (result.success === true) {
+				EventEmitter.emit(LISTENER, { message: !message.starred ? I18n.t('Message_unstarred') : I18n.t('Message_starred') });
+			} else {
+				await db.action(async() => {
+					await message.update((m) => {
+						m.starred = !m.starred;
 					});
+				});
 			}
 		} catch (e) {
 			logEvent(events.ROOM_MSG_ACTION_STAR_F);
@@ -224,8 +224,8 @@ const MessageActions = React.memo(forwardRef(({
 					m.pinned = !m.pinned;
 				});
 			});
-			let result = await RocketChat.togglePinMessage(message.id, !message.pinned);
-			if(result.success != true){
+			const result = await RocketChat.togglePinMessage(message.id, !message.pinned);
+			if (result.success !== true) {
 				await db.action(async() => {
 					await message.update((m) => {
 						m.pinned = !m.pinned;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Updates the state pinned and starred of the message in the local database before any API call happens and if error is returned, the changes are reverted back in local db.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#2324

## Screenshots
![Peek 2020-12-12 03-16](https://user-images.githubusercontent.com/58601732/101958127-b2bcad00-3c28-11eb-915f-024a05045c86.gif)
Pin and Star State is changed immediately.

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
In case of an error, we can show a Toast, so that the user can know and repeat his action.
