### PR TITLE
WIP [FIX] Mutual TLS without client cert (#2452)

### DIFF
--- a/patches/react-native-webview+10.3.2.patch
+++ b/patches/react-native-webview+10.3.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
-index ab869cf..2aa7a9e 100644
+index ab869cf..08ce7ce 100644
 --- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
 +++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
 @@ -84,6 +84,12 @@ import java.util.Map;
@@ -44,8 +44,8 @@ index ab869cf..2aa7a9e 100644
    }
  
    @Override
-@@ -742,12 +754,54 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
- 
+@@ -742,12 +754,56 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
+
    protected static class RNCWebViewClient extends WebViewClient {
  
 +    protected ReactContext reactContext;
@@ -93,6 +93,8 @@ index ab869cf..2aa7a9e 100644
 +          }
 +        };
 +        task.execute();
++      } else {
++         super.onReceivedClientCertRequest(view, request);
 +      }
 +    }
 +


### PR DESCRIPTION
## Proposed changes
Proceed request also when no certificate is configured but it is was requested by the server. Server should handle this situation, for example IDP server can return html login/password form instead of mutual TLS authentication. The majority of the codes on Android is doing that - https://www.programcreek.com/java-api-examples/?api=android.webkit.ClientCertRequest

## Issue(s)	
https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/2452

## How to test or reproduce

Configure SAML auth and set Custom Entry Point to `https://client.badssl.com/` - try auth with SAML without any cert:

Before: empty AuthenticationWebView (IDP site is not loaded)
<img src="https://user-images.githubusercontent.com/1182932/103950799-77cd6c80-5135-11eb-95c1-5dfa8088de03.png" width="200">

After: IDP page is loaded (there will be expected error page 400 in the `https://client.badssl.com/` case)
<img src="https://user-images.githubusercontent.com/1182932/104001050-01615680-5197-11eb-8b25-b57b61b5b5a5.png" width="200">

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
