### PR TITLE
[IMPROVEMENT] Applying SOLID and Clean Code on RoomInfoView

### DIFF
--- a/app/views/RoomInfoView/Components/Buttons/Button.js
+++ b/app/views/RoomInfoView/Components/Buttons/Button.js
@@ -1,0 +1,42 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { Text } from 'react-native';
+import { BorderlessButton } from 'react-native-gesture-handler';
+import { LISTENER } from '../../../../containers/Toast';
+import EventEmitter from '../../../../utils/events';
+import I18n from '../../../../i18n';
+import styles from '../styles';
+import { CustomIcon } from '../../../../lib/Icons';
+import { withTheme } from '../../../../theme';
+import { themes } from '../../../../constants/colors';
+
+const renderButton = ({
+	onPress, iconName, text, isDirect, createDirect, theme
+}) => {
+	const onActionPress = async() => {
+		try {
+			if (isDirect) {
+				await createDirect();
+			}
+			onPress();
+		} catch {
+			EventEmitter.emit(LISTENER, { message: I18n.t('error-action-not-allowed', { action: I18n.t('Create_Direct_Messages') }) });
+		}
+	};
+
+	return (
+		<BorderlessButton
+			onPress={onActionPress}
+			style={styles.roomButton}
+		>
+			<CustomIcon
+				name={iconName}
+				size={30}
+				color={themes[theme].actionTintColor}
+			/>
+			<Text style={[styles.roomButtonText, { color: themes[theme].actionTintColor }]}>{text}</Text>
+		</BorderlessButton>
+	);
+};
+
+export default withTheme(renderButton);

--- a/app/views/RoomInfoView/Components/Buttons/index.js
+++ b/app/views/RoomInfoView/Components/Buttons/index.js
@@ -1,0 +1,15 @@
+
+import React from 'react';
+import { View } from 'react-native';
+import renderButton from './Button';
+import styles from '../styles';
+import I18n from '../../../../i18n';
+
+const renderButtons = (isDirect, createDirect, jitsiEnabled, videoCall, goRoom) => (
+	<View style={styles.roomButtonsContainer}>
+		{renderButton(goRoom, 'message', I18n.t('Message'), isDirect, createDirect)}
+		{jitsiEnabled && isDirect ? renderButton(videoCall, 'camera', I18n.t('Video_call'), isDirect, createDirect) : null}
+	</View>
+);
+
+export default renderButtons;

--- a/app/views/RoomInfoView/Components/avatar.js
+++ b/app/views/RoomInfoView/Components/avatar.js
@@ -1,0 +1,31 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { View } from 'react-native';
+import Avatar from '../../../containers/Avatar';
+import Status from '../../../containers/Status';
+import { withTheme } from '../../../theme';
+import styles from './styles';
+import sharedStyles from '../../Styles';
+import { themes } from '../../../constants/colors';
+
+const renderAvatar = ({
+	room, roomUser, roomType, theme
+}) => (
+	<Avatar
+		text={room.name || roomUser?.username}
+		style={styles.avatar}
+		type={roomType}
+		size={100}
+		rid={room?.rid}
+	>
+		{roomType === 'd' && roomUser?._id
+			? (
+				<View style={[sharedStyles.status, { backgroundColor: themes[theme].auxiliaryBackground }]}>
+					<Status size={20} id={roomUser?._id} />
+				</View>
+			)
+			: null}
+	</Avatar>
+);
+
+export default withTheme(renderAvatar);

--- a/app/views/RoomInfoView/Components/content.js
+++ b/app/views/RoomInfoView/Components/content.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import Livechat from '../Livechat';
+import Channel from '../Channel';
+import Direct from '../Direct';
+
+const Content = (room, roomUser, theme, isDirect, type) => {
+	if (isDirect) {
+		return <Direct roomUser={roomUser} theme={theme} />;
+	} else if (type === 'l') {
+		return <Livechat room={room} roomUser={roomUser} theme={theme} />;
+	}
+	return <Channel room={room} theme={theme} />;
+};
+
+export default Content;

--- a/app/views/RoomInfoView/Components/header.js
+++ b/app/views/RoomInfoView/Components/header.js
@@ -1,0 +1,48 @@
+
+import React from 'react';
+import * as HeaderButton from '../../../containers/HeaderButton';
+import { logEvent, events } from '../../../utils/log';
+import I18n from '../../../i18n';
+
+const Header = (roomUser, room, showEdit, navigation, route) => {
+	const t = route.params?.t;
+	const rid = route.params?.rid;
+	const showCloseModal = route.params?.showCloseModal;
+	let headerLeft;
+
+	if (showCloseModal) {
+		headerLeft = <HeaderButton.CloseModal navigation={navigation} />;
+	}
+
+	let headerRight;
+
+	if (showEdit) {
+		headerRight = () => (
+			<HeaderButton.Container>
+				<HeaderButton.Item
+					iconName='edit'
+					onPress={() => {
+						const isLivechat = t === 'l';
+						logEvent(events[`RI_GO_${ isLivechat ? 'LIVECHAT' : 'RI' }_EDIT`]);
+						navigation.navigate(isLivechat ? 'LivechatEditView' : 'RoomInfoEditView', { rid, room, roomUser });
+					}}
+					testID='room-info-view-edit-button'
+				/>
+			</HeaderButton.Container>
+		);
+	}
+
+	let title = I18n.t('Room_Info');
+
+	if (t === 'd') {
+		title = I18n.t('User_Info');
+	}
+
+	navigation.setOptions({
+		headerLeft,
+		title,
+		headerRight
+	});
+};
+
+export default Header;

--- a/app/views/RoomInfoView/Components/roomTitle.js
+++ b/app/views/RoomInfoView/Components/roomTitle.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import RoomTypeIcon from '../../../containers/RoomTypeIcon';
+import { themes } from '../../../constants/colors';
+import Markdown from '../../../containers/markdown';
+import RocketChat from '../../../lib/rocketchat';
+import styles from './styles';
+
+export default (room, type, name, username, statusText, theme) => {
+	if (type === 'd') {
+		return (
+			<>
+				<Text testID='room-info-view-name' style={[styles.roomTitle, { color: themes[theme].titleText }]}>{ name }</Text>
+				{username && <Text testID='room-info-view-username' style={[styles.roomUsername, { color: themes[theme].auxiliaryText }]}>{`@${ username }`}</Text>}
+				{!!statusText && <View testID='room-info-view-custom-status'><Markdown msg={statusText} style={[styles.roomUsername, { color: themes[theme].auxiliaryText }]} preview theme={theme} /></View>}
+			</>
+		);
+	}
+
+	return (
+		<View style={styles.roomTitleRow}>
+			<RoomTypeIcon type={room.prid ? 'discussion' : room.t} key='room-info-type' status={room.visitor?.status} />
+			<Text testID='room-info-view-name' style={[styles.roomTitle, { color: themes[theme].titleText }]} key='room-info-name'>{RocketChat.getRoomTitle(room)}</Text>
+		</View>
+	);
+};

--- a/app/views/RoomInfoView/Components/styles.js
+++ b/app/views/RoomInfoView/Components/styles.js
@@ -1,0 +1,86 @@
+import { StyleSheet } from 'react-native';
+
+import sharedStyles from '../../Styles';
+
+export default StyleSheet.create({
+	container: {
+		flex: 1
+	},
+	scroll: {
+		flex: 1,
+		flexDirection: 'column'
+	},
+	item: {
+		paddingVertical: 10,
+		paddingHorizontal: 20,
+		justifyContent: 'center'
+	},
+	avatarContainer: {
+		minHeight: 320,
+		flexDirection: 'column',
+		alignItems: 'center',
+		justifyContent: 'center',
+		marginBottom: 20,
+		paddingVertical: 8
+	},
+	avatar: {
+		marginHorizontal: 10
+	},
+	roomTitleContainer: {
+		paddingTop: 20,
+		marginHorizontal: 16,
+		alignItems: 'center'
+	},
+	roomTitle: {
+		fontSize: 20,
+		...sharedStyles.textAlignCenter,
+		...sharedStyles.textMedium
+	},
+	roomUsername: {
+		fontSize: 18,
+		...sharedStyles.textAlignCenter,
+		...sharedStyles.textRegular
+	},
+	roomTitleRow: {
+		flexDirection: 'row',
+		alignItems: 'center'
+	},
+	itemLabel: {
+		marginBottom: 10,
+		fontSize: 14,
+		...sharedStyles.textMedium
+	},
+	itemContent: {
+		fontSize: 14,
+		...sharedStyles.textRegular
+	},
+	itemContent__empty: {
+		fontStyle: 'italic'
+	},
+	rolesContainer: {
+		flexDirection: 'row',
+		flexWrap: 'wrap'
+	},
+	roleBadge: {
+		padding: 6,
+		borderRadius: 2,
+		marginRight: 6,
+		marginBottom: 6
+	},
+	role: {
+		fontSize: 14,
+		...sharedStyles.textRegular
+	},
+	roomButtonsContainer: {
+		flexDirection: 'row',
+		paddingTop: 30
+	},
+	roomButton: {
+		alignItems: 'center',
+		paddingHorizontal: 20,
+		justifyContent: 'space-between'
+	},
+	roomButtonText: {
+		marginTop: 5
+	}
+});

--- a/app/views/RoomInfoView/Services/createDirect.js
+++ b/app/views/RoomInfoView/Services/createDirect.js
@@ -1,0 +1,27 @@
+import isEmpty from 'lodash/isEmpty';
+import RocketChat from '../../../lib/rocketchat';
+
+const createDirect = (setState, props) => new Promise(async(resolve, reject) => {
+	const { route } = props;
+
+	// We don't need to create a direct
+	const member = route.params?.member;
+	if (!isEmpty(member)) {
+		return resolve();
+	}
+
+	// TODO: Check if some direct with the user already exists on database
+	try {
+		const { roomUser: { username } } = this.state;
+		const result = await RocketChat.createDirectMessage(username);
+		if (result.success) {
+			const { room: { rid } } = result;
+			return setState(({ room }) => ({ room: { ...room, rid } }), resolve);
+		}
+	} catch {
+		// do nothing
+	}
+	reject();
+});
+
+export default createDirect;

--- a/app/views/RoomInfoView/Services/getRuleDescription.js
+++ b/app/views/RoomInfoView/Services/getRuleDescription.js
@@ -1,0 +1,17 @@
+import database from '../../../lib/database';
+
+const getRoleDescription = async(id) => {
+	const db = database.active;
+	try {
+		const rolesCollection = db.get('roles');
+		const role = await rolesCollection.find(id);
+		if (role) {
+			return role.description;
+		}
+		return null;
+	} catch (e) {
+		return null;
+	}
+};
+
+export default getRoleDescription;

--- a/app/views/RoomInfoView/Services/goRoom.js
+++ b/app/views/RoomInfoView/Services/goRoom.js
@@ -1,0 +1,38 @@
+import Navigation from '../../../lib/Navigation';
+import { logEvent, events } from '../../../utils/log';
+import RocketChat from '../../../lib/rocketchat';
+import { goRoom } from '../../../utils/goRoom';
+
+const goRoomService = (state, props) => {
+	logEvent(events.RI_GO_ROOM_USER);
+	const { roomUser, room } = state;
+	const { name, username } = roomUser;
+	const { rooms, navigation, isMasterDetail } = props;
+	const params = {
+		rid: room.rid,
+		name: RocketChat.getRoomTitle({
+			t: room.t,
+			fname: name,
+			name: username
+		}),
+		t: room.t,
+		roomUserId: RocketChat.getUidDirectMessage(room)
+	};
+
+	if (room.rid) {
+		// if it's on master detail layout, we close the modal and replace RoomView
+		if (isMasterDetail) {
+			Navigation.navigate('DrawerNavigator');
+			goRoom({ item: params, isMasterDetail });
+		} else {
+			let navigate = navigation.push;
+			// if this is a room focused
+			if (rooms.includes(room.rid)) {
+				({ navigate } = navigation);
+			}
+			navigate('RoomView', params);
+		}
+	}
+};
+
+export default goRoomService;

--- a/app/views/RoomInfoView/Services/loadRoom.js
+++ b/app/views/RoomInfoView/Services/loadRoom.js
@@ -1,0 +1,35 @@
+import RocketChat from '../../../lib/rocketchat';
+import log from '../../../utils/log';
+import setHeader from '../Components/header';
+
+
+const loadRoom = async(route, editRoomPermission, navigation, roomUser, roomState, showEdit, setState, rid) => {
+	let room = route.params?.room;
+
+	const permissions = await RocketChat.hasPermission([editRoomPermission], room.rid);
+	if (permissions[0] && !room.prid) {
+		setState({ showEdit: true }, () => setHeader(roomUser, roomState, showEdit, navigation, route));
+	}
+
+	if (room && room.observe) {
+		const roomObservable = room.observe();
+		return roomObservable
+			.subscribe((changes) => {
+				setState({ room: changes }, () => setHeader(roomUser, roomState, showEdit, navigation, route));
+			});
+	} else {
+		try {
+			const result = await RocketChat.getRoomInfo(rid);
+			if (result.success) {
+				({ room } = result);
+				setState({ room: { ...roomState, ...room } });
+			}
+		} catch (e) {
+			log(e);
+		}
+	}
+
+	return null;
+};
+
+export default loadRoom;

--- a/app/views/RoomInfoView/Services/loadUser.js
+++ b/app/views/RoomInfoView/Services/loadUser.js
@@ -1,0 +1,29 @@
+import isEmpty from 'lodash/isEmpty';
+import getRoleDescription from './getRuleDescription';
+import RocketChat from '../../../lib/rocketchat';
+
+const loadUser = async(room, roomUser) => {
+	if (isEmpty(roomUser)) {
+		try {
+			const roomUserId = RocketChat.getUidDirectMessage(room);
+			const result = await RocketChat.getUserInfo(roomUserId);
+			if (result.success) {
+				const { user } = result;
+				const { roles } = user;
+				if (roles && roles.length) {
+					user.parsedRoles = await Promise.all(roles.map(async(role) => {
+						const description = await getRoleDescription(role);
+						return description;
+					}));
+				}
+
+				return user;
+			}
+		} catch {
+			// do nothing
+		}
+	}
+};
+
+export default loadUser;
+

--- a/app/views/RoomInfoView/Services/loadVisitor.js
+++ b/app/views/RoomInfoView/Services/loadVisitor.js
@@ -1,0 +1,26 @@
+import UAParser from 'ua-parser-js';
+import setHeader from '../Components/header';
+import RocketChat from '../../../lib/rocketchat';
+
+const loadVisitor = async(state, props, setState) => {
+	const { roomUser, room, showEdit } = state;
+	const { navigation, route } = props;
+
+	try {
+		const result = await RocketChat.getVisitorInfo(room?.visitor?._id);
+		if (result.success) {
+			const { visitor } = result;
+			if (visitor.userAgent) {
+				const ua = new UAParser();
+				ua.setUA(visitor.userAgent);
+				visitor.os = `${ ua.getOS().name } ${ ua.getOS().version }`;
+				visitor.browser = `${ ua.getBrowser().name } ${ ua.getBrowser().version }`;
+			}
+			setState({ roomUser: visitor }, () => setHeader(roomUser, room, showEdit, navigation, route));
+		}
+	} catch (error) {
+		// Do nothing
+	}
+};
+
+export default loadVisitor;

--- a/app/views/RoomInfoView/index  (original).js
+++ b/app/views/RoomInfoView/index  (original).js
@@ -1,0 +1,384 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Text, ScrollView } from 'react-native';
+import { BorderlessButton } from 'react-native-gesture-handler';
+import { connect } from 'react-redux';
+import UAParser from 'ua-parser-js';
+import isEmpty from 'lodash/isEmpty';
+
+import database from '../../lib/database';
+import { CustomIcon } from '../../lib/Icons';
+import Status from '../../containers/Status';
+import Avatar from '../../containers/Avatar';
+import styles from './styles';
+import sharedStyles from '../Styles';
+import RocketChat from '../../lib/rocketchat';
+import RoomTypeIcon from '../../containers/RoomTypeIcon';
+import I18n from '../../i18n';
+import * as HeaderButton from '../../containers/HeaderButton';
+import StatusBar from '../../containers/StatusBar';
+import log, { logEvent, events } from '../../utils/log';
+import { themes } from '../../constants/colors';
+import { withTheme } from '../../theme';
+import Markdown from '../../containers/markdown';
+import { LISTENER } from '../../containers/Toast';
+import EventEmitter from '../../utils/events';
+
+import Livechat from './Livechat';
+import Channel from './Channel';
+import Direct from './Direct';
+import SafeAreaView from '../../containers/SafeAreaView';
+import { goRoom } from '../../utils/goRoom';
+import Navigation from '../../lib/Navigation';
+
+const getRoomTitle = (room, type, name, username, statusText, theme) => (type === 'd'
+	? (
+		<>
+			<Text testID='room-info-view-name' style={[styles.roomTitle, { color: themes[theme].titleText }]}>{ name }</Text>
+			{username && <Text testID='room-info-view-username' style={[styles.roomUsername, { color: themes[theme].auxiliaryText }]}>{`@${ username }`}</Text>}
+			{!!statusText && <View testID='room-info-view-custom-status'><Markdown msg={statusText} style={[styles.roomUsername, { color: themes[theme].auxiliaryText }]} preview theme={theme} /></View>}
+		</>
+	)
+	: (
+		<View style={styles.roomTitleRow}>
+			<RoomTypeIcon type={room.prid ? 'discussion' : room.t} key='room-info-type' status={room.visitor?.status} />
+			<Text testID='room-info-view-name' style={[styles.roomTitle, { color: themes[theme].titleText }]} key='room-info-name'>{RocketChat.getRoomTitle(room)}</Text>
+		</View>
+	)
+);
+
+class RoomInfoView extends React.Component {
+	static propTypes = {
+		navigation: PropTypes.object,
+		route: PropTypes.object,
+		rooms: PropTypes.array,
+		theme: PropTypes.string,
+		isMasterDetail: PropTypes.bool,
+		jitsiEnabled: PropTypes.bool,
+		editRoomPermission: PropTypes.array
+	}
+
+	constructor(props) {
+		super(props);
+		const room = props.route.params?.room;
+		const roomUser = props.route.params?.member;
+		this.rid = props.route.params?.rid;
+		this.t = props.route.params?.t;
+		this.state = {
+			room: room || { rid: this.rid, t: this.t },
+			roomUser: roomUser || {},
+			showEdit: false
+		};
+	}
+
+	componentDidMount() {
+		if (this.isDirect) {
+			this.loadUser();
+		} else {
+			this.loadRoom();
+		}
+		this.setHeader();
+
+		const { navigation } = this.props;
+		this.unsubscribeFocus = navigation.addListener('focus', () => {
+			if (this.isLivechat) {
+				this.loadVisitor();
+			}
+		});
+	}
+
+	componentWillUnmount() {
+		if (this.subscription && this.subscription.unsubscribe) {
+			this.subscription.unsubscribe();
+		}
+		if (this.unsubscribeFocus) {
+			this.unsubscribeFocus();
+		}
+	}
+
+	setHeader = () => {
+		const { roomUser, room, showEdit } = this.state;
+		const { navigation, route } = this.props;
+		const t = route.params?.t;
+		const rid = route.params?.rid;
+		const showCloseModal = route.params?.showCloseModal;
+		navigation.setOptions({
+			headerLeft: showCloseModal ? () => <HeaderButton.CloseModal navigation={navigation} /> : undefined,
+			title: t === 'd' ? I18n.t('User_Info') : I18n.t('Room_Info'),
+			headerRight: showEdit
+				? () => (
+					<HeaderButton.Container>
+						<HeaderButton.Item
+							iconName='edit'
+							onPress={() => {
+								const isLivechat = t === 'l';
+								logEvent(events[`RI_GO_${ isLivechat ? 'LIVECHAT' : 'RI' }_EDIT`]);
+								navigation.navigate(isLivechat ? 'LivechatEditView' : 'RoomInfoEditView', { rid, room, roomUser });
+							}}
+							testID='room-info-view-edit-button'
+						/>
+					</HeaderButton.Container>
+				)
+				: null
+		});
+	}
+
+	get isDirect() {
+		const { room } = this.state;
+		return room.t === 'd';
+	}
+
+	get isLivechat() {
+		const { room } = this.state;
+		return room.t === 'l';
+	}
+
+	getRoleDescription = async(id) => {
+		const db = database.active;
+		try {
+			const rolesCollection = db.get('roles');
+			const role = await rolesCollection.find(id);
+			if (role) {
+				return role.description;
+			}
+			return null;
+		} catch (e) {
+			return null;
+		}
+	};
+
+	loadVisitor = async() => {
+		const { room } = this.state;
+		try {
+			const result = await RocketChat.getVisitorInfo(room?.visitor?._id);
+			if (result.success) {
+				const { visitor } = result;
+				if (visitor.userAgent) {
+					const ua = new UAParser();
+					ua.setUA(visitor.userAgent);
+					visitor.os = `${ ua.getOS().name } ${ ua.getOS().version }`;
+					visitor.browser = `${ ua.getBrowser().name } ${ ua.getBrowser().version }`;
+				}
+				this.setState({ roomUser: visitor }, () => this.setHeader());
+			}
+		} catch (error) {
+			// Do nothing
+		}
+	}
+
+	loadUser = async() => {
+		const { room, roomUser } = this.state;
+
+		if (isEmpty(roomUser)) {
+			try {
+				const roomUserId = RocketChat.getUidDirectMessage(room);
+				const result = await RocketChat.getUserInfo(roomUserId);
+				if (result.success) {
+					const { user } = result;
+					const { roles } = user;
+					if (roles && roles.length) {
+						user.parsedRoles = await Promise.all(roles.map(async(role) => {
+							const description = await this.getRoleDescription(role);
+							return description;
+						}));
+					}
+
+					this.setState({ roomUser: user });
+				}
+			} catch {
+				// do nothing
+			}
+		}
+	}
+
+	loadRoom = async() => {
+		const { room: roomState } = this.state;
+		const { route, editRoomPermission } = this.props;
+		let room = route.params?.room;
+		if (room && room.observe) {
+			this.roomObservable = room.observe();
+			this.subscription = this.roomObservable
+				.subscribe((changes) => {
+					this.setState({ room: changes }, () => this.setHeader());
+				});
+		} else {
+			try {
+				const result = await RocketChat.getRoomInfo(this.rid);
+				if (result.success) {
+					({ room } = result);
+					this.setState({ room: { ...roomState, ...room } });
+				}
+			} catch (e) {
+				log(e);
+			}
+		}
+
+		const permissions = await RocketChat.hasPermission([editRoomPermission], room.rid);
+		if (permissions[0] && !room.prid) {
+			this.setState({ showEdit: true }, () => this.setHeader());
+		}
+	}
+
+	createDirect = () => new Promise(async(resolve, reject) => {
+		const { route } = this.props;
+
+		// We don't need to create a direct
+		const member = route.params?.member;
+		if (!isEmpty(member)) {
+			return resolve();
+		}
+
+		// TODO: Check if some direct with the user already exists on database
+		try {
+			const { roomUser: { username } } = this.state;
+			const result = await RocketChat.createDirectMessage(username);
+			if (result.success) {
+				const { room: { rid } } = result;
+				return this.setState(({ room }) => ({ room: { ...room, rid } }), resolve);
+			}
+		} catch {
+			// do nothing
+		}
+		reject();
+	})
+
+	goRoom = () => {
+		logEvent(events.RI_GO_ROOM_USER);
+		const { roomUser, room } = this.state;
+		const { name, username } = roomUser;
+		const { rooms, navigation, isMasterDetail } = this.props;
+		const params = {
+			rid: room.rid,
+			name: RocketChat.getRoomTitle({
+				t: room.t,
+				fname: name,
+				name: username
+			}),
+			t: room.t,
+			roomUserId: RocketChat.getUidDirectMessage(room)
+		};
+
+		if (room.rid) {
+			// if it's on master detail layout, we close the modal and replace RoomView
+			if (isMasterDetail) {
+				Navigation.navigate('DrawerNavigator');
+				goRoom({ item: params, isMasterDetail });
+			} else {
+				let navigate = navigation.push;
+				// if this is a room focused
+				if (rooms.includes(room.rid)) {
+					({ navigate } = navigation);
+				}
+				navigate('RoomView', params);
+			}
+		}
+	}
+
+	videoCall = () => {
+		const { room } = this.state;
+		RocketChat.callJitsi(room);
+	}
+
+	renderAvatar = (room, roomUser) => {
+		const { theme } = this.props;
+
+		return (
+			<Avatar
+				text={room.name || roomUser.username}
+				style={styles.avatar}
+				type={this.t}
+				size={100}
+				rid={room?.rid}
+			>
+				{this.t === 'd' && roomUser._id
+					? (
+						<View style={[sharedStyles.status, { backgroundColor: themes[theme].auxiliaryBackground }]}>
+							<Status size={20} id={roomUser._id} />
+						</View>
+					)
+					: null}
+			</Avatar>
+		);
+	}
+
+	renderButton = (onPress, iconName, text) => {
+		const { theme } = this.props;
+
+		const onActionPress = async() => {
+			try {
+				if (this.isDirect) {
+					await this.createDirect();
+				}
+				onPress();
+			} catch {
+				EventEmitter.emit(LISTENER, { message: I18n.t('error-action-not-allowed', { action: I18n.t('Create_Direct_Messages') }) });
+			}
+		};
+
+		return (
+			<BorderlessButton
+				onPress={onActionPress}
+				style={styles.roomButton}
+			>
+				<CustomIcon
+					name={iconName}
+					size={30}
+					color={themes[theme].actionTintColor}
+				/>
+				<Text style={[styles.roomButtonText, { color: themes[theme].actionTintColor }]}>{text}</Text>
+			</BorderlessButton>
+		);
+	}
+
+	renderButtons = () => {
+		const { jitsiEnabled } = this.props;
+		return (
+			<View style={styles.roomButtonsContainer}>
+				{this.renderButton(this.goRoom, 'message', I18n.t('Message'))}
+				{jitsiEnabled && this.isDirect ? this.renderButton(this.videoCall, 'camera', I18n.t('Video_call')) : null}
+			</View>
+		);
+	}
+
+	renderContent = () => {
+		const { room, roomUser } = this.state;
+		const { theme } = this.props;
+
+		if (this.isDirect) {
+			return <Direct roomUser={roomUser} theme={theme} />;
+		} else if (this.t === 'l') {
+			return <Livechat room={room} roomUser={roomUser} theme={theme} />;
+		}
+		return <Channel room={room} theme={theme} />;
+	}
+
+	render() {
+		const { room, roomUser } = this.state;
+		const { theme } = this.props;
+		return (
+			<ScrollView style={[styles.scroll, { backgroundColor: themes[theme].backgroundColor }]}>
+				<StatusBar />
+				<SafeAreaView
+					style={{ backgroundColor: themes[theme].backgroundColor }}
+					testID='room-info-view'
+				>
+					<View style={[styles.avatarContainer, { backgroundColor: themes[theme].auxiliaryBackground }]}>
+						{this.renderAvatar(room, roomUser)}
+						<View style={styles.roomTitleContainer}>{ getRoomTitle(room, this.t, roomUser?.name, roomUser?.username, roomUser?.statusText, theme) }</View>
+						{this.renderButtons()}
+					</View>
+					{this.renderContent()}
+				</SafeAreaView>
+			</ScrollView>
+		);
+	}
+}
+
+const mapStateToProps = state => ({
+	rooms: state.room.rooms,
+	isMasterDetail: state.app.isMasterDetail,
+	jitsiEnabled: state.settings.Jitsi_Enabled || false,
+	editRoomPermission: state.permissions['edit-room']
+});
+
+export default connect(mapStateToProps)(withTheme(RoomInfoView));

--- a/app/views/RoomInfoView/index.js
+++ b/app/views/RoomInfoView/index.js
@@ -1,63 +1,28 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/no-unused-prop-types */
 import React from 'react';
-import PropTypes from 'prop-types';
-import { View, Text, ScrollView } from 'react-native';
-import { BorderlessButton } from 'react-native-gesture-handler';
-import { connect } from 'react-redux';
-import UAParser from 'ua-parser-js';
-import isEmpty from 'lodash/isEmpty';
+import { View, ScrollView } from 'react-native';
 
-import database from '../../lib/database';
-import { CustomIcon } from '../../lib/Icons';
-import Status from '../../containers/Status';
-import Avatar from '../../containers/Avatar';
+import { connect } from 'react-redux';
 import styles from './styles';
-import sharedStyles from '../Styles';
 import RocketChat from '../../lib/rocketchat';
-import RoomTypeIcon from '../../containers/RoomTypeIcon';
-import I18n from '../../i18n';
-import * as HeaderButton from '../../containers/HeaderButton';
+
 import StatusBar from '../../containers/StatusBar';
-import log, { logEvent, events } from '../../utils/log';
 import { themes } from '../../constants/colors';
 import { withTheme } from '../../theme';
-import Markdown from '../../containers/markdown';
-import { LISTENER } from '../../containers/Toast';
-import EventEmitter from '../../utils/events';
 
-import Livechat from './Livechat';
-import Channel from './Channel';
-import Direct from './Direct';
 import SafeAreaView from '../../containers/SafeAreaView';
-import { goRoom } from '../../utils/goRoom';
-import Navigation from '../../lib/Navigation';
-
-const getRoomTitle = (room, type, name, username, statusText, theme) => (type === 'd'
-	? (
-		<>
-			<Text testID='room-info-view-name' style={[styles.roomTitle, { color: themes[theme].titleText }]}>{ name }</Text>
-			{username && <Text testID='room-info-view-username' style={[styles.roomUsername, { color: themes[theme].auxiliaryText }]}>{`@${ username }`}</Text>}
-			{!!statusText && <View testID='room-info-view-custom-status'><Markdown msg={statusText} style={[styles.roomUsername, { color: themes[theme].auxiliaryText }]} preview theme={theme} /></View>}
-		</>
-	)
-	: (
-		<View style={styles.roomTitleRow}>
-			<RoomTypeIcon type={room.prid ? 'discussion' : room.t} key='room-info-type' status={room.visitor?.status} />
-			<Text testID='room-info-view-name' style={[styles.roomTitle, { color: themes[theme].titleText }]} key='room-info-name'>{RocketChat.getRoomTitle(room)}</Text>
-		</View>
-	)
-);
+import getRoomTitle from './Components/roomTitle';
+import setHeader from './Components/header';
+import renderContent from './Components/content';
+import renderButtons from './Components/Buttons';
+import loadUser from './Services/loadUser';
+import goRoom from './Services/goRoom';
+import Avatar from './Components/avatar';
+import createDirect from './Services/createDirect';
+import loadVisitor from './Services/loadVisitor';
 
 class RoomInfoView extends React.Component {
-	static propTypes = {
-		navigation: PropTypes.object,
-		route: PropTypes.object,
-		rooms: PropTypes.array,
-		theme: PropTypes.string,
-		isMasterDetail: PropTypes.bool,
-		jitsiEnabled: PropTypes.bool,
-		editRoomPermission: PropTypes.array
-	}
-
 	constructor(props) {
 		super(props);
 		const room = props.route.params?.room;
@@ -71,18 +36,20 @@ class RoomInfoView extends React.Component {
 		};
 	}
 
-	componentDidMount() {
+	async componentDidMount() {
+		const { roomUser, room, showEdit } = this.state;
+		const { navigation, route, editRoomPermission } = this.props;
 		if (this.isDirect) {
-			this.loadUser();
+			this.setState({ roomUser: await loadUser(room, roomUser) });
 		} else {
-			this.loadRoom();
+			this.subscription = this.loadRoom(route, editRoomPermission, navigation, roomUser, room, showEdit, this.setState, this.rid);
 		}
-		this.setHeader();
 
-		const { navigation } = this.props;
+		setHeader(roomUser, room, showEdit, navigation, route);
+
 		this.unsubscribeFocus = navigation.addListener('focus', () => {
 			if (this.isLivechat) {
-				this.loadVisitor();
+				loadVisitor(this.state, this.props, this.setState);
 			}
 		});
 	}
@@ -96,33 +63,6 @@ class RoomInfoView extends React.Component {
 		}
 	}
 
-	setHeader = () => {
-		const { roomUser, room, showEdit } = this.state;
-		const { navigation, route } = this.props;
-		const t = route.params?.t;
-		const rid = route.params?.rid;
-		const showCloseModal = route.params?.showCloseModal;
-		navigation.setOptions({
-			headerLeft: showCloseModal ? () => <HeaderButton.CloseModal navigation={navigation} /> : undefined,
-			title: t === 'd' ? I18n.t('User_Info') : I18n.t('Room_Info'),
-			headerRight: showEdit
-				? () => (
-					<HeaderButton.Container>
-						<HeaderButton.Item
-							iconName='edit'
-							onPress={() => {
-								const isLivechat = t === 'l';
-								logEvent(events[`RI_GO_${ isLivechat ? 'LIVECHAT' : 'RI' }_EDIT`]);
-								navigation.navigate(isLivechat ? 'LivechatEditView' : 'RoomInfoEditView', { rid, room, roomUser });
-							}}
-							testID='room-info-view-edit-button'
-						/>
-					</HeaderButton.Container>
-				)
-				: null
-		});
-	}
-
 	get isDirect() {
 		const { room } = this.state;
 		return room.t === 'd';
@@ -133,228 +73,9 @@ class RoomInfoView extends React.Component {
 		return room.t === 'l';
 	}
 
-	getRoleDescription = async(id) => {
-		const db = database.active;
-		try {
-			const rolesCollection = db.get('roles');
-			const role = await rolesCollection.find(id);
-			if (role) {
-				return role.description;
-			}
-			return null;
-		} catch (e) {
-			return null;
-		}
-	};
-
-	loadVisitor = async() => {
-		const { room } = this.state;
-		try {
-			const result = await RocketChat.getVisitorInfo(room?.visitor?._id);
-			if (result.success) {
-				const { visitor } = result;
-				if (visitor.userAgent) {
-					const ua = new UAParser();
-					ua.setUA(visitor.userAgent);
-					visitor.os = `${ ua.getOS().name } ${ ua.getOS().version }`;
-					visitor.browser = `${ ua.getBrowser().name } ${ ua.getBrowser().version }`;
-				}
-				this.setState({ roomUser: visitor }, () => this.setHeader());
-			}
-		} catch (error) {
-			// Do nothing
-		}
-	}
-
-	loadUser = async() => {
-		const { room, roomUser } = this.state;
-
-		if (isEmpty(roomUser)) {
-			try {
-				const roomUserId = RocketChat.getUidDirectMessage(room);
-				const result = await RocketChat.getUserInfo(roomUserId);
-				if (result.success) {
-					const { user } = result;
-					const { roles } = user;
-					if (roles && roles.length) {
-						user.parsedRoles = await Promise.all(roles.map(async(role) => {
-							const description = await this.getRoleDescription(role);
-							return description;
-						}));
-					}
-
-					this.setState({ roomUser: user });
-				}
-			} catch {
-				// do nothing
-			}
-		}
-	}
-
-	loadRoom = async() => {
-		const { room: roomState } = this.state;
-		const { route, editRoomPermission } = this.props;
-		let room = route.params?.room;
-		if (room && room.observe) {
-			this.roomObservable = room.observe();
-			this.subscription = this.roomObservable
-				.subscribe((changes) => {
-					this.setState({ room: changes }, () => this.setHeader());
-				});
-		} else {
-			try {
-				const result = await RocketChat.getRoomInfo(this.rid);
-				if (result.success) {
-					({ room } = result);
-					this.setState({ room: { ...roomState, ...room } });
-				}
-			} catch (e) {
-				log(e);
-			}
-		}
-
-		const permissions = await RocketChat.hasPermission([editRoomPermission], room.rid);
-		if (permissions[0] && !room.prid) {
-			this.setState({ showEdit: true }, () => this.setHeader());
-		}
-	}
-
-	createDirect = () => new Promise(async(resolve, reject) => {
-		const { route } = this.props;
-
-		// We don't need to create a direct
-		const member = route.params?.member;
-		if (!isEmpty(member)) {
-			return resolve();
-		}
-
-		// TODO: Check if some direct with the user already exists on database
-		try {
-			const { roomUser: { username } } = this.state;
-			const result = await RocketChat.createDirectMessage(username);
-			if (result.success) {
-				const { room: { rid } } = result;
-				return this.setState(({ room }) => ({ room: { ...room, rid } }), resolve);
-			}
-		} catch {
-			// do nothing
-		}
-		reject();
-	})
-
-	goRoom = () => {
-		logEvent(events.RI_GO_ROOM_USER);
-		const { roomUser, room } = this.state;
-		const { name, username } = roomUser;
-		const { rooms, navigation, isMasterDetail } = this.props;
-		const params = {
-			rid: room.rid,
-			name: RocketChat.getRoomTitle({
-				t: room.t,
-				fname: name,
-				name: username
-			}),
-			t: room.t,
-			roomUserId: RocketChat.getUidDirectMessage(room)
-		};
-
-		if (room.rid) {
-			// if it's on master detail layout, we close the modal and replace RoomView
-			if (isMasterDetail) {
-				Navigation.navigate('DrawerNavigator');
-				goRoom({ item: params, isMasterDetail });
-			} else {
-				let navigate = navigation.push;
-				// if this is a room focused
-				if (rooms.includes(room.rid)) {
-					({ navigate } = navigation);
-				}
-				navigate('RoomView', params);
-			}
-		}
-	}
-
-	videoCall = () => {
-		const { room } = this.state;
-		RocketChat.callJitsi(room);
-	}
-
-	renderAvatar = (room, roomUser) => {
-		const { theme } = this.props;
-
-		return (
-			<Avatar
-				text={room.name || roomUser.username}
-				style={styles.avatar}
-				type={this.t}
-				size={100}
-				rid={room?.rid}
-			>
-				{this.t === 'd' && roomUser._id
-					? (
-						<View style={[sharedStyles.status, { backgroundColor: themes[theme].auxiliaryBackground }]}>
-							<Status size={20} id={roomUser._id} />
-						</View>
-					)
-					: null}
-			</Avatar>
-		);
-	}
-
-	renderButton = (onPress, iconName, text) => {
-		const { theme } = this.props;
-
-		const onActionPress = async() => {
-			try {
-				if (this.isDirect) {
-					await this.createDirect();
-				}
-				onPress();
-			} catch {
-				EventEmitter.emit(LISTENER, { message: I18n.t('error-action-not-allowed', { action: I18n.t('Create_Direct_Messages') }) });
-			}
-		};
-
-		return (
-			<BorderlessButton
-				onPress={onActionPress}
-				style={styles.roomButton}
-			>
-				<CustomIcon
-					name={iconName}
-					size={30}
-					color={themes[theme].actionTintColor}
-				/>
-				<Text style={[styles.roomButtonText, { color: themes[theme].actionTintColor }]}>{text}</Text>
-			</BorderlessButton>
-		);
-	}
-
-	renderButtons = () => {
-		const { jitsiEnabled } = this.props;
-		return (
-			<View style={styles.roomButtonsContainer}>
-				{this.renderButton(this.goRoom, 'message', I18n.t('Message'))}
-				{jitsiEnabled && this.isDirect ? this.renderButton(this.videoCall, 'camera', I18n.t('Video_call')) : null}
-			</View>
-		);
-	}
-
-	renderContent = () => {
-		const { room, roomUser } = this.state;
-		const { theme } = this.props;
-
-		if (this.isDirect) {
-			return <Direct roomUser={roomUser} theme={theme} />;
-		} else if (this.t === 'l') {
-			return <Livechat room={room} roomUser={roomUser} theme={theme} />;
-		}
-		return <Channel room={room} theme={theme} />;
-	}
-
 	render() {
 		const { room, roomUser } = this.state;
-		const { theme } = this.props;
+		const { theme, jitsiEnabled } = this.props;
 		return (
 			<ScrollView style={[styles.scroll, { backgroundColor: themes[theme].backgroundColor }]}>
 				<StatusBar />
@@ -363,11 +84,11 @@ class RoomInfoView extends React.Component {
 					testID='room-info-view'
 				>
 					<View style={[styles.avatarContainer, { backgroundColor: themes[theme].auxiliaryBackground }]}>
-						{this.renderAvatar(room, roomUser)}
+						<Avatar room={room} roomUser={roomUser} roomType={this.t} />
 						<View style={styles.roomTitleContainer}>{ getRoomTitle(room, this.t, roomUser?.name, roomUser?.username, roomUser?.statusText, theme) }</View>
-						{this.renderButtons()}
+						{renderButtons(this.isDirect, () => createDirect(this.setState, this.props), jitsiEnabled, () => RocketChat.callJitsi(room), () => goRoom(this.state, this.props))}
 					</View>
-					{this.renderContent()}
+					{renderContent(room, roomUser, theme)}
 				</SafeAreaView>
 			</ScrollView>
 		);


### PR DESCRIPTION
Signed-off-by: Guilherme Deusdará <guibanci@gmail.com>

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Refactor RoomInfoView.js using Solid and Clean Code principles

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
This is not testable. Coding changes only

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

