### PR TITLE
[REGRESSION] Fallback not working when device's language is available

### DIFF
--- a/app/i18n/index.js
+++ b/app/i18n/index.js
@@ -95,6 +95,7 @@ export const setLanguage = (l) => {
 	moment.locale(toMomentLocale(locale));
 };
 
+i18n.translations = { en: translations.en?.() };
 const defaultLanguage = { languageTag: 'en', isRTL: false };
 const availableLanguages = Object.keys(translations);
 const { languageTag } = RNLocalize.findBestAvailableLanguage(availableLanguages) || defaultLanguage;

--- a/app/i18n/locales/nl.json
+++ b/app/i18n/locales/nl.json
@@ -123,7 +123,6 @@
   "creating_invite": "uitnodiging maken",
   "Channel_Name": "Kanaal Name",
   "Channels": "Kanalen",
-  "Chats": "Chats",
   "Call_already_ended": "Gesprek al beeïndigd!",
   "Click_to_join": "Klik om lid te worden!",
   "Close": "Sluiten",

--- a/e2e/tests/assorted/04-setting.spec.js
+++ b/e2e/tests/assorted/04-setting.spec.js
@@ -63,19 +63,6 @@ describe('Settings screen', () => {
 	});
 
 	describe('Usage', async() => {
-		it('should navigate to language view', async() => {
-			await element(by.id('settings-view-language')).tap();
-			await waitFor(element(by.id('language-view'))).toBeVisible().withTimeout(60000);
-			await expect(element(by.id('language-view-zh-CN'))).toExist();
-			await expect(element(by.id('language-view-de'))).toExist();
-			await expect(element(by.id('language-view-en'))).toExist();
-			await expect(element(by.id('language-view-fr'))).toExist();
-			await expect(element(by.id('language-view-pt-BR'))).toExist();
-			await expect(element(by.id('language-view-pt-PT'))).toExist();
-			await expect(element(by.id('language-view-ru'))).toExist();
-			await tapBack();
-		});
-	
 		it('should tap clear cache and navigate to roomslistview', async() => {
 			await waitFor(element(by.id('settings-view'))).toBeVisible().withTimeout(2000);
 			await element(by.id('settings-view-clear-cache')).tap();

--- a/e2e/tests/assorted/12-i18n.spec.js
+++ b/e2e/tests/assorted/12-i18n.spec.js
@@ -1,0 +1,114 @@
+const {
+	device, element, by, waitFor
+} = require('detox');
+const { navigateToLogin, login, sleep } = require('../../helpers/app');
+const { post } = require('../../helpers/data_setup');
+
+const data = require('../../data');
+const testuser = data.users.regular
+const defaultLaunchArgs = { permissions: { notifications: 'YES' } };
+
+const navToLanguage = async() => {
+	await waitFor(element(by.id('rooms-list-view'))).toBeVisible().withTimeout(10000);
+	await element(by.id('rooms-list-view-sidebar')).tap();
+	await waitFor(element(by.id('sidebar-view'))).toBeVisible().withTimeout(2000);
+	await waitFor(element(by.id('sidebar-settings'))).toBeVisible().withTimeout(2000);
+	await element(by.id('sidebar-settings')).tap();
+	await waitFor(element(by.id('settings-view'))).toBeVisible().withTimeout(2000);
+	await element(by.id('settings-view-language')).tap();
+	await waitFor(element(by.id('language-view'))).toBeVisible().withTimeout(10000);
+};
+
+describe('i18n', () => {
+	describe('OS language', () => {
+		it('OS set to \'en\' and proper translate to \'en\'', async() => {
+			await device.launchApp({
+				...defaultLaunchArgs,
+				languageAndLocale: {
+					language: "en",
+					locale: "en"
+				},
+				delete: true
+			});
+			await waitFor(element(by.id('onboarding-view'))).toBeVisible().withTimeout(20000);
+			await expect(element(by.id('join-workspace').and(by.label('Join a workspace')))).toBeVisible();
+			await expect(element(by.id('create-workspace-button').and(by.label('Create a new workspace')))).toBeVisible();
+		});
+	
+		it('OS set to unavailable language and fallback to \'en\'', async() => {
+			await device.launchApp({
+				...defaultLaunchArgs,
+				languageAndLocale: {
+					language: "es-MX",
+					locale: "es-MX"
+				}
+			});
+			await waitFor(element(by.id('onboarding-view'))).toBeVisible().withTimeout(20000);
+			await expect(element(by.id('join-workspace').and(by.label('Join a workspace')))).toBeVisible();
+			await expect(element(by.id('create-workspace-button').and(by.label('Create a new workspace')))).toBeVisible();
+		});
+	
+		/**
+		 * This test might become outdated as soon as we support the language
+		 * Although this seems to be a bad approach, that's the intention for having fallback enabled
+		 */
+		it('OS set to available language and fallback to \'en\' on strings missing translation', async() => {
+			await device.launchApp({
+				...defaultLaunchArgs,
+				languageAndLocale: {
+					language: "nl",
+					locale: "nl"
+				}
+			});
+			await waitFor(element(by.id('onboarding-view'))).toBeVisible().withTimeout(20000);
+			await expect(element(by.id('join-workspace').and(by.label('Join a workspace')))).toBeVisible(); // Missing nl translation
+			await expect(element(by.id('create-workspace-button').and(by.label('Een nieuwe workspace maken')))).toBeVisible();
+		});
+	});
+
+	describe('Rocket.Chat language', () => {
+		before(async() => {
+			await device.launchApp(defaultLaunchArgs);
+			await navigateToLogin();
+			await login(testuser.username, testuser.password);
+		});
+
+		it('should select \'en\'', async() => {
+			await navToLanguage();
+			await element(by.id('language-view-en')).tap();
+			await waitFor(element(by.id('rooms-list-view'))).toBeVisible().withTimeout(10000);
+			await element(by.id('rooms-list-view-sidebar')).tap();
+			await waitFor(element(by.id('sidebar-view'))).toBeVisible().withTimeout(2000);
+			await expect(element(by.id('sidebar-chats').withDescendant(by.label('Chats')))).toBeVisible();
+			await expect(element(by.id('sidebar-profile').withDescendant(by.label('Profile')))).toBeVisible();
+			await expect(element(by.id('sidebar-settings').withDescendant(by.label('Settings')))).toBeVisible();
+			await element(by.id('sidebar-close-drawer')).tap();
+		});
+
+		it('should select \'nl\' and fallback to \'en\'', async() => {
+			await navToLanguage();
+			await element(by.id('language-view-nl')).tap();
+			await waitFor(element(by.id('rooms-list-view'))).toBeVisible().withTimeout(10000);
+			await element(by.id('rooms-list-view-sidebar')).tap();
+			await waitFor(element(by.id('sidebar-view'))).toBeVisible().withTimeout(2000);
+			await expect(element(by.id('sidebar-chats').withDescendant(by.label('Chats')))).toBeVisible(); // fallback to en
+			await expect(element(by.id('sidebar-profile').withDescendant(by.label('Profiel')))).toBeVisible();
+			await expect(element(by.id('sidebar-settings').withDescendant(by.label('Instellingen')))).toBeVisible();
+			await element(by.id('sidebar-close-drawer')).tap();
+		});
+
+		it('should set unsupported language and fallback to \'en\'', async() => {
+			await post('users.setPreferences', { data: { language: 'eo' } }); // Set language to Esperanto
+			await device.launchApp(defaultLaunchArgs);
+			await waitFor(element(by.id('rooms-list-view'))).toBeVisible().withTimeout(10000);
+			await element(by.id('rooms-list-view-sidebar')).tap();
+			await waitFor(element(by.id('sidebar-view'))).toBeVisible().withTimeout(2000);
+			// give the app some time to apply new language
+			await sleep(3000);
+			await expect(element(by.id('sidebar-chats').withDescendant(by.label('Chats')))).toBeVisible();
+			await expect(element(by.id('sidebar-profile').withDescendant(by.label('Profile')))).toBeVisible();
+			await expect(element(by.id('sidebar-settings').withDescendant(by.label('Settings')))).toBeVisible();
+			await post('users.setPreferences', { data: { language: 'en' } }); // Set back to english
+		});
+	})
+});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Adds `en` language by default to `i18n` object.
Added e2e tests to make sure we don't have such regressions anymore.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes #3087 

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
