### PR TITLE
[Fix] build fail because of OpenSSL 1.1.x and RSA issue.  Issue. no 3…

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -7,7 +7,7 @@ def all_pods
   config = use_native_modules!
   use_unimodules!
   use_react_native!(:path => config["reactNativePath"])
-  use_flipper!
+  use_flipper!({ 'Flipper-Folly' => '2.2.0' }) 
 end
 
 abstract_target 'defaults' do


### PR DESCRIPTION
Fixed the issue 
1. iOS issue with RSA and Build fail with OpenSSL 1.1.x. Tested on Xcode 12.4. 