### PR TITLE
[FIX] Discussion preview

### DIFF
--- a/app/views/RoomView/index.js
+++ b/app/views/RoomView/index.js
@@ -636,7 +636,7 @@ class RoomView extends React.Component {
 	onDiscussionPress = debounce((item) => {
 		const { navigation } = this.props;
 		navigation.push('RoomView', {
-			rid: item.drid, prid: item.rid, name: item.msg, t: 'p'
+			rid: item.drid, prid: item.rid, name: item.msg, t: this.t
 		});
 	}, 1000, true)
 


### PR DESCRIPTION
discussion preview was not working for discussions in open channel, because room type was passed as private. 
before:
![Simulator Screen Shot - iPhone 12 - 2021-08-31 at 22 19 03](https://user-images.githubusercontent.com/60778000/131544597-a6bbe9ec-01ec-4c15-8fe9-70a9d096a11b.png)


after:
![Simulator Screen Shot - iPhone 12 - 2021-08-31 at 22 20 19](https://user-images.githubusercontent.com/60778000/131544648-879daa79-3fe0-45ee-adae-73d826b2913b.png)
