### PR TITLE
[FIX] Preserve voice message if recording is interrupted on IOS

### DIFF
--- a/app/containers/MessageBox/RecordAudio.js
+++ b/app/containers/MessageBox/RecordAudio.js
@@ -12,11 +12,11 @@ import { themes } from '../../constants/colors';
 import { CustomIcon } from '../../lib/Icons';
 import { logEvent, events } from '../../utils/log';
 
-const RECORDING_EXTENSION = '.aac';
+const RECORDING_EXTENSION = '.m4a';
 const RECORDING_SETTINGS = {
 	android: {
 		extension: RECORDING_EXTENSION,
-		outputFormat: Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AAC_ADTS,
+		outputFormat: Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_MPEG_4,
 		audioEncoder: Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AAC,
 		sampleRate: Audio.RECORDING_OPTIONS_PRESET_LOW_QUALITY.android.sampleRate,
 		numberOfChannels: Audio.RECORDING_OPTIONS_PRESET_LOW_QUALITY.android.numberOfChannels,
@@ -34,7 +34,7 @@ const RECORDING_SETTINGS = {
 const RECORDING_MODE = {
 	allowsRecordingIOS: true,
 	playsInSilentModeIOS: true,
-	staysActiveInBackground: false,
+	staysActiveInBackground: true,
 	shouldDuckAndroid: true,
 	playThroughEarpieceAndroid: false,
 	interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
@@ -140,7 +140,7 @@ export default class RecordAudio extends React.PureComponent {
 				const fileURI = this.recording.getURI();
 				const fileData = await getInfoAsync(fileURI);
 				const fileInfo = {
-					name: `${ Date.now() }.aac`,
+					name: `${ Date.now() }.m4a`,
 					mime: 'audio/aac',
 					type: 'audio/aac',
 					store: 'Uploads',

--- a/app/containers/message/Audio.js
+++ b/app/containers/message/Audio.js
@@ -22,7 +22,7 @@ import { withDimensions } from '../../dimensions';
 const mode = {
 	allowsRecordingIOS: false,
 	playsInSilentModeIOS: true,
-	staysActiveInBackground: false,
+	staysActiveInBackground: true,
 	shouldDuckAndroid: true,
 	playThroughEarpieceAndroid: false,
 	interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,

--- a/ios/RocketChatRN/Info.plist
+++ b/ios/RocketChatRN/Info.plist
@@ -103,6 +103,7 @@
 	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>fetch</string>
 		<string>voip</string>
 	</array>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
When an event interrupts an ongoing voice recording in IOS, the OS stops the recording. This was not handled properly before: The message was immediately completely lost and it was not possible to make a new voice message before force-quitting and restarting the app (because the Expo recorder was left in loaded state).

This PR stops the recording in this case, indicating it was stopped. The user can send or discard the voice message up to that point at any time afterwards.

I also changed the GUI to make it more clear. See below.

## Issue(s)	
#3002 

## How to test or reproduce
Run the version on an iPhone. Start a voice message recording, while the recording is running, call the iPhone or activate Siri.
IOS stops the recording.
Old behavior: The recorded message was trashed immediately, after that you can't start a new recording (as the Expo recorder was left loaded) - you need to fully restart the app.
My behavior: The UI indicates that the recording is stopped. After the interruption you can still send or trash it at any time. Expo Recorder will not be stuck in loaded state.

## Screenshots

Record in progress: I've replaced the red cross and green check by a red trash icon and a green send icon. IMHO this is much more clear: The green icon in fact immediately **sends** the message, the red icon immediately **trashes** the message (all my users highly appreciate this change as well).
Behind the time display the "record" symbol states that the recording is running.
<img width="387" alt="2021-09-17_21-56-55" src="https://user-images.githubusercontent.com/3321655/133846413-94191a98-abe2-4f55-9dcf-d89f772756ee.png">

This is an incoming call. As soon as IOS stops the recording, I'll indicate this with the "pause" symbol behind the time display. The time is stopped and shows the length of the message.
<img width="375" alt="2021-09-17_22-00-28" src="https://user-images.githubusercontent.com/3321655/133846794-1cd31660-1a3f-4dd4-8482-5e7748c77f7d.png">

After the call was finished, you can still send or trash the waiting message at any time:
<img width="381" alt="2021-09-17_22-01-34" src="https://user-images.githubusercontent.com/3321655/133846902-a3034124-0f2e-4a95-89a4-bb217fb7f5a7.png">


## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
Would be fine to have this in the next release together with my previous fix merge to have the voice message fixes complete.
