### PR TITLE
[FIX] Preserve voice message if recording is interrupted

### DIFF
--- a/app/containers/MessageBox/RecordAudio.tsx
+++ b/app/containers/MessageBox/RecordAudio.tsx
@@ -63,20 +63,24 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 
 	private recording: any;
 
+	private LastDuration: number;
+
 	constructor(props: IMessageBoxRecordAudioProps) {
 		super(props);
 		this.isRecorderBusy = false;
+		this.LastDuration = 0;
 		this.state = {
 			isRecording: false,
+			isRecorderActive: false,
 			recordingDurationMillis: 0
 		};
 	}
 
 	componentDidUpdate() {
 		const { recordingCallback } = this.props;
-		const { isRecording } = this.state;
+		const { isRecorderActive } = this.state;
 
-		recordingCallback(isRecording);
+		recordingCallback(isRecorderActive);
 	}
 
 	componentWillUnmount() {
@@ -88,6 +92,10 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 	get duration() {
 		const { recordingDurationMillis } = this.state;
 		return formatTime(Math.floor(recordingDurationMillis / 1000));
+	}
+
+	get GetLastDuration() {
+		return formatTime(Math.floor(this.LastDuration / 1000));
 	}
 
 	isRecordingPermissionGranted = async () => {
@@ -108,17 +116,20 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 			isRecording: status.isRecording,
 			recordingDurationMillis: status.durationMillis
 		});
+		this.LastDuration = status.durationMillis;
 	};
 
 	startRecordingAudio = async () => {
 		logEvent(events.ROOM_AUDIO_RECORD);
 		if (!this.isRecorderBusy) {
 			this.isRecorderBusy = true;
+			this.LastDuration = 0;
 			try {
 				const canRecord = await this.isRecordingPermissionGranted();
 				if (canRecord) {
 					await Audio.setAudioModeAsync(RECORDING_MODE);
 
+					this.setState({ isRecorderActive: true });
 					this.recording = new Audio.Recording();
 					await this.recording.prepareToRecordAsync(RECORDING_SETTINGS);
 					this.recording.setOnRecordingStatusUpdate(this.onRecordingStatusUpdate);
@@ -159,7 +170,7 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 			} catch (error) {
 				logEvent(events.ROOM_AUDIO_FINISH_F);
 			}
-			this.setState({ isRecording: false, recordingDurationMillis: 0 });
+			this.setState({ isRecording: false, isRecorderActive: false, recordingDurationMillis: 0 });
 			deactivateKeepAwake();
 			this.isRecorderBusy = false;
 		}
@@ -174,7 +185,7 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 			} catch (error) {
 				logEvent(events.ROOM_AUDIO_CANCEL_F);
 			}
-			this.setState({ isRecording: false, recordingDurationMillis: 0 });
+			this.setState({ isRecording: false, isRecorderActive: false, recordingDurationMillis: 0 });
 			deactivateKeepAwake();
 			this.isRecorderBusy = false;
 		}
@@ -183,8 +194,10 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 	render() {
 		const { theme } = this.props;
 		const { isRecording } = this.state;
+		const { isRecorderActive } = this.state;
 
-		if (!isRecording) {
+		// Show normal message box when recorder is not active and no recording is running
+		if (!isRecording && !isRecorderActive) {
 			return (
 				<BorderlessButton
 					onPress={this.startRecordingAudio}
@@ -198,6 +211,36 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 			);
 		}
 
+		// Show recording UI with "pause" symbol and the time of the last recording.
+		// Will appear when something stopped the recording (i.e. a call in IOS)
+		if (!isRecording && isRecorderActive) {
+			return (
+				<View style={styles.recordingContent}>
+					<View style={styles.textArea}>
+						<BorderlessButton
+							onPress={this.cancelRecordingAudio}
+							// @ts-ignore
+							accessibilityLabel={I18n.t('Cancel_recording')}
+							accessibilityTraits='button'
+							style={styles.actionButton}>
+							<CustomIcon size={24} color={themes[theme].dangerColor} name='delete' />
+						</BorderlessButton>
+						<Text style={[styles.recordingCancelText, { color: themes[theme].titleText }]}>{this.GetLastDuration} &nbsp;</Text>
+						<CustomIcon size={24} color='black' name='pause' />
+					</View>
+					<BorderlessButton
+						onPress={this.finishRecordingAudio}
+						// @ts-ignore
+						accessibilityLabel={I18n.t('Finish_recording')}
+						accessibilityTraits='button'
+						style={styles.actionButton}>
+						<CustomIcon size={24} color={themes[theme].successColor} name='send-filled' />
+					</BorderlessButton>
+				</View>
+			);
+		}
+
+		// Show normal recording UI with a "record" symbol
 		return (
 			<View style={styles.recordingContent}>
 				<View style={styles.textArea}>
@@ -207,9 +250,10 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 						accessibilityLabel={I18n.t('Cancel_recording')}
 						accessibilityTraits='button'
 						style={styles.actionButton}>
-						<CustomIcon size={24} color={themes[theme].dangerColor} name='close' />
+						<CustomIcon size={24} color={themes[theme].dangerColor} name='delete' />
 					</BorderlessButton>
-					<Text style={[styles.recordingCancelText, { color: themes[theme].titleText }]}>{this.duration}</Text>
+					<Text style={[styles.recordingCancelText, { color: themes[theme].titleText }]}>{this.duration} &nbsp;</Text>
+					<CustomIcon size={24} color='red' name='record' />
 				</View>
 				<BorderlessButton
 					onPress={this.finishRecordingAudio}
@@ -217,7 +261,7 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 					accessibilityLabel={I18n.t('Finish_recording')}
 					accessibilityTraits='button'
 					style={styles.actionButton}>
-					<CustomIcon size={24} color={themes[theme].successColor} name='check' />
+					<CustomIcon size={24} color={themes[theme].successColor} name='send-filled' />
 				</BorderlessButton>
 			</View>
 		);

--- a/app/containers/MessageBox/RecordAudio.tsx
+++ b/app/containers/MessageBox/RecordAudio.tsx
@@ -193,10 +193,8 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 
 	render() {
 		const { theme } = this.props;
-		const { isRecording } = this.state;
-		const { isRecorderActive } = this.state;
+		const { isRecording, isRecorderActive } = this.state;
 
-		// Show normal message box when recorder is not active and no recording is running
 		if (!isRecording && !isRecorderActive) {
 			return (
 				<BorderlessButton
@@ -211,8 +209,6 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 			);
 		}
 
-		// Show recording UI with "pause" symbol and the time of the last recording.
-		// Will appear when something stopped the recording (i.e. a call in IOS)
 		if (!isRecording && isRecorderActive) {
 			return (
 				<View style={styles.recordingContent}>
@@ -225,8 +221,7 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 							style={styles.actionButton}>
 							<CustomIcon size={24} color={themes[theme].dangerColor} name='delete' />
 						</BorderlessButton>
-						<Text style={[styles.recordingCancelText, { color: themes[theme].titleText }]}>{this.GetLastDuration} &nbsp;</Text>
-						<CustomIcon size={24} color='black' name='pause' />
+						<Text style={[styles.recordingDurationText, { color: themes[theme].titleText }]}>{this.GetLastDuration}</Text>
 					</View>
 					<BorderlessButton
 						onPress={this.finishRecordingAudio}
@@ -234,13 +229,12 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 						accessibilityLabel={I18n.t('Finish_recording')}
 						accessibilityTraits='button'
 						style={styles.actionButton}>
-						<CustomIcon size={24} color={themes[theme].successColor} name='send-filled' />
+						<CustomIcon size={24} color={themes[theme].tintColor} name='send-filled' />
 					</BorderlessButton>
 				</View>
 			);
 		}
 
-		// Show normal recording UI with a "record" symbol
 		return (
 			<View style={styles.recordingContent}>
 				<View style={styles.textArea}>
@@ -252,8 +246,8 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 						style={styles.actionButton}>
 						<CustomIcon size={24} color={themes[theme].dangerColor} name='delete' />
 					</BorderlessButton>
-					<Text style={[styles.recordingCancelText, { color: themes[theme].titleText }]}>{this.duration} &nbsp;</Text>
-					<CustomIcon size={24} color='red' name='record' />
+					<Text style={[styles.recordingDurationText, { color: themes[theme].titleText }]}>{this.duration}</Text>
+					<CustomIcon size={24} color={themes[theme].dangerColor} name='record' />
 				</View>
 				<BorderlessButton
 					onPress={this.finishRecordingAudio}
@@ -261,7 +255,7 @@ export default class RecordAudio extends React.PureComponent<IMessageBoxRecordAu
 					accessibilityLabel={I18n.t('Finish_recording')}
 					accessibilityTraits='button'
 					style={styles.actionButton}>
-					<CustomIcon size={24} color={themes[theme].successColor} name='send-filled' />
+					<CustomIcon size={24} color={themes[theme].tintColor} name='send-filled' />
 				</BorderlessButton>
 			</View>
 		);

--- a/app/containers/MessageBox/styles.ts
+++ b/app/containers/MessageBox/styles.ts
@@ -139,7 +139,8 @@ export default StyleSheet.create({
 		flex: 1,
 		justifyContent: 'space-between'
 	},
-	recordingCancelText: {
+	recordingDurationText: {
+		width: 60,
 		fontSize: 16,
 		...sharedStyles.textRegular
 	},


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
When an event interrupts an ongoing voice recording in IOS, the OS stops the recording. This was not handled properly before: The message was immediately completely lost and it was not possible to make a new voice message before force-quitting and restarting the app (because the Expo recorder was left in loaded state).

This PR stops the recording in this case, indicating it was stopped. The user can send or discard the voice message up to that point at any time afterwards.

I also changed the GUI to make it more clear. See below.

## Issue(s)	
#3002 
https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/3388

## How to test or reproduce
### New behavior
- Start a voice message recording
- while the recording is running, call the device or activate Siri.
- App should stop the recording, but give you a way to send the message

### Old behavior
- Same steps, but the app would trash the voice message

## Screenshots

Record in progress: I've replaced the red cross and green check by a red trash icon and a green send icon. IMHO this is much more clear: The green icon in fact immediately **sends** the message, the red icon immediately **trashes** the message (all my users highly appreciate this change as well).
Behind the time display the "record" symbol states that the recording is running.
<img width="387" alt="2021-09-17_21-56-55" src="https://user-images.githubusercontent.com/3321655/133846413-94191a98-abe2-4f55-9dcf-d89f772756ee.png">

This is an incoming call. As soon as IOS stops the recording, I'll indicate this with the "pause" symbol behind the time display. The time is stopped and shows the length of the message.
<img width="375" alt="2021-09-17_22-00-28" src="https://user-images.githubusercontent.com/3321655/133846794-1cd31660-1a3f-4dd4-8482-5e7748c77f7d.png">

After the call was finished, you can still send or trash the waiting message at any time:
<img width="381" alt="2021-09-17_22-01-34" src="https://user-images.githubusercontent.com/3321655/133846902-a3034124-0f2e-4a95-89a4-bb217fb7f5a7.png">


## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
Would be fine to have this in the next release together with my previous fix merge to have the voice message fixes complete.
