### PR TITLE
[FEATURE] Pull down to refresh read receipts

### DIFF
--- a/app/views/ReadReceiptView/index.js
+++ b/app/views/ReadReceiptView/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FlatList, Text, View } from 'react-native';
+import { FlatList, Text, View, RefreshControl } from 'react-native';
 import { dequal } from 'dequal';
 import moment from 'moment';
 import { connect } from 'react-redux';
@@ -31,7 +31,8 @@ class ReadReceiptView extends React.Component {
 	static propTypes = {
 		route: PropTypes.object,
 		Message_TimeAndDateFormat: PropTypes.string,
-		theme: PropTypes.string
+		theme: PropTypes.string,
+		refreshing: PropTypes.bool
 	};
 
 	constructor(props) {
@@ -49,7 +50,7 @@ class ReadReceiptView extends React.Component {
 
 	shouldComponentUpdate(nextProps, nextState) {
 		const { loading, receipts } = this.state;
-		const { theme } = this.props;
+		const { theme, refreshing } = this.props;
 		if (nextProps.theme !== theme) {
 			return true;
 		}
@@ -140,12 +141,22 @@ class ReadReceiptView extends React.Component {
 								borderColor: themes[theme].separatorColor
 							}
 						]}
+						refreshControl={
+							<RefreshControl refreshing={refreshing} onRefresh={this.onRefresh} tintColor={themes[theme].auxiliaryText} />
+						}
 						keyExtractor={item => item._id}
 					/>
 				)}
 			</SafeAreaView>
 		);
 	}
+	onRefresh = () => {
+		const { loading } = this.state;
+		if (loading) {
+			return;
+		}
+		this.load();
+	};
 }
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
## Proposed changes
This PR adds the ability for users to pull down to refresh read receipts. Currently, to refresh read receipts you have to close out, long press on a message, scroll the popup and find "Read Receipts", tap it, and repeat. This PR makes it simple to refresh by pulling down to refresh.

## Screenshots

https://user-images.githubusercontent.com/6295044/136109343-74153d29-cd48-4f30-b8b4-fbb923d7c885.mp4

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
