### PR TITLE
[IMPROVEMENT] Fixed Unsafe Cryptographic Encryption Mode

### DIFF
--- a/patches/react-native-mmkv-storage+0.3.5.patch
+++ b/patches/react-native-mmkv-storage+0.3.5.patch
@@ -155,3 +155,155 @@ index e7c914b..891cf93 100644
          return;
      }
      
+diff --git a/android/build.gradle b/android/build.gradle
+index 81daca5..308e3a1 100644
+--- a/node_modules/react-native-mmkv-storage/android/build.gradle
++++ b/node_modules/react-native-mmkv-storage/android/build.gradle
+@@ -43,6 +43,6 @@ repositories {
+ dependencies {
+     implementation 'com.facebook.react:react-native:+'
+     implementation 'com.tencent:mmkv-static:1.2.1'
+-    implementation "com.scottyab:secure-preferences-lib:0.1.4"
++    implementation "androidx.security:security-crypto:1.0.0"
+ }
+-  
+\ No newline at end of file
++  
+diff --git a/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/Constants.java b/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/Constants.java
+index 0e336d9..8503394 100644
+--- a/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/Constants.java
++++ b/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/Constants.java
+@@ -8,7 +8,7 @@ public class Constants {
+     public static final String KEYSTORE_PROVIDER_3 = "AndroidOpenSSL";
+ 
+     public static final String RSA_ALGORITHM = "RSA/ECB/PKCS1Padding";
+-    public static final String AES_ALGORITHM = "AES/ECB/PKCS5Padding";
++    public static final String AES_ALGORITHM = "AES/GCM/NoPadding";
+ 
+     public static final String TAG = "RNSecureStorage";
+ 
+@@ -16,6 +16,7 @@ public class Constants {
+     public static final String SKS_KEY_FILENAME = "SKS_KEY_FILE";
+     public static final String SKS_DATA_FILENAME = "SKS_DATA_FILE";
+ 
++    public static final String AES_IV_FILENAME = "__iv";
+ 
+     public static final int DATA_TYPE_STRING = 1;
+     public static final int DATA_TYPE_INT = 2;
+diff --git a/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/SecureKeystore.java b/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/SecureKeystore.java
+index b733e2f..0e11892 100644
+--- a/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/SecureKeystore.java
++++ b/node_modules/react-native-mmkv-storage/android/src/main/java/com/ammarahmed/mmkv/SecureKeystore.java
+@@ -8,13 +8,14 @@ import android.security.KeyPairGeneratorSpec;
+ import android.util.Log;
+ 
+ import androidx.annotation.Nullable;
++import androidx.security.crypto.EncryptedSharedPreferences;
++import androidx.security.crypto.MasterKeys;
+ 
+ import com.facebook.react.bridge.Callback;
+ import com.facebook.react.bridge.ReactApplicationContext;
+ import com.facebook.react.bridge.ReactMethod;
+ import com.facebook.react.bridge.ReadableMap;
+ import com.facebook.react.uimanager.IllegalViewOperationException;
+-import com.securepreferences.SecurePreferences;
+ 
+ import java.io.ByteArrayInputStream;
+ import java.io.ByteArrayOutputStream;
+@@ -25,6 +26,7 @@ import java.security.GeneralSecurityException;
+ import java.security.KeyPairGenerator;
+ import java.security.KeyStore;
+ import java.security.PrivateKey;
++import java.security.SecureRandom;
+ import java.security.PublicKey;
+ import java.util.ArrayList;
+ import java.util.Calendar;
+@@ -37,6 +39,7 @@ import javax.crypto.KeyGenerator;
+ import javax.crypto.SecretKey;
+ import javax.crypto.spec.SecretKeySpec;
+ import javax.security.auth.x500.X500Principal;
++import javax.crypto.spec.IvParameterSpec;
+ 
+ public class SecureKeystore {
+ 
+@@ -53,7 +56,17 @@ public class SecureKeystore {
+ 
+         reactContext = reactApplicationContext;
+         if (!useKeystore()) {
+-            prefs = new SecurePreferences(reactApplicationContext, (String) null, "e4b001df9a082298dd090bb7455c45d92fbd5ddd.xml");
++            try {
++                prefs = EncryptedSharedPreferences.create(
++                        "e4b001df9a082298dd090bb7455c45d92fbd5dda.xml",
++                        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
++                        reactContext,
++                        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
++                        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
++                );
++            } catch (Exception e) {
++                e.printStackTrace();
++            }
+         }
+     }
+ 
+@@ -64,6 +77,19 @@ public class SecureKeystore {
+                 directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+     }
+ 
++    private IvParameterSpec getIv(Context context) throws IOException {
++        byte[] iv;
++        if(Storage.exists(context, Constants.AES_IV_FILENAME)){
++            iv = Storage.readValues(context, Constants.AES_IV_FILENAME );
++        }
++        else {
++            iv = new byte[16];
++            new SecureRandom().nextBytes(iv);
++            Storage.writeValues(context, Constants.AES_IV_FILENAME, iv);
++        }
++        return new IvParameterSpec(iv);
++    }
++
+ 
+     public void setSecureKey(String key, String value, @Nullable ReadableMap options, Callback callback) {
+ 
+@@ -254,9 +280,9 @@ public class SecureKeystore {
+         return encryptCipherText(cipher, plainTextBytes);
+     }
+ 
+-    private byte[] encryptAesPlainText(SecretKey secretKey, String plainText) throws GeneralSecurityException, IOException {
++    private byte[] encryptAesPlainText(SecretKey secretKey, IvParameterSpec iv, String plainText) throws GeneralSecurityException, IOException {
+         Cipher cipher = Cipher.getInstance(Constants.AES_ALGORITHM);
+-        cipher.init(Cipher.ENCRYPT_MODE, secretKey);
++        cipher.init(Cipher.ENCRYPT_MODE, secretKey, iv);
+         return encryptCipherText(cipher, plainText);
+     }
+ 
+@@ -293,7 +319,7 @@ public class SecureKeystore {
+ 
+     public void setCipherText(Context context, String alias, String input) throws GeneralSecurityException, IOException {
+         Storage.writeValues(context, Constants.SKS_DATA_FILENAME + alias,
+-                encryptAesPlainText(getOrCreateSecretKey(context, alias), input));
++                encryptAesPlainText(getOrCreateSecretKey(context, alias), getIv(context), input));
+     }
+ 
+     private PrivateKey getPrivateKey(String alias) throws GeneralSecurityException, IOException {
+@@ -308,9 +334,9 @@ public class SecureKeystore {
+         return decryptCipherText(cipher, cipherTextBytes);
+     }
+ 
+-    private byte[] decryptAesCipherText(SecretKey secretKey, byte[] cipherTextBytes) throws GeneralSecurityException, IOException {
++    private byte[] decryptAesCipherText(SecretKey secretKey, IvParameterSpec iv, byte[] cipherTextBytes) throws GeneralSecurityException, IOException {
+         Cipher cipher = Cipher.getInstance(Constants.AES_ALGORITHM);
+-        cipher.init(Cipher.DECRYPT_MODE, secretKey);
++        cipher.init(Cipher.DECRYPT_MODE, secretKey, iv);
+         return decryptCipherText(cipher, cipherTextBytes);
+     }
+ 
+@@ -335,7 +361,7 @@ public class SecureKeystore {
+     public String getPlainText(Context context, String alias) throws GeneralSecurityException, IOException {
+         SecretKey secretKey = getSymmetricKey(context, alias);
+         byte[] cipherTextBytes = Storage.readValues(context, Constants.SKS_DATA_FILENAME + alias);
+-        return new String(decryptAesCipherText(secretKey, cipherTextBytes), "UTF-8");
++        return new String(decryptAesCipherText(secretKey, getIv(context), cipherTextBytes), "UTF-8");
+     }
+ 
+     public boolean exists(Context context, String alias) throws IOException {


### PR DESCRIPTION

## Proposed changes
This PR fixes issue mentioned in #3525. As recommended in google documentation, encryption methods were rewritten to use `AES/GCM/NoPadding`. Besides that, deprecated `com.scottyab:secure-preferences-lib` was replaced with safer `androidx.security:security-crypto`

## Issue(s)	
`react-native-mmkv-storage` dependency use unsafe chiper encryption mode. It [doesn't comply](https://support.google.com/faqs/answer/10046138) with google recomendations

## How to test or reproduce
Upload bundle to Google Play Store. It will not pass security checks.

## Screenshots
![image](https://user-images.githubusercontent.com/1212355/143940695-084afe24-2843-4284-b2ae-5ad9b2b60c9a.png)

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
