### PR TITLE
[FIX] Consistent Default Device Name For Android Detox

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,13 +241,13 @@
 				}
 			},
 			"and.emu.debug": {
-				"device": "Pixel_API_28_AOSP",
+				"device": "ANDROID_API_28",
 				"type": "android.emulator",
 				"binaryPath": "android/app/build/outputs/apk/e2ePlay/debug/app-e2e-play-debug.apk",
 				"build": "cd android && ./gradlew app:assembleE2ePlayDebug app:assembleE2ePlayDebugAndroidTest -DtestBuildType=debug && cd .."
 			},
 			"and.emu.release": {
-				"device": "Pixel_API_28_AOSP",
+				"device": "ANDROID_API_28",
 				"type": "android.emulator",
 				"binaryPath": "android/app/build/outputs/apk/e2ePlay/release/app-e2e-play-release.apk",
 				"build": "cd android && ./gradlew app:assembleE2ePlayRelease app:assembleE2ePlayReleaseAndroidTest -DtestBuildType=release && cd .."

--- a/package.json
+++ b/package.json
@@ -240,13 +240,13 @@
 					}
 				}
 			},
-			"and.emu.debug": {
+			"android.emu.debug": {
 				"device": "ANDROID_API_28",
 				"type": "android.emulator",
 				"binaryPath": "android/app/build/outputs/apk/e2ePlay/debug/app-e2e-play-debug.apk",
 				"build": "cd android && ./gradlew app:assembleE2ePlayDebug app:assembleE2ePlayDebugAndroidTest -DtestBuildType=debug && cd .."
 			},
-			"and.emu.release": {
+			"android.emu.release": {
 				"device": "ANDROID_API_28",
 				"type": "android.emulator",
 				"binaryPath": "android/app/build/outputs/apk/e2ePlay/release/app-e2e-play-release.apk",


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

Makes the name of the default android device being used consistent in package.json and the instructions in /e2e/README.md

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
