### PR TITLE
[FIX] Merge subscription and room logic using unparsed data

### DIFF
--- a/app/lib/methods/helpers/mergeSubscriptionsRooms.ts
+++ b/app/lib/methods/helpers/mergeSubscriptionsRooms.ts
@@ -29,18 +29,18 @@ export const merge = (subscription: ISubscription | IServerSubscription, room?: 
 		if (compareServerVersion(serverVersion, 'lowerThan', '3.7.0')) {
 			const updatedAt = room?._updatedAt ? new Date(room._updatedAt) : null;
 			// @ts-ignore
-			const lastMessageTs = subscription?.lastMessage?.ts ? new Date(subscription.lastMessage.ts) : null;
+			const lastMessageTs = mergedSubscription?.lastMessage?.ts ? new Date(mergedSubscription.lastMessage.ts) : null;
 			// @ts-ignore
 			// If all parameters are null it will return zero, if only one is null it will return its timestamp only.
 			// "It works", but it's not the best solution. It does not accept "Date" as a parameter, but it works.
 			mergedSubscription.roomUpdatedAt = Math.max(updatedAt, lastMessageTs);
 		} else {
 			// https://github.com/RocketChat/Rocket.Chat/blob/develop/app/ui-sidenav/client/roomList.js#L180
-			const lastRoomUpdate = room?.lm || subscription.ts || subscription._updatedAt;
+			const lastRoomUpdate = room?.lm || mergedSubscription.ts || mergedSubscription._updatedAt;
 			// @ts-ignore Same as above scenario
-			mergedSubscription.roomUpdatedAt = subscription.lr
+			mergedSubscription.roomUpdatedAt = mergedSubscription.lr
 				? // @ts-ignore Same as above scenario
-				  Math.max(new Date(subscription.lr), new Date(lastRoomUpdate))
+				  Math.max(new Date(mergedSubscription.lr), new Date(lastRoomUpdate))
 				: lastRoomUpdate;
 		}
 		mergedSubscription.ro = room?.ro ?? false;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
After #3782, we started using `subscription` without parsing with `EJSON.fromJSONValue`.
Date comparisons would end as null.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
