### PR TITLE
Chore: Migrate REST API - getSyncThreadsList to Typescript

### DIFF
--- a/app/definitions/rest/v1/chat.ts
+++ b/app/definitions/rest/v1/chat.ts
@@ -47,6 +47,14 @@ export type ChatEndpoints = {
 			total: number;
 		}>;
 	};
+	'chat.syncThreadsList': {
+		GET: (params: { rid: IServerRoom['_id']; updatedSince: string }) => {
+			threads: {
+				update: IMessage[];
+				remove: IMessage[];
+			};
+		};
+	};
 	'chat.delete': {
 		POST: (params: { msgId: string; roomId: string }) => {
 			_id: string;

--- a/app/lib/rocketchat/services/restApi.ts
+++ b/app/lib/rocketchat/services/restApi.ts
@@ -665,10 +665,8 @@ export const getThreadsList = ({ rid, count, offset, text }: { rid: string; coun
 	return sdk.get('chat.getThreadsList', params);
 };
 
-export const getSyncThreadsList = ({ rid, updatedSince }: { rid: string; updatedSince: string }): any =>
+export const getSyncThreadsList = ({ rid, updatedSince }: { rid: string; updatedSince: string }) =>
 	// RC 1.0
-	// TODO: missing definitions from server
-	// @ts-ignore
 	sdk.get('chat.syncThreadsList', {
 		rid,
 		updatedSince


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
Migrate REST API - getSyncThreadsList to Typescript

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
