### PR TITLE
Regression: Fix problem to load starred, mentions, pinned and files messages

### DIFF
--- a/app/views/MessagesView/index.tsx
+++ b/app/views/MessagesView/index.tsx
@@ -86,7 +86,7 @@ class MessagesView extends React.Component<IMessagesViewProps, IMessagesViewStat
 			loading: false,
 			messages: [],
 			fileLoading: true,
-			total: 0
+			total: -1
 		};
 		this.setHeader();
 		this.rid = props.route.params?.rid;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
In this PR #4113, I introduced a bug that made it impossible to load starred, mentions, pinned and files messages. 
The proposal of this PR is fix this bug.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
In a room, go to actions and load the files, mentions, starred and pinned messages. Please verify if we can do and undo the actions. 
E.g: 
* star a message, go to actions -> starred messages -> unstar that message. 
* pinned a message, go to actions -> pinned messages -> unpin that message.

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
