### PR TITLE
Regression: Add showInput prop to add the option to show actionSheetContent without input

### DIFF
--- a/app/containers/ActionSheet/ActionSheetContentWithInputAndSubmit/index.tsx
+++ b/app/containers/ActionSheet/ActionSheetContentWithInputAndSubmit/index.tsx
@@ -75,7 +75,8 @@ const ActionSheetContentWithInputAndSubmit = ({
 	iconName,
 	iconColor,
 	customText,
-	confirmBackgroundColor
+	confirmBackgroundColor,
+	showInput = true
 }: {
 	onSubmit: (inputValue: string) => void;
 	onCancel?: () => void;
@@ -89,6 +90,7 @@ const ActionSheetContentWithInputAndSubmit = ({
 	iconColor?: string;
 	customText?: React.ReactElement;
 	confirmBackgroundColor?: string;
+	showInput?: boolean;
 }): React.ReactElement => {
 	const { colors } = useTheme();
 	const [inputValue, setInputValue] = useState('');
@@ -106,29 +108,31 @@ const ActionSheetContentWithInputAndSubmit = ({
 				<Text style={[styles.subtitleText, { color: colors.titleText }]}>{description}</Text>
 				{customText}
 			</>
-			<FormTextInput
-				value={inputValue}
-				placeholder={placeholder}
-				onChangeText={value => setInputValue(value)}
-				onSubmitEditing={() => {
-					// fix android animation
-					setTimeout(() => {
-						hideActionSheet();
-					}, 100);
-					if (inputValue) onSubmit(inputValue);
-				}}
-				testID={testID}
-				secureTextEntry={secureTextEntry}
-				inputStyle={{ borderWidth: 2 }}
-				bottomSheet={isIOS}
-			/>
+			{showInput ? (
+				<FormTextInput
+					value={inputValue}
+					placeholder={placeholder}
+					onChangeText={value => setInputValue(value)}
+					onSubmitEditing={() => {
+						// fix android animation
+						setTimeout(() => {
+							hideActionSheet();
+						}, 100);
+						if (inputValue) onSubmit(inputValue);
+					}}
+					testID={testID}
+					secureTextEntry={secureTextEntry}
+					inputStyle={{ borderWidth: 2 }}
+					bottomSheet={isIOS}
+				/>
+			) : null}
 			<FooterButtons
 				confirmBackgroundColor={confirmBackgroundColor || colors.actionTintColor}
 				cancelAction={onCancel || hideActionSheet}
 				confirmAction={() => onSubmit(inputValue)}
 				cancelTitle={i18n.t('Cancel')}
 				confirmTitle={confirmTitle || i18n.t('Save')}
-				disabled={!inputValue}
+				disabled={!showInput ? false : !inputValue}
 			/>
 		</View>
 	);

--- a/app/views/ProfileView/components/DeleteAccountActionSheetContent/index.tsx
+++ b/app/views/ProfileView/components/DeleteAccountActionSheetContent/index.tsx
@@ -97,6 +97,7 @@ function ConfirmDeleteAccountActionSheetContent({ changeOwnerRooms = '', removed
 			testID='room-info-edit-view-name'
 			confirmTitle={i18n.t('Delete_Account_confirm')}
 			confirmBackgroundColor={colors.dangerColor}
+			showInput={false}
 			customText={
 				<>
 					{!!changeOwnerRooms && <AlertText text={changeOwnerRooms} />}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Add showInput prop to add the option to show actionSheetContent without input

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Try to delete an account with created rooms

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
