### PR TITLE
Chore: Ignore icons on Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,5 @@ npm-debug.log
 yarn-error.log
 
 app/i18n/locales/
+app/containers/CustomIcon/mappedIcons.js
+app/containers/CustomIcon/selection.json

--- a/app/containers/ActionSheet/ActionSheet.tsx
+++ b/app/containers/ActionSheet/ActionSheet.tsx
@@ -142,7 +142,8 @@ const ActionSheet = React.memo(
 						onChange={index => index === -1 && onClose()}
 						// We need this to allow horizontal swipe gestures inside bottom sheet like in reaction picker
 						enableContentPanningGesture={data?.enableContentPanningGesture ?? true}
-						{...androidTablet}>
+						{...androidTablet}
+					>
 						<BottomSheetContent options={data?.options} hide={hide} children={data?.children} hasCancel={data?.hasCancel} />
 					</BottomSheet>
 				)}

--- a/app/containers/ReactionsList.tsx
+++ b/app/containers/ReactionsList.tsx
@@ -62,7 +62,8 @@ const TabBarItem = ({ tab, index, goToPage, baseUrl, getCustomEmoji }: ITabBarIt
 			}}
 			style={({ pressed }: { pressed: boolean }) => ({
 				opacity: pressed ? 0.7 : 1
-			})}>
+			})}
+		>
 			<View style={styles.tabBarItem}>
 				<Emoji
 					content={tab.emoji}
@@ -91,7 +92,8 @@ const ReactionsTabBar = ({ tabs, activeTab, goToPage, baseUrl, getCustomEmoji, w
 								width: tabWidth,
 								borderBottomWidth: isActiveTab ? 2 : 1,
 								borderColor: isActiveTab ? colors.tintActive : colors.separatorColor
-							}}>
+							}}
+						>
 							<TabBarItem tab={tab} index={index} goToPage={goToPage} baseUrl={baseUrl} getCustomEmoji={getCustomEmoji} />
 						</View>
 					);

--- a/app/views/CloseLivechatView.tsx
+++ b/app/views/CloseLivechatView.tsx
@@ -75,7 +75,8 @@ const CloseLivechatView = ({ navigation, route }: IBaseScreen<ChatsStackParamLis
 		<KeyboardView
 			style={{ backgroundColor: colors.auxiliaryBackground }}
 			contentContainerStyle={sharedStyles.container}
-			keyboardVerticalOffset={128}>
+			keyboardVerticalOffset={128}
+		>
 			<ScrollView {...scrollPersistTaps} style={styles.container}>
 				<SafeAreaView>
 					<FormTextInput


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
yarn prettier-lint should not change the indentation of CustomIcon/mappedIcons  and CustomIcons/selection.json 

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
