### PR TITLE
[FIX] Messages not loading on some edge cases

### DIFF
--- a/app/actions/actionsTypes.ts
+++ b/app/actions/actionsTypes.ts
@@ -30,7 +30,7 @@ export const ROOM = createRequestTypes('ROOM', [
 	'FORWARD',
 	'USER_TYPING',
 	'HISTORY_REQUEST',
-	'HISTORY_FINISHED' // TODO: I'm not sure about this naming, but I don't see value on handling failure atm
+	'HISTORY_FINISHED'
 ]);
 export const INQUIRY = createRequestTypes('INQUIRY', [
 	...defaultTypes,

--- a/app/actions/actionsTypes.ts
+++ b/app/actions/actionsTypes.ts
@@ -28,7 +28,10 @@ export const ROOM = createRequestTypes('ROOM', [
 	'DELETE',
 	'REMOVED',
 	'FORWARD',
-	'USER_TYPING'
+	'USER_TYPING',
+	'HISTORY_REQUEST',
+	'HISTORY_SUCCESS',
+	'HISTORY_FAILURE'
 ]);
 export const INQUIRY = createRequestTypes('INQUIRY', [
 	...defaultTypes,

--- a/app/actions/actionsTypes.ts
+++ b/app/actions/actionsTypes.ts
@@ -30,8 +30,7 @@ export const ROOM = createRequestTypes('ROOM', [
 	'FORWARD',
 	'USER_TYPING',
 	'HISTORY_REQUEST',
-	'HISTORY_SUCCESS',
-	'HISTORY_FAILURE'
+	'HISTORY_FINISHED' // TODO: I'm not sure about this naming, but I don't see value on handling failure atm
 ]);
 export const INQUIRY = createRequestTypes('INQUIRY', [
 	...defaultTypes,

--- a/app/actions/room.ts
+++ b/app/actions/room.ts
@@ -104,18 +104,18 @@ export function roomHistoryRequest({
 	rid,
 	t,
 	tmid,
-	loaderItem
+	loaderId
 }: {
 	rid: string;
 	t: SubscriptionType;
 	tmid?: string;
-	loaderItem: TAnyMessageModel;
+	loaderId: string;
 }): any {
 	return {
 		type: ROOM.HISTORY_REQUEST,
 		rid,
 		t,
 		tmid,
-		loaderItem
+		loaderId
 	};
 }

--- a/app/actions/room.ts
+++ b/app/actions/room.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 
-import { ERoomType } from '../definitions/ERoomType';
+import { ERoomType, SubscriptionType, TAnyMessageModel } from '../definitions';
 import { ROOM } from './actionsTypes';
 
 // TYPE RETURN RELATED
@@ -97,5 +97,25 @@ export function userTyping(rid: string, status = true): IUserTyping {
 		type: ROOM.USER_TYPING,
 		rid,
 		status
+	};
+}
+
+export function roomHistoryRequest({
+	rid,
+	t,
+	tmid,
+	loaderItem
+}: {
+	rid: string;
+	t: SubscriptionType;
+	tmid?: string;
+	loaderItem: TAnyMessageModel;
+}): any {
+	return {
+		type: ROOM.HISTORY_REQUEST,
+		rid,
+		t,
+		tmid,
+		loaderItem
 	};
 }

--- a/app/actions/room.ts
+++ b/app/actions/room.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 
-import { ERoomType, SubscriptionType, TAnyMessageModel } from '../definitions';
+import { ERoomType, SubscriptionType } from '../definitions';
 import { ROOM } from './actionsTypes';
 
 // TYPE RETURN RELATED
@@ -44,7 +44,25 @@ interface IUserTyping extends Action {
 	status: boolean;
 }
 
-export type TActionsRoom = TSubscribeRoom & TUnsubscribeRoom & ILeaveRoom & IDeleteRoom & IForwardRoom & IUserTyping;
+export interface IRoomHistoryRequest extends Action {
+	rid: string;
+	t: SubscriptionType;
+	tmid?: string;
+	loaderId: string;
+}
+
+export interface IRoomHistoryFinished extends Action {
+	loaderId: string;
+}
+
+export type TActionsRoom = TSubscribeRoom &
+	TUnsubscribeRoom &
+	ILeaveRoom &
+	IDeleteRoom &
+	IForwardRoom &
+	IUserTyping &
+	IRoomHistoryRequest &
+	IRoomHistoryFinished;
 
 export function subscribeRoom(rid: string): TSubscribeRoom {
 	return {
@@ -110,12 +128,19 @@ export function roomHistoryRequest({
 	t: SubscriptionType;
 	tmid?: string;
 	loaderId: string;
-}): any {
+}): IRoomHistoryRequest {
 	return {
 		type: ROOM.HISTORY_REQUEST,
 		rid,
 		t,
 		tmid,
+		loaderId
+	};
+}
+
+export function roomHistoryFinished({ loaderId }: { loaderId: string }): IRoomHistoryFinished {
+	return {
+		type: ROOM.HISTORY_FINISHED,
 		loaderId
 	};
 }

--- a/app/actions/room.ts
+++ b/app/actions/room.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 
-import { ERoomType } from '../definitions';
+import { ERoomType, RoomType } from '../definitions';
 import { ROOM } from './actionsTypes';
 
 // TYPE RETURN RELATED
@@ -46,7 +46,7 @@ interface IUserTyping extends Action {
 
 export interface IRoomHistoryRequest extends Action {
 	rid: string;
-	t: ERoomType;
+	t: RoomType;
 	loaderId: string;
 }
 
@@ -117,7 +117,7 @@ export function userTyping(rid: string, status = true): IUserTyping {
 	};
 }
 
-export function roomHistoryRequest({ rid, t, loaderId }: { rid: string; t: ERoomType; loaderId: string }): IRoomHistoryRequest {
+export function roomHistoryRequest({ rid, t, loaderId }: { rid: string; t: RoomType; loaderId: string }): IRoomHistoryRequest {
 	return {
 		type: ROOM.HISTORY_REQUEST,
 		rid,

--- a/app/actions/room.ts
+++ b/app/actions/room.ts
@@ -47,7 +47,6 @@ interface IUserTyping extends Action {
 export interface IRoomHistoryRequest extends Action {
 	rid: string;
 	t: SubscriptionType;
-	tmid?: string;
 	loaderId: string;
 }
 
@@ -121,19 +120,16 @@ export function userTyping(rid: string, status = true): IUserTyping {
 export function roomHistoryRequest({
 	rid,
 	t,
-	tmid,
 	loaderId
 }: {
 	rid: string;
 	t: SubscriptionType;
-	tmid?: string;
 	loaderId: string;
 }): IRoomHistoryRequest {
 	return {
 		type: ROOM.HISTORY_REQUEST,
 		rid,
 		t,
-		tmid,
 		loaderId
 	};
 }

--- a/app/actions/room.ts
+++ b/app/actions/room.ts
@@ -1,6 +1,6 @@
 import { Action } from 'redux';
 
-import { ERoomType, SubscriptionType } from '../definitions';
+import { ERoomType } from '../definitions';
 import { ROOM } from './actionsTypes';
 
 // TYPE RETURN RELATED
@@ -46,7 +46,7 @@ interface IUserTyping extends Action {
 
 export interface IRoomHistoryRequest extends Action {
 	rid: string;
-	t: SubscriptionType;
+	t: ERoomType;
 	loaderId: string;
 }
 
@@ -117,15 +117,7 @@ export function userTyping(rid: string, status = true): IUserTyping {
 	};
 }
 
-export function roomHistoryRequest({
-	rid,
-	t,
-	loaderId
-}: {
-	rid: string;
-	t: SubscriptionType;
-	loaderId: string;
-}): IRoomHistoryRequest {
+export function roomHistoryRequest({ rid, t, loaderId }: { rid: string; t: ERoomType; loaderId: string }): IRoomHistoryRequest {
 	return {
 		type: ROOM.HISTORY_REQUEST,
 		rid,

--- a/app/containers/message/index.tsx
+++ b/app/containers/message/index.tsx
@@ -407,7 +407,8 @@ class MessageContainer extends React.Component<IMessageContainerProps, IMessageC
 					threadBadgeColor,
 					toggleFollowThread,
 					replies
-				}}>
+				}}
+			>
 				{/* @ts-ignore*/}
 				<Message
 					id={id}

--- a/app/definitions/index.ts
+++ b/app/definitions/index.ts
@@ -29,6 +29,7 @@ export * from './ISearch';
 export * from './TUserStatus';
 export * from './IProfile';
 export * from './IReaction';
+export * from './ERoomType';
 
 export interface IBaseScreen<T extends Record<string, object | undefined>, S extends string> {
 	navigation: StackNavigationProp<T, S>;

--- a/app/lib/methods/getMoreMessages.ts
+++ b/app/lib/methods/getMoreMessages.ts
@@ -1,6 +1,6 @@
-import { SubscriptionType, TAnyMessageModel } from '../../../definitions';
-import { loadNextMessages, loadMessagesForRoom } from '../../../lib/methods';
-import { MessageTypeLoad } from '../../../lib/constants';
+import { SubscriptionType, TAnyMessageModel } from '../../definitions';
+import { loadNextMessages, loadMessagesForRoom } from '.';
+import { MessageTypeLoad } from '../constants';
 
 const getMoreMessages = ({
 	rid,

--- a/app/lib/methods/getMoreMessages.ts
+++ b/app/lib/methods/getMoreMessages.ts
@@ -5,12 +5,10 @@ import { MessageTypeLoad } from '../constants';
 const getMoreMessages = ({
 	rid,
 	t,
-	tmid,
 	loaderItem
 }: {
 	rid: string;
 	t: SubscriptionType;
-	tmid?: string;
 	loaderItem: TAnyMessageModel;
 }): Promise<void> => {
 	if ([MessageTypeLoad.MORE, MessageTypeLoad.PREVIOUS_CHUNK].includes(loaderItem.t as MessageTypeLoad)) {
@@ -25,7 +23,6 @@ const getMoreMessages = ({
 	if (loaderItem.t === MessageTypeLoad.NEXT_CHUNK) {
 		return loadNextMessages({
 			rid,
-			tmid,
 			ts: loaderItem.ts as Date,
 			loaderItem
 		});

--- a/app/lib/methods/index.ts
+++ b/app/lib/methods/index.ts
@@ -16,6 +16,7 @@ export * from './getSingleMessage';
 export * from './getSlashCommands';
 export * from './getThreadName';
 export * from './getUsersPresence';
+export * from './getMoreMessages';
 export * from './loadMessagesForRoom';
 export * from './loadMissedMessages';
 export * from './loadNextMessages';

--- a/app/lib/methods/loadNextMessages.ts
+++ b/app/lib/methods/loadNextMessages.ts
@@ -15,7 +15,6 @@ const COUNT = 50;
 interface ILoadNextMessages {
 	rid: string;
 	ts: Date;
-	tmid?: string;
 	loaderItem: TMessageModel;
 }
 
@@ -32,7 +31,6 @@ export function loadNextMessages(args: ILoadNextMessages): Promise<void> {
 					const loadMoreItem = {
 						_id: generateLoadMoreId(lastMessage._id),
 						rid: lastMessage.rid,
-						tmid: args.tmid,
 						ts: moment(lastMessage.ts).add(1, 'millisecond'),
 						t: MessageTypeLoad.NEXT_CHUNK
 					};

--- a/app/lib/methods/loadSurroundingMessages.ts
+++ b/app/lib/methods/loadSurroundingMessages.ts
@@ -19,9 +19,6 @@ export function loadSurroundingMessages({ messageId, rid }: { messageId: string;
 			let messages: IMessage[] = EJSON.fromJSONValue(data?.messages);
 			messages = orderBy(messages, 'ts');
 
-			const message = messages.find(m => m._id === messageId);
-			const tmid = message?.tmid;
-
 			if (messages?.length) {
 				if (data?.moreBefore) {
 					const firstMessage = messages[0];
@@ -30,7 +27,6 @@ export function loadSurroundingMessages({ messageId, rid }: { messageId: string;
 						const loadMoreItem = {
 							_id: generateLoadMoreId(firstMessage._id),
 							rid: firstMessage.rid,
-							tmid,
 							ts: moment(firstMessage.ts).subtract(1, 'millisecond').toDate(),
 							t: MessageTypeLoad.PREVIOUS_CHUNK,
 							msg: firstMessage.msg
@@ -46,7 +42,6 @@ export function loadSurroundingMessages({ messageId, rid }: { messageId: string;
 						const loadMoreItem = {
 							_id: generateLoadMoreId(lastMessage._id),
 							rid: lastMessage.rid,
-							tmid,
 							ts: moment(lastMessage.ts).add(1, 'millisecond').toDate(),
 							t: MessageTypeLoad.NEXT_CHUNK,
 							msg: lastMessage.msg

--- a/app/reducers/room.test.ts
+++ b/app/reducers/room.test.ts
@@ -1,4 +1,13 @@
-import { deleteRoom, forwardRoom, leaveRoom, removedRoom, subscribeRoom, unsubscribeRoom } from '../actions/room';
+import {
+	deleteRoom,
+	forwardRoom,
+	leaveRoom,
+	removedRoom,
+	roomHistoryFinished,
+	roomHistoryRequest,
+	subscribeRoom,
+	unsubscribeRoom
+} from '../actions/room';
 import { ERoomType } from '../definitions/ERoomType';
 import { mockedStore } from './mockedStore';
 import { initialState } from './room';
@@ -47,5 +56,17 @@ describe('test room reducer', () => {
 		mockedStore.dispatch(removedRoom());
 		const { isDeleting } = mockedStore.getState().room;
 		expect(isDeleting).toEqual(false);
+	});
+
+	it('should return historyLoaders with one item after call historyRequest', () => {
+		mockedStore.dispatch(roomHistoryRequest({ rid: 'GENERAL', t: ERoomType.c, loaderId: 'loader' }));
+		const { historyLoaders } = mockedStore.getState().room;
+		expect(historyLoaders).toEqual(['loader']);
+	});
+
+	it('should return historyLoaders with empty array after call historyFinished', () => {
+		mockedStore.dispatch(roomHistoryFinished({ loaderId: 'loader' }));
+		const { historyLoaders } = mockedStore.getState().room;
+		expect(historyLoaders).toEqual([]);
 	});
 });

--- a/app/reducers/room.test.ts
+++ b/app/reducers/room.test.ts
@@ -59,7 +59,7 @@ describe('test room reducer', () => {
 	});
 
 	it('should return historyLoaders with one item after call historyRequest', () => {
-		mockedStore.dispatch(roomHistoryRequest({ rid: 'GENERAL', t: ERoomType.c, loaderId: 'loader' }));
+		mockedStore.dispatch(roomHistoryRequest({ rid: 'GENERAL', t: 'c', loaderId: 'loader' }));
 		const { historyLoaders } = mockedStore.getState().room;
 		expect(historyLoaders).toEqual(['loader']);
 	});

--- a/app/reducers/room.ts
+++ b/app/reducers/room.ts
@@ -7,12 +7,14 @@ export interface IRoom {
 	rid: string;
 	isDeleting: boolean;
 	subscribedRoom: string;
+	historyLoaders: string[];
 }
 
 export const initialState: IRoom = {
 	rid: '',
 	isDeleting: false,
-	subscribedRoom: ''
+	subscribedRoom: '',
+	historyLoaders: []
 };
 
 export default function (state = initialState, action: TActionsRoom): IRoom {
@@ -55,6 +57,16 @@ export default function (state = initialState, action: TActionsRoom): IRoom {
 			return {
 				...state,
 				isDeleting: false
+			};
+		case ROOM.HISTORY_REQUEST:
+			return {
+				...state,
+				historyLoaders: [...state.historyLoaders, action.loaderId]
+			};
+		case ROOM.HISTORY_FINISHED:
+			return {
+				...state,
+				historyLoaders: state.historyLoaders.filter(loaderId => loaderId !== action.loaderId)
 			};
 		default:
 			return state;

--- a/app/sagas/room.js
+++ b/app/sagas/room.js
@@ -10,7 +10,7 @@ import I18n from '../i18n';
 import { showErrorAlert } from '../lib/methods/helpers/info';
 import { LISTENER } from '../containers/Toast';
 import { Services } from '../lib/services';
-import getMoreMessages from '../views/RoomView/services/getMoreMessages';
+import getMoreMessages from '../lib/methods/getMoreMessages';
 
 function* watchHistoryRequests() {
 	const requestChan = yield actionChannel(types.ROOM.HISTORY_REQUEST);

--- a/app/sagas/room.js
+++ b/app/sagas/room.js
@@ -11,14 +11,15 @@ import { showErrorAlert } from '../lib/methods/helpers/info';
 import { LISTENER } from '../containers/Toast';
 import { Services } from '../lib/services';
 import getMoreMessages from '../lib/methods/getMoreMessages';
+import { getMessageById } from '../lib/database/services/Message';
 
 function* watchHistoryRequests() {
 	const requestChan = yield actionChannel(types.ROOM.HISTORY_REQUEST);
 	while (true) {
-		const { rid, t, tmid, loaderItem } = yield take(requestChan);
+		const { rid, t, tmid, loaderId } = yield take(requestChan);
 
-		// Prevents some loader from running twice
-		if (loaderItem?.syncStatus !== 'deleted') {
+		const loaderItem = yield getMessageById(loaderId);
+		if (loaderItem) {
 			try {
 				yield getMoreMessages({ rid, t, tmid, loaderItem });
 			} catch (e) {

--- a/app/sagas/room.js
+++ b/app/sagas/room.js
@@ -24,6 +24,8 @@ function* watchHistoryRequests() {
 				yield getMoreMessages({ rid, t, tmid, loaderItem });
 			} catch (e) {
 				log(e);
+			} finally {
+				yield put({ type: types.ROOM.HISTORY_FINISHED, loaderId });
 			}
 		}
 	}

--- a/app/sagas/room.js
+++ b/app/sagas/room.js
@@ -12,20 +12,19 @@ import { LISTENER } from '../containers/Toast';
 import { Services } from '../lib/services';
 import getMoreMessages from '../views/RoomView/services/getMoreMessages';
 
-function* handleHistoryRequest({ rid, t, tmid, loaderItem }) {
-	console.log(`starting handle request ${loaderItem.ts}`);
-	// yield delay(10000);
-	yield getMoreMessages({ rid, t, tmid, loaderItem });
-	console.log(`ending handle request ${loaderItem.ts}`);
-}
-
 function* watchHistoryRequests() {
 	const requestChan = yield actionChannel(types.ROOM.HISTORY_REQUEST);
 	while (true) {
 		const { rid, t, tmid, loaderItem } = yield take(requestChan);
-		yield call(handleHistoryRequest, { rid, t, tmid, loaderItem });
 
-		// yield put({ type: types.ROOM.HISTORY.REQUEST, rid, end, t });
+		// Prevents some loader from running twice
+		if (loaderItem?.syncStatus !== 'deleted') {
+			try {
+				yield getMoreMessages({ rid, t, tmid, loaderItem });
+			} catch (e) {
+				log(e);
+			}
+		}
 	}
 }
 

--- a/app/sagas/room.js
+++ b/app/sagas/room.js
@@ -1,5 +1,5 @@
 import { Alert } from 'react-native';
-import { delay, put, race, select, take, takeLatest, actionChannel, call } from 'redux-saga/effects';
+import { delay, put, race, select, take, takeLatest, actionChannel } from 'redux-saga/effects';
 
 import EventEmitter from '../lib/methods/helpers/events';
 import Navigation from '../lib/navigation/appNavigation';

--- a/app/sagas/rooms.js
+++ b/app/sagas/rooms.js
@@ -66,7 +66,7 @@ const handleRoomsRequest = function* handleRoomsRequest({ params }) {
 				 */
 				.filter(sub => subscribedRoom !== sub.rid)
 				.map(sub => sub.lastMessage && buildMessage(sub.lastMessage))
-				.filter(lm => lm);
+				.filter(lm => lm && lm._id && lm.rid);
 			const lastMessagesIds = lastMessages.map(lm => lm._id).filter(lm => lm);
 			const existingMessages = yield messagesCollection.query(Q.where('id', Q.oneOf(lastMessagesIds))).fetch();
 			const messagesToUpdate = existingMessages.filter(i1 => lastMessages.find(i2 => i1.id === i2._id));

--- a/app/views/RoomView/LoadMore/LoadMore.stories.tsx
+++ b/app/views/RoomView/LoadMore/LoadMore.stories.tsx
@@ -6,14 +6,13 @@ import { ThemeContext, TSupportedThemes } from '../../../theme';
 import { Message } from '../../../containers/message/Message.stories';
 import { MessageTypeLoad, themes } from '../../../lib/constants';
 import LoadMoreComponent from '.';
-import { ERoomType } from '../../../definitions';
 
 export default {
 	title: 'RoomView/LoadMore'
 };
 
 const LoadMore = ({ ...props }) => (
-	<LoadMoreComponent rid='rid' t={ERoomType.c} loaderId='loaderId' type={MessageTypeLoad.MORE} runOnRender={false} {...props} />
+	<LoadMoreComponent rid='rid' t='c' loaderId='loaderId' type={MessageTypeLoad.MORE} runOnRender={false} {...props} />
 );
 
 export const Basic = () => (

--- a/app/views/RoomView/LoadMore/LoadMore.stories.tsx
+++ b/app/views/RoomView/LoadMore/LoadMore.stories.tsx
@@ -6,21 +6,14 @@ import { ThemeContext, TSupportedThemes } from '../../../theme';
 import { Message } from '../../../containers/message/Message.stories';
 import { MessageTypeLoad, themes } from '../../../lib/constants';
 import LoadMoreComponent from '.';
-import { SubscriptionType } from '../../../definitions';
+import { ERoomType } from '../../../definitions';
 
 export default {
 	title: 'RoomView/LoadMore'
 };
 
 const LoadMore = ({ ...props }) => (
-	<LoadMoreComponent
-		rid='rid'
-		t={SubscriptionType.CHANNEL}
-		loaderId='loaderId'
-		type={MessageTypeLoad.MORE}
-		runOnRender={false}
-		{...props}
-	/>
+	<LoadMoreComponent rid='rid' t={ERoomType.c} loaderId='loaderId' type={MessageTypeLoad.MORE} runOnRender={false} {...props} />
 );
 
 export const Basic = () => (

--- a/app/views/RoomView/LoadMore/LoadMore.stories.tsx
+++ b/app/views/RoomView/LoadMore/LoadMore.stories.tsx
@@ -6,33 +6,41 @@ import { ThemeContext, TSupportedThemes } from '../../../theme';
 import { Message } from '../../../containers/message/Message.stories';
 import { MessageTypeLoad, themes } from '../../../lib/constants';
 import LoadMoreComponent from '.';
+import { SubscriptionType } from '../../../definitions';
 
 export default {
 	title: 'RoomView/LoadMore'
 };
 
-const load = () => new Promise(res => setTimeout(res, 1000));
-
-const LoadMore = ({ ...props }) => <LoadMoreComponent type={MessageTypeLoad.MORE} load={load} runOnRender={false} {...props} />;
+const LoadMore = ({ ...props }) => (
+	<LoadMoreComponent
+		rid='rid'
+		t={SubscriptionType.CHANNEL}
+		loaderId='loaderId'
+		type={MessageTypeLoad.MORE}
+		runOnRender={false}
+		{...props}
+	/>
+);
 
 export const Basic = () => (
 	<>
-		<LoadMore />
-		<LoadMore runOnRender />
-		<LoadMore type={MessageTypeLoad.PREVIOUS_CHUNK} />
-		<LoadMore type={MessageTypeLoad.NEXT_CHUNK} />
+		<LoadMore loaderId='1' />
+		<LoadMore loaderId='2' runOnRender />
+		<LoadMore loaderId='3' type={MessageTypeLoad.PREVIOUS_CHUNK} />
+		<LoadMore loaderId='4' type={MessageTypeLoad.NEXT_CHUNK} />
 	</>
 );
 
 const ThemeStory = ({ theme }: { theme: TSupportedThemes }) => (
 	<ThemeContext.Provider value={{ theme, colors: themes[theme] }}>
 		<ScrollView style={{ backgroundColor: themes[theme].backgroundColor }}>
-			<LoadMore type={MessageTypeLoad.PREVIOUS_CHUNK} />
+			<LoadMore loaderId='5' type={MessageTypeLoad.PREVIOUS_CHUNK} />
 			<Message msg='Hey!' theme={theme} />
 			<Message msg={longText} theme={theme} isHeader={false} />
 			<Message msg='Older message' theme={theme} isHeader={false} />
-			<LoadMore type={MessageTypeLoad.NEXT_CHUNK} />
-			<LoadMore type={MessageTypeLoad.MORE} />
+			<LoadMore loaderId='6' type={MessageTypeLoad.NEXT_CHUNK} />
+			<LoadMore loaderId='7' type={MessageTypeLoad.MORE} />
 			<Message msg={longText} theme={theme} />
 			<Message msg='This is the third message' isHeader={false} theme={theme} />
 			<Message msg='This is the second message' isHeader={false} theme={theme} />

--- a/app/views/RoomView/LoadMore/index.tsx
+++ b/app/views/RoomView/LoadMore/index.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { useDispatch } from 'react-redux';
 
 import { MessageTypeLoad } from '../../../lib/constants';
-import { ERoomType, MessageType } from '../../../definitions';
+import { MessageType, RoomType } from '../../../definitions';
 import { useTheme } from '../../../theme';
 import Touch from '../../../containers/Touch';
 import sharedStyles from '../../Styles';
@@ -32,7 +32,7 @@ const LoadMore = React.memo(
 		runOnRender
 	}: {
 		rid: string;
-		t: ERoomType;
+		t: RoomType;
 		loaderId: string;
 		type: MessageType;
 		runOnRender: boolean;

--- a/app/views/RoomView/LoadMore/index.tsx
+++ b/app/views/RoomView/LoadMore/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { useDispatch } from 'react-redux';
 
-import { MessageTypeLoad, themes } from '../../../lib/constants';
+import { MessageTypeLoad } from '../../../lib/constants';
 import { ERoomType, MessageType } from '../../../definitions';
 import { useTheme } from '../../../theme';
 import Touch from '../../../containers/Touch';
@@ -37,7 +37,7 @@ const LoadMore = React.memo(
 		type: MessageType;
 		runOnRender: boolean;
 	}): React.ReactElement => {
-		const { theme } = useTheme();
+		const { colors } = useTheme();
 		const dispatch = useDispatch();
 		const loading = useAppSelector(state => state.room.historyLoaders.some(historyLoader => historyLoader === loaderId));
 
@@ -60,9 +60,9 @@ const LoadMore = React.memo(
 		return (
 			<Touch onPress={handleLoad} style={styles.button} enabled={!loading}>
 				{loading ? (
-					<ActivityIndicator color={themes[theme].auxiliaryText} />
+					<ActivityIndicator color={colors.auxiliaryText} />
 				) : (
-					<Text style={[styles.text, { color: themes[theme].titleText }]}>{I18n.t(text)}</Text>
+					<Text style={[styles.text, { color: colors.titleText }]}>{I18n.t(text)}</Text>
 				)}
 			</Touch>
 		);

--- a/app/views/RoomView/LoadMore/index.tsx
+++ b/app/views/RoomView/LoadMore/index.tsx
@@ -23,50 +23,52 @@ const styles = StyleSheet.create({
 	}
 });
 
-const LoadMore = ({
-	rid,
-	t,
-	tmid,
-	loaderId,
-	type,
-	runOnRender
-}: {
-	rid: string;
-	t: SubscriptionType;
-	tmid?: string;
-	loaderId: string;
-	type: MessageType;
-	runOnRender: boolean;
-}): React.ReactElement => {
-	const { theme } = useTheme();
-	const dispatch = useDispatch();
-	const loading = useAppSelector(state => state.room.historyLoaders.find(historyLoader => historyLoader === loaderId));
+const LoadMore = React.memo(
+	({
+		rid,
+		t,
+		tmid,
+		loaderId,
+		type,
+		runOnRender
+	}: {
+		rid: string;
+		t: SubscriptionType;
+		tmid?: string;
+		loaderId: string;
+		type: MessageType;
+		runOnRender: boolean;
+	}): React.ReactElement => {
+		const { theme } = useTheme();
+		const dispatch = useDispatch();
+		const loading = useAppSelector(state => state.room.historyLoaders.find(historyLoader => historyLoader === loaderId));
 
-	const handleLoad = () => dispatch(roomHistoryRequest({ rid, t, tmid, loaderId }));
+		const handleLoad = () => dispatch(roomHistoryRequest({ rid, t, tmid, loaderId }));
 
-	useEffect(() => {
-		if (runOnRender) {
-			handleLoad();
+		useEffect(() => {
+			if (runOnRender) {
+				handleLoad();
+			}
+		}, []);
+
+		let text = 'Load_More';
+		if (type === MessageTypeLoad.NEXT_CHUNK) {
+			text = 'Load_Newer';
 		}
-	}, []);
+		if (type === MessageTypeLoad.PREVIOUS_CHUNK) {
+			text = 'Load_Older';
+		}
 
-	let text = 'Load_More';
-	if (type === MessageTypeLoad.NEXT_CHUNK) {
-		text = 'Load_Newer';
+		return (
+			<Touch onPress={handleLoad} style={styles.button} enabled={!loading}>
+				{loading ? (
+					<ActivityIndicator color={themes[theme].auxiliaryText} />
+				) : (
+					<Text style={[styles.text, { color: themes[theme].titleText }]}>{I18n.t(text)}</Text>
+				)}
+			</Touch>
+		);
 	}
-	if (type === MessageTypeLoad.PREVIOUS_CHUNK) {
-		text = 'Load_Older';
-	}
-
-	return (
-		<Touch onPress={handleLoad} style={styles.button} enabled={!loading}>
-			{loading ? (
-				<ActivityIndicator color={themes[theme].auxiliaryText} />
-			) : (
-				<Text style={[styles.text, { color: themes[theme].titleText }]}>{I18n.t(text)}</Text>
-			)}
-		</Touch>
-	);
-};
+);
 
 export default LoadMore;

--- a/app/views/RoomView/LoadMore/index.tsx
+++ b/app/views/RoomView/LoadMore/index.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { useDispatch } from 'react-redux';
 
 import { MessageTypeLoad, themes } from '../../../lib/constants';
-import { MessageType, SubscriptionType, TAnyMessageModel } from '../../../definitions';
+import { MessageType, SubscriptionType } from '../../../definitions';
 import { useTheme } from '../../../theme';
 import Touch from '../../../containers/Touch';
 import sharedStyles from '../../Styles';
@@ -23,18 +23,17 @@ const styles = StyleSheet.create({
 });
 
 const LoadMore = ({
-	// load,
 	rid,
 	t,
 	tmid,
-	loaderItem,
+	loaderId,
 	type,
 	runOnRender
 }: {
 	rid: string;
 	t: SubscriptionType;
 	tmid?: string;
-	loaderItem: TAnyMessageModel;
+	loaderId: string;
 	type: MessageType;
 	runOnRender: boolean;
 }): React.ReactElement => {
@@ -42,19 +41,18 @@ const LoadMore = ({
 	const [loading, setLoading] = useState(false);
 	const dispatch = useDispatch();
 
-	const handleLoad = useCallback(() => {
+	const handleLoad = () => {
 		try {
 			if (loading) {
 				return;
 			}
 			setLoading(true);
-			// await load();
 			// FIXME: add loading item to reducer
-			dispatch(roomHistoryRequest({ rid, t, tmid, loaderItem }));
+			dispatch(roomHistoryRequest({ rid, t, tmid, loaderId }));
 		} finally {
 			setLoading(false);
 		}
-	}, [loading]);
+	};
 
 	useEffect(() => {
 		if (runOnRender) {

--- a/app/views/RoomView/LoadMore/index.tsx
+++ b/app/views/RoomView/LoadMore/index.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { useDispatch } from 'react-redux';
 
 import { MessageTypeLoad, themes } from '../../../lib/constants';
-import { MessageType, SubscriptionType } from '../../../definitions';
+import { ERoomType, MessageType } from '../../../definitions';
 import { useTheme } from '../../../theme';
 import Touch from '../../../containers/Touch';
 import sharedStyles from '../../Styles';
@@ -27,23 +27,21 @@ const LoadMore = React.memo(
 	({
 		rid,
 		t,
-		tmid,
 		loaderId,
 		type,
 		runOnRender
 	}: {
 		rid: string;
-		t: SubscriptionType;
-		tmid?: string;
+		t: ERoomType;
 		loaderId: string;
 		type: MessageType;
 		runOnRender: boolean;
 	}): React.ReactElement => {
 		const { theme } = useTheme();
 		const dispatch = useDispatch();
-		const loading = useAppSelector(state => state.room.historyLoaders.find(historyLoader => historyLoader === loaderId));
+		const loading = useAppSelector(state => state.room.historyLoaders.some(historyLoader => historyLoader === loaderId));
 
-		const handleLoad = () => dispatch(roomHistoryRequest({ rid, t, tmid, loaderId }));
+		const handleLoad = () => dispatch(roomHistoryRequest({ rid, t, loaderId }));
 
 		useEffect(() => {
 			if (runOnRender) {

--- a/app/views/RoomView/LoadMore/index.tsx
+++ b/app/views/RoomView/LoadMore/index.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text } from 'react-native';
+import { useDispatch } from 'react-redux';
 
 import { MessageTypeLoad, themes } from '../../../lib/constants';
-import { MessageType } from '../../../definitions';
+import { MessageType, SubscriptionType, TAnyMessageModel } from '../../../definitions';
 import { useTheme } from '../../../theme';
 import Touch from '../../../containers/Touch';
 import sharedStyles from '../../Styles';
 import I18n from '../../../i18n';
+import { roomHistoryRequest } from '../../../actions/room';
 
 const styles = StyleSheet.create({
 	button: {
@@ -21,24 +23,34 @@ const styles = StyleSheet.create({
 });
 
 const LoadMore = ({
-	load,
+	// load,
+	rid,
+	t,
+	tmid,
+	loaderItem,
 	type,
 	runOnRender
 }: {
-	load: Function;
+	rid: string;
+	t: SubscriptionType;
+	tmid?: string;
+	loaderItem: TAnyMessageModel;
 	type: MessageType;
 	runOnRender: boolean;
 }): React.ReactElement => {
 	const { theme } = useTheme();
 	const [loading, setLoading] = useState(false);
+	const dispatch = useDispatch();
 
-	const handleLoad = useCallback(async () => {
+	const handleLoad = useCallback(() => {
 		try {
 			if (loading) {
 				return;
 			}
 			setLoading(true);
-			await load();
+			// await load();
+			// FIXME: add loading item to reducer
+			dispatch(roomHistoryRequest({ rid, t, tmid, loaderItem }));
 		} finally {
 			setLoading(false);
 		}

--- a/app/views/RoomView/LoadMore/index.tsx
+++ b/app/views/RoomView/LoadMore/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { useDispatch } from 'react-redux';
 
@@ -9,6 +9,7 @@ import Touch from '../../../containers/Touch';
 import sharedStyles from '../../Styles';
 import I18n from '../../../i18n';
 import { roomHistoryRequest } from '../../../actions/room';
+import { useAppSelector } from '../../../lib/hooks';
 
 const styles = StyleSheet.create({
 	button: {
@@ -38,21 +39,10 @@ const LoadMore = ({
 	runOnRender: boolean;
 }): React.ReactElement => {
 	const { theme } = useTheme();
-	const [loading, setLoading] = useState(false);
 	const dispatch = useDispatch();
+	const loading = useAppSelector(state => state.room.historyLoaders.find(historyLoader => historyLoader === loaderId));
 
-	const handleLoad = () => {
-		try {
-			if (loading) {
-				return;
-			}
-			setLoading(true);
-			// FIXME: add loading item to reducer
-			dispatch(roomHistoryRequest({ rid, t, tmid, loaderId }));
-		} finally {
-			setLoading(false);
-		}
-	};
+	const handleLoad = () => dispatch(roomHistoryRequest({ rid, t, tmid, loaderId }));
 
 	useEffect(() => {
 		if (runOnRender) {

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -174,18 +174,18 @@ interface IRoomViewState {
 	[key: string]: any;
 	joined: boolean;
 	room:
-	| TSubscriptionModel
-	| {
-		rid: string;
-		t: string;
-		name?: string;
-		fname?: string;
-		prid?: string;
-		joinCodeRequired?: boolean;
-		status?: string;
-		lastMessage?: ILastMessage;
-		sysMes?: boolean;
-		onHold?: boolean;
+		| TSubscriptionModel
+		| {
+				rid: string;
+				t: string;
+				name?: string;
+				fname?: string;
+				prid?: string;
+				joinCodeRequired?: boolean;
+				status?: string;
+				lastMessage?: ILastMessage;
+				sysMes?: boolean;
+				onHold?: boolean;
 		  };
 	roomUpdate: {
 		[K in TRoomUpdate]?: any;
@@ -1337,7 +1337,11 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 		if (item.t && MESSAGE_TYPE_ANY_LOAD.includes(item.t as MessageTypeLoad)) {
 			content = (
 				<LoadMore
-					load={() => this.onLoadMoreMessages(item)}
+					// load={() => this.onLoadMoreMessages(item)}
+					rid={room.rid}
+					t={room.t as any}
+					tmid={this.tmid}
+					loaderItem={item} // whole item?
 					type={item.t}
 					runOnRender={item.t === MessageTypeLoad.MORE && !previousItem}
 				/>
@@ -1502,7 +1506,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 		return (
 			<>
 				<MessageActions
-					ref={ref => this.messageActions = ref}
+					ref={ref => (this.messageActions = ref)}
 					tmid={this.tmid}
 					room={room}
 					user={user}
@@ -1512,7 +1516,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 					onReactionPress={this.onReactionPress}
 					isReadOnly={readOnly}
 				/>
-				<MessageErrorActions ref={ref => this.messageErrorActions = ref} tmid={this.tmid} />
+				<MessageErrorActions ref={ref => (this.messageErrorActions = ref)} tmid={this.tmid} />
 			</>
 		);
 	};

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -75,7 +75,8 @@ import {
 	TThreadModel,
 	ICustomEmojis,
 	IEmoji,
-	TGetCustomEmoji
+	TGetCustomEmoji,
+	RoomType
 } from '../../definitions';
 import { E2E_MESSAGE_TYPE, E2E_STATUS, MESSAGE_TYPE_ANY_LOAD, MessageTypeLoad, themes } from '../../lib/constants';
 import { TListRef } from './List/List';
@@ -685,7 +686,11 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 				await loadThreadMessages({ tmid: this.tmid, rid: this.rid });
 			} else {
 				const newLastOpen = new Date();
-				await RoomServices.getMessages(room);
+				await RoomServices.getMessages({
+					rid: room.rid,
+					lastOpen: 'lastOpen' in room ? room.lastOpen : undefined,
+					t: room.t as RoomType
+				});
 
 				// if room is joined
 				if (joined && 'id' in room) {
@@ -1328,7 +1333,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 			content = (
 				<LoadMore
 					rid={room.rid}
-					t={room.t as any}
+					t={room.t as RoomType}
 					loaderId={item.id}
 					type={item.t}
 					runOnRender={item.t === MessageTypeLoad.MORE && !previousItem}

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -1329,7 +1329,6 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 				<LoadMore
 					rid={room.rid}
 					t={room.t as any}
-					tmid={this.tmid}
 					loaderId={item.id}
 					type={item.t}
 					runOnRender={item.t === MessageTypeLoad.MORE && !previousItem}

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -1330,7 +1330,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 					rid={room.rid}
 					t={room.t as any}
 					tmid={this.tmid}
-					loaderItem={item} // whole item?
+					loaderId={item.id}
 					type={item.t}
 					runOnRender={item.t === MessageTypeLoad.MORE && !previousItem}
 				/>

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -1301,16 +1301,6 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 		return false;
 	};
 
-	onLoadMoreMessages = (loaderItem: TAnyMessageModel) => {
-		const { room } = this.state;
-		return RoomServices.getMoreMessages({
-			rid: room.rid,
-			tmid: this.tmid,
-			t: room.t as any,
-			loaderItem
-		});
-	};
-
 	goToCannedResponses = () => {
 		const { room } = this.state;
 		Navigation.navigate('CannedResponsesListView', { rid: room.rid });
@@ -1337,7 +1327,6 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 		if (item.t && MESSAGE_TYPE_ANY_LOAD.includes(item.t as MessageTypeLoad)) {
 			content = (
 				<LoadMore
-					// load={() => this.onLoadMoreMessages(item)}
 					rid={room.rid}
 					t={room.t as any}
 					tmid={this.tmid}

--- a/app/views/RoomView/services/getMessages.ts
+++ b/app/views/RoomView/services/getMessages.ts
@@ -1,10 +1,22 @@
-import { loadMessagesForRoom, loadMissedMessages } from '../../../lib/methods';
+import { loadMessagesForRoom, loadMissedMessages, RoomTypes } from '../../../lib/methods';
 
-const getMessages = ({ rid, t, lastOpen }: { rid: string; t?: string; lastOpen?: Date }): Promise<void> => {
-	if (lastOpen) {
-		return loadMissedMessages({ rid, lastOpen });
+interface IBaseParams {
+	rid: string;
+}
+
+interface ILoadMessagesForRoomParams extends IBaseParams {
+	t: RoomTypes;
+}
+
+interface ILoadMissedMessagesParams extends IBaseParams {
+	lastOpen: Date;
+}
+
+const getMessages = (params: ILoadMissedMessagesParams | ILoadMessagesForRoomParams): Promise<void> => {
+	if ('lastOpen' in params) {
+		return loadMissedMessages(params);
 	}
-	return loadMessagesForRoom({ rid, t: t as any });
+	return loadMessagesForRoom(params);
 };
 
 export default getMessages;

--- a/app/views/RoomView/services/getMessages.ts
+++ b/app/views/RoomView/services/getMessages.ts
@@ -1,23 +1,10 @@
 import { loadMessagesForRoom, loadMissedMessages } from '../../../lib/methods';
 
-// TODO: clarify latest vs lastOpen
-const getMessages = ({
-	rid,
-	t,
-	latest,
-	lastOpen,
-	loaderItem
-}: {
-	rid: string;
-	t?: string;
-	latest?: Date;
-	lastOpen?: Date;
-	loaderItem?: any; // TODO: type this
-}): Promise<void> => {
+const getMessages = ({ rid, t, lastOpen }: { rid: string; t?: string; lastOpen?: Date }): Promise<void> => {
 	if (lastOpen) {
 		return loadMissedMessages({ rid, lastOpen });
 	}
-	return loadMessagesForRoom({ rid, t: t as any, latest, loaderItem });
+	return loadMessagesForRoom({ rid, t: t as any });
 };
 
 export default getMessages;

--- a/app/views/RoomView/services/index.ts
+++ b/app/views/RoomView/services/index.ts
@@ -1,9 +1,7 @@
 import getMessages from './getMessages';
-import getMoreMessages from './getMoreMessages';
 import getMessageInfo from './getMessageInfo';
 
 export default {
 	getMessages,
-	getMoreMessages,
 	getMessageInfo
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Fixes a use case where the app would fail to persist data on local db without adding a new loader item ("load more").
It could be reproduced by scrolling through messages history while receiving multiple messages on the same room.
That would make `LoadMore` component to mount -> unmount -> mount, which would call `useEffect` twice and create a race condition during load.

I fixed by adding the load logic inside a saga channel (queue), since we don't have a better option to deal with message loading atm.
`LoadMore` dispatches the redux action to the saga queue, which calls them in sequence.
If the same loader was called more than once, it's ignored.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Closes https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/4793

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Go to a room with enough messages to trigger pagination
- Receive messages while scrolling through history
- Eventually the app would reach a point where it can't load more messages, but it should

It's easily reproducible by running these two scripts at the same time.

```sh
#!/bin/bash
for i in {1..1500}
do
  curl --location --request POST 'http://localhost:3000/api/v1/chat.postMessage' \
		--header 'content-type: application/json' \
		--header 'x-auth-token: <<TOKEN>>' \
		--header 'x-user-id: <<USERID>>' \
		--data-raw '{
				"roomId": "<<RID>>",
				"msg": '$i'
		}'
	sleep 0.3
done
```

```sh
#!/bin/bash
while true
do
  adb shell input swipe 800 350 800 1000 50
	sleep 0.5
done
```

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[NATIVE-223]

[NATIVE-223]: https://rocketchat.atlassian.net/browse/NATIVE-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ