### PR TITLE
fix: change reactions list scroll to use a single snap point

### DIFF
--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -906,7 +906,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 		const { selectedMessage } = this.state;
 		this.handleCloseEmoji(showActionSheet, {
 			children: <ReactionsList reactions={selectedMessage?.reactions} getCustomEmoji={this.getCustomEmoji} />,
-			snaps: ['50%', '80%'],
+			snaps: ['50%'],
 			enableContentPanningGesture: false
 		});
 	};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
There is a bug in the component provided by the library where it fails to determine its height when there are multiple snap points. For instance, with the array ['50%, '80%'], the component interpreted that the height of the scroll was 80% of the device's height, causing a part of the scroll to be hidden during the first 50%. On iOS, this resulted in bouncing to the end of the scroll, revealing more users to list, while on Android, this bounce did not occur, making it appear as if the scroll was at the end.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Go to a channel and search for a message with more than 8 user's reactions with the same reactions
- Do a long press on the reactions
- The reaction's list should appear and you should be able to see all the users that reacted with that emoji

## Screenshots

#### Before
https://user-images.githubusercontent.com/47038980/232520418-ce7d61d4-2b69-4273-8446-ec7274522e4a.mov

#### After
https://user-images.githubusercontent.com/47038980/232520476-cb91eb14-e3a6-4dc2-a57d-a9d215a22b03.mov


## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[NATIVE-206]

[NATIVE-206]: https://rocketchat.atlassian.net/browse/NATIVE-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ