### PR TITLE
fix: avoid component Message render twice in a row

### DIFF
--- a/app/containers/message/Blocks.ts
+++ b/app/containers/message/Blocks.ts
@@ -1,14 +1,13 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { messageBlockWithContext } from '../UIKit/MessageBlock';
 import { IMessageBlocks } from './interfaces';
 
-const Blocks = React.memo(({ blocks, id: mid, rid, blockAction }: IMessageBlocks) => {
-	if (blocks && blocks.length > 0) {
-		const appId = blocks[0]?.appId || '';
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const comp = useRef(
-			React.createElement(
+const Blocks = React.memo(
+	({ blocks, id: mid, rid, blockAction }: IMessageBlocks) => {
+		if (blocks && blocks.length > 0) {
+			const appId = blocks[0]?.appId || '';
+			return React.createElement(
 				messageBlockWithContext({
 					action: async ({ actionId, value, blockId }: { actionId: string; value: string; blockId: string }) => {
 						if (blockAction) {
@@ -26,12 +25,21 @@ const Blocks = React.memo(({ blocks, id: mid, rid, blockAction }: IMessageBlocks
 					rid
 				}),
 				{ blocks }
-			)
-		);
-		return comp.current;
+			);
+		}
+		return null;
+	},
+	(prevProps, nextProps) => {
+		if (
+			('type' in prevProps.blocks[0] && prevProps.blocks[0].type === 'video_conf') ||
+			('type' in nextProps.blocks[0] && nextProps.blocks[0].type === 'video_conf')
+		) {
+			// Avoid multiple request on the VideoConferenceBlock
+			return true;
+		}
+		return false;
 	}
-	return null;
-});
+);
 
 Blocks.displayName = 'MessageBlocks';
 

--- a/app/containers/message/Blocks.ts
+++ b/app/containers/message/Blocks.ts
@@ -3,45 +3,31 @@ import React from 'react';
 import { messageBlockWithContext } from '../UIKit/MessageBlock';
 import { IMessageBlocks } from './interfaces';
 
-const Blocks = React.memo(
-	({ blocks, id: mid, rid, blockAction }: IMessageBlocks) => {
-		if (blocks && blocks.length > 0) {
-			const appId = blocks[0]?.appId || '';
-			return React.createElement(
-				messageBlockWithContext({
-					action: async ({ actionId, value, blockId }: { actionId: string; value: string; blockId: string }) => {
-						if (blockAction) {
-							await blockAction({
-								actionId,
-								appId,
-								value,
-								blockId,
-								rid,
-								mid
-							});
-						}
-					},
-					appId,
-					rid
-				}),
-				{ blocks }
-			);
-		}
-		return null;
-	},
-	(prevProps, nextProps) => {
-		if (
-			// @ts-ignore
-			('type' in prevProps.blocks[0] && prevProps.blocks[0].type === 'video_conf') ||
-			// @ts-ignore
-			('type' in nextProps.blocks[0] && nextProps.blocks[0].type === 'video_conf')
-		) {
-			// Avoid multiple request on the VideoConferenceBlock
-			return true;
-		}
-		return false;
+const Blocks = ({ blocks, id: mid, rid, blockAction }: IMessageBlocks) => {
+	if (blocks && blocks.length > 0) {
+		const appId = blocks[0]?.appId || '';
+		return React.createElement(
+			messageBlockWithContext({
+				action: async ({ actionId, value, blockId }: { actionId: string; value: string; blockId: string }) => {
+					if (blockAction) {
+						await blockAction({
+							actionId,
+							appId,
+							value,
+							blockId,
+							rid,
+							mid
+						});
+					}
+				},
+				appId,
+				rid
+			}),
+			{ blocks }
+		);
 	}
-);
+	return null;
+};
 
 Blocks.displayName = 'MessageBlocks';
 

--- a/app/containers/message/Blocks.ts
+++ b/app/containers/message/Blocks.ts
@@ -31,7 +31,9 @@ const Blocks = React.memo(
 	},
 	(prevProps, nextProps) => {
 		if (
+			// @ts-ignore
 			('type' in prevProps.blocks[0] && prevProps.blocks[0].type === 'video_conf') ||
+			// @ts-ignore
 			('type' in nextProps.blocks[0] && nextProps.blocks[0].type === 'video_conf')
 		) {
 			// Avoid multiple request on the VideoConferenceBlock

--- a/app/containers/message/index.tsx
+++ b/app/containers/message/index.tsx
@@ -76,18 +76,27 @@ class MessageContainer extends React.Component<IMessageContainerProps, IMessageC
 		theme: 'light' as TSupportedThemes
 	};
 
-	state = { isManualUnignored: false };
-
 	private subscription?: Subscription;
+	private mounted: boolean;
 
-	componentDidMount() {
+	constructor(props: IMessageContainerProps) {
+		super(props);
+		this.state = { isManualUnignored: false };
+		this.mounted = false;
+
 		const { item } = this.props;
 		if (item && item.observe) {
 			const observable = item.observe();
 			this.subscription = observable.subscribe(() => {
-				this.forceUpdate();
+				if (this.mounted) {
+					this.forceUpdate();
+				}
 			});
 		}
+	}
+
+	componentDidMount() {
+		this.mounted = true;
 	}
 
 	shouldComponentUpdate(nextProps: IMessageContainerProps, nextState: IMessageContainerState) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
This PR does a refactor on the Message component, changing the way observes the `changes` incoming from the message are rendered. Before this PR, whenever the message is mounted, we are calling the observe and force update at the first change that was occurring immediately. Now, we start to observe the changes at the constructor and can force an update just after the component is mounted. With this approach, we avoid force rendering the component twice, just after mount a the component.


Note: The issue was reported because of the poll's result. When pressed the button, nothing happens and no feedback was showing to the user, or at least if his vote was computed. And we found that we were stopping re-render the MD blocks with any changes on this PR https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/4619, however, this regression was introduced to solve a problem when creating the video-conf block, because @GleidsonDaniel noticed that always when opening a room, each video-conf block was requesting to the API twice in a row, while the correct behavior was to request just once. So this PR is: 
- fix the issue of the poll's result
- fix the wrong behavior to render twice in a row


## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

- Create a poll
- Vote and should re-render properly
- Also you must test the re-render of the messages: send a new message, edit it, quote, emoji reaction. Do this with different accounts and from different platforms, like login into the web and sending a message, editing it, reaction, delete. Meanwhile, the user on the mobile should see the same messages as the user on the web

## Screenshots

#### Before

https://user-images.githubusercontent.com/47038980/234134391-3bfcb1dc-cadb-4d97-b5c4-8a7e47161174.mov



#### After

https://user-images.githubusercontent.com/47038980/234134254-11567ec0-9584-497f-9be1-0e662e7d33a9.mov



## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[TC-656]

[TC-656]: https://rocketchat.atlassian.net/browse/TC-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ