### PR TITLE
fix: properly set new room to be encrypted according to server settings

### DIFF
--- a/app/lib/constants/defaultSettings.ts
+++ b/app/lib/constants/defaultSettings.ts
@@ -102,6 +102,9 @@ export const defaultSettings = {
 	E2E_Enable: {
 		type: 'valueAsBoolean'
 	},
+	E2E_Enabled_Default_PrivateRooms: {
+		type: 'valueAsBoolean'
+	},
 	Accounts_Directory_DefaultView: {
 		type: 'valueAsString'
 	},

--- a/app/lib/methods/getSettings.ts
+++ b/app/lib/methods/getSettings.ts
@@ -21,7 +21,8 @@ const serverInfoKeys = [
 	'Force_Screen_Lock',
 	'Force_Screen_Lock_After',
 	'uniqueID',
-	'E2E_Enable'
+	'E2E_Enable',
+	'E2E_Enabled_Default_PrivateRooms'
 ];
 
 // these settings are used only on onboarding process
@@ -84,6 +85,9 @@ const serverInfoUpdate = async (serverInfo: IPreparedSettings[], iconSetting: IS
 		}
 		if (setting._id === 'E2E_Enable') {
 			return { ...allSettings, E2E_Enable: setting.valueAsBoolean };
+		}
+		if (setting._id === 'E2E_Enabled_Default_PrivateRooms') {
+			return { ...allSettings, E2E_Enabled_Default_PrivateRooms: setting.valueAsBoolean };
 		}
 		return allSettings;
 	}, {});

--- a/app/views/CreateChannelView/RoomSettings/index.tsx
+++ b/app/views/CreateChannelView/RoomSettings/index.tsx
@@ -13,7 +13,8 @@ export const RoomSettings = ({
 	isTeam,
 	setValue,
 	createChannelPermission,
-	createPrivateChannelPermission
+	createPrivateChannelPermission,
+	defaultEncryptionOn
 }: {
 	isTeam: boolean;
 	setValue: UseFormSetValue<IFormData>;
@@ -22,17 +23,12 @@ export const RoomSettings = ({
 }) => {
 	const [type, setType] = useState(true);
 	const [readOnly, setReadOnly] = useState(false);
-
-	const { encryptionEnabled, defaultEncryptionOn } = useAppSelector(state => {
-		const defaultEncryptionOn = state.settings.E2E_Enabled_Default_PrivateRooms;
-		return {
-			encryptionEnabled: state.encryption.enabled,
-			defaultEncryptionOn
-		};
-	});
-
 	const [encrypted, setEncrypted] = useState(defaultEncryptionOn);
 	const [broadcast, setBroadcast] = useState(false);
+
+	const { encryptionEnabled } = useAppSelector(state => ({
+		encryptionEnabled: state.encryption.enabled
+	}));
 
 	const onValueChangeType = useCallback(
 		(value: boolean) => {

--- a/app/views/CreateChannelView/RoomSettings/index.tsx
+++ b/app/views/CreateChannelView/RoomSettings/index.tsx
@@ -22,12 +22,17 @@ export const RoomSettings = ({
 }) => {
 	const [type, setType] = useState(true);
 	const [readOnly, setReadOnly] = useState(false);
-	const [encrypted, setEncrypted] = useState(false);
-	const [broadcast, setBroadcast] = useState(false);
 
-	const { encryptionEnabled } = useAppSelector(state => ({
-		encryptionEnabled: state.encryption.enabled
-	}));
+	const { encryptionEnabled, defaultEncryptionOn } = useAppSelector(state => {
+		const defaultEncryptionOn = state.settings.E2E_Enabled_Default_PrivateRooms;
+		return {
+			encryptionEnabled: state.encryption.enabled,
+			defaultEncryptionOn
+		};
+	});
+
+	const [encrypted, setEncrypted] = useState(defaultEncryptionOn);
+	const [broadcast, setBroadcast] = useState(false);
 
 	const onValueChangeType = useCallback(
 		(value: boolean) => {

--- a/app/views/CreateChannelView/RoomSettings/index.tsx
+++ b/app/views/CreateChannelView/RoomSettings/index.tsx
@@ -20,6 +20,7 @@ export const RoomSettings = ({
 	setValue: UseFormSetValue<IFormData>;
 	createChannelPermission: boolean;
 	createPrivateChannelPermission: boolean;
+	defaultEncryptionOn: boolean;
 }) => {
 	const [type, setType] = useState(true);
 	const [readOnly, setReadOnly] = useState(false);

--- a/app/views/CreateChannelView/RoomSettings/index.tsx
+++ b/app/views/CreateChannelView/RoomSettings/index.tsx
@@ -14,17 +14,17 @@ export const RoomSettings = ({
 	setValue,
 	createChannelPermission,
 	createPrivateChannelPermission,
-	defaultEncryptionOn
+	e2eEnabledDefaultPrivateRooms
 }: {
 	isTeam: boolean;
 	setValue: UseFormSetValue<IFormData>;
 	createChannelPermission: boolean;
 	createPrivateChannelPermission: boolean;
-	defaultEncryptionOn: boolean;
+	e2eEnabledDefaultPrivateRooms: boolean;
 }) => {
 	const [type, setType] = useState(true);
 	const [readOnly, setReadOnly] = useState(false);
-	const [encrypted, setEncrypted] = useState(defaultEncryptionOn);
+	const [encrypted, setEncrypted] = useState(e2eEnabledDefaultPrivateRooms);
 	const [broadcast, setBroadcast] = useState(false);
 
 	const { encryptionEnabled } = useAppSelector(state => ({

--- a/app/views/CreateChannelView/index.tsx
+++ b/app/views/CreateChannelView/index.tsx
@@ -68,12 +68,15 @@ export interface IFormData {
 const CreateChannelView = () => {
 	const [createChannelPermission, createPrivateChannelPermission] = usePermissions(['create-c', 'create-p']);
 
-	const { defaultEncryptionOn } = useAppSelector(state => {
-		const defaultEncryptionOn = state.encryption.enabled && (state.settings.E2E_Enabled_Default_PrivateRooms as boolean);
-		return {
-			defaultEncryptionOn
-		};
-	});
+	const { isFetching, useRealName, users, e2eEnabledDefaultPrivateRooms } = useAppSelector(
+		state => ({
+			isFetching: state.createChannel.isFetching,
+			users: state.selectedUsers.users,
+			useRealName: state.settings.UI_Use_Real_Name as boolean,
+			e2eEnabledDefaultPrivateRooms: state.encryption.enabled && (state.settings.E2E_Enabled_Default_PrivateRooms as boolean)
+		}),
+		shallowEqual
+	);
 
 	const {
 		control,
@@ -81,7 +84,13 @@ const CreateChannelView = () => {
 		formState: { isDirty },
 		setValue
 	} = useForm<IFormData>({
-		defaultValues: { channelName: '', broadcast: false, encrypted: defaultEncryptionOn, readOnly: false, type: createPrivateChannelPermission }
+		defaultValues: {
+			channelName: '',
+			broadcast: false,
+			encrypted: e2eEnabledDefaultPrivateRooms,
+			readOnly: false,
+			type: createPrivateChannelPermission
+		}
 	});
 
 	const navigation = useNavigation<StackNavigationProp<ChatsStackParamList, 'CreateChannelView'>>();
@@ -90,15 +99,6 @@ const CreateChannelView = () => {
 	const teamId = params?.teamId;
 	const { colors } = useTheme();
 	const dispatch = useDispatch();
-
-	const { isFetching, useRealName, users } = useAppSelector(
-		state => ({
-			isFetching: state.createChannel.isFetching,
-			users: state.selectedUsers.users,
-			useRealName: state.settings.UI_Use_Real_Name as boolean
-		}),
-		shallowEqual
-	);
 
 	useEffect(() => {
 		sendLoadingEvent({ visible: isFetching });
@@ -161,7 +161,7 @@ const CreateChannelView = () => {
 							createPrivateChannelPermission={createPrivateChannelPermission}
 							isTeam={isTeam}
 							setValue={setValue}
-							defaultEncryptionOn={defaultEncryptionOn}
+							e2eEnabledDefaultPrivateRooms={e2eEnabledDefaultPrivateRooms}
 						/>
 					</View>
 					{users.length > 0 ? (

--- a/app/views/CreateChannelView/index.tsx
+++ b/app/views/CreateChannelView/index.tsx
@@ -68,13 +68,20 @@ export interface IFormData {
 const CreateChannelView = () => {
 	const [createChannelPermission, createPrivateChannelPermission] = usePermissions(['create-c', 'create-p']);
 
+	const { defaultEncryptionOn } = useAppSelector(state => {
+		const defaultEncryptionOn = state.encryption.enabled && state.settings.E2E_Enabled_Default_PrivateRooms;
+		return {
+			defaultEncryptionOn
+		};
+	});
+
 	const {
 		control,
 		handleSubmit,
 		formState: { isDirty },
 		setValue
 	} = useForm<IFormData>({
-		defaultValues: { channelName: '', broadcast: false, encrypted: false, readOnly: false, type: createPrivateChannelPermission }
+		defaultValues: { channelName: '', broadcast: false, encrypted: defaultEncryptionOn, readOnly: false, type: createPrivateChannelPermission }
 	});
 
 	const navigation = useNavigation<StackNavigationProp<ChatsStackParamList, 'CreateChannelView'>>();
@@ -154,6 +161,7 @@ const CreateChannelView = () => {
 							createPrivateChannelPermission={createPrivateChannelPermission}
 							isTeam={isTeam}
 							setValue={setValue}
+							defaultEncryptionOn={defaultEncryptionOn}
 						/>
 					</View>
 					{users.length > 0 ? (

--- a/app/views/CreateChannelView/index.tsx
+++ b/app/views/CreateChannelView/index.tsx
@@ -69,7 +69,7 @@ const CreateChannelView = () => {
 	const [createChannelPermission, createPrivateChannelPermission] = usePermissions(['create-c', 'create-p']);
 
 	const { defaultEncryptionOn } = useAppSelector(state => {
-		const defaultEncryptionOn = state.encryption.enabled && state.settings.E2E_Enabled_Default_PrivateRooms;
+		const defaultEncryptionOn = state.encryption.enabled && (state.settings.E2E_Enabled_Default_PrivateRooms as boolean);
 		return {
 			defaultEncryptionOn
 		};

--- a/app/views/RoomsListView/Header/Header.tsx
+++ b/app/views/RoomsListView/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, TextInputProps, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
+import { StyleSheet, Text, TextInputProps, TouchableOpacityProps, View } from 'react-native';
 
 import I18n from '../../../i18n';
 import sharedStyles from '../../Styles';

--- a/app/views/RoomsListView/Header/Header.tsx
+++ b/app/views/RoomsListView/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, TextInputProps, TouchableOpacityProps, View } from 'react-native';
+import { StyleSheet, Text, TextInputProps, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
 
 import I18n from '../../../i18n';
 import sharedStyles from '../../Styles';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

Properly set new room to be encrypted according to server settings

## Issue(s)	

Closes: #5175 
Resolve: #5189

## How to test or reproduce

1. Go to server workspace administration
2. Go to settings
3. Go to "E2E Encryption"
4. Enable "E2E Encryption" and "Enable encryption for Private Rooms by default"
5. Save changes
6. Open app in mobile
7. Create a new room
8. Skip adding participants
9. In the next screen you will see room creation parameters, with the encryption flag turned off

## Screenshots

![image](https://github.com/RocketChat/Rocket.Chat.ReactNative/assets/1235688/d64236b9-e785-460c-936e-b647abba6d7f)

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
