### PR TITLE
fix: added check and handled the permissions err for downloading photos in ios

### DIFF
--- a/app/views/AttachmentView.tsx
+++ b/app/views/AttachmentView.tsx
@@ -3,7 +3,7 @@ import { HeaderBackground, useHeaderHeight } from '@react-navigation/elements';
 import { StackNavigationOptions } from '@react-navigation/stack';
 import { ResizeMode, Video } from 'expo-av';
 import React from 'react';
-import { PermissionsAndroid, useWindowDimensions, View } from 'react-native';
+import { PermissionsAndroid, useWindowDimensions, View, Linking } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { shallowEqual } from 'react-redux';
 import RNFetchBlob from 'rn-fetch-blob';
@@ -24,7 +24,6 @@ import { getUserSelector } from '../selectors/login';
 import { TNavigation } from '../stacks/stackType';
 import { useTheme } from '../theme';
 import { LOCAL_DOCUMENT_DIRECTORY, getFilename } from '../lib/methods/handleMediaDownload';
-import { Linking } from 'react-native';
 
 const RenderContent = ({
 	setLoading,
@@ -147,7 +146,7 @@ const AttachmentView = (): React.ReactElement => {
 
 	const handleSave = async () => {
 		const { title_link, image_url, image_type, video_url, video_type } = attachment;
-		// When the attachment is a video, the video_url refers to local file and the title_link to the link
+		// 	When the attachment is a video, the video_url refers to local file and the title_link to the link
 		const url = video_url || title_link || image_url;
 
 		if (!url) {
@@ -187,7 +186,7 @@ const AttachmentView = (): React.ReactElement => {
 			EventEmitter.emit(LISTENER, { message: I18n.t('saved_to_gallery') });
 		} catch (e) {
 			const err = e as Error;
-			//check if the error is due to permission in ios and show alert
+			//	check if the error is due to permission in ios and show alert
 			if (isIOS) {
 				if (err?.message.includes('PHPhotosErrorDomain error 3311')) {
 					showConfirmationAlert({
@@ -195,7 +194,7 @@ const AttachmentView = (): React.ReactElement => {
 						message: 'Photos permission not granted,Click ok to proceed to settings and enable it',
 						confirmationText: 'Ok',
 						onPress: async () => {
-							Linking.openURL('app-settings:').catch(() => {
+							await Linking.openURL('app-settings:').catch(() => {
 								console.error('Failed to open app settings');
 							});
 						}


### PR DESCRIPTION


## Proposed changes
To handle the permissions error in IOS if permission is denied once. We can only ask the user for permissions once in IOS. Hence if the the user is already denied the permission , this pr gives a better error message and helps to redirect the user to settings page.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#5285 

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->


## Screenshots

https://github.com/RocketChat/Rocket.Chat.ReactNative/assets/47176488/075b0510-ffc6-477f-91a3-8fe5cab5dd1e



## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

