### PR TITLE
chore: updated params of getDirectory

### DIFF
--- a/app/lib/services/restApi.ts
+++ b/app/lib/services/restApi.ts
@@ -823,23 +823,35 @@ export const executeCommandPreview = (
 	});
 
 export const getDirectory = ({
-	query,
+	text,
+	type,
+	workspace,
 	count,
 	offset,
 	sort
 }: {
-	query: { [key: string]: string };
+	text: string;
+	type: string;
+	workspace: string;
 	count: number;
 	offset: number;
 	sort: { [key: string]: number };
-}) =>
-	// RC 1.0
-	sdk.get('directory', {
-		query,
+}) => {
+	const serverVersion = reduxStore.getState().server.version;
+	const params: any = {
 		count,
 		offset,
 		sort
-	});
+	};
+	if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
+		params.text = text;
+		params.type = type;
+		params.workspace = workspace;
+	} else {
+		params.query = { text, type, workspace };
+	}
+	return sdk.get('directory', params);
+};
 
 export const saveAutoTranslate = ({
 	rid,

--- a/app/views/DirectoryView/index.tsx
+++ b/app/views/DirectoryView/index.tsx
@@ -108,9 +108,10 @@ class DirectoryView extends React.Component<IDirectoryViewProps, IDirectoryViewS
 
 		try {
 			const { data, type, globalUsers } = this.state;
-			const query = { text, type, workspace: globalUsers ? 'all' : 'local' };
 			const directories = await Services.getDirectory({
-				query,
+				text,
+				type,
+				workspace: globalUsers ? 'all' : 'local',
 				offset: data.length,
 				count: 50,
 				sort: type === 'users' ? { username: 1 } : { usersCount: -1 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Update the query parameters for `/directory`.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/NATIVE-703

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Open the app;
- Go to directoryView;

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
