### PR TITLE
Fix: Single image shown multiple times

### DIFF
--- a/app/containers/message/hooks/useMediaAutoDownload.tsx
+++ b/app/containers/message/hooks/useMediaAutoDownload.tsx
@@ -136,10 +136,10 @@ export const useMediaAutoDownload = ({
 			urlToCache: url
 		});
 		if (result?.exists && !isEncrypted) {
-			if(!currentFile?.title_link) {
-				persistMessageWithCacheFile(id, result.uri, file.encryption, file.image_url || url);
+			if (!currentFile?.title_link) {
+				await persistMessageWithCacheFile(id, result.uri, file.encryption, file.image_url || url);
 			}
-			
+
 			updateCurrentFile(result.uri);
 		}
 		return result?.exists;

--- a/app/containers/message/hooks/useMediaAutoDownload.tsx
+++ b/app/containers/message/hooks/useMediaAutoDownload.tsx
@@ -9,6 +9,7 @@ import {
 	getMediaCache,
 	isDownloadActive,
 	MediaTypes,
+	persistMessageWithCacheFile,
 	TDownloadState
 } from '../../../lib/methods/handleMediaDownload';
 import { emitter } from '../../../lib/methods/helpers';
@@ -135,6 +136,10 @@ export const useMediaAutoDownload = ({
 			urlToCache: url
 		});
 		if (result?.exists && !isEncrypted) {
+			if(!currentFile.title_link) {
+				persistMessageWithCacheFile(id, result.uri, file.encryption, file.image_url || url);
+			}
+			
 			updateCurrentFile(result.uri);
 		}
 		return result?.exists;
@@ -150,7 +155,7 @@ export const useMediaAutoDownload = ({
 			download();
 			return;
 		}
-		if (!showAttachment || isEncrypted) {
+		if (!showAttachment || !currentFile.title_link || isEncrypted) {
 			return;
 		}
 		showAttachment(currentFile);

--- a/app/containers/message/hooks/useMediaAutoDownload.tsx
+++ b/app/containers/message/hooks/useMediaAutoDownload.tsx
@@ -136,7 +136,7 @@ export const useMediaAutoDownload = ({
 			urlToCache: url
 		});
 		if (result?.exists && !isEncrypted) {
-			if(!currentFile.title_link) {
+			if(!currentFile?.title_link) {
 				persistMessageWithCacheFile(id, result.uri, file.encryption, file.image_url || url);
 			}
 			

--- a/app/containers/message/hooks/useMediaAutoDownload.tsx
+++ b/app/containers/message/hooks/useMediaAutoDownload.tsx
@@ -150,7 +150,7 @@ export const useMediaAutoDownload = ({
 			download();
 			return;
 		}
-		if (!showAttachment || !currentFile.title_link || isEncrypted) {
+		if (!showAttachment || isEncrypted) {
 			return;
 		}
 		showAttachment(currentFile);

--- a/app/lib/methods/handleMediaDownload.ts
+++ b/app/lib/methods/handleMediaDownload.ts
@@ -212,7 +212,7 @@ const mapAttachments = ({
 }): TMessageModel['attachments'] =>
 	attachments?.map(att => ({
 		...att,
-		title_link: downloadUrl === att.image_url ? uri : att.title_link,
+		title_link: att.image_url && downloadUrl.includes(att.image_url) ? uri : att.title_link,
 		e2e: encryption ? 'done' : undefined
 	}));
 

--- a/app/lib/methods/handleMediaDownload.ts
+++ b/app/lib/methods/handleMediaDownload.ts
@@ -202,26 +202,28 @@ export async function cancelDownload(messageUrl: string): Promise<void> {
 const mapAttachments = ({
 	attachments,
 	uri,
-	encryption
+	encryption,
+	downloadUrl
 }: {
 	attachments?: IAttachment[];
 	uri: string;
 	encryption: boolean;
+	downloadUrl: string;
 }): TMessageModel['attachments'] =>
 	attachments?.map(att => ({
 		...att,
-		title_link: uri,
+		title_link: downloadUrl === att.image_url ? uri : att.title_link,
 		e2e: encryption ? 'done' : undefined
 	}));
 
-const persistMessage = async (messageId: string, uri: string, encryption: boolean) => {
+const persistMessage = async (messageId: string, uri: string, encryption: boolean, downloadUrl: string) => {
 	const db = database.active;
 	const batch: Model[] = [];
 	const messageRecord = await getMessageById(messageId);
 	if (messageRecord) {
 		batch.push(
 			messageRecord.prepareUpdate(m => {
-				m.attachments = mapAttachments({ attachments: m.attachments, uri, encryption });
+				m.attachments = mapAttachments({ attachments: m.attachments, uri, encryption, downloadUrl });
 			})
 		);
 	}
@@ -229,7 +231,7 @@ const persistMessage = async (messageId: string, uri: string, encryption: boolea
 	if (threadRecord) {
 		batch.push(
 			threadRecord.prepareUpdate(m => {
-				m.attachments = mapAttachments({ attachments: m.attachments, uri, encryption });
+				m.attachments = mapAttachments({ attachments: m.attachments, uri, encryption, downloadUrl });
 			})
 		);
 	}
@@ -237,7 +239,7 @@ const persistMessage = async (messageId: string, uri: string, encryption: boolea
 	if (threadMessageRecord) {
 		batch.push(
 			threadMessageRecord.prepareUpdate(m => {
-				m.attachments = mapAttachments({ attachments: m.attachments, uri, encryption });
+				m.attachments = mapAttachments({ attachments: m.attachments, uri, encryption, downloadUrl });
 			})
 		);
 	}
@@ -282,7 +284,7 @@ export function downloadMediaFile({
 				await Encryption.addFileToDecryptFileQueue(messageId, result.uri, encryption, originalChecksum);
 			}
 
-			await persistMessage(messageId, result.uri, !!encryption);
+			await persistMessage(messageId, result.uri, !!encryption, downloadUrl);
 
 			emitter.emit(`downloadMedia${downloadUrl}`, result.uri);
 			return resolve(result.uri);

--- a/app/lib/methods/handleMediaDownload.ts
+++ b/app/lib/methods/handleMediaDownload.ts
@@ -212,7 +212,7 @@ const mapAttachments = ({
 }): TMessageModel['attachments'] =>
 	attachments?.map(att => ({
 		...att,
-		title_link: att.image_url && downloadUrl.includes(att.image_url) ? uri : att.title_link,
+		title_link: att.image_url && !downloadUrl.startsWith("file://") && downloadUrl.includes(att.image_url) ? uri : att.title_link,
 		e2e: encryption ? 'done' : undefined
 	}));
 
@@ -272,7 +272,7 @@ export function downloadMediaFile({
 			if (!path) {
 				return reject();
 			}
-			downloadKey = mediaDownloadKey(downloadUrl);
+			downloadKey = messageId + mediaDownloadKey(downloadUrl);
 			downloadQueue[downloadKey] = FileSystem.createDownloadResumable(downloadUrl, path);
 			const result = await downloadQueue[downloadKey].downloadAsync();
 
@@ -295,4 +295,8 @@ export function downloadMediaFile({
 			delete downloadQueue[downloadKey];
 		}
 	});
+}
+
+export const persistMessageWithCacheFile = async (messageId: string, uri: string, encryption: TAttachmentEncryption | undefined, downloadUrl: string) => {
+	await persistMessage(messageId, uri, !!encryption, downloadUrl);
 }


### PR DESCRIPTION
## Proposed changes
This pull request fixes the issue where if we attach multiple image URLs in a single message payload, the App only showed the last image multiple times. The root cause was in attachment caching logic. While mapping through the attachments array, we were incorrectly updating all attachment URLs to the same value. To fix this, I modified the code to compare the download URL with each attachment's image URL during the mapping process:

```
attachments?.map(att => ({
    ...att,
    title_link: downloadUrl === att.image_url ? uri : att.title_link,
    e2e: encryption ? 'done' : undefined
}));
```

## Issue(s)	
https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/5942

## How to test or reproduce
To test this issue please use the following api
```
URL: https://********.rocket.chat/api/v1/chat.postMessage
Method: POST
Header: {
     'X-Auth-Token': '**********',
     'X-User-Id': '**********'
}
body: {
  "roomId": "",
  "attachments": [
    {
      "image_url": "https://i.pinimg.com/474x/c4/23/63/c423639b72feb5c93a14144fb50008c3.jpg" //or any random image url
    },
    {
      "image_url": "https://i.pinimg.com/474x/fc/98/6e/fc986eb80193639da37bf34cc5f6ef57.jpg" //or any random image url
    }
  ]
}
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules