### PR TITLE
fix: Check for null before setting 'canUpload' in ShareView

### DIFF
--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -185,9 +185,18 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 	getAttachments = async () => {
 		const { mediaAllowList, maxFileSize } = this.state;
 		const permissionToUploadFile = await this.getPermissionMobileUpload();
+		if (!this.files.length && this.files.length < 1) {
+			return {
+				attachments: [],
+				selected: {} as IShareAttachment
+			};
+		}
 
 		const items = await Promise.all(
 			this.files.map(async item => {
+				if (!item) {
+					return null;
+				}
 				// Check server settings
 				const { success: canUpload, error } = canUploadFile({
 					file: item,
@@ -195,6 +204,7 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 					maxFileSize,
 					permissionToUploadFile
 				});
+
 				item.canUpload = canUpload;
 				item.error = error;
 
@@ -410,6 +420,7 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 
 	render() {
 		console.count(`${this.constructor.name}.render calls`);
+
 		const { readOnly, room } = this.state;
 		const { theme } = this.props;
 		if (readOnly || isBlocked(room)) {

--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -204,7 +204,6 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 					maxFileSize,
 					permissionToUploadFile
 				});
-
 				item.canUpload = canUpload;
 				item.error = error;
 

--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -419,7 +419,6 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 
 	render() {
 		console.count(`${this.constructor.name}.render calls`);
-
 		const { readOnly, room } = this.state;
 		const { theme } = this.props;
 		if (readOnly || isBlocked(room)) {

--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -195,7 +195,7 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 		const items = await Promise.all(
 			this.files.map(async item => {
 				if (!item) {
-					return null;
+					return {} as IShareAttachment;
 				}
 				// Check server settings
 				const { success: canUpload, error } = canUploadFile({

--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -185,7 +185,7 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 	getAttachments = async () => {
 		const { mediaAllowList, maxFileSize } = this.state;
 		const permissionToUploadFile = await this.getPermissionMobileUpload();
-		if (!this.files.length && this.files.length < 1) {
+		if (!this.files || this.files.length < 1) {
 			return {
 				attachments: [],
 				selected: {} as IShareAttachment


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Prevent TypeError: Cannot set property 'canUpload' of null.
## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/NATIVE-694

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
