### PR TITLE
Fix: Prevent DM name editing in mobile client

### DIFF
--- a/app/views/RoomInfoView/index.tsx
+++ b/app/views/RoomInfoView/index.tsx
@@ -196,7 +196,7 @@ const RoomInfoView = (): React.ReactElement => {
 			const sub = subRoom.observe();
 			subscription.current = sub.subscribe(changes => {
 				setRoom(changes.asPlain());
-				setHeader(canEdit);
+				setHeader((roomType === SubscriptionType.DIRECT) ? false : canEdit);
 			});
 		} else {
 			try {
@@ -209,7 +209,7 @@ const RoomInfoView = (): React.ReactElement => {
 			}
 		}
 		setShowEdit(canEdit);
-		setHeader(canEdit);
+		setHeader((roomType === SubscriptionType.DIRECT) ? false : canEdit);
 	};
 
 	const createDirect = () =>


### PR DESCRIPTION
## Proposed changes
Fixed a issue where direct message names could be edited in the mobile app, while this functionality is correctly restricted in the web client. Mobile app was not checking the channel type before allowing name edits.

## Issue(s)	
Closes https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/5904

## Screenshots
|Before|After|
| --- | --- |
| <img width="378" alt="Screenshot 2024-11-09 at 3 56 41 PM" src="https://github.com/user-attachments/assets/33608506-a4ac-4087-81c6-bfa4933e5c52"> | <img width="378" alt="Screenshot 2024-11-09 at 3 56 59 PM" src="https://github.com/user-attachments/assets/0375b027-d79b-4d50-b3de-fd2f01fa0c31"> |

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules