### PR TITLE
fix: Display username when member name is missing in members list

### DIFF
--- a/app/views/RoomMembersView/index.tsx
+++ b/app/views/RoomMembersView/index.tsx
@@ -387,7 +387,7 @@ const RoomMembersView = (): React.ReactElement => {
 				renderItem={({ item }) => (
 					<View style={{ backgroundColor: colors.surfaceRoom }}>
 						<UserItem
-							name={item.name as string}
+							name={item.name || item.username}
 							username={item.username}
 							onPress={() => onPressUser(item)}
 							testID={`room-members-view-item-${item.username}`}

--- a/app/views/RoomMembersView/index.tsx
+++ b/app/views/RoomMembersView/index.tsx
@@ -385,7 +385,7 @@ const RoomMembersView = (): React.ReactElement => {
 			<FlatList
 				data={filteredMembers || state.members}
 				renderItem={({ item }) => (
-					<View style={{ backgroundColor: colors.surfaceRoom }}>
+					<View style={{ backgroundColor: colors.surfaceRoom, marginBottom: 0.5 }}>
 						<UserItem
 							name={item.name || item.username}
 							username={item.username}

--- a/app/views/RoomMembersView/index.tsx
+++ b/app/views/RoomMembersView/index.tsx
@@ -385,7 +385,7 @@ const RoomMembersView = (): React.ReactElement => {
 			<FlatList
 				data={filteredMembers || state.members}
 				renderItem={({ item }) => (
-					<View style={{ backgroundColor: colors.surfaceRoom, marginBottom: 0.5 }}>
+					<View style={{ backgroundColor: colors.surfaceRoom }}>
 						<UserItem
 							name={item.name || item.username}
 							username={item.username}


### PR DESCRIPTION
## Proposed changes
Currently, when a member's name is missing, the app renders nothing, while the web client displays the username in such cases. This PR aligns the app’s behavior with the web client by ensuring the username is shown when the member name is missing. Additionally, I noticed that the divider between two members is either too light or missing, so I’ve fixed this issue by adding a `marginBottom` of *0.5* to the member component.

## Issue(s)	
none

## Screenshots
|Before|After|
| --- | --- |
| <img width="378" alt="Screenshot 2024-11-13 at 12 08 54 AM" src="https://github.com/user-attachments/assets/83c7504d-113f-42b8-a23e-6319922a4f15"> | <img width="378" alt="Screenshot 2024-11-13 at 12 09 37 AM" src="https://github.com/user-attachments/assets/1caef458-015a-4e4b-b59d-c0a1eae510e3"> |

### Web Reference
<img width="381" alt="Screenshot 2024-11-13 at 12 11 31 AM" src="https://github.com/user-attachments/assets/adca03a2-af0f-4879-8369-3ee95f053d33">

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
