### PR TITLE
fix: Add workspace requiring extra tap to connect

### DIFF
--- a/app/views/NewServerView/index.tsx
+++ b/app/views/NewServerView/index.tsx
@@ -315,7 +315,7 @@ class NewServerView extends React.Component<INewServerViewProps, INewServerViewS
 				style={formContainerStyle}
 				showAppVersion={showBottomInfo}
 				testID='new-server-view'
-				keyboardShouldPersistTaps='never'>
+				keyboardShouldPersistTaps='handled'>
 				<FormContainerInner accessibilityLabel={I18n.t('Add_server')}>
 					<Image
 						style={[


### PR DESCRIPTION
## Proposed changes
When attempting to add a new workspace, clicking the Connect button caused the keyboard to close without executing the intended functionality. This PR resolves the issue by ensuring that pressing the Connect button triggers the appropriate function instead of just dismissing the keyboard. The button now behaves as expected.

## Issue(s)	
Closes #6025

## Screenshots
https://github.com/user-attachments/assets/985d5781-69e7-4dec-8b99-77d0c6b39aaf

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules