### PR TITLE
fix: announcement banner closing issue and visibility in hidden thread channels

### DIFF
--- a/app/views/RoomView/Banner.tsx
+++ b/app/views/RoomView/Banner.tsx
@@ -32,7 +32,7 @@ const Banner = React.memo(
 						onPress={toggleModal}
 					>
 						<MarkdownPreview msg={text} style={[styles.bannerText]} />
-						<BorderlessButton onPress={closeBanner}>
+						<BorderlessButton onPress={closeBanner} hitSlop={10}>
 							<CustomIcon color={themes[theme].fontSecondaryInfo} name='close' size={20} />
 						</BorderlessButton>
 					</BorderlessButton>

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -1515,7 +1515,11 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 				}}>
 				<SafeAreaView style={{ backgroundColor: themes[theme].surfaceRoom }} testID='room-view'>
 					<StatusBar />
-					<Banner title={I18n.t('Announcement')} text={announcement} bannerClosed={bannerClosed} closeBanner={this.closeBanner} />
+					{
+						(!this.tmid) ? (
+							<Banner title={I18n.t('Announcement')} text={announcement} bannerClosed={bannerClosed} closeBanner={this.closeBanner} />
+						) : null
+					}
 					<List
 						ref={this.list}
 						listRef={this.flatList}


### PR DESCRIPTION
## Proposed changes
This PR resolves two issues with the announcement banner. 
- Announcement banner close button was difficult to interact, which has been fixed by adding a hitSlop to improve touch responsiveness. 
- The banner was visible in both normal chats and thread channels, this has been fixed to ensure the banner is hidden in thread channels.

## Issue(s)	
N/A

## How to test or reproduce
1. Go to any channel which have announcement message
2. Go to any thread in the same channel
3. Observe the announcement message is visible at the top of the channel

## Screenshots
| Scenario | Before| After |
| --- | --- | --- |
| Close button hitbox | <img width="380" alt="Screenshot 2024-11-30 at 3 12 17 PM" src="https://github.com/user-attachments/assets/7ddb93d8-5ee3-46e9-a42f-2c2d88f32bb7"> | <img width="376" alt="Screenshot 2024-11-30 at 3 08 33 PM" src="https://github.com/user-attachments/assets/770e62d6-f4d7-43e6-bc94-43cc12505932"> |
| Thread channel | <img width="377" alt="Screenshot 2024-11-30 at 3 11 19 PM" src="https://github.com/user-attachments/assets/75d819de-0a0f-451d-9449-3d59ed9de655"> | <img width="377" alt="Screenshot 2024-11-30 at 3 10 19 PM" src="https://github.com/user-attachments/assets/be40f627-e439-4f95-84df-261b7b6d85a2"> |

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules