### PR TITLE
fix: resolve ts-ignore issues for legal in settings view

### DIFF
--- a/app/stacks/InsideStack.tsx
+++ b/app/stacks/InsideStack.tsx
@@ -187,7 +187,6 @@ const SettingsStackNavigator = () => {
 			<SettingsStack.Screen name='DefaultBrowserView' component={DefaultBrowserView} />
 			<SettingsStack.Screen name='MediaAutoDownloadView' component={MediaAutoDownloadView} />
 			<SettingsStack.Screen name='GetHelpView' component={GetHelpView} />
-			{/* @ts-ignore */}
 			<SettingsStack.Screen name='LegalView' component={LegalView} />
 			<SettingsStack.Screen
 				name='ScreenLockConfigView'

--- a/app/stacks/InsideStack.tsx
+++ b/app/stacks/InsideStack.tsx
@@ -73,6 +73,7 @@ import AddExistingChannelView from '../views/AddExistingChannelView';
 import SelectListView from '../views/SelectListView';
 import DiscussionsView from '../views/DiscussionsView';
 import ChangeAvatarView from '../views/ChangeAvatarView';
+import LegalView from '../views/LegalView';
 import {
 	AdminPanelStackParamList,
 	ChatsStackParamList,
@@ -186,6 +187,8 @@ const SettingsStackNavigator = () => {
 			<SettingsStack.Screen name='DefaultBrowserView' component={DefaultBrowserView} />
 			<SettingsStack.Screen name='MediaAutoDownloadView' component={MediaAutoDownloadView} />
 			<SettingsStack.Screen name='GetHelpView' component={GetHelpView} />
+			{/* @ts-ignore */}
+			<SettingsStack.Screen name='LegalView' component={LegalView} />
 			<SettingsStack.Screen
 				name='ScreenLockConfigView'
 				// @ts-ignore

--- a/app/stacks/MasterDetailStack/index.tsx
+++ b/app/stacks/MasterDetailStack/index.tsx
@@ -45,6 +45,7 @@ import NewMessageView from '../../views/NewMessageView';
 import CreateChannelView from '../../views/CreateChannelView';
 import UserPreferencesView from '../../views/UserPreferencesView';
 import UserNotificationPrefView from '../../views/UserNotificationPreferencesView';
+import LegalView from '../../views/LegalView';
 import SecurityPrivacyView from '../../views/SecurityPrivacyView';
 import MediaAutoDownloadView from '../../views/MediaAutoDownloadView';
 import E2EEncryptionSecurityView from '../../views/E2EEncryptionSecurityView';
@@ -166,6 +167,8 @@ const ModalStackNavigator = React.memo(({ navigation }: INavigation) => {
 					options={props => ReadReceiptsView.navigationOptions!({ ...props, isMasterDetail: true })}
 				/>
 				<ModalStack.Screen name='SettingsView' component={SettingsView} />
+				{/* @ts-ignore */}
+				<ModalStack.Screen name='LegalView' component={LegalView} />
 				<ModalStack.Screen name='LanguageView' component={LanguageView} />
 				<ModalStack.Screen name='ThemeView' component={ThemeView} />
 				<ModalStack.Screen name='DefaultBrowserView' component={DefaultBrowserView} />

--- a/app/stacks/MasterDetailStack/index.tsx
+++ b/app/stacks/MasterDetailStack/index.tsx
@@ -167,7 +167,6 @@ const ModalStackNavigator = React.memo(({ navigation }: INavigation) => {
 					options={props => ReadReceiptsView.navigationOptions!({ ...props, isMasterDetail: true })}
 				/>
 				<ModalStack.Screen name='SettingsView' component={SettingsView} />
-				{/* @ts-ignore */}
 				<ModalStack.Screen name='LegalView' component={LegalView} />
 				<ModalStack.Screen name='LanguageView' component={LanguageView} />
 				<ModalStack.Screen name='ThemeView' component={ThemeView} />

--- a/app/stacks/MasterDetailStack/types.ts
+++ b/app/stacks/MasterDetailStack/types.ts
@@ -197,6 +197,7 @@ export type ModalStackParamList = {
 	MediaAutoDownloadView: undefined;
 	E2EEncryptionSecurityView: undefined;
 	PushTroubleshootView: undefined;
+	LegalView: undefined;
 	SupportedVersionsWarning: {
 		showCloseButton?: boolean;
 	};

--- a/app/stacks/OutsideStack.tsx
+++ b/app/stacks/OutsideStack.tsx
@@ -32,7 +32,6 @@ const _OutsideStack = () => {
 			<Outside.Screen name='SendEmailConfirmationView' component={SendEmailConfirmationView} />
 			{/* @ts-ignore */}
 			<Outside.Screen name='RegisterView' component={RegisterView} options={RegisterView.navigationOptions} />
-			{/* @ts-ignore */}
 			<Outside.Screen name='LegalView' component={LegalView} />
 		</Outside.Navigator>
 	);

--- a/app/stacks/types.ts
+++ b/app/stacks/types.ts
@@ -202,6 +202,7 @@ export type ProfileStackParamList = {
 };
 
 export type SettingsStackParamList = {
+	LegalView: undefined;
 	SettingsView: undefined;
 	SecurityPrivacyView: undefined;
 	E2EEncryptionSecurityView: undefined;

--- a/app/views/LegalView.tsx
+++ b/app/views/LegalView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import I18n from '../i18n';
@@ -18,7 +18,7 @@ const LegalView = ({ navigation }: ILegalViewProps): React.ReactElement => {
 	const server = useSelector((state: IApplicationState) => state.server.server);
 	const { theme } = useTheme();
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		navigation.setOptions({
 			title: I18n.t('Legal')
 		});

--- a/app/views/LegalView.tsx
+++ b/app/views/LegalView.tsx
@@ -1,5 +1,7 @@
 import React, { useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import I18n from '../i18n';
 import StatusBar from '../containers/StatusBar';
@@ -9,8 +11,7 @@ import SafeAreaView from '../containers/SafeAreaView';
 import * as List from '../containers/List';
 import { SettingsStackParamList } from '../stacks/types';
 import { IApplicationState } from '../definitions';
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
 
 const LegalView = () => {
 	const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList, 'LegalView'>>();
@@ -21,7 +22,7 @@ const LegalView = () => {
 		navigation.setOptions({
 			title: I18n.t('Legal')
 		});
-	}, []);
+	}, [navigation]);
 
 	const onPressItem = ({ route }: { route: string }) => {
 		if (!server) {

--- a/app/views/LegalView.tsx
+++ b/app/views/LegalView.tsx
@@ -12,7 +12,6 @@ import * as List from '../containers/List';
 import { SettingsStackParamList } from '../stacks/types';
 import { IApplicationState } from '../definitions';
 
-
 const LegalView = () => {
 	const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList, 'LegalView'>>();
 	const server = useSelector((state: IApplicationState) => state.server.server);

--- a/app/views/LegalView.tsx
+++ b/app/views/LegalView.tsx
@@ -7,14 +7,17 @@ import openLink from '../lib/methods/helpers/openLink';
 import { useTheme } from '../theme';
 import SafeAreaView from '../containers/SafeAreaView';
 import * as List from '../containers/List';
-import { OutsideParamList } from '../stacks/types';
+import { OutsideParamList, SettingsStackParamList } from '../stacks/types';
 import { IBaseScreen, IApplicationState } from '../definitions';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 interface ILegalViewProps extends IBaseScreen<OutsideParamList, 'LegalView'> {
 	server: string;
 }
 
-const LegalView = ({ navigation }: ILegalViewProps): React.ReactElement => {
+const LegalView = () => {
+	const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList, 'LegalView'>>();
 	const server = useSelector((state: IApplicationState) => state.server.server);
 	const { theme } = useTheme();
 

--- a/app/views/LegalView.tsx
+++ b/app/views/LegalView.tsx
@@ -7,14 +7,10 @@ import openLink from '../lib/methods/helpers/openLink';
 import { useTheme } from '../theme';
 import SafeAreaView from '../containers/SafeAreaView';
 import * as List from '../containers/List';
-import { OutsideParamList, SettingsStackParamList } from '../stacks/types';
-import { IBaseScreen, IApplicationState } from '../definitions';
+import { SettingsStackParamList } from '../stacks/types';
+import { IApplicationState } from '../definitions';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-
-interface ILegalViewProps extends IBaseScreen<OutsideParamList, 'LegalView'> {
-	server: string;
-}
 
 const LegalView = () => {
 	const navigation = useNavigation<NativeStackNavigationProp<SettingsStackParamList, 'LegalView'>>();

--- a/app/views/SettingsView/index.tsx
+++ b/app/views/SettingsView/index.tsx
@@ -288,6 +288,13 @@ const SettingsView = (): React.ReactElement => {
 					/>
 					<List.Separator />
 					<List.Item
+						title='Legal'
+						onPress={() => navigateToScreen('LegalView')}
+						testID='settings-view-legal'
+						left={() => <List.Icon name='book' />}
+					/>
+					<List.Separator />
+					<List.Item
 						title={I18n.t('Version_no', { version: getReadableVersion })}
 						onPress={copyAppVersion}
 						testID='settings-view-version'

--- a/e2e/tests/assorted/04-setting.spec.ts
+++ b/e2e/tests/assorted/04-setting.spec.ts
@@ -65,8 +65,12 @@ describe('Settings screen', () => {
 			await expect(element(by.id('settings-view-media-auto-download'))).toExist();
 		});
 
-		it('should have licence', async () => {
+		it('should have license', async () => {
 			await expect(element(by.id('settings-view-license'))).toExist();
+		});
+
+		it('should have legal', async () => {
+			await expect(element(by.id('settings-view-legal'))).toExist();
 		});
 
 		it('should have version no', async () => {
@@ -105,6 +109,36 @@ describe('Settings screen', () => {
 			await waitFor(element(by.id(`rooms-list-view-item-${room}`)))
 				.toExist()
 				.withTimeout(10000);
+		});
+
+		describe('Legal button', () => {
+			it('should navigate to legalview', async () => {
+				await element(by.id('rooms-list-view-sidebar')).tap();
+				await waitFor(element(by.id('sidebar-view')))
+					.toBeVisible()
+					.withTimeout(2000);
+				await waitFor(element(by.id('sidebar-settings')))
+					.toBeVisible()
+					.withTimeout(2000);
+				await element(by.id('sidebar-settings')).tap();
+				await waitFor(element(by.id('settings-view')))
+					.toBeVisible()
+					.withTimeout(2000);
+
+				await expect(element(by.id('settings-view-legal'))).toExist();
+				await element(by.id('settings-view-legal')).tap();
+				await waitFor(element(by.id('legal-view')))
+					.toBeVisible()
+					.withTimeout(4000);
+			});
+
+			it('should have terms of service button', async () => {
+				await expect(element(by.id('legal-terms-button'))).toBeVisible();
+			});
+
+			it('should have privacy policy button', async () => {
+				await expect(element(by.id('legal-privacy-button'))).toBeVisible();
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Proposed changes
This PR removes the use of `@ts-ignore` for the Legal button in the SettingsView component by properly addressing the underlying TypeScript issues. Types have been updated or adjusted to ensure compatibility, and the code has been refactored to maintain type safety and functionality. All changes have been tested to confirm the button's functionality and adherence to TypeScript standards

## Issue(s)	
N/A

## How to test or reproduce
N/A

## Screenshots

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
