### PR TITLE
fix: add Name field to SetUsernameView

### DIFF
--- a/app/lib/services/restApi.ts
+++ b/app/lib/services/restApi.ts
@@ -626,7 +626,7 @@ export const saveRoomSettings = (
 	sdk.methodCallWrapper('saveRoomSettings', rid, params);
 
 export const saveUserProfile = (
-	data: IProfileParams | Pick<IProfileParams, 'username'>,
+	data: IProfileParams | Pick<IProfileParams, 'username' | 'name'>,
 	customFields?: { [key: string | number]: string }
 ) =>
 	// RC 0.62.2

--- a/app/views/SetUsernameView.tsx
+++ b/app/views/SetUsernameView.tsx
@@ -121,7 +121,7 @@ const SetUsernameView = () => {
 						placeholder={I18n.t('Name')}
 						returnKeyType='send'
 						onSubmitEditing={handleSubmit(submit)}
-						testID='set-username-view-input'
+						testID='set-name-view-input'
 						clearButtonMode='while-editing'
 						containerStyle={sharedStyles.inputLastChild}
 					/>

--- a/app/views/SetUsernameView.tsx
+++ b/app/views/SetUsernameView.tsx
@@ -32,10 +32,12 @@ const styles = StyleSheet.create({
 
 interface ISubmit {
 	username: string;
+	name: string;
 }
 
 const schema = yup.object().shape({
-	username: yup.string().required()
+	username: yup.string().required(),
+	name: yup.string().required()
 });
 
 const SetUsernameView = () => {
@@ -67,13 +69,13 @@ const SetUsernameView = () => {
 		init();
 	}, []);
 
-	const submit = async ({ username }: ISubmit) => {
+	const submit = async ({ username, name }: ISubmit) => {
 		if (!isValid) {
 			return;
 		}
 		setLoading(true);
 		try {
-			await Services.saveUserProfile({ username });
+			await Services.saveUserProfile({ username, name });
 			dispatch(loginRequest({ resume: token }));
 		} catch (e: any) {
 			showErrorAlert(e.message, I18n.t('Oops'));
@@ -97,6 +99,26 @@ const SetUsernameView = () => {
 						name='username'
 						autoFocus
 						placeholder={I18n.t('Username')}
+						returnKeyType='send'
+						onSubmitEditing={handleSubmit(submit)}
+						testID='set-username-view-input'
+						clearButtonMode='while-editing'
+						containerStyle={sharedStyles.inputLastChild}
+					/>
+					<Text
+						style={[
+							sharedStyles.loginTitle,
+							sharedStyles.textBold,
+							styles.loginTitle,
+							{ color: colors.fontTitlesLabels, marginBottom: 10 }
+						]}>
+						{I18n.t('Name')}
+					</Text>
+					<ControlledFormTextInput
+						control={control}
+						name='name'
+						autoFocus
+						placeholder={I18n.t('Name')}
 						returnKeyType='send'
 						onSubmitEditing={handleSubmit(submit)}
 						testID='set-username-view-input'


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

Asks the name from the user during signup using Social Auth so to not leave the name slot empty.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#6138 

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Use a new email address not used in Rocket Chat.
2. Sign up using Social Auth.
3. There is no field to ask for the name of the user and as a result

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


I thoroughly debugged the SocialOAuth flow, checking all params in sdk.ts and all auth related functions such as  login() [connect.ts], loginTOTP() [connect.ts], also tracing requests and their responses from and to @rocket.chat/sdk, and verifying backend auth routes. I found that in the result.me section ([screenshot](https://github.com/user-attachments/assets/a826fa0d-fa4a-4013-8d9c-aafbef107b59)), key values like name and username are coming as undefined, seemingly from the `@rocket.chat/sdk`.

To cross-check, I tried calling users.wholeInfo with users.getUsernameSuggestion to check the user details there, but since the backend doesn’t store name from Social OAuth, it doesn’t return anything substantial. 

I also analyzed how the **web client** handles this and found that it doesn’t rely on the SDK but has a different embedded indigenous auth system.

After 15+ test signups and deletions in the React Native app analyzing each through different methods, I couldn’t automate fetching the name. 

So, as a **fix**, I propose adding a controlled text input below the username field in app/views/SetUsernameView.tsx, allowing users to enter their name manually. This can be further improved by introducing a `users.getNameSuggestion` route, similar to `getUsernameSuggestion`, both of which can be called in the existing useEffect to enhance UX while keeping flexibility for users to modify their name.

Let me know if I’ve missed something or if there’s a better approach. Thanks!
