### PR TITLE
chore: added new github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,83 @@
+name: "Bug Report"
+description: "Report a bug to help us improve."
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thank you for taking the time to report this bug!  
+        Before submitting, please check if a similar issue exists.  
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Describe the Bug"
+      description: "A clear and concise description of the issue."
+      placeholder: "A bug happened!"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Steps to Reproduce"
+      description: "List the steps to reproduce the issue."
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Observe the issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "Expected Behavior"
+      description: "What should have happened?"
+      placeholder: "Describe the expected outcome."
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: "Actual Behavior"
+      description: "What actually happened?"
+      placeholder: "Describe what actually happens."
+
+  - type: input
+    id: server-version
+    attributes:
+      label: "Rocket.Chat Server Version"
+      placeholder: "Enter the server version"
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: "Rocket.Chat App Version"
+      placeholder: "Enter the app version"
+    validations:
+      required: true
+
+  - type: input
+    id: device-name
+    attributes:
+      label: "Device Name"
+      placeholder: "e.g., iPhone 13, Samsung Galaxy S22"
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: "OS Version"
+      placeholder: "e.g., iOS 17, Android 14"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: "Provide any other relevant information about the problem."

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,7 +1,7 @@
 name: "Bug Report"
 description: "Report a bug to help us improve."
-title: "[bug]: "
-labels: ["bug"]
+title: "bug: "
+labels: ["🐛 bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-suggestion.yml
@@ -1,0 +1,89 @@
+name: "Feature Suggestion"
+description: "Suggest a new feature to improve our mobile application."
+title: "[feature]: "
+labels: ["enhancement"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thank you for suggesting a new feature for our mobile application!
+        Please provide as much detail as possible below so we can evaluate your idea.
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: "Feature Description"
+      description: "A clear and concise description of the proposed feature."
+      placeholder: "Describe the feature you are proposing..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "Motivation and Use Case"
+      description: "Explain why this feature would improve the mobile experience and describe any specific use cases or issues it addresses."
+      placeholder: "Explain the benefits and use case for the feature..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation-ideas
+    attributes:
+      label: "Implementation Ideas"
+      description: "Share any thoughts on how this feature might be implemented."
+      placeholder: "Share your ideas or potential solutions..."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: existing-feature
+    attributes:
+      label: "Is this feature available in the API or web version?"
+      description: "Select an option if this feature is already present elsewhere."
+      options:
+        - "Available in API"
+        - "Available in Web Version"
+        - "Not available"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: input
+    id: server-version
+    attributes:
+      label: "Rocket.Chat Server Version"
+      placeholder: "Enter the server version"
+    validations:
+      required: false
+
+  - type: input
+    id: app-version
+    attributes:
+      label: "Rocket.Chat App Version"
+      placeholder: "Enter the app version"
+    validations:
+      required: false
+
+  - type: input
+    id: device-name
+    attributes:
+      label: "Device Name"
+      placeholder: "e.g., iPhone 13, Samsung Galaxy S22"
+    validations:
+      required: false
+
+  - type: input
+    id: os-version
+    attributes:
+      label: "OS Version"
+      placeholder: "e.g., iOS 17, Android 14"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: "Any additional information or context to help us better understand your suggestion."

--- a/.github/ISSUE_TEMPLATE/2-feature-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-suggestion.yml
@@ -2,7 +2,6 @@ name: "Feature Suggestion"
 description: "Suggest a new feature to improve our mobile application."
 title: "feature request: "
 labels: ["🎉 feature"]
-assignees: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-suggestion.yml
@@ -1,7 +1,7 @@
 name: "Feature Suggestion"
 description: "Suggest a new feature to improve our mobile application."
-title: "[feature]: "
-labels: ["enhancement"]
+title: "feature request: "
+labels: ["🎉 feature"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community Support
+    url: https://open.rocket.chat/channel/react-native
+    about: Please ask and answer questions here.


### PR DESCRIPTION
## Proposed changes
This PR migrates our repository’s old issue template to a new, structured format. GitHub recent changes removed support for the old template, which resulted in a blank form being displayed to users while creating issue.

## Issue(s)	
N/A

## How to test or reproduce
1. Create a issue in this Repo
2. It will display blank template

## Screenshots
1. What users will see after clicking New Issue button
<img width="803" alt="Screenshot 2025-03-03 at 11 10 16 PM" src="https://github.com/user-attachments/assets/1a08bb56-e488-4db1-818d-523af9b84460" />

2. Bug report preview
<img width="454" alt="Screenshot 2025-03-03 at 11 10 42 PM" src="https://github.com/user-attachments/assets/a783effb-7984-46ed-89f0-59720930563e" />

3. Feature suggestion preview
<img width="450" alt="Screenshot 2025-03-03 at 11 11 07 PM" src="https://github.com/user-attachments/assets/a16db8f7-9c86-4cce-975b-d8ac5588ea2f" />


## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules