### PR TITLE
fix: gif reactions not animating on iOS

### DIFF
--- a/app/containers/EmojiPicker/EmojiCategory.tsx
+++ b/app/containers/EmojiPicker/EmojiCategory.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlatList } from 'react-native-gesture-handler';
+import { FlatList } from 'react-native';
 
 import { IEmoji } from '../../definitions/IEmoji';
 import scrollPersistTaps from '../../lib/methods/helpers/scrollPersistTaps';

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"dequal": "2.0.3",
 		"ejson": "2.2.3",
 		"expo": "^50.0.14",
-		"expo-apple-authentication": "^6.3.0",
+		"expo-apple-authentication": "6.3.0",
 		"expo-av": "^13.10.5",
 		"expo-camera": "^14.1.1",
 		"expo-document-picker": "11.10.1",

--- a/patches/expo-image+1.10.6.patch
+++ b/patches/expo-image+1.10.6.patch
@@ -21,3 +21,206 @@ index 071907c..9f8cc5e 100644
      // We don't use the `GlideUrl` directly but we want to replace the default okhttp loader anyway
      // to make sure that the app will use only one client.
      registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
+diff --git a/node_modules/expo-image/ios/AnimatedImage.swift b/node_modules/expo-image/ios/AnimatedImage.swift
+new file mode 100644
+index 0000000..34f8faf
+--- /dev/null
++++ b/node_modules/expo-image/ios/AnimatedImage.swift
+@@ -0,0 +1,37 @@
++// Copyright 2024-present 650 Industries. All rights reserved.
++
++import SDWebImage
++
++/**
++ Custom `SDAnimatedImage` that fixes issues with `images` and `duration` not being available.
++ */
++final class AnimatedImage: SDAnimatedImage {
++  var frames: [SDImageFrame]?
++
++  // MARK: - UIImage
++
++  override var images: [UIImage]? {
++    preloadAllFrames()
++    return frames?.map({ $0.image })
++  }
++
++  override var duration: TimeInterval {
++    preloadAllFrames()
++    return frames?.reduce(0, { $0 + $1.duration }) ?? 0.0
++  }
++
++  // MARK: - SDAnimatedImage
++
++  override func preloadAllFrames() {
++    if frames != nil {
++      return
++    }
++    frames = [UInt](0..<animatedImageFrameCount).compactMap { index in
++      guard let image = animatedImageFrame(at: index) else {
++        return nil
++      }
++      let duration = animatedImageDuration(at: index)
++      return SDImageFrame(image: image, duration: duration)
++    }
++  }
++}
+diff --git a/node_modules/expo-image/ios/ImageUtils.swift b/node_modules/expo-image/ios/ImageUtils.swift
+index d6c9e52..90194e3 100644
+--- a/node_modules/expo-image/ios/ImageUtils.swift
++++ b/node_modules/expo-image/ios/ImageUtils.swift
+@@ -4,16 +4,12 @@ import SDWebImage
+ import ExpoModulesCore
+ 
+ /**
+- Checks if the image is animated and returns an SDAnimatedImage if it does. Otherwise returns the UIImage.
++ An exception to throw when it its not possible to generate a blurhash for a given URL.
+  */
+-func createAnimatedIfNeeded(image: UIImage?, data: Data?) -> UIImage? {
+-  let isAnimated = image?.sd_isAnimated ?? false
+-
+-  if isAnimated, let data = data {
+-    return SDAnimatedImage(data: data)
++public final class BlurhashGenerationException: Exception {
++  override public var reason: String {
++    "Unable to generate blurhash, make sure the image exists at the given URL"
+   }
+-
+-  return image
+ }
+ 
+ func cacheTypeToString(_ cacheType: SDImageCacheType) -> String {
+@@ -107,18 +103,21 @@ func shouldDownscale(image: UIImage, toSize size: CGSize, scale: Double) -> Bool
+  Resizes the animated image to fit in the given size and scale.
+  */
+ func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) async -> UIImage {
+-  // For animated images, the `images` member is non-nil and represents an array of animation frames.
+-  if let images = image.images {
+-    // Resize each animation frame separately.
+-    let resizedImages = await concurrentMap(images) { image in
+-      return resize(image: image, toSize: size, scale: scale)
+-    }
++  // If there are no image frames, only resize the main image.
++  guard let images = await image.images else {
++    return resize(image: image, toSize: size, scale: scale)
++  }
+ 
+-    // `animatedImage(with:duration:)` can return `nil`, probably when scales are not the same
+-    // so it should never happen in our case, but let's handle it gracefully.
+-    if let animatedImage = UIImage.animatedImage(with: resizedImages, duration: image.duration) {
+-      return animatedImage
+-    }
++  // Resize all animated image frames.
++  let resizedImages = await concurrentMap(images) { image in
++    return resize(image: image, toSize: size, scale: scale)
++  }
++
++  // Create the new animated image with the resized frames.
++  // `animatedImage(with:duration:)` can return `nil`, probably when scales are not the same
++  // so it should never happen in our case, but let's make sure to handle it gracefully.
++  if let newAnimatedImage = await UIImage.animatedImage(with: resizedImages, duration: image.duration) {
++    return newAnimatedImage
+   }
+   return resize(image: image, toSize: size, scale: scale)
+ }
+diff --git a/node_modules/expo-image/ios/ImageView.swift b/node_modules/expo-image/ios/ImageView.swift
+index 245d5c5..9211d92 100644
+--- a/node_modules/expo-image/ios/ImageView.swift
++++ b/node_modules/expo-image/ios/ImageView.swift
+@@ -129,6 +129,10 @@ public final class ImageView: ExpoView {
+     context[.cacheKeyFilter] = createCacheKeyFilter(source.cacheKey)
+     context[.imageTransformer] = createTransformPipeline()
+ 
++    // Tell SDWebImage to use our own class for animated formats,
++    // which has better compatibility with the UIImage and fixes issues with the image duration.
++    context[.animatedImageClass] = AnimatedImage.self
++
+     // Assets from the bundler have `scale` prop which needs to be passed to the context,
+     // otherwise they would be saved in cache with scale = 1.0 which may result in
+     // incorrectly rendered images for resize modes that don't scale (`center` and `repeat`).
+@@ -163,6 +167,11 @@ public final class ImageView: ExpoView {
+     context[ImageView.contextSourceKey] = source
+     context[ImageView.screenScaleKey] = screenScale
+ 
++    // Do it here so we don't waste resources trying to fetch from a remote URL
++    if maybeRenderLocalAsset(from: source) {
++      return
++    }
++
+     onLoadStart([:])
+ 
+     pendingOperation = imageManager.loadImage(
+@@ -217,8 +226,7 @@ public final class ImageView: ExpoView {
+       return
+     }
+ 
+-    // Create an SDAnimatedImage if needed then handle the image
+-    if let image = createAnimatedIfNeeded(image: image, data: data) {
++    if let image {
+       onLoad([
+         "cacheType": cacheTypeToString(cacheType),
+         "source": [
+@@ -249,6 +257,25 @@ public final class ImageView: ExpoView {
+     }
+   }
+ 
++  private func maybeRenderLocalAsset(from source: ImageSource) -> Bool {
++    let path: String? = {
++      // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
++      // It also crashes with EXC_BREAKPOINT when parsing data:image uris
++      // manually drop the leading slash below iOS 16
++      if let path = source.uri?.path {
++        return String(path.dropFirst())
++      }
++      return nil
++    }()
++
++    if let path, let local = UIImage(named: path) {
++      renderImage(local)
++      return true
++    }
++
++    return false
++  }
++
+   // MARK: - Placeholder
+ 
+   /**
+@@ -296,6 +323,7 @@ public final class ImageView: ExpoView {
+ 
+     context[.imageScaleFactor] = placeholder.scale
+     context[.cacheKeyFilter] = createCacheKeyFilter(placeholder.cacheKey)
++    context[.animatedImageClass] = AnimatedImage.self
+ 
+     // Cache placeholders on the disk. Should we let the user choose whether
+     // to cache them or apply the same policy as with the proper image?
+@@ -389,11 +417,11 @@ public final class ImageView: ExpoView {
+       sdImageView.image = image
+     }
+ 
+-    #if !os(tvOS)
++#if !os(tvOS)
+     if enableLiveTextInteraction {
+       analyzeImage()
+     }
+-    #endif
++#endif
+   }
+ 
+   // MARK: - Helpers
+@@ -433,7 +461,7 @@ public final class ImageView: ExpoView {
+   }
+ 
+   // MARK: - Live Text Interaction
+-  #if !os(tvOS)
++#if !os(tvOS)
+   @available(iOS 16.0, macCatalyst 17.0, *)
+   static let imageAnalyzer = ImageAnalyzer.isSupported ? ImageAnalyzer() : nil
+ 
+@@ -483,5 +511,5 @@ public final class ImageView: ExpoView {
+     }
+     return interaction as? ImageAnalysisInteraction
+   }
+-  #endif
++#endif
+ }
+\ No newline at end of file

--- a/yarn.lock
+++ b/yarn.lock
@@ -7566,7 +7566,7 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-expo-apple-authentication@^6.3.0:
+expo-apple-authentication@6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/expo-apple-authentication/-/expo-apple-authentication-6.3.0.tgz#0e591efbb70e97f87c1fcadfb8ca97a1d78bf47b"
   integrity sha512-eYoRMlh7qKkWdbNe5TV5n0/1mLMRDFDxt+uetyu0XMdn70vZSTaPr5yewyGzoFHRx5t4QCEj8wTobcjoqH5PGw==


### PR DESCRIPTION
## Proposed changes
Currently, GIF reactions are not animating on iOS after migrating from react-native-fast-image to expo-image. This PR applies a patch to fix GIF animation issues and restore proper GIF reaction support on iOS.

## Issue(s)	
Closes https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6222

## How to test or reproduce
React with animated emoji on message and observe

## Screenshots
https://github.com/user-attachments/assets/e0bd8cab-77b9-43f9-8b5f-5361b6f1fe72


## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
To resolve another iOS related issue, I replaced the FlatList import from `react-native-gesture-handler` with `react-native`. When using FlatList from gesture-handler, opening the emoji selection from the message input was triggering the error: "nativeViewGestureHandler must be used as a descendant of GestureHandlerRootView."