### PR TITLE
fix: filtered threads indicator not displaying on screen mount

### DIFF
--- a/app/views/ThreadMessagesView/index.tsx
+++ b/app/views/ThreadMessagesView/index.tsx
@@ -212,6 +212,7 @@ class ThreadMessagesView extends React.Component<IThreadMessagesViewProps, IThre
 			if (savedFilter) {
 				this.setState({ currentFilter: savedFilter as Filter }, () => {
 					this.setHeader();
+					resolve();
 				});
 			}
 			resolve();

--- a/app/views/ThreadMessagesView/index.tsx
+++ b/app/views/ThreadMessagesView/index.tsx
@@ -210,7 +210,9 @@ class ThreadMessagesView extends React.Component<IThreadMessagesViewProps, IThre
 		new Promise<void>(resolve => {
 			const savedFilter = UserPreferences.getString(THREADS_FILTER);
 			if (savedFilter) {
-				this.setState({ currentFilter: savedFilter as Filter }, () => resolve());
+				this.setState({ currentFilter: savedFilter as Filter }, () => {
+					this.setHeader();
+				});
 			}
 			resolve();
 		});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
This PR fixes the issue with the indicator introduced in https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6186. Previously, the indicator was rendered only after the filter was applied, but it failed to render when the screen was initially mounted. This PR ensures that the indicator is correctly rendered every time the screen is mounted.

## Issue(s)	
Closes: https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/6236

## How to test or reproduce
1. Apply a filter in thread in any channel and press back button
2. Go to same channel again and click on thread
3. Observe thread icon

## Screenshots
Before: https://github.com/user-attachments/assets/8019784b-8852-4868-9f42-f02d8de87f49
After: https://github.com/user-attachments/assets/23a31788-4246-4b60-8b55-e3ec57566198

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A