### PR TITLE
chore: Unifing usage of openAppSetting

### DIFF
--- a/app/lib/methods/helpers/ImagePicker/getPermissions.ts
+++ b/app/lib/methods/helpers/ImagePicker/getPermissions.ts
@@ -1,7 +1,6 @@
-import { Linking } from 'react-native';
-
 import ImagePicker from './ImagePicker';
 import { isIOS } from '../deviceInfo';
+import { openAppSettings } from '../openAppSettings';
 
 export const getPermissions = async (type: 'camera' | 'library') => {
 	// Doesn't need permission to read
@@ -12,7 +11,7 @@ export const getPermissions = async (type: 'camera' | 'library') => {
 	const method = type === 'camera' ? 'requestCameraPermissionsAsync' : 'requestMediaLibraryPermissionsAsync';
 	const requestResult = await ImagePicker[method]();
 	if (!requestResult.canAskAgain) {
-		Linking.openURL('app-settings:');
+		await openAppSettings();
 		return Promise.reject();
 	}
 	if (!requestResult.granted) {

--- a/app/lib/methods/helpers/openAppSettings.ts
+++ b/app/lib/methods/helpers/openAppSettings.ts
@@ -1,11 +1,16 @@
 import { Linking } from 'react-native';
 
 import { isIOS } from './deviceInfo';
+import log from './log';
 
-export const openAppSettings = (): void => {
-	if (isIOS) {
-		Linking.openURL('app-settings:');
-	} else {
-		Linking.openSettings();
+export const openAppSettings = async(): Promise<void> => {
+	try {
+		if (isIOS) {
+			await Linking.openURL('app-settings:');
+		} else {
+			await Linking.openSettings();
+		}
+	} catch(e) {
+		log(e);
 	}
 };

--- a/app/views/PushTroubleshootView/components/DeviceNotificationSettings.tsx
+++ b/app/views/PushTroubleshootView/components/DeviceNotificationSettings.tsx
@@ -1,6 +1,5 @@
 import notifee from '@notifee/react-native';
 import React from 'react';
-import { Linking } from 'react-native';
 
 import * as List from '../../../containers/List';
 import i18n from '../../../i18n';
@@ -8,6 +7,7 @@ import { useAppSelector } from '../../../lib/hooks';
 import { isIOS, showErrorAlert } from '../../../lib/methods/helpers';
 import { useTheme } from '../../../theme';
 import CustomListSection from './CustomListSection';
+import { openAppSettings } from '../../../lib/methods/helpers/openAppSettings';
 
 export default function DeviceNotificationSettings(): React.ReactElement {
 	const { colors } = useTheme();
@@ -15,11 +15,11 @@ export default function DeviceNotificationSettings(): React.ReactElement {
 		deviceNotificationEnabled: state.troubleshootingNotification.deviceNotificationEnabled
 	}));
 
-	const goToNotificationSettings = () => {
+	const goToNotificationSettings = async() => {
 		if (isIOS) {
-			Linking.openURL('app-settings:');
+			await openAppSettings();
 		} else {
-			notifee.openNotificationSettings();
+			await notifee.openNotificationSettings();
 		}
 	};
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Made the openAppSettings function better by adding try-catch and async await
Used openAppSettings where applicable
## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 --> #6252

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
