### PR TITLE
fix: markdown formatting in message

### DIFF
--- a/app/containers/markdown/components/Plain.tsx
+++ b/app/containers/markdown/components/Plain.tsx
@@ -3,7 +3,6 @@ import { Text } from 'react-native';
 import { Plain as PlainProps } from '@rocket.chat/message-parser';
 
 import { useTheme } from '../../../theme';
-import styles from '../styles';
 
 interface IPlainProps {
 	value: PlainProps['value'];
@@ -12,7 +11,7 @@ interface IPlainProps {
 const Plain = ({ value }: IPlainProps): React.ReactElement => {
 	const { colors } = useTheme();
 	return (
-		<Text accessibilityLabel={value} style={[styles.plainText, { color: colors.fontDefault }]}>
+		<Text accessibilityLabel={value} style={{ color: colors.fontDefault }}>
 			{value}
 		</Text>
 	);

--- a/app/containers/markdown/styles.ts
+++ b/app/containers/markdown/styles.ts
@@ -30,12 +30,6 @@ export default StyleSheet.create({
 	del: {
 		textDecorationLine: 'line-through'
 	},
-	plainText: {
-		...sharedStyles.textRegular,
-		fontSize: 16,
-		flexShrink: 1,
-		lineHeight: 22
-	},
 	text: {
 		lineHeight: 22,
 		fontSize: 16,


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue where message content with Markdown formatting, such as bold text and italic, was being rendered as plain text.

Regression introduced in https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6326

## Issue(s)	
Closes: https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/6363
Closes #6361

## How to test or reproduce
N/A

## Screenshots
| Before | After |
| --- | --- |
|  <img width="375" alt="Screenshot 2025-05-16 at 12 59 29 AM" src="https://github.com/user-attachments/assets/150d9013-c6da-4f3e-8f31-f72031b2b5c4" /> | <img width="376" alt="Screenshot 2025-05-16 at 12 59 53 AM" src="https://github.com/user-attachments/assets/c6674d41-6da7-4ff8-a57c-547016136f22" /> | 

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A