### PR TITLE
fix: CreateDiscussionView padding and discussion E2E tests

### DIFF
--- a/app/containers/KeyboardView.tsx
+++ b/app/containers/KeyboardView.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
+import { StyleProp, ViewStyle } from 'react-native';
 
 import { useTheme } from '../theme';
 
 interface IKeyboardViewProps {
 	backgroundColor?: string;
 	children: React.ReactElement[] | React.ReactElement;
+	style?: StyleProp<ViewStyle>;
 }
 
-const KeyboardView = ({ backgroundColor, children }: IKeyboardViewProps) => {
+const KeyboardView = ({ backgroundColor, children, style }: IKeyboardViewProps) => {
 	const { colors } = useTheme();
 	return (
-		<KeyboardAvoidingView style={[{ flex: 1, backgroundColor: backgroundColor || colors.surfaceRoom }]} behavior='padding'>
+		<KeyboardAvoidingView style={[{ flex: 1, backgroundColor: backgroundColor || colors.surfaceRoom }, style]} behavior='padding'>
 			{children}
 		</KeyboardAvoidingView>
 	);

--- a/app/containers/UIKit/MultiSelect/Input.tsx
+++ b/app/containers/UIKit/MultiSelect/Input.tsx
@@ -25,7 +25,7 @@ const Input = ({ children, onPress, loading, inputStyle, placeholder, disabled, 
 			style={[{ backgroundColor: colors.surfaceRoom }, styles.inputBorder, inputStyle]}
 			background={Touchable.Ripple(colors.surfaceNeutral)}
 			disabled={disabled}>
-			<View style={[styles.input, styles.inputBorder, { borderColor: colors.strokeLight }, innerInputStyle]}>
+			<View style={[styles.input, styles.inputBorder, { borderColor: colors.strokeMedium }, innerInputStyle]}>
 				{placeholder ? <Text style={[styles.pickerText, { color: colors.fontSecondaryInfo }]}>{placeholder}</Text> : children}
 				{loading ? (
 					<ActivityIndicator style={styles.icon} />

--- a/app/views/CreateDiscussionView/index.tsx
+++ b/app/views/CreateDiscussionView/index.tsx
@@ -107,10 +107,12 @@ const CreateDiscussionView = ({ route, navigation }: ICreateChannelViewProps) =>
 
 	useEffect(() => {
 		if (loading === prevLoading.current) {
+			prevLoading.current = loading;
 			return;
 		}
 
 		handleSubmitEvent({ loading, failure, isMasterDetail, error, result });
+		prevLoading.current = loading;
 	}, [loading]);
 
 	useLayoutEffect(() => {
@@ -122,7 +124,7 @@ const CreateDiscussionView = ({ route, navigation }: ICreateChannelViewProps) =>
 	}, [navigation, route]);
 
 	return (
-		<KeyboardView backgroundColor={colors.surfaceHover}>
+		<KeyboardView style={styles.container} backgroundColor={colors.surfaceHover}>
 			<StatusBar />
 			<SafeAreaView testID='create-discussion-view'>
 				<ScrollView {...scrollPersistTaps}>

--- a/app/views/CreateDiscussionView/styles.ts
+++ b/app/views/CreateDiscussionView/styles.ts
@@ -4,7 +4,6 @@ import sharedStyles from '../Styles';
 
 export default StyleSheet.create({
 	container: {
-		flex: 1,
 		paddingHorizontal: 16,
 		paddingVertical: 32
 	},


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
 - It fixes missing padding on createDiscussionView (regression introduced here: https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6380);
 - it fixes E2E `e2e/tests/room/04-discussion.spec.ts` tests failing (regression introduced here: https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6446).

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/NATIVE-933
https://rocketchat.atlassian.net/browse/NATIVE-934

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Open the app;
- Navigate to DiscussionView;
- Try to create a discussion;

## Screenshots
| Before | After |
| ----- | ----- |
| ![Simulator Screenshot - iPhone 16 - 2025-07-04 at 15 22 35](https://github.com/user-attachments/assets/ec91e216-10a3-49c3-bb8d-e755212fbf84) | ![Simulator Screenshot - iPhone 16 - 2025-07-04 at 18 02 03](https://github.com/user-attachments/assets/3f185a39-befe-4a51-a5bc-1260ad018f57) | 


## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
