### PR TITLE
refactor: Use HeaderTitle component on RoomHeader

### DIFF
--- a/app/containers/CustomHeader/components/HeaderTitle.tsx
+++ b/app/containers/CustomHeader/components/HeaderTitle.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+  Text,
+  TextStyle,
+  StyleProp
+} from 'react-native';
+import { PlatformPressable } from '@react-navigation/elements';
+
+import { MarkdownPreview } from '../../markdown';
+import styles from '../styles';
+
+interface IHeaderTitle {
+  title: string;
+  tmid?: string;
+  prid?: string;
+  onPress?: () => void;
+  testID?: string;
+  style?: StyleProp<TextStyle>;
+  numberOfLines?: number;
+}
+
+const HeaderTitle = ({
+  title,
+  tmid,
+  prid,
+  onPress,
+  testID,
+  style,
+  numberOfLines = 1
+}: IHeaderTitle) => {
+  // Filter out falsy values and ensure type is TextStyle[]
+  const mergedStyleArray: TextStyle[] = [styles.title, style]
+    .flat()
+    .filter((s): s is TextStyle => !!s);
+
+  const inner =
+    tmid || prid ? (
+      <MarkdownPreview msg={title} style={mergedStyleArray} testID={testID} />
+    ) : (
+      <Text
+        style={[styles.title, style]}
+        numberOfLines={numberOfLines}
+        testID={testID}
+      >
+        {title}
+      </Text>
+    );
+
+  if (onPress) {
+    return (
+      <PlatformPressable onPress={onPress} testID={testID}>
+        {inner}
+      </PlatformPressable>
+    );
+  }
+
+  return inner;
+};
+
+export default HeaderTitle;

--- a/app/containers/CustomHeader/styles.ts
+++ b/app/containers/CustomHeader/styles.ts
@@ -1,0 +1,10 @@
+import { StyleSheet } from 'react-native';
+
+import sharedStyles from '../../views/Styles';
+
+export default StyleSheet.create({
+	title: {
+		flexShrink: 1,
+		...sharedStyles.textSemibold
+	}
+});

--- a/app/containers/message/__snapshots__/Message.test.tsx.snap
+++ b/app/containers/message/__snapshots__/Message.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Story Snapshots: Archived should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message is inside an archived room.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message is inside an archived room.  "
         accessible={true}
         style={
           [
@@ -369,7 +369,7 @@ exports[`Story Snapshots: ArchivedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message is inside an archived room.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message is inside an archived room.  "
         accessible={true}
         style={
           [
@@ -693,7 +693,7 @@ exports[`Story Snapshots: Basic should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -1004,7 +1004,7 @@ exports[`Story Snapshots: Basic should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
         accessible={true}
         style={
           [
@@ -1328,7 +1328,7 @@ exports[`Story Snapshots: BasicLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -1639,7 +1639,7 @@ exports[`Story Snapshots: BasicLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
         accessible={true}
         style={
           [
@@ -1963,7 +1963,7 @@ exports[`Story Snapshots: BlockQuote should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM > Testing block quote.  "
+        accessibilityLabel="diego.mello 10:00:00 am > Testing block quote.  "
         accessible={true}
         style={
           [
@@ -2305,7 +2305,7 @@ exports[`Story Snapshots: BlockQuote should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM > Testing block quote
+        accessibilityLabel="diego.mello 10:00:00 am > Testing block quote
 Testing block quote.  "
         accessible={true}
         style={
@@ -2708,7 +2708,7 @@ exports[`Story Snapshots: BlockQuoteLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM > Testing block quote.  "
+        accessibilityLabel="diego.mello 10:00:00 am > Testing block quote.  "
         accessible={true}
         style={
           [
@@ -3050,7 +3050,7 @@ exports[`Story Snapshots: BlockQuoteLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM > Testing block quote
+        accessibilityLabel="diego.mello 10:00:00 am > Testing block quote
 Testing block quote.  "
         accessible={true}
         style={
@@ -3453,7 +3453,7 @@ exports[`Story Snapshots: Broadcast should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Broadcasted message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Broadcasted message.  "
         accessible={true}
         style={
           [
@@ -3884,7 +3884,7 @@ exports[`Story Snapshots: BroadcastLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Broadcasted message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Broadcasted message.  "
         accessible={true}
         style={
           [
@@ -4315,7 +4315,7 @@ exports[`Story Snapshots: ColoredAttachments should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -5322,7 +5322,7 @@ exports[`Story Snapshots: ColoredAttachmentsLargeFont should match snapshot 1`] 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -6329,7 +6329,7 @@ exports[`Story Snapshots: CustomFields should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -7201,7 +7201,7 @@ exports[`Story Snapshots: CustomFieldsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -8073,7 +8073,7 @@ exports[`Story Snapshots: CustomStyle should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -8401,7 +8401,7 @@ exports[`Story Snapshots: CustomStyleLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -8729,7 +8729,7 @@ exports[`Story Snapshots: DateAndUnreadSeparators should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="rocket.cat 10:00:00 AM Fourth message.  "
+        accessibilityLabel="rocket.cat 10:00:00 am Fourth message.  "
         accessible={true}
         style={
           [
@@ -9104,7 +9104,7 @@ exports[`Story Snapshots: DateAndUnreadSeparators should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Third message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Third message.  "
         accessible={true}
         style={
           [
@@ -9461,7 +9461,7 @@ exports[`Story Snapshots: DateAndUnreadSeparators should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="rocket.cat 10:00:00 AM Second message.  "
+        accessibilityLabel="rocket.cat 10:00:00 am Second message.  "
         accessible={true}
         style={
           [
@@ -9589,7 +9589,7 @@ exports[`Story Snapshots: DateAndUnreadSeparators should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="rocket.cat 10:00:00 AM Second message.  "
+        accessibilityLabel="rocket.cat 10:00:00 am Second message.  "
         accessible={true}
         style={
           [
@@ -9959,7 +9959,7 @@ exports[`Story Snapshots: DateAndUnreadSeparators should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM First message.  "
+        accessibilityLabel="diego.mello 10:00:00 am First message.  "
         accessible={true}
         style={
           [
@@ -10283,7 +10283,7 @@ exports[`Story Snapshots: DateAndUnreadSeparatorsLargeFont should match snapshot
       }
     >
       <View
-        accessibilityLabel="rocket.cat 10:00:00 AM Fourth message.  "
+        accessibilityLabel="rocket.cat 10:00:00 am Fourth message.  "
         accessible={true}
         style={
           [
@@ -10658,7 +10658,7 @@ exports[`Story Snapshots: DateAndUnreadSeparatorsLargeFont should match snapshot
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Third message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Third message.  "
         accessible={true}
         style={
           [
@@ -11015,7 +11015,7 @@ exports[`Story Snapshots: DateAndUnreadSeparatorsLargeFont should match snapshot
       }
     >
       <View
-        accessibilityLabel="rocket.cat 10:00:00 AM Second message.  "
+        accessibilityLabel="rocket.cat 10:00:00 am Second message.  "
         accessible={true}
         style={
           [
@@ -11162,7 +11162,7 @@ exports[`Story Snapshots: DateAndUnreadSeparatorsLargeFont should match snapshot
       }
     >
       <View
-        accessibilityLabel="rocket.cat 10:00:00 AM Second message.  "
+        accessibilityLabel="rocket.cat 10:00:00 am Second message.  "
         accessible={true}
         style={
           [
@@ -11532,7 +11532,7 @@ exports[`Story Snapshots: DateAndUnreadSeparatorsLargeFont should match snapshot
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM First message.  "
+        accessibilityLabel="diego.mello 10:00:00 am First message.  "
         accessible={true}
         style={
           [
@@ -11856,7 +11856,7 @@ exports[`Story Snapshots: Discussion should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is a discussion.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is a discussion.  "
         accessible={true}
         style={
           [
@@ -12279,7 +12279,7 @@ exports[`Story Snapshots: Discussion should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is a discussion.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is a discussion.  "
         accessible={true}
         style={
           [
@@ -12704,7 +12704,7 @@ exports[`Story Snapshots: Discussion should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
         accessible={true}
         style={
           [
@@ -13129,7 +13129,7 @@ exports[`Story Snapshots: Discussion should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is a discussion.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is a discussion.  "
         accessible={true}
         style={
           [
@@ -13567,7 +13567,7 @@ exports[`Story Snapshots: DiscussionLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is a discussion.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is a discussion.  "
         accessible={true}
         style={
           [
@@ -13990,7 +13990,7 @@ exports[`Story Snapshots: DiscussionLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is a discussion.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is a discussion.  "
         accessible={true}
         style={
           [
@@ -14415,7 +14415,7 @@ exports[`Story Snapshots: DiscussionLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
         accessible={true}
         style={
           [
@@ -14840,7 +14840,7 @@ exports[`Story Snapshots: DiscussionLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is a discussion.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is a discussion.  "
         accessible={true}
         style={
           [
@@ -15278,7 +15278,7 @@ exports[`Story Snapshots: Edited should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message header.  "
         accessible={true}
         style={
           [
@@ -15625,7 +15625,7 @@ exports[`Story Snapshots: Edited should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message without header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message without header.  "
         accessible={true}
         style={
           [
@@ -15802,7 +15802,7 @@ exports[`Story Snapshots: EditedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message header.  "
         accessible={true}
         style={
           [
@@ -16149,7 +16149,7 @@ exports[`Story Snapshots: EditedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message without header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message without header.  "
         accessible={true}
         style={
           [
@@ -16345,7 +16345,7 @@ exports[`Story Snapshots: Editing should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message being edited.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message being edited.  "
         accessible={true}
         style={
           [
@@ -16669,7 +16669,7 @@ exports[`Story Snapshots: EditingLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message being edited.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message being edited.  "
         accessible={true}
         style={
           [
@@ -16993,7 +16993,7 @@ exports[`Story Snapshots: Emojis should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 👊🤙👏.  "
+        accessibilityLabel="diego.mello 10:00:00 am 👊🤙👏.  "
         accessible={true}
         style={
           [
@@ -17303,7 +17303,7 @@ exports[`Story Snapshots: Emojis should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 👏.  "
+        accessibilityLabel="diego.mello 10:00:00 am 👏.  "
         accessible={true}
         style={
           [
@@ -17594,7 +17594,7 @@ exports[`Story Snapshots: Emojis should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM :react_rocket: :nyan_rocket: :marioparty:.  "
+        accessibilityLabel="diego.mello 10:00:00 am :react_rocket: :nyan_rocket: :marioparty:.  "
         accessible={true}
         style={
           [
@@ -17962,7 +17962,7 @@ exports[`Story Snapshots: Emojis should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM :react_rocket:.  "
+        accessibilityLabel="diego.mello 10:00:00 am :react_rocket:.  "
         accessible={true}
         style={
           [
@@ -18266,7 +18266,7 @@ exports[`Story Snapshots: Emojis should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 🤙:react_rocket:.  "
+        accessibilityLabel="diego.mello 10:00:00 am 🤙:react_rocket:.  "
         accessible={true}
         style={
           [
@@ -18589,7 +18589,7 @@ exports[`Story Snapshots: Emojis should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 🤙:react_rocket:🤙🤙.  "
+        accessibilityLabel="diego.mello 10:00:00 am 🤙:react_rocket:🤙🤙.  "
         accessible={true}
         style={
           [
@@ -18970,7 +18970,7 @@ exports[`Story Snapshots: EmojisLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 👊🤙👏.  "
+        accessibilityLabel="diego.mello 10:00:00 am 👊🤙👏.  "
         accessible={true}
         style={
           [
@@ -19280,7 +19280,7 @@ exports[`Story Snapshots: EmojisLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 👏.  "
+        accessibilityLabel="diego.mello 10:00:00 am 👏.  "
         accessible={true}
         style={
           [
@@ -19571,7 +19571,7 @@ exports[`Story Snapshots: EmojisLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM :react_rocket: :nyan_rocket: :marioparty:.  "
+        accessibilityLabel="diego.mello 10:00:00 am :react_rocket: :nyan_rocket: :marioparty:.  "
         accessible={true}
         style={
           [
@@ -19939,7 +19939,7 @@ exports[`Story Snapshots: EmojisLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM :react_rocket:.  "
+        accessibilityLabel="diego.mello 10:00:00 am :react_rocket:.  "
         accessible={true}
         style={
           [
@@ -20243,7 +20243,7 @@ exports[`Story Snapshots: EmojisLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 🤙:react_rocket:.  "
+        accessibilityLabel="diego.mello 10:00:00 am 🤙:react_rocket:.  "
         accessible={true}
         style={
           [
@@ -20566,7 +20566,7 @@ exports[`Story Snapshots: EmojisLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 🤙:react_rocket:🤙🤙.  "
+        accessibilityLabel="diego.mello 10:00:00 am 🤙:react_rocket:🤙🤙.  "
         accessible={true}
         style={
           [
@@ -20947,7 +20947,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -21329,7 +21329,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message Encrypted without Header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message Encrypted without Header.  "
         accessible={true}
         style={
           [
@@ -21528,7 +21528,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message Encrypted with Reactions.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message Encrypted with Reactions.  "
         accessible={true}
         style={
           [
@@ -22455,7 +22455,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message Thread reply encrypted.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message Thread reply encrypted.  "
           accessible={true}
           style={
             [
@@ -22635,7 +22635,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Temp message encrypted.  "
+        accessibilityLabel="diego.mello 10:00:00 am Temp message encrypted.  "
         accessible={true}
         style={
           [
@@ -23023,7 +23023,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message Edited encrypted.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message Edited encrypted.  "
         accessible={true}
         style={
           [
@@ -23371,7 +23371,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message has error and is encrypted.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message has error and is encrypted.  "
         accessible={true}
         style={
           [
@@ -23823,7 +23823,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Read Receipt encrypted with Header.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am Read Receipt encrypted with Header.  Message was read"
         accessible={true}
         style={
           [
@@ -24235,7 +24235,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Read Receipt encrypted without Header.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am Read Receipt encrypted without Header.  Message was read"
         accessible={true}
         style={
           [
@@ -24477,7 +24477,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -24859,7 +24859,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message Encrypted without Header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message Encrypted without Header.  "
         accessible={true}
         style={
           [
@@ -25077,7 +25077,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message Encrypted with Reactions.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message Encrypted with Reactions.  "
         accessible={true}
         style={
           [
@@ -26004,7 +26004,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message Thread reply encrypted.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message Thread reply encrypted.  "
           accessible={true}
           style={
             [
@@ -26184,7 +26184,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Temp message encrypted.  "
+        accessibilityLabel="diego.mello 10:00:00 am Temp message encrypted.  "
         accessible={true}
         style={
           [
@@ -26572,7 +26572,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message Edited encrypted.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message Edited encrypted.  "
         accessible={true}
         style={
           [
@@ -26920,7 +26920,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message has error and is encrypted.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message has error and is encrypted.  "
         accessible={true}
         style={
           [
@@ -27372,7 +27372,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Read Receipt encrypted with Header.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am Read Receipt encrypted with Header.  Message was read"
         accessible={true}
         style={
           [
@@ -27784,7 +27784,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Read Receipt encrypted without Header.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am Read Receipt encrypted without Header.  Message was read"
         accessible={true}
         style={
           [
@@ -28011,7 +28011,7 @@ exports[`Story Snapshots: Error should match snapshot 1`] = `
   <View>
     <View>
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message has error.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message has error.  "
         accessible={true}
         style={
           [
@@ -28359,7 +28359,7 @@ exports[`Story Snapshots: Error should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message has error too.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message has error too.  "
         accessible={true}
         style={
           [
@@ -28537,7 +28537,7 @@ exports[`Story Snapshots: ErrorLargeFont should match snapshot 1`] = `
   <View>
     <View>
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message has error.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message has error.  "
         accessible={true}
         style={
           [
@@ -28885,7 +28885,7 @@ exports[`Story Snapshots: ErrorLargeFont should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This message has error too.  "
+        accessibilityLabel="diego.mello 10:00:00 am This message has error too.  "
         accessible={true}
         style={
           [
@@ -29116,7 +29116,7 @@ exports[`Story Snapshots: FullName should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Diego Mello 10:00:00 AM Message.  "
+        accessibilityLabel="Diego Mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -29440,7 +29440,7 @@ exports[`Story Snapshots: FullNameLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Diego Mello 10:00:00 AM Message.  "
+        accessibilityLabel="Diego Mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -29764,7 +29764,7 @@ exports[`Story Snapshots: GroupedMessages should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM ....  "
+        accessibilityLabel="diego.mello 10:00:00 am ....  "
         accessible={true}
         style={
           [
@@ -30075,7 +30075,7 @@ exports[`Story Snapshots: GroupedMessages should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 AM Different user.  "
+        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 am Different user.  "
         accessible={true}
         style={
           [
@@ -30386,7 +30386,7 @@ exports[`Story Snapshots: GroupedMessages should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the third message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the third message.  "
         accessible={true}
         style={
           [
@@ -30514,7 +30514,7 @@ exports[`Story Snapshots: GroupedMessages should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the second message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the second message.  "
         accessible={true}
         style={
           [
@@ -30642,7 +30642,7 @@ exports[`Story Snapshots: GroupedMessages should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the first message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the first message.  "
         accessible={true}
         style={
           [
@@ -30966,7 +30966,7 @@ exports[`Story Snapshots: GroupedMessagesLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM ....  "
+        accessibilityLabel="diego.mello 10:00:00 am ....  "
         accessible={true}
         style={
           [
@@ -31277,7 +31277,7 @@ exports[`Story Snapshots: GroupedMessagesLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 AM Different user.  "
+        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 am Different user.  "
         accessible={true}
         style={
           [
@@ -31588,7 +31588,7 @@ exports[`Story Snapshots: GroupedMessagesLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the third message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the third message.  "
         accessible={true}
         style={
           [
@@ -31735,7 +31735,7 @@ exports[`Story Snapshots: GroupedMessagesLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the second message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the second message.  "
         accessible={true}
         style={
           [
@@ -31882,7 +31882,7 @@ exports[`Story Snapshots: GroupedMessagesLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the first message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the first message.  "
         accessible={true}
         style={
           [
@@ -32219,7 +32219,7 @@ exports[`Story Snapshots: Ignored should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am undefined.  "
           accessible={true}
           style={
             [
@@ -32420,7 +32420,7 @@ exports[`Story Snapshots: IgnoredLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am undefined.  "
           accessible={true}
           style={
             [
@@ -32608,7 +32608,7 @@ exports[`Story Snapshots: Lists should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM * Dogs
+        accessibilityLabel="diego.mello 10:00:00 am * Dogs
   * cats
   - cats.  "
         accessible={true}
@@ -33043,7 +33043,7 @@ exports[`Story Snapshots: Lists should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 1. Dogs 
+        accessibilityLabel="diego.mello 10:00:00 am 1. Dogs 
  2. Cats.  "
         accessible={true}
         style={
@@ -33444,7 +33444,7 @@ exports[`Story Snapshots: Lists should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 1. Dogs.  "
+        accessibilityLabel="diego.mello 10:00:00 am 1. Dogs.  "
         accessible={true}
         style={
           [
@@ -33797,7 +33797,7 @@ exports[`Story Snapshots: Lists should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 2. Cats.  "
+        accessibilityLabel="diego.mello 10:00:00 am 2. Cats.  "
         accessible={true}
         style={
           [
@@ -33980,7 +33980,7 @@ exports[`Story Snapshots: ListsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM * Dogs
+        accessibilityLabel="diego.mello 10:00:00 am * Dogs
   * cats
   - cats.  "
         accessible={true}
@@ -34415,7 +34415,7 @@ exports[`Story Snapshots: ListsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 1. Dogs 
+        accessibilityLabel="diego.mello 10:00:00 am 1. Dogs 
  2. Cats.  "
         accessible={true}
         style={
@@ -34816,7 +34816,7 @@ exports[`Story Snapshots: ListsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 1. Dogs.  "
+        accessibilityLabel="diego.mello 10:00:00 am 1. Dogs.  "
         accessible={true}
         style={
           [
@@ -35169,7 +35169,7 @@ exports[`Story Snapshots: ListsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM 2. Cats.  "
+        accessibilityLabel="diego.mello 10:00:00 am 2. Cats.  "
         accessible={true}
         style={
           [
@@ -35371,7 +35371,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM this is a normal message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am this is a normal message.  "
         accessible={true}
         style={
           [
@@ -35682,7 +35682,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Edited message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Edited message.  "
         accessible={true}
         style={
           [
@@ -36029,7 +36029,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Translated message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Translated message.  "
         accessible={true}
         style={
           [
@@ -36375,7 +36375,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Encrypted message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Encrypted message.  "
         accessible={true}
         style={
           [
@@ -36723,7 +36723,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Error message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Error message.  "
         accessible={true}
         style={
           [
@@ -37105,7 +37105,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Message with read receipt.  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Message with read receipt.  Message was read"
         accessible={true}
         style={
           [
@@ -37447,7 +37447,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Message with read receipt.  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Message with read receipt.  Message was read"
         accessible={true}
         style={
           [
@@ -37825,7 +37825,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Show all icons .  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Show all icons .  Message was read"
         accessible={true}
         style={
           [
@@ -38342,7 +38342,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  Message was read"
         accessible={true}
         style={
           [
@@ -38676,7 +38676,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM small message.  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am small message.  Message was read"
         accessible={true}
         style={
           [
@@ -39057,7 +39057,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM this is a normal message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am this is a normal message.  "
         accessible={true}
         style={
           [
@@ -39368,7 +39368,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Edited message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Edited message.  "
         accessible={true}
         style={
           [
@@ -39715,7 +39715,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Translated message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Translated message.  "
         accessible={true}
         style={
           [
@@ -40061,7 +40061,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Encrypted message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Encrypted message.  "
         accessible={true}
         style={
           [
@@ -40409,7 +40409,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Error message.  "
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Error message.  "
         accessible={true}
         style={
           [
@@ -40791,7 +40791,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Message with read receipt.  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Message with read receipt.  Message was read"
         accessible={true}
         style={
           [
@@ -41133,7 +41133,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Message with read receipt.  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Message with read receipt.  Message was read"
         accessible={true}
         style={
           [
@@ -41511,7 +41511,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Show all icons .  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Show all icons .  Message was read"
         accessible={true}
         style={
           [
@@ -42028,7 +42028,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  Message was read"
         accessible={true}
         style={
           [
@@ -42381,7 +42381,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
     </View>
     <View>
       <View
-        accessibilityLabel="Long name user looooong name user 10:00:00 AM small message.  Message was read"
+        accessibilityLabel="Long name user looooong name user 10:00:00 am small message.  Message was read"
         accessible={true}
         style={
           [
@@ -42781,7 +42781,7 @@ exports[`Story Snapshots: Mentions should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM rocket.cat diego.mello all here general.  "
+        accessibilityLabel="diego.mello 10:00:00 am rocket.cat diego.mello all here general.  "
         accessible={true}
         style={
           [
@@ -43236,7 +43236,7 @@ exports[`Story Snapshots: Mentions should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM rocket.cat Lorem ipsum dolor diego.mello sit amet, all consectetur adipiscing here elit, sed do eiusmod tempor general incididunt ut labore et dolore magna aliqua..  "
+        accessibilityLabel="diego.mello 10:00:00 am rocket.cat Lorem ipsum dolor diego.mello sit amet, all consectetur adipiscing here elit, sed do eiusmod tempor general incididunt ut labore et dolore magna aliqua..  "
         accessible={true}
         style={
           [
@@ -43721,7 +43721,7 @@ exports[`Story Snapshots: MentionsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM rocket.cat diego.mello all here general.  "
+        accessibilityLabel="diego.mello 10:00:00 am rocket.cat diego.mello all here general.  "
         accessible={true}
         style={
           [
@@ -44176,7 +44176,7 @@ exports[`Story Snapshots: MentionsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM rocket.cat Lorem ipsum dolor diego.mello sit amet, all consectetur adipiscing here elit, sed do eiusmod tempor general incididunt ut labore et dolore magna aliqua..  "
+        accessibilityLabel="diego.mello 10:00:00 am rocket.cat Lorem ipsum dolor diego.mello sit amet, all consectetur adipiscing here elit, sed do eiusmod tempor general incididunt ut labore et dolore magna aliqua..  "
         accessible={true}
         style={
           [
@@ -44661,7 +44661,7 @@ exports[`Story Snapshots: Message should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -44937,7 +44937,7 @@ exports[`Story Snapshots: MessageLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -45213,7 +45213,7 @@ exports[`Story Snapshots: MessageWithReadReceipt should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was not read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was not read"
         accessible={true}
         style={
           [
@@ -45555,7 +45555,7 @@ exports[`Story Snapshots: MessageWithReadReceipt should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was not read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was not read"
         accessible={true}
         style={
           [
@@ -45714,7 +45714,7 @@ exports[`Story Snapshots: MessageWithReadReceipt should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was read"
         accessible={true}
         style={
           [
@@ -46056,7 +46056,7 @@ exports[`Story Snapshots: MessageWithReadReceipt should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was read"
         accessible={true}
         style={
           [
@@ -46228,7 +46228,7 @@ exports[`Story Snapshots: MessageWithReadReceiptLargeFont should match snapshot 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was not read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was not read"
         accessible={true}
         style={
           [
@@ -46570,7 +46570,7 @@ exports[`Story Snapshots: MessageWithReadReceiptLargeFont should match snapshot 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was not read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was not read"
         accessible={true}
         style={
           [
@@ -46748,7 +46748,7 @@ exports[`Story Snapshots: MessageWithReadReceiptLargeFont should match snapshot 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was read"
         accessible={true}
         style={
           [
@@ -47090,7 +47090,7 @@ exports[`Story Snapshots: MessageWithReadReceiptLargeFont should match snapshot 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  Message was read"
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  Message was read"
         accessible={true}
         style={
           [
@@ -47281,7 +47281,7 @@ exports[`Story Snapshots: MessageWithReply should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  "
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  "
         accessible={true}
         style={
           [
@@ -47735,7 +47735,7 @@ exports[`Story Snapshots: MessageWithReply should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  "
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  "
         accessible={true}
         style={
           [
@@ -48221,7 +48221,7 @@ exports[`Story Snapshots: MessageWithReply should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Looks cool!.  "
+        accessibilityLabel="diego.mello 10:00:00 am Looks cool!.  "
         accessible={true}
         style={
           [
@@ -48839,7 +48839,7 @@ exports[`Story Snapshots: MessageWithReply should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Yes, I am.  "
+        accessibilityLabel="diego.mello 10:00:00 am Yes, I am.  "
         accessible={true}
         style={
           [
@@ -49519,7 +49519,7 @@ exports[`Story Snapshots: MessageWithReplyLargeFont should match snapshot 1`] = 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  "
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  "
         accessible={true}
         style={
           [
@@ -49973,7 +49973,7 @@ exports[`Story Snapshots: MessageWithReplyLargeFont should match snapshot 1`] = 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM I'm fine!.  "
+        accessibilityLabel="diego.mello 10:00:00 am I'm fine!.  "
         accessible={true}
         style={
           [
@@ -50459,7 +50459,7 @@ exports[`Story Snapshots: MessageWithReplyLargeFont should match snapshot 1`] = 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Looks cool!.  "
+        accessibilityLabel="diego.mello 10:00:00 am Looks cool!.  "
         accessible={true}
         style={
           [
@@ -51077,7 +51077,7 @@ exports[`Story Snapshots: MessageWithReplyLargeFont should match snapshot 1`] = 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Yes, I am.  "
+        accessibilityLabel="diego.mello 10:00:00 am Yes, I am.  "
         accessible={true}
         style={
           [
@@ -51757,7 +51757,7 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM How are you?.  "
+        accessibilityLabel="diego.mello 10:00:00 am How are you?.  "
         accessible={true}
         style={
           [
@@ -52464,7 +52464,7 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -52769,7 +52769,7 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -53074,7 +53074,7 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -53379,7 +53379,7 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -53684,7 +53684,7 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -53989,7 +53989,7 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message undefined.  "
           accessible={true}
           style={
             [
@@ -54158,7 +54158,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM How are you?.  "
+        accessibilityLabel="diego.mello 10:00:00 am How are you?.  "
         accessible={true}
         style={
           [
@@ -54865,7 +54865,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -55170,7 +55170,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -55475,7 +55475,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -55780,7 +55780,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -56085,7 +56085,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -56390,7 +56390,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message undefined.  "
           accessible={true}
           style={
             [
@@ -56559,7 +56559,7 @@ exports[`Story Snapshots: Pinned should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message header.  "
         accessible={true}
         style={
           [
@@ -56900,7 +56900,7 @@ exports[`Story Snapshots: Pinned should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message without header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message without header.  "
         accessible={true}
         style={
           [
@@ -57071,7 +57071,7 @@ exports[`Story Snapshots: PinnedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message header.  "
         accessible={true}
         style={
           [
@@ -57412,7 +57412,7 @@ exports[`Story Snapshots: PinnedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message without header.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message without header.  "
         accessible={true}
         style={
           [
@@ -57602,7 +57602,7 @@ exports[`Story Snapshots: Reactions should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Reactions.  "
+        accessibilityLabel="diego.mello 10:00:00 am Reactions.  "
         accessible={true}
         style={
           [
@@ -58431,7 +58431,7 @@ exports[`Story Snapshots: Reactions should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Multiple Reactions.  "
+        accessibilityLabel="diego.mello 10:00:00 am Multiple Reactions.  "
         accessible={true}
         style={
           [
@@ -59711,7 +59711,7 @@ exports[`Story Snapshots: ReactionsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Reactions.  "
+        accessibilityLabel="diego.mello 10:00:00 am Reactions.  "
         accessible={true}
         style={
           [
@@ -60540,7 +60540,7 @@ exports[`Story Snapshots: ReactionsLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Multiple Reactions.  "
+        accessibilityLabel="diego.mello 10:00:00 am Multiple Reactions.  "
         accessible={true}
         style={
           [
@@ -61820,7 +61820,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM How are you?.  "
+        accessibilityLabel="diego.mello 10:00:00 am How are you?.  "
         accessible={true}
         style={
           [
@@ -62415,7 +62415,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -62608,7 +62608,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -62801,7 +62801,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message undefined.  "
           accessible={true}
           style={
             [
@@ -62970,7 +62970,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM How are you?.  "
+        accessibilityLabel="diego.mello 10:00:00 am How are you?.  "
         accessible={true}
         style={
           [
@@ -63565,7 +63565,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -63758,7 +63758,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -63951,7 +63951,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message undefined.  "
           accessible={true}
           style={
             [
@@ -64245,7 +64245,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should ma
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -64438,7 +64438,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should ma
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message Cool!.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message Cool!.  "
           accessible={true}
           style={
             [
@@ -64631,7 +64631,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should ma
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -64824,7 +64824,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should ma
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message undefined.  "
           accessible={true}
           style={
             [
@@ -65118,7 +65118,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
           </View>
         </View>
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM replying to thread message I'm fine!.  "
+          accessibilityLabel="diego.mello 10:00:00 am replying to thread message I'm fine!.  "
           accessible={true}
           style={
             [
@@ -65311,7 +65311,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message Cool!.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message Cool!.  "
           accessible={true}
           style={
             [
@@ -65504,7 +65504,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
           accessible={true}
           style={
             [
@@ -65697,7 +65697,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM thread message undefined.  "
+          accessibilityLabel="diego.mello 10:00:00 am thread message undefined.  "
           accessible={true}
           style={
             [
@@ -65866,7 +65866,7 @@ exports[`Story Snapshots: ShowButtonAsAttachment should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -66238,7 +66238,7 @@ exports[`Story Snapshots: ShowButtonAsAttachment should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -66787,7 +66787,7 @@ exports[`Story Snapshots: ShowButtonAsAttachmentLargeFont should match snapshot 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -67159,7 +67159,7 @@ exports[`Story Snapshots: ShowButtonAsAttachmentLargeFont should match snapshot 
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -67708,7 +67708,7 @@ exports[`Story Snapshots: StaticAvatar should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -68032,7 +68032,7 @@ exports[`Story Snapshots: StaticAvatarLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -68335,7 +68335,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM message removed.  "
+          accessibilityLabel="diego.mello 10:00:00 am message removed.  "
           accessible={true}
           style={
             [
@@ -68512,7 +68512,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM joined the channel.  "
+          accessibilityLabel="diego.mello 10:00:00 am joined the channel.  "
           accessible={true}
           style={
             [
@@ -68689,7 +68689,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM Pinned a message:.  "
+          accessibilityLabel="diego.mello 10:00:00 am Pinned a message:.  "
           accessible={true}
           style={
             [
@@ -69013,7 +69013,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM left the channel.  "
+          accessibilityLabel="diego.mello 10:00:00 am left the channel.  "
           accessible={true}
           style={
             [
@@ -69190,7 +69190,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed rocket.cat.  "
           accessible={true}
           style={
             [
@@ -69367,7 +69367,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM added rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am added rocket.cat.  "
           accessible={true}
           style={
             [
@@ -69544,7 +69544,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM muted rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am muted rocket.cat.  "
           accessible={true}
           style={
             [
@@ -69721,7 +69721,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM unmuted rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am unmuted rocket.cat.  "
           accessible={true}
           style={
             [
@@ -69898,7 +69898,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM defined rocket.cat as admin.  "
+          accessibilityLabel="diego.mello 10:00:00 am defined rocket.cat as admin.  "
           accessible={true}
           style={
             [
@@ -70075,7 +70075,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed rocket.cat as admin.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed rocket.cat as admin.  "
           accessible={true}
           style={
             [
@@ -70252,7 +70252,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room name to: New name.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room name to: New name.  "
           accessible={true}
           style={
             [
@@ -70429,7 +70429,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room description to: new description.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room description to: new description.  "
           accessible={true}
           style={
             [
@@ -70606,7 +70606,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room announcement to: new announcement.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room announcement to: new announcement.  "
           accessible={true}
           style={
             [
@@ -70783,7 +70783,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room topic to: new topic.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room topic to: new topic.  "
           accessible={true}
           style={
             [
@@ -70960,7 +70960,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room to public.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room to public.  "
           accessible={true}
           style={
             [
@@ -71137,7 +71137,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM disabled E2E encryption for this room.  "
+          accessibilityLabel="diego.mello 10:00:00 am disabled E2E encryption for this room.  "
           accessible={true}
           style={
             [
@@ -71314,7 +71314,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM enabled E2E encryption for this room.  "
+          accessibilityLabel="diego.mello 10:00:00 am enabled E2E encryption for this room.  "
           accessible={true}
           style={
             [
@@ -71491,7 +71491,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed @rocket.cat from this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed @rocket.cat from this team.  "
           accessible={true}
           style={
             [
@@ -71668,7 +71668,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM added @rocket.cat to this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am added @rocket.cat to this team.  "
           accessible={true}
           style={
             [
@@ -71845,7 +71845,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM added #channel-name to this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am added #channel-name to this team.  "
           accessible={true}
           style={
             [
@@ -72022,7 +72022,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM converted #channel-name to a team.  "
+          accessibilityLabel="diego.mello 10:00:00 am converted #channel-name to a team.  "
           accessible={true}
           style={
             [
@@ -72199,7 +72199,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM converted #channel-name to channel.  "
+          accessibilityLabel="diego.mello 10:00:00 am converted #channel-name to channel.  "
           accessible={true}
           style={
             [
@@ -72376,7 +72376,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM deleted #channel-name.  "
+          accessibilityLabel="diego.mello 10:00:00 am deleted #channel-name.  "
           accessible={true}
           style={
             [
@@ -72553,7 +72553,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed #channel-name from this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed #channel-name from this team.  "
           accessible={true}
           style={
             [
@@ -72743,7 +72743,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM message removed.  "
+          accessibilityLabel="diego.mello 10:00:00 am message removed.  "
           accessible={true}
           style={
             [
@@ -72920,7 +72920,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM joined the channel.  "
+          accessibilityLabel="diego.mello 10:00:00 am joined the channel.  "
           accessible={true}
           style={
             [
@@ -73097,7 +73097,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM Pinned a message:.  "
+          accessibilityLabel="diego.mello 10:00:00 am Pinned a message:.  "
           accessible={true}
           style={
             [
@@ -73421,7 +73421,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM left the channel.  "
+          accessibilityLabel="diego.mello 10:00:00 am left the channel.  "
           accessible={true}
           style={
             [
@@ -73598,7 +73598,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed rocket.cat.  "
           accessible={true}
           style={
             [
@@ -73775,7 +73775,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM added rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am added rocket.cat.  "
           accessible={true}
           style={
             [
@@ -73952,7 +73952,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM muted rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am muted rocket.cat.  "
           accessible={true}
           style={
             [
@@ -74129,7 +74129,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM unmuted rocket.cat.  "
+          accessibilityLabel="diego.mello 10:00:00 am unmuted rocket.cat.  "
           accessible={true}
           style={
             [
@@ -74306,7 +74306,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM defined rocket.cat as admin.  "
+          accessibilityLabel="diego.mello 10:00:00 am defined rocket.cat as admin.  "
           accessible={true}
           style={
             [
@@ -74483,7 +74483,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed rocket.cat as admin.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed rocket.cat as admin.  "
           accessible={true}
           style={
             [
@@ -74660,7 +74660,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room name to: New name.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room name to: New name.  "
           accessible={true}
           style={
             [
@@ -74837,7 +74837,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room description to: new description.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room description to: new description.  "
           accessible={true}
           style={
             [
@@ -75014,7 +75014,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room announcement to: new announcement.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room announcement to: new announcement.  "
           accessible={true}
           style={
             [
@@ -75191,7 +75191,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room topic to: new topic.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room topic to: new topic.  "
           accessible={true}
           style={
             [
@@ -75368,7 +75368,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM changed room to public.  "
+          accessibilityLabel="diego.mello 10:00:00 am changed room to public.  "
           accessible={true}
           style={
             [
@@ -75545,7 +75545,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM disabled E2E encryption for this room.  "
+          accessibilityLabel="diego.mello 10:00:00 am disabled E2E encryption for this room.  "
           accessible={true}
           style={
             [
@@ -75722,7 +75722,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM enabled E2E encryption for this room.  "
+          accessibilityLabel="diego.mello 10:00:00 am enabled E2E encryption for this room.  "
           accessible={true}
           style={
             [
@@ -75899,7 +75899,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed @rocket.cat from this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed @rocket.cat from this team.  "
           accessible={true}
           style={
             [
@@ -76076,7 +76076,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM added @rocket.cat to this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am added @rocket.cat to this team.  "
           accessible={true}
           style={
             [
@@ -76253,7 +76253,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM added #channel-name to this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am added #channel-name to this team.  "
           accessible={true}
           style={
             [
@@ -76430,7 +76430,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM converted #channel-name to a team.  "
+          accessibilityLabel="diego.mello 10:00:00 am converted #channel-name to a team.  "
           accessible={true}
           style={
             [
@@ -76607,7 +76607,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM converted #channel-name to channel.  "
+          accessibilityLabel="diego.mello 10:00:00 am converted #channel-name to channel.  "
           accessible={true}
           style={
             [
@@ -76784,7 +76784,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM deleted #channel-name.  "
+          accessibilityLabel="diego.mello 10:00:00 am deleted #channel-name.  "
           accessible={true}
           style={
             [
@@ -76961,7 +76961,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
         }
       >
         <View
-          accessibilityLabel="diego.mello 10:00:00 AM removed #channel-name from this team.  "
+          accessibilityLabel="diego.mello 10:00:00 am removed #channel-name from this team.  "
           accessible={true}
           style={
             [
@@ -77172,7 +77172,7 @@ exports[`Story Snapshots: Temp should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Temp message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Temp message.  "
         accessible={true}
         style={
           [
@@ -77502,7 +77502,7 @@ exports[`Story Snapshots: TempLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Temp message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Temp message.  "
         accessible={true}
         style={
           [
@@ -77832,7 +77832,7 @@ exports[`Story Snapshots: ThumbnailFromServer should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM this is a thumbnail.  "
+        accessibilityLabel="diego.mello 10:00:00 am this is a thumbnail.  "
         accessible={true}
         style={
           [
@@ -78339,7 +78339,7 @@ exports[`Story Snapshots: ThumbnailFromServerLargeFont should match snapshot 1`]
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM this is a thumbnail.  "
+        accessibilityLabel="diego.mello 10:00:00 am this is a thumbnail.  "
         accessible={true}
         style={
           [
@@ -78846,7 +78846,7 @@ exports[`Story Snapshots: TimeFormat should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Testing.  "
+        accessibilityLabel="diego.mello 10:00:00 am Testing.  "
         accessible={true}
         style={
           [
@@ -79170,7 +79170,7 @@ exports[`Story Snapshots: TimeFormatLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Testing.  "
+        accessibilityLabel="diego.mello 10:00:00 am Testing.  "
         accessible={true}
         style={
           [
@@ -79494,7 +79494,7 @@ exports[`Story Snapshots: Translated should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message translated.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message translated.  "
         accessible={true}
         style={
           [
@@ -79853,7 +79853,7 @@ exports[`Story Snapshots: TranslatedLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message translated.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message translated.  "
         accessible={true}
         style={
           [
@@ -80212,7 +80212,7 @@ exports[`Story Snapshots: TwoShortCustomFieldsWithMarkdown should match snapshot
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -81173,7 +81173,7 @@ exports[`Story Snapshots: TwoShortCustomFieldsWithMarkdownLargeFont should match
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -82134,7 +82134,7 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -82397,7 +82397,7 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message :nyan_rocket:.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message :nyan_rocket:.  "
         accessible={true}
         style={
           [
@@ -82740,7 +82740,7 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -82833,7 +82833,7 @@ exports[`Story Snapshots: URLImagePreview should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -83096,7 +83096,7 @@ exports[`Story Snapshots: URLImagePreview should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -83372,7 +83372,7 @@ exports[`Story Snapshots: URLImagePreviewLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -83635,7 +83635,7 @@ exports[`Story Snapshots: URLImagePreviewLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -83911,7 +83911,7 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -84174,7 +84174,7 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message :nyan_rocket:.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message :nyan_rocket:.  "
         accessible={true}
         style={
           [
@@ -84517,7 +84517,7 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -84629,7 +84629,7 @@ exports[`Story Snapshots: WithAlias should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -84959,7 +84959,7 @@ exports[`Story Snapshots: WithAlias should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 AM Message.  "
+        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -85302,7 +85302,7 @@ exports[`Story Snapshots: WithAliasLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -85632,7 +85632,7 @@ exports[`Story Snapshots: WithAliasLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 AM Message.  "
+        accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -85975,7 +85975,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -86562,7 +86562,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM First message.  "
+        accessibilityLabel="diego.mello 10:00:00 am First message.  "
         accessible={true}
         style={
           [
@@ -86690,7 +86690,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -87062,7 +87062,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -87387,7 +87387,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -87725,7 +87725,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -88312,7 +88312,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM First message.  "
+        accessibilityLabel="diego.mello 10:00:00 am First message.  "
         accessible={true}
         style={
           [
@@ -88459,7 +88459,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -88850,7 +88850,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -89194,7 +89194,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -89551,7 +89551,7 @@ exports[`Story Snapshots: WithFile should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -90016,7 +90016,7 @@ exports[`Story Snapshots: WithFile should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -90311,7 +90311,7 @@ exports[`Story Snapshots: WithFileLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -90776,7 +90776,7 @@ exports[`Story Snapshots: WithFileLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -91090,7 +91090,7 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -91564,7 +91564,7 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -92070,7 +92070,7 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -92576,7 +92576,7 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -93050,7 +93050,7 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -93556,7 +93556,7 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -94062,7 +94062,7 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -94525,7 +94525,7 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -94922,7 +94922,7 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -95385,7 +95385,7 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM undefined.  "
+        accessibilityLabel="diego.mello 10:00:00 am undefined.  "
         accessible={true}
         style={
           [
@@ -95782,7 +95782,7 @@ exports[`Story Snapshots: WithoutHeader should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [
@@ -95923,7 +95923,7 @@ exports[`Story Snapshots: WithoutHeaderLargeFont should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Message.  "
         accessible={true}
         style={
           [

--- a/app/views/RoomView/LoadMore/__snapshots__/LoadMore.test.tsx.snap
+++ b/app/views/RoomView/LoadMore/__snapshots__/LoadMore.test.tsx.snap
@@ -450,7 +450,7 @@ exports[`Story Snapshots: BlackTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Hey!.  "
+        accessibilityLabel="diego.mello 10:00:00 am Hey!.  "
         accessible={true}
         style={
           [
@@ -761,7 +761,7 @@ exports[`Story Snapshots: BlackTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
         accessible={true}
         style={
           [
@@ -889,7 +889,7 @@ exports[`Story Snapshots: BlackTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Older message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Older message.  "
         accessible={true}
         style={
           [
@@ -1183,7 +1183,7 @@ exports[`Story Snapshots: BlackTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
         accessible={true}
         style={
           [
@@ -1494,7 +1494,7 @@ exports[`Story Snapshots: BlackTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the third message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the third message.  "
         accessible={true}
         style={
           [
@@ -1622,7 +1622,7 @@ exports[`Story Snapshots: BlackTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the second message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the second message.  "
         accessible={true}
         style={
           [
@@ -1750,7 +1750,7 @@ exports[`Story Snapshots: BlackTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the first message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the first message.  "
         accessible={true}
         style={
           [
@@ -2157,7 +2157,7 @@ exports[`Story Snapshots: DarkTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Hey!.  "
+        accessibilityLabel="diego.mello 10:00:00 am Hey!.  "
         accessible={true}
         style={
           [
@@ -2468,7 +2468,7 @@ exports[`Story Snapshots: DarkTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
         accessible={true}
         style={
           [
@@ -2596,7 +2596,7 @@ exports[`Story Snapshots: DarkTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Older message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Older message.  "
         accessible={true}
         style={
           [
@@ -2890,7 +2890,7 @@ exports[`Story Snapshots: DarkTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
         accessible={true}
         style={
           [
@@ -3201,7 +3201,7 @@ exports[`Story Snapshots: DarkTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the third message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the third message.  "
         accessible={true}
         style={
           [
@@ -3329,7 +3329,7 @@ exports[`Story Snapshots: DarkTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the second message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the second message.  "
         accessible={true}
         style={
           [
@@ -3457,7 +3457,7 @@ exports[`Story Snapshots: DarkTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the first message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the first message.  "
         accessible={true}
         style={
           [
@@ -3864,7 +3864,7 @@ exports[`Story Snapshots: LightTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Hey!.  "
+        accessibilityLabel="diego.mello 10:00:00 am Hey!.  "
         accessible={true}
         style={
           [
@@ -4175,7 +4175,7 @@ exports[`Story Snapshots: LightTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
         accessible={true}
         style={
           [
@@ -4303,7 +4303,7 @@ exports[`Story Snapshots: LightTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Older message.  "
+        accessibilityLabel="diego.mello 10:00:00 am Older message.  "
         accessible={true}
         style={
           [
@@ -4597,7 +4597,7 @@ exports[`Story Snapshots: LightTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
+        accessibilityLabel="diego.mello 10:00:00 am Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries.  "
         accessible={true}
         style={
           [
@@ -4908,7 +4908,7 @@ exports[`Story Snapshots: LightTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the third message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the third message.  "
         accessible={true}
         style={
           [
@@ -5036,7 +5036,7 @@ exports[`Story Snapshots: LightTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the second message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the second message.  "
         accessible={true}
         style={
           [
@@ -5164,7 +5164,7 @@ exports[`Story Snapshots: LightTheme should match snapshot 1`] = `
       }
     >
       <View
-        accessibilityLabel="diego.mello 10:00:00 AM This is the first message.  "
+        accessibilityLabel="diego.mello 10:00:00 am This is the first message.  "
         accessible={true}
         style={
           [


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
This PR introduces a new reusable HeaderTitle component to create consistent and pressable headers across the application, it uses PlatformPressable for onPress handling. This refactor simplifies the RoomHeader and promotes code reuse. 

## Proposed changes
This pull request refactors the RoomHeader to use a new, reusable HeaderTitle component. The key motivation for this change is to make the room header title pressable and to improve code modularity.

The new HeaderTitle component encapsulates the logic for displaying the room title and handles press events via the new PlatformPressable utility, ensuring consistent behavior across platforms.

## Issue(s) 
Closes #6255

## How to test or reproduce
1. Go to any chat room.
2. The header of the room should be visible.
3. Tap on the header title.
4. The action to view Room Info should be triggered.
5. Verify that the header appears and functions correctly on both iOS and Android.

## Screenshots
<!-- Please add any relevant screenshots here. -->

https://github.com/user-attachments/assets/c3209cd3-6560-4218-9f98-5e02df22e7e3



## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an x in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
The main goal was to create a more modular and reusable header component. By extracting the title into its own HeaderTitle component and using a PlatformPressable wrapper, we've made the UI more consistent and easier to maintain.
