### PR TITLE
fix: keyboard overlap send button and toolbar when switching to keyboard's emoji mode

### DIFF
--- a/app/containers/MessageComposer/hooks/useEmojiKeyboard.tsx
+++ b/app/containers/MessageComposer/hooks/useEmojiKeyboard.tsx
@@ -50,6 +50,11 @@ const useKeyboardAnimation = () => {
 				'worklet';
 
 				height.value = e.height;
+			},
+			onEnd: e => {
+				'worklet';
+
+				height.value = Math.max(e.height, 0);
 			}
 		},
 		[]


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue where, when we open a chat room and try to send an emoji using the OS provided keyboard, it overlaps the toolbar on iOS and hides the TextInput on Android. This makes it difficult to send the emoji directly; to send it, we first have to open the keyboard in text mode.

## Issue(s)	
Closes https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/6550

## How to test or reproduce
1. Go to any chat room
2. Click the text input
3. Click on keyboard emoji button
4. Observe the toolbar and send button is getting overlapped on iOS and TextInput is not visible on Android

## Screenshots
| OS | Before | After |
| --- | --- | --- |
| Android | <img width="377" height="794" alt="Screenshot 2025-08-12 at 4 35 37 PM" src="https://github.com/user-attachments/assets/99ac1b98-877b-487d-9e48-7f89976a2c89" /> | <img width="376" height="794" alt="Screenshot 2025-08-12 at 4 34 05 PM" src="https://github.com/user-attachments/assets/bdfd3e65-7a5b-40d1-8ffe-dc4578ebddff" /> |
| iOS | <img width="351" height="713" alt="Screenshot 2025-08-12 at 4 35 13 PM" src="https://github.com/user-attachments/assets/773bcfdd-8090-4dbb-9837-f2850322ec05" /> | <img width="355" height="706" alt="Screenshot 2025-08-12 at 4 34 33 PM" src="https://github.com/user-attachments/assets/3790fca7-2141-4ad8-855e-45392f146363" /> |

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
My change is not affecting the normal keyboard behaviour

<img width="377" height="829" alt="Screenshot 2025-08-12 at 4 36 50 PM" src="https://github.com/user-attachments/assets/e48f1430-7a99-4382-bd65-a0eb929fe169" /> 
<img width="377" height="781" alt="Screenshot 2025-08-12 at 4 38 33 PM" src="https://github.com/user-attachments/assets/3c734cd4-c0b2-4a90-bab3-6506b73db2eb" />

Got this solution from http://github.com/kirillzyusko/react-native-keyboard-controller/issues/600
