### PR TITLE
chore: using setup_ci for ios build

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,7 +13,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs: 
+jobs:
   run-eslint-and-test:
     name: ESLint and Test
     if: ${{ github.repository == 'RocketChat/Rocket.Chat.ReactNative' }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,7 +13,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
+jobs: 
   run-eslint-and-test:
     name: ESLint and Test
     if: ${{ github.repository == 'RocketChat/Rocket.Chat.ReactNative' }}

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :ios
 
 platform :ios do
   before_all do
-    setup_circle_ci	
+    setup_ci	
     create_keychain(	
       name: ENV["MATCH_KEYCHAIN_NAME"],	
       password: ENV["MATCH_KEYCHAIN_PASSWORD"],	


### PR DESCRIPTION
## Proposed changes
During the migration from CircleCI to GitHub Actions in https://github.com/RocketChat/Rocket.Chat.ReactNative/pull/6447, I forgot to change [setup_circle_ci](https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/ios/fastlane/Fastfile#L20) to [setup_ci](https://docs.fastlane.tools/actions/setup_ci/), which is more suitable and recommended by fastlane for GitHub Actions. The previous setup was causing the iOS build to hang on Signing NotificationService.appex, which resulted in the build failing. Hopefully, this change will fix the hanging issue.

### Working Actions
[Run 1](https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/17067295823)
[Run 2](https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/17065016163/attempts/1)
[Run 3](https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/17065016163/attempts/2)
[Run 4](https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/17065016163)

## Issue(s)
N/A

## How to test or reproduce
N/A

## Screenshots
N/A

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
N/A

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
This will break the iOS builds on Circle CI