### PR TITLE
fix: show correct toast message on star and unstar

### DIFF
--- a/app/containers/MessageActions/index.tsx
+++ b/app/containers/MessageActions/index.tsx
@@ -295,7 +295,7 @@ const MessageActions = React.memo(
 				logEvent(message.starred ? events.ROOM_MSG_ACTION_UNSTAR : events.ROOM_MSG_ACTION_STAR);
 				try {
 					await Services.toggleStarMessage(message.id, message.starred as boolean); // TODO: reevaluate `message.starred` type on IMessage
-                    console.log('message.starred', message.starred);
+					console.log('message.starred', message.starred);
 					EventEmitter.emit(LISTENER, { message: message.starred ? I18n.t('Message_starred') : I18n.t('Message_unstarred') });
 				} catch (e) {
 					logEvent(events.ROOM_MSG_ACTION_STAR_F);

--- a/app/containers/MessageActions/index.tsx
+++ b/app/containers/MessageActions/index.tsx
@@ -295,7 +295,8 @@ const MessageActions = React.memo(
 				logEvent(message.starred ? events.ROOM_MSG_ACTION_UNSTAR : events.ROOM_MSG_ACTION_STAR);
 				try {
 					await Services.toggleStarMessage(message.id, message.starred as boolean); // TODO: reevaluate `message.starred` type on IMessage
-					EventEmitter.emit(LISTENER, { message: message.starred ? I18n.t('Message_unstarred') : I18n.t('Message_starred') });
+                    console.log('message.starred', message.starred);
+					EventEmitter.emit(LISTENER, { message: message.starred ? I18n.t('Message_starred') : I18n.t('Message_unstarred') });
 				} catch (e) {
 					logEvent(events.ROOM_MSG_ACTION_STAR_F);
 					log(e);


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue with toast messages showing incorrect text. Previously, when a message was starred, the toast displayed "Message unstarred", and when a message was unstarred, it displayed "Message starred". This PR resolves the issue and ensures the correct messages are shown.

## Issue(s)	
N/A

## How to test or reproduce
1. Send a message in room
2. Star it
3. Observe toast message
4. Unstar it
5. Observe toast message

## Screenshots
| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/033d7147-b2d1-4413-be86-367b729c66a8 | https://github.com/user-attachments/assets/8554ab12-723d-4a7d-9083-f168a7d502cb |

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
