### PR TITLE
fix: submit button not enabled when toggling switches in room edit

### DIFF
--- a/app/views/RoomInfoEditView/index.tsx
+++ b/app/views/RoomInfoEditView/index.tsx
@@ -3,6 +3,7 @@ import { BlockContext } from '@rocket.chat/ui-kit';
 import { dequal } from 'dequal';
 import { AccessibilityInfo, Alert, Keyboard, ScrollView, Text, View } from 'react-native';
 import { useForm } from 'react-hook-form';
+import { type SetValueConfig } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 
@@ -38,6 +39,10 @@ const MESSAGE_TYPE_VALUES = MessageTypeValues.map(m => ({
 	value: m.value,
 	text: { text: I18n.t('Hide_type_messages', { type: I18n.t(m.text) }) }
 }));
+
+const dirtyOptions: SetValueConfig = {
+	shouldDirty: true
+};
 
 const schema = yup.object().shape({
 	name: yup.string().required(I18n.t('Name_required'))
@@ -283,29 +288,29 @@ const RoomInfoEditView = ({ navigation, route }: IRoomInfoEditViewProps) => {
 
 	const toggleRoomType = (value: boolean) => {
 		logEvent(events.RI_EDIT_TOGGLE_ROOM_TYPE);
-		setValue('t', value);
-		setValue('encrypted', value && encrypted);
+		setValue('t', value, dirtyOptions);
+		setValue('encrypted', value && encrypted, dirtyOptions);
 	};
 
 	const toggleReadOnly = (value: boolean) => {
 		logEvent(events.RI_EDIT_TOGGLE_READ_ONLY);
-		setValue('readOnly', value);
+		setValue('readOnly', value, dirtyOptions);
 	};
 
 	const toggleReactions = (value: boolean) => {
 		logEvent(events.RI_EDIT_TOGGLE_REACTIONS);
-		setValue('reactWhenReadOnly', value);
+		setValue('reactWhenReadOnly', value, dirtyOptions);
 	};
 
 	const toggleHideSystemMessages = (value: boolean) => {
 		logEvent(events.RI_EDIT_TOGGLE_SYSTEM_MSG);
-		setValue('enableSysMes', value);
-		setValue('systemMessages', value ? systemMessages : []);
+		setValue('enableSysMes', value, dirtyOptions);
+		setValue('systemMessages', value ? systemMessages : [], dirtyOptions);
 	};
 
 	const toggleEncrypted = (value: boolean) => {
 		logEvent(events.RI_EDIT_TOGGLE_ENCRYPTED);
-		setValue('encrypted', value);
+		setValue('encrypted', value, dirtyOptions);
 	};
 
 	const onResetPress = () => {


### PR DESCRIPTION
## Proposed changes
In the Room Edit screen, the Save Changes button wasn’t enabling when toggling switches, Based on https://github.com/react-hook-form/react-hook-form/issues/72#issuecomment-656500986 comment , I am passing { shouldDirty } as the third parameter in setValue to ensure that it updates the value as soon as we click the switch and enables the submit button.

## Issue(s)	
N/A

## How to test or reproduce
1. Go to any room edit screen
2. Click on Public or Private
3. Observe 'Save Changes' and 'Cancel' button

## Screenshots
| OS | Before | After |
| --- | --- | --- |
| Android | https://github.com/user-attachments/assets/f4cde33e-e7cc-4fc2-b332-7dbd89a9ece1 | https://github.com/user-attachments/assets/69a55ad1-bea1-4c60-873e-52c2e5cc20f5 |
| iOS | https://github.com/user-attachments/assets/bcb20607-e1b3-4135-9389-4290e5b47249 | https://github.com/user-attachments/assets/3328efd8-f0b5-449b-ba29-d163c8ecf59a |

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Room settings toggles now correctly register changes, enabling the Save/Update action and showing unsaved-changes prompts as expected.
  * Affected toggles include: Room Type, Encryption, Read-only, React when read-only, and System messages.
  * Improves reliability when editing room info, reducing the risk of losing changes before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->