### PR TITLE
fix: e2ee attachment getting locked after interaction

### DIFF
--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -265,10 +265,10 @@ export default class RoomSubscription {
 						message.attachments = message.attachments?.map(att => {
 							const existing = messageRecord.attachments?.find(
 								a =>
-									a.image_url === att.image_url ||
-									a.video_url === att.video_url ||
-									a.audio_url === att.audio_url ||
-									a.thumb_url === att.thumb_url
+									(a.image_url && a.image_url === att.image_url) ||
+									(a.video_url && a.video_url === att.video_url) ||
+									(a.audio_url && a.audio_url === att.audio_url) ||
+									(a.thumb_url && a.thumb_url === att.thumb_url)
 							);
 
 							return {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
Whenever we or someone try to interact with an attachment in e2ee channel like reacting to that message or read receipt event happen, we receive websocket event which just overwrite the attachment payload provided from backend which removes the e2ee done and cache property from the local database (this thing is done in the app), so before updating the message, i am just trying to get the attachment from the local db and add the e2ee key and local cache path to each object. 

## Issue(s)	
Closes: https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/5977
https://rocketchat.atlassian.net/browse/COMM-86

## How to test or reproduce
1. Enable E2EE in DM or Private Channel
2. Send an attachment
3. React with any emoji
4. Observe the same attachment

It will show overlay component with key icon if we use the code from develop

## Screenshots
Before
https://github.com/user-attachments/assets/8b5c1e5a-8d7c-4d77-a79d-2b6aa506b168 

After
https://github.com/user-attachments/assets/5d496425-4a95-4be4-a526-651cd8746bde 

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachments in encrypted messages now inherit existing encryption metadata correctly; attachment title links are preserved only when encryption is fully completed, otherwise original links are kept.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->