### PR TITLE
fix: make readonly permission reactive in RoomView

### DIFF
--- a/app/lib/methods/helpers/isReadOnly.ts
+++ b/app/lib/methods/helpers/isReadOnly.ts
@@ -7,8 +7,9 @@ const canPostReadOnly = async (room: Partial<ISubscription>, username: string, p
 	const isUnmuted = !!room?.unmuted?.find(m => m === username);
 	// Use provided permission or fallback to static snapshot for backward compatibility
 	const permissionToCheck = postReadOnlyPermission ?? reduxStore.getState().permissions['post-readonly'];
-	const permission = await hasPermission([permissionToCheck], room.rid);
-	return permission[0] || isUnmuted;
+	const permissions = (await hasPermission([permissionToCheck], room.rid)) ?? [false];
+	const canPost = !!permissions[0];
+	return canPost || isUnmuted;
 };
 
 const isMuted = (room: Partial<ISubscription>, username: string) =>

--- a/app/lib/methods/helpers/isReadOnly.ts
+++ b/app/lib/methods/helpers/isReadOnly.ts
@@ -2,19 +2,23 @@ import { store as reduxStore } from '../../store/auxStore';
 import { type ISubscription } from '../../../definitions';
 import { hasPermission } from './helpers';
 
-const canPostReadOnly = async (room: Partial<ISubscription>, username: string) => {
+const canPostReadOnly = async (room: Partial<ISubscription>, username: string, postReadOnlyPermission?: string[]) => {
 	// RC 6.4.0
 	const isUnmuted = !!room?.unmuted?.find(m => m === username);
-	// TODO: this is not reactive. If this permission changes, the component won't be updated
-	const postReadOnlyPermission = reduxStore.getState().permissions['post-readonly'];
-	const permission = await hasPermission([postReadOnlyPermission], room.rid);
+	// Use provided permission or fallback to static snapshot for backward compatibility
+	const permissionToCheck = postReadOnlyPermission ?? reduxStore.getState().permissions['post-readonly'];
+	const permission = await hasPermission([permissionToCheck], room.rid);
 	return permission[0] || isUnmuted;
 };
 
 const isMuted = (room: Partial<ISubscription>, username: string) =>
 	room && room.muted && room.muted.find && !!room.muted.find(m => m === username);
 
-export const isReadOnly = async (room: Partial<ISubscription>, username: string): Promise<boolean> => {
+export const isReadOnly = async (
+	room: Partial<ISubscription>,
+	username: string,
+	postReadOnlyPermission?: string[]
+): Promise<boolean> => {
 	if (room.archived) {
 		return true;
 	}
@@ -22,7 +26,7 @@ export const isReadOnly = async (room: Partial<ISubscription>, username: string)
 		return true;
 	}
 	if (room?.ro) {
-		const allowPost = await canPostReadOnly(room, username);
+		const allowPost = await canPostReadOnly(room, username, postReadOnlyPermission);
 		if (allowPost) {
 			return false;
 		}

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -28,6 +28,7 @@ export interface IRoomViewProps extends IActionSheetProvider, IBaseScreen<ChatsS
 	insets: EdgeInsets;
 	transferLivechatGuestPermission?: string[]; // TODO: Check if its the correct type
 	viewCannedResponsesPermission?: string[]; // TODO: Check if its the correct type
+	postReadOnlyPermission?: string[];
 	livechatAllowManualOnHold?: boolean;
 	inAppFeedback?: { [key: string]: string };
 	encryptionEnabled: boolean;

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -248,7 +248,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 	shouldComponentUpdate(nextProps: IRoomViewProps, nextState: IRoomViewState) {
 		const { state } = this;
 		const { roomUpdate, member, isOnHold, isAutocompleteVisible } = state;
-		const { theme, insets, route, encryptionEnabled, airGappedRestrictionRemainingDays } = this.props;
+		const { theme, insets, route, encryptionEnabled, airGappedRestrictionRemainingDays, postReadOnlyPermission } = this.props;
 		if (theme !== nextProps.theme) {
 			return true;
 		}
@@ -256,6 +256,9 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 			return true;
 		}
 		if (airGappedRestrictionRemainingDays !== nextProps.airGappedRestrictionRemainingDays) {
+			return true;
+		}
+		if (!dequal(postReadOnlyPermission, nextProps.postReadOnlyPermission)) {
 			return true;
 		}
 		if (member.statusText !== nextState.member.statusText) {
@@ -310,6 +313,8 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 		if (insets.left !== prevProps.insets.left || insets.right !== prevProps.insets.right) {
 			this.setHeader();
 		}
+		// Update readOnly when permission changes or room updates
+		// Always call setReadOnly to ensure it's up to date (it will only update state if value changed)
 		this.setReadOnly();
 	}
 
@@ -568,8 +573,8 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 
 	setReadOnly = async () => {
 		const { room } = this.state;
-		const { user } = this.props;
-		const readOnly = await isReadOnly(room as ISubscription, user.username as string);
+		const { user, postReadOnlyPermission } = this.props;
+		const readOnly = await isReadOnly(room as ISubscription, user.username as string, postReadOnlyPermission);
 		this.setState({ readOnly });
 	};
 
@@ -1576,6 +1581,7 @@ const mapStateToProps = (state: IApplicationState) => ({
 	Hide_System_Messages: state.settings.Hide_System_Messages as string[],
 	transferLivechatGuestPermission: state.permissions['transfer-livechat-guest'],
 	viewCannedResponsesPermission: state.permissions['view-canned-responses'],
+	postReadOnlyPermission: state.permissions['post-readonly'],
 	livechatAllowManualOnHold: state.settings.Livechat_allow_manual_on_hold as boolean,
 	airGappedRestrictionRemainingDays: state.settings.Cloud_Workspace_AirGapped_Restrictions_Remaining_Days,
 	inAppFeedback: state.inAppFeedback,


### PR DESCRIPTION
When an admin grants the "post-readonly" permission while a user is in a read-only room, the composer stays disabled until they navigate away or restart the app. The UI doesn't update immediately.

Issue(s)
Closes #6802

### Solution
- Updated `isReadOnly` to accept the permission as a parameter instead of reading it statically.
- Made RoomView subscribe to permission changes from Redux.
- Added detection so the component re-renders when the permission changes.
- The composer now enables/disables immediately when permissions change.

### Changes
- Modified `isReadOnly` to accept `postReadOnlyPermission` as an optional parameter.
- Updated RoomView to get the permission from Redux props.
- Added permission change detection in `shouldComponentUpdate`.
- The component now updates immediately when the permission changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Read-only logic updated to honor an optional post-readonly permission source, keeping backward compatibility.
  * Room view now reacts to changes in that permission so read-only status and UI updates happen more reliably when permissions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->