### PR TITLE
fix(sync): fallback to sync from 0 if lastOpen is missing to prevent ignored deletions

### DIFF
--- a/app/lib/methods/loadMissedMessages.ts
+++ b/app/lib/methods/loadMissedMessages.ts
@@ -21,7 +21,7 @@ const getSyncMessagesFromCursor = async (
 ) => {
 	const promises = [];
 
-	if (lastOpen && !updatedNext && !deletedNext) {
+	if ((lastOpen || lastOpen === 0) && !updatedNext && !deletedNext) {
 		promises.push(syncMessages({ roomId, next: lastOpen, type: 'UPDATED' }));
 		promises.push(syncMessages({ roomId, next: lastOpen, type: 'DELETED' }));
 	}
@@ -67,7 +67,7 @@ async function load({
 			lastOpenTimestamp = new Date(lastOpen).getTime();
 		} else {
 			const lastUpdate = await getLastUpdate(roomId);
-			lastOpenTimestamp = lastUpdate?.getTime();
+			lastOpenTimestamp = lastUpdate?.getTime() ?? 0;
 		}
 		const result = await getSyncMessagesFromCursor(roomId, lastOpenTimestamp, updatedNext, deletedNext);
 		return result;


### PR DESCRIPTION
## Description
Fixes #6835.
When `lastOpen` is missing (e.g., after a crash or bad state), the app was skipping the sync process for missed messages entirely. This caused deletions that happened while offline to be ignored, resulting in "zombie" messages.
This fix ensures that if `lastOpen` is missing, we fallback to syncing from timestamp `0`, guaranteeing that the state is reconciled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missed messages to ensure proper synchronization of updated and deleted messages in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->