### PR TITLE
Add cmd+K keyboard shortcut support for iPad with external keyboard

### DIFF
--- a/app/containers/SearchHeader.tsx
+++ b/app/containers/SearchHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type StyleProp, StyleSheet, View, type ViewStyle } from 'react-native';
+import { Platform, type StyleProp, StyleSheet, View, type ViewStyle } from 'react-native';
 
 import I18n from '../i18n';
 import { useTheme } from '../theme';
@@ -35,7 +35,7 @@ const SearchHeader = ({ onSearchChangeText, testID, style }: ISearchHeaderProps)
 			<TextInput
 				autoFocus
 				style={[styles.title, isLight && { color: themes[theme].fontTitlesLabels }]}
-				placeholder={I18n.t('Search')}
+				placeholder={Platform.OS === 'ios' ? `${I18n.t('Search')} (⌘ + K)` : I18n.t('Search')}
 				onChangeText={onSearchChangeText}
 				testID={testID}
 				autoComplete='off'

--- a/app/lib/native/NativeKeyboardCommand.ts
+++ b/app/lib/native/NativeKeyboardCommand.ts
@@ -1,0 +1,22 @@
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
+
+const { KeyboardCommand } = NativeModules;
+
+class KeyboardCommandModule {
+	private eventEmitter: NativeEventEmitter | null = null;
+
+	constructor() {
+		if (Platform.OS === 'ios' && KeyboardCommand) {
+			this.eventEmitter = new NativeEventEmitter(KeyboardCommand);
+		}
+	}
+
+	addListener(callback: (event: { command: string }) => void) {
+		if (!this.eventEmitter) {
+			return { remove: () => {} };
+		}
+		return this.eventEmitter.addListener('onKeyboardCommand', callback);
+	}
+}
+
+export default new KeyboardCommandModule();

--- a/ios/KeyboardCommandModule.h
+++ b/ios/KeyboardCommandModule.h
@@ -1,0 +1,5 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface KeyboardCommandModule : RCTEventEmitter <RCTBridgeModule>
+@end

--- a/ios/KeyboardCommandModule.m
+++ b/ios/KeyboardCommandModule.m
@@ -1,0 +1,107 @@
+#import "KeyboardCommandModule.h"
+#import <React/RCTLog.h>
+#import <UIKit/UIKit.h>
+
+@interface KeyCommandHandler : UIViewController
+@property (nonatomic, weak) KeyboardCommandModule *eventEmitter;
+@end
+
+@implementation KeyCommandHandler
+
+- (void)loadView {
+  self.view = [[UIView alloc] init];
+}
+
+- (NSArray<UIKeyCommand *> *)keyCommands {
+  return @[
+    [UIKeyCommand keyCommandWithInput:@"k"
+                         modifierFlags:UIKeyModifierCommand
+                                action:@selector(handleCommandK)
+                  discoverabilityTitle:@"Search"]
+  ];
+}
+
+- (void)handleCommandK {
+  if (self.eventEmitter) {
+    [self.eventEmitter sendEventWithName:@"onKeyboardCommand" body:@{@"command": @"commandK"}];
+  }
+}
+
+- (BOOL)canBecomeFirstResponder {
+  return YES;
+}
+
+@end
+
+@interface KeyboardCommandModule ()
+@property (nonatomic, strong) KeyCommandHandler *keyCommandHandler;
+@end
+
+@implementation KeyboardCommandModule
+
+RCT_EXPORT_MODULE(KeyboardCommand);
+
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+  return @[@"onKeyboardCommand"];
+}
+
+- (void)startObserving {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self registerKeyCommands];
+  });
+}
+
+- (void)stopObserving {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (self.keyCommandHandler) {
+      [self.keyCommandHandler willMoveToParentViewController:nil];
+      [self.keyCommandHandler.view removeFromSuperview];
+      [self.keyCommandHandler removeFromParentViewController];
+      self.keyCommandHandler = nil;
+    }
+  });
+}
+
+- (void)registerKeyCommands {
+  UIWindow *keyWindow = nil;
+  for (UIWindow *window in [UIApplication sharedApplication].windows) {
+    if (window.isKeyWindow) {
+      keyWindow = window;
+      break;
+    }
+  }
+  
+  if (!keyWindow || !keyWindow.rootViewController) {
+    return;
+  }
+  
+  if (self.keyCommandHandler) {
+    [self.keyCommandHandler willMoveToParentViewController:nil];
+    [self.keyCommandHandler.view removeFromSuperview];
+    [self.keyCommandHandler removeFromParentViewController];
+    self.keyCommandHandler = nil;
+  }
+  
+  KeyCommandHandler *handler = [[KeyCommandHandler alloc] init];
+  handler.eventEmitter = self;
+  self.keyCommandHandler = handler;
+  
+  UIViewController *rootVC = keyWindow.rootViewController;
+  while (rootVC.presentedViewController) {
+    rootVC = rootVC.presentedViewController;
+  }
+  
+  [rootVC addChildViewController:handler];
+  [rootVC.view addSubview:handler.view];
+  handler.view.frame = CGRectZero;
+  handler.view.alpha = 0;
+  handler.view.userInteractionEnabled = NO;
+  handler.view.hidden = YES;
+  [handler didMoveToParentViewController:rootVC];
+}
+
+@end

--- a/ios/KeyboardCommandModule.m
+++ b/ios/KeyboardCommandModule.m
@@ -1,40 +1,10 @@
 #import "KeyboardCommandModule.h"
 #import <React/RCTLog.h>
+#import <React/RCTKeyCommands.h>
 #import <UIKit/UIKit.h>
 
-@interface KeyCommandHandler : UIViewController
-@property (nonatomic, weak) KeyboardCommandModule *eventEmitter;
-@end
-
-@implementation KeyCommandHandler
-
-- (void)loadView {
-  self.view = [[UIView alloc] init];
-}
-
-- (NSArray<UIKeyCommand *> *)keyCommands {
-  return @[
-    [UIKeyCommand keyCommandWithInput:@"k"
-                         modifierFlags:UIKeyModifierCommand
-                                action:@selector(handleCommandK)
-                  discoverabilityTitle:@"Search"]
-  ];
-}
-
-- (void)handleCommandK {
-  if (self.eventEmitter) {
-    [self.eventEmitter sendEventWithName:@"onKeyboardCommand" body:@{@"command": @"commandK"}];
-  }
-}
-
-- (BOOL)canBecomeFirstResponder {
-  return YES;
-}
-
-@end
-
 @interface KeyboardCommandModule ()
-@property (nonatomic, strong) KeyCommandHandler *keyCommandHandler;
+@property (nonatomic, assign) BOOL registered;
 @end
 
 @implementation KeyboardCommandModule
@@ -50,58 +20,31 @@ RCT_EXPORT_MODULE(KeyboardCommand);
 }
 
 - (void)startObserving {
+  if (self.registered) {
+    return;
+  }
+  self.registered = YES;
   dispatch_async(dispatch_get_main_queue(), ^{
-    [self registerKeyCommands];
+    if (![[RCTKeyCommands sharedInstance] isKeyCommandRegisteredForInput:@"k" modifierFlags:UIKeyModifierCommand]) {
+      [[RCTKeyCommands sharedInstance] registerKeyCommandWithInput:@"k"
+                                                     modifierFlags:UIKeyModifierCommand
+                                                            action:^(UIKeyCommand *command) {
+                                                              [self sendEventWithName:@"onKeyboardCommand" body:@{@"command": @"commandK"}];
+                                                            }];
+    }
   });
 }
 
 - (void)stopObserving {
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (self.keyCommandHandler) {
-      [self.keyCommandHandler willMoveToParentViewController:nil];
-      [self.keyCommandHandler.view removeFromSuperview];
-      [self.keyCommandHandler removeFromParentViewController];
-      self.keyCommandHandler = nil;
-    }
-  });
-}
-
-- (void)registerKeyCommands {
-  UIWindow *keyWindow = nil;
-  for (UIWindow *window in [UIApplication sharedApplication].windows) {
-    if (window.isKeyWindow) {
-      keyWindow = window;
-      break;
-    }
-  }
-  
-  if (!keyWindow || !keyWindow.rootViewController) {
+  if (!self.registered) {
     return;
   }
-  
-  if (self.keyCommandHandler) {
-    [self.keyCommandHandler willMoveToParentViewController:nil];
-    [self.keyCommandHandler.view removeFromSuperview];
-    [self.keyCommandHandler removeFromParentViewController];
-    self.keyCommandHandler = nil;
-  }
-  
-  KeyCommandHandler *handler = [[KeyCommandHandler alloc] init];
-  handler.eventEmitter = self;
-  self.keyCommandHandler = handler;
-  
-  UIViewController *rootVC = keyWindow.rootViewController;
-  while (rootVC.presentedViewController) {
-    rootVC = rootVC.presentedViewController;
-  }
-  
-  [rootVC addChildViewController:handler];
-  [rootVC.view addSubview:handler.view];
-  handler.view.frame = CGRectZero;
-  handler.view.alpha = 0;
-  handler.view.userInteractionEnabled = NO;
-  handler.view.hidden = YES;
-  [handler didMoveToParentViewController:rootVC];
+  self.registered = NO;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if ([[RCTKeyCommands sharedInstance] isKeyCommandRegisteredForInput:@"k" modifierFlags:UIKeyModifierCommand]) {
+      [[RCTKeyCommands sharedInstance] unregisterKeyCommandWithInput:@"k" modifierFlags:UIKeyModifierCommand];
+    }
+  });
 }
 
 @end

--- a/ios/RocketChatRN.xcodeproj/project.pbxproj
+++ b/ios/RocketChatRN.xcodeproj/project.pbxproj
@@ -364,6 +364,8 @@
 		A2C6E2DD38F8BEE19BFB2E1D /* SecureStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B215A42CFB843397273C7EA /* SecureStorage.m */; };
 		A48B46D92D3FFBD200945489 /* A11yFlowModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A48B46D82D3FFBD200945489 /* A11yFlowModule.m */; };
 		A48B46DA2D3FFBD200945489 /* A11yFlowModule.m in Sources */ = {isa = PBXBuildFile; fileRef = A48B46D82D3FFBD200945489 /* A11yFlowModule.m */; };
+		D1E9B0A32F9C123400000003 /* KeyboardCommandModule.m in Sources */ = {isa = PBXBuildFile; fileRef = D1E9B0A22F9C123400000002 /* KeyboardCommandModule.m */; };
+		D1E9B0A42F9C123400000004 /* KeyboardCommandModule.m in Sources */ = {isa = PBXBuildFile; fileRef = D1E9B0A22F9C123400000002 /* KeyboardCommandModule.m */; };
 		ACCF5C382F186B5D43B2C952 /* Pods_defaults_Rocket_Chat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85094D3182EA9331CC444733 /* Pods_defaults_Rocket_Chat.framework */; };
 		BC404914E86821389EEB543D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391C4F7AA7023CD41EEBD106 /* ExpoModulesProvider.swift */; };
 		DD2BA30A89E64F189C2C24AC /* libWatermelonDB.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BA7E862283664608B3894E34 /* libWatermelonDB.a */; };
@@ -647,6 +649,8 @@
 		A46AABC73B7E9703E69AF850 /* Pods_defaults_RocketChatRN.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_defaults_RocketChatRN.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A48B46D72D3FFBD200945489 /* A11yFlowModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = A11yFlowModule.h; sourceTree = "<group>"; };
 		A48B46D82D3FFBD200945489 /* A11yFlowModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = A11yFlowModule.m; sourceTree = "<group>"; };
+		D1E9B0A12F9C123400000001 /* KeyboardCommandModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeyboardCommandModule.h; sourceTree = "<group>"; };
+		D1E9B0A22F9C123400000002 /* KeyboardCommandModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeyboardCommandModule.m; sourceTree = "<group>"; };
 		B179038FDD7AAF285047814B /* SecureStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SecureStorage.h; sourceTree = "<group>"; };
 		B37C79D9BD0742CE936B6982 /* libc++.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		BA7E862283664608B3894E34 /* libWatermelonDB.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libWatermelonDB.a; sourceTree = "<group>"; };
@@ -730,6 +734,8 @@
 				7ACFE7D82DDE48760090D9BC /* AppDelegate.swift */,
 				A48B46D72D3FFBD200945489 /* A11yFlowModule.h */,
 				A48B46D82D3FFBD200945489 /* A11yFlowModule.m */,
+				D1E9B0A12F9C123400000001 /* KeyboardCommandModule.h */,
+				D1E9B0A22F9C123400000002 /* KeyboardCommandModule.m */,
 				7A8B30742BCD9D3F00146A40 /* SSLPinning.h */,
 				7A8B30752BCD9D3F00146A40 /* SSLPinning.mm */,
 				65B9A7192AFC24190088956F /* ringtone.mp3 */,
@@ -1825,7 +1831,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$TARGET_BUILD_DIR/$INFOPLIST_PATH",
+				$TARGET_BUILD_DIR/$INFOPLIST_PATH,
 			);
 			name = "Upload source maps to Bugsnag";
 			outputFileListPaths = (
@@ -1845,7 +1851,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$TARGET_BUILD_DIR/$INFOPLIST_PATH",
+				$TARGET_BUILD_DIR/$INFOPLIST_PATH,
 			);
 			name = "Upload source maps to Bugsnag";
 			outputFileListPaths = (
@@ -2061,6 +2067,7 @@
 				7ACFE7DA2DDE48760090D9BC /* AppDelegate.swift in Sources */,
 				1E9A71742B59F36E00477BA2 /* ClientSSL.swift in Sources */,
 				A48B46D92D3FFBD200945489 /* A11yFlowModule.m in Sources */,
+				D1E9B0A32F9C123400000003 /* KeyboardCommandModule.m in Sources */,
 				3F56D232A9EBA1C9C749F15F /* MMKVBridge.mm in Sources */,
 				7AACF8AC2C94B28B0082844E /* DecryptedContent.swift in Sources */,
 				1ED038A52B50900800C007D4 /* Bundle+Extensions.swift in Sources */,
@@ -2336,6 +2343,7 @@
 				7ACFE7D92DDE48760090D9BC /* AppDelegate.swift in Sources */,
 				1E9A71752B59F36E00477BA2 /* ClientSSL.swift in Sources */,
 				A48B46DA2D3FFBD200945489 /* A11yFlowModule.m in Sources */,
+				D1E9B0A42F9C123400000004 /* KeyboardCommandModule.m in Sources */,
 				3F56D232A9EBA1C9C749F160 /* MMKVBridge.mm in Sources */,
 				7AACF8AE2C94B28B0082844E /* DecryptedContent.swift in Sources */,
 				1ED038A72B50900800C007D4 /* Bundle+Extensions.swift in Sources */,
@@ -2593,7 +2601,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/rn-extensions-share/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-firebase/ios/RNFirebase/**",
-					"$PODS_CONFIGURATION_BUILD_DIR/Firebase",
+					$PODS_CONFIGURATION_BUILD_DIR/Firebase,
 				);
 				INFOPLIST_FILE = ShareRocketChatRN/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -2669,7 +2677,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/rn-extensions-share/ios/**",
 					"$(SRCROOT)/../node_modules/react-native-firebase/ios/RNFirebase/**",
-					"$PODS_CONFIGURATION_BUILD_DIR/Firebase",
+					$PODS_CONFIGURATION_BUILD_DIR/Firebase,
 				);
 				INFOPLIST_FILE = ShareRocketChatRN/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;


### PR DESCRIPTION
Adds support for `cmd+K` keyboard shortcut on iPad with external keyboard to open the channel search functionality, matching the web version behavior. The implementation uses React Native's `RCTKeyCommands` API to register the keyboard shortcut at the app level.

## Issue(s)	
Closes  #3464

## How to test or reproduce
1. Connect an external keyboard to an iPad
2. Launch the Rocket.Chat app
3. Press `cmd+K` - the search overlay will appear

## Video
https://github.com/user-attachments/assets/06a6b278-d95d-4549-84ab-5e36b54b3ff7

## Types of changes
- [x] New feature

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules