### PR TITLE
fix: resolve buggy windows pathlength limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"react-native-gesture-handler": "2.24.0",
 		"react-native-image-crop-picker": "RocketChat/react-native-image-crop-picker#5346870b0be10d300dc53924309dc6adc9946d50",
 		"react-native-katex": "git+https://github.com/RocketChat/react-native-katex.git",
-		"react-native-keyboard-controller": "^1.17.1",
+		"react-native-keyboard-controller": "^1.20.6",
 		"react-native-linear-gradient": "2.6.2",
 		"react-native-localize": "2.1.1",
 		"react-native-math-view": "3.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12721,12 +12721,12 @@ react-native-is-edge-to-edge@^1.2.1:
   version "1.3.0"
   resolved "git+https://github.com/RocketChat/react-native-katex.git#37e579804fe238732d8a4b06dec073610ab062b1"
 
-react-native-keyboard-controller@^1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.17.1.tgz#46efe148c1bdd0ee22094dcb2660f70f81e6544e"
-  integrity sha512-YM3GYvtkuWimCKkZFURn5hIb1WiKOQqi2DijdwZSF5QSSzGqfqwzEEC3bm1xCN8HGHAEIXAaWIBUsc3Xp5L+Ng==
+react-native-keyboard-controller@^1.20.6:
+  version "1.20.6"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.20.6.tgz#139a66f36734a69648822bf2e7ec3c90e7b3dc8e"
+  integrity sha512-RS6FjIjTFtAMQGdcXp3m6jUs1XgDa8qkpO5c4ix1S5HS0z3L2E1LUOY5rD73YUADOO3MfQN1z3JkHdBtzKucbg==
   dependencies:
-    react-native-is-edge-to-edge "^1.1.6"
+    react-native-is-edge-to-edge "^1.2.1"
 
 react-native-linear-gradient@2.6.2:
   version "2.6.2"


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
This PR upgrades `react-native-keyboard-controller` from `v1.17.1` to `v1.20.6`.

While building the Android app on Windows, the previous version generates deeply nested native codegen paths during the CMake/Ninja build step. This can exceed the Windows 260-character path length limit, leading to build failures such as:

> `Filename longer than 260 characters`

Updating to `v1.20.6` helps reduce this issue and improves compatibility with newer React Native and Android build tooling. The change is limited to dependency updates and does not modify any application logic.


## Issue(s)	
Closes #6923 

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
This bugfix is related to updating one problematic React Native dependency when compiling on Windows:
https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1247



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated react-native-keyboard-controller dependency to the latest compatible version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->