### PR TITLE
Add permission check for view-outside-room in Directory screen

### DIFF
--- a/app/views/DirectoryView/Options.tsx
+++ b/app/views/DirectoryView/Options.tsx
@@ -15,6 +15,7 @@ interface IDirectoryOptionsProps {
 	isFederationEnabled: boolean;
 	changeType: Function;
 	toggleWorkspace(): void;
+	hasViewOutsideRoomPermission: boolean;
 }
 
 const DirectoryOptions = ({
@@ -22,7 +23,8 @@ const DirectoryOptions = ({
 	globalUsers,
 	isFederationEnabled,
 	changeType,
-	toggleWorkspace
+	toggleWorkspace,
+	hasViewOutsideRoomPermission
 }: IDirectoryOptionsProps) => {
 	const { colors } = useTheme();
 	const insets = useSafeAreaInsets();
@@ -40,13 +42,23 @@ const DirectoryOptions = ({
 			icon = 'teams';
 		}
 
+		const isDisabled = itemType === 'users' && !hasViewOutsideRoomPermission;
+
 		return (
 			<List.Radio
 				title={text}
 				value={itemType}
 				isSelected={propType === itemType}
-				onPress={() => changeType(itemType)}
-				left={() => <CustomIcon name={icon} size={22} color={colors.fontDefault} style={styles.filterItemIcon} />}
+				onPress={() => !isDisabled && changeType(itemType)}
+				disabled={isDisabled}
+				left={() => (
+					<CustomIcon
+						name={icon}
+						size={22}
+						color={isDisabled ? colors.fontDisabled : colors.fontDefault}
+						style={styles.filterItemIcon}
+					/>
+				)}
 			/>
 		);
 	};

--- a/app/views/DirectoryView/index.tsx
+++ b/app/views/DirectoryView/index.tsx
@@ -131,9 +131,8 @@ class DirectoryView extends React.Component<IDirectoryViewProps, IDirectoryViewS
 				type,
 				workspace: globalUsers ? 'all' : 'local',
 				offset: data.length,
-
 				count: 50,
-				sort: { usersCount: -1 }
+				sort: type === 'users' ? { username: 1 } : { usersCount: -1 }
 			});
 			if (directories.success) {
 				this.setState(prev => ({


### PR DESCRIPTION
This PR fixes the Directory screen issue where users without the `view-outside-room` permission experience a continuous loading indicator when trying to access the "Users" filter. The fix adds client-side permission checks to prevent API calls that would result in 400 errors and provides better user feedback.

The changes include:
- Adding permission check for `view-outside-room` before allowing access to Users directory
- Disabling the "Users" filter option in the Directory screen when the user lacks the required permission

## Issue(s)	
Closes #6877

## How to test or reproduce
1. Log in as a user without the `view-outside-room` permission (or disable this permission for the user role)
2. Navigate to the Directory screen
3. Verify that:
   - The "Users" filter option is disabled/grayed out in the filter menu
   - No continuous loading indicator appears
   - Channels and Teams filters work normally

## Screenshots

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/9df3835c-050c-4e72-aec7-33d8f5a075a0" alt="Before" width="286" height="633" /> | <img src="https://github.com/user-attachments/assets/07b1e951-2b35-48d7-b50a-00613bc6a881" alt="After" width="301" height="646" /> |

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
This fix implements client-side permission validation to prevent the 400 Bad Request error that was occurring when users without the `view-outside-room` permission tried to access the Users directory. By checking permissions before making API calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory now respects role-based permissions: items users aren't allowed to view appear disabled and show visual disabled styling.
  * Default directory view falls back to channels when users lack permission to view user listings.
* **Bug Fixes**
  * Attempting to access restricted directory views now shows an error notification and prevents navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->