### PR TITLE
fix: restrict max width of 2FA dialog on tablet screens

### DIFF
--- a/app/containers/TwoFactor/styles.ts
+++ b/app/containers/TwoFactor/styles.ts
@@ -10,7 +10,9 @@ export default StyleSheet.create({
 	},
 	content: {
 		padding: 16,
-		width: '100%',
+		width: '100%', 
+		maxWidth: 480, // <-- New: Stops it from stretching too wide on large screens.
+		alignSelf: 'center',// <-- New: Forces it to stay in the middle of the ipad Screen.
 		borderRadius: 4
 	},
 	title: {


### PR DESCRIPTION
## Description
Fixed an issue where the Two-Factor Authentication dialog would stretch to 100% width on tablet screens, causing a misalignment.

## Changes
- Added `maxWidth: 480` to the content container in `styles.ts`.
- Added `alignSelf: 'center'` to ensure the dialog stays centered on larger viewports.

## How to test
1. Open the app on a Tablet emulator.
2. Navigate to the 2FA screen.
3. Verify that the input box is no longer full-width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the layout of the two-factor authentication component on larger screens with improved centering and optimized width constraints for better visual presentation on tablets and desktop devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->