### PR TITLE
feat: offline sync queue - reconcile TEMP messages on restart, auto-r…

### DIFF
--- a/app/lib/methods/messageSync.ts
+++ b/app/lib/methods/messageSync.ts
@@ -1,0 +1,84 @@
+import { Q } from '@nozbe/watermelondb';
+
+import database from '../database';
+import log from './helpers/log';
+import { messagesStatus } from '../constants/messagesStatus';
+import { changeMessageStatus, resendMessage } from './sendMessage';
+import getSingleMessage from './getSingleMessage';
+import type { TMessageModel } from '../../definitions';
+
+const TEMP_RECONCILIATION_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Reconciles stuck TEMP messages (e.g. after app crash/kill) on app restart.
+ * For each TEMP message older than the threshold: if it exists on server, mark SENT; otherwise resend.
+ */
+export async function reconcileTempMessages(): Promise<void> {
+	const db = database.active;
+	if (!db) {
+		return;
+	}
+
+	const msgCollection = db.get('messages');
+	const threshold = Date.now() - TEMP_RECONCILIATION_THRESHOLD_MS;
+
+	try {
+		const tempMessages = await msgCollection
+			.query(Q.where('status', messagesStatus.TEMP), Q.where('ts', Q.lt(threshold)))
+			.fetch();
+
+		// Process one-by-one so one failure does not stop the rest
+		/* eslint-disable no-await-in-loop */
+		for (const record of tempMessages as TMessageModel[]) {
+			try {
+				const serverMessage = await getSingleMessage(record.id);
+				if (serverMessage) {
+					await changeMessageStatus(
+						record.id,
+						messagesStatus.SENT,
+						record.tmid ?? undefined,
+						serverMessage
+					);
+				}
+			} catch {
+				try {
+					await resendMessage(record, record.tmid ?? undefined);
+				} catch (e) {
+					log(e);
+				}
+			}
+		}
+		/* eslint-enable no-await-in-loop */
+	} catch (e) {
+		log(e);
+	}
+}
+
+/**
+ * Retries all ERROR messages (e.g. after network reconnection).
+ */
+export async function retryErrorMessages(): Promise<void> {
+	const db = database.active;
+	if (!db) {
+		return;
+	}
+
+	const msgCollection = db.get('messages');
+
+	try {
+		const errorMessages = await msgCollection.query(Q.where('status', messagesStatus.ERROR)).fetch();
+
+		// Process one-by-one so one failure does not stop the rest
+		/* eslint-disable no-await-in-loop */
+		for (const record of errorMessages as TMessageModel[]) {
+			try {
+				await resendMessage(record, record.tmid ?? undefined);
+			} catch (e) {
+				log(e);
+			}
+		}
+		/* eslint-enable no-await-in-loop */
+	} catch (e) {
+		log(e);
+	}
+}

--- a/app/lib/methods/sendMessage.ts
+++ b/app/lib/methods/sendMessage.ts
@@ -10,7 +10,7 @@ import sdk from '../services/sdk';
 import { E2E_MESSAGE_TYPE, E2E_STATUS } from '../constants/keys';
 import { messagesStatus } from '../constants/messagesStatus';
 
-const changeMessageStatus = async (id: string, status: number, tmid?: string, message?: IMessage) => {
+export const changeMessageStatus = async (id: string, status: number, tmid?: string, message?: IMessage) => {
 	const db = database.active;
 	const msgCollection = db.get('messages');
 	const threadMessagesCollection = db.get('thread_messages');

--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -15,6 +15,7 @@ import createDiscussion from './createDiscussion';
 import encryption from './encryption';
 import videoConf from './videoConf';
 import troubleshootingNotification from './troubleshootingNotification';
+import messageSync from './messageSync';
 
 const root = function* root() {
 	yield all([
@@ -32,7 +33,8 @@ const root = function* root() {
 		inquiry(),
 		encryption(),
 		videoConf(),
-		troubleshootingNotification()
+		troubleshootingNotification(),
+		messageSync()
 	]);
 };
 

--- a/app/sagas/login.js
+++ b/app/sagas/login.js
@@ -39,6 +39,7 @@ import appNavigation from '../lib/navigation/appNavigation';
 import { showActionSheetRef } from '../containers/ActionSheet';
 import { SupportedVersionsWarning } from '../containers/SupportedVersions';
 import { isIOS } from '../lib/methods/helpers';
+import { reconcileTempMessages } from '../lib/methods/messageSync';
 
 const getServer = state => state.server.server;
 const loginWithPasswordCall = args => loginWithPassword(args);
@@ -223,6 +224,14 @@ const fetchUsersRoles = function* fetchRoomsFork() {
 	}
 };
 
+const reconcileTempMessagesSaga = function* reconcileTempMessagesSaga() {
+	try {
+		yield call(reconcileTempMessages);
+	} catch (e) {
+		log(e);
+	}
+};
+
 const handleLoginSuccess = function* handleLoginSuccess({ user }) {
 	try {
 		getUserPresence(user.id);
@@ -239,6 +248,7 @@ const handleLoginSuccess = function* handleLoginSuccess({ user }) {
 		yield fork(fetchEnterpriseModulesFork, { user });
 		yield fork(subscribeSettingsFork);
 		yield fork(fetchUsersRoles);
+		yield fork(reconcileTempMessagesSaga);
 
 		setLanguage(user?.language);
 

--- a/app/sagas/messageSync.js
+++ b/app/sagas/messageSync.js
@@ -1,0 +1,25 @@
+import { call, select, takeEvery } from 'redux-saga/effects';
+
+import { METEOR } from '../actions/actionsTypes';
+import log from '../lib/methods/helpers/log';
+import { retryErrorMessages } from '../lib/methods/messageSync';
+
+const getUser = state => state.login.user;
+
+const retryErrorMessagesSaga = function* retryErrorMessagesSaga() {
+	const user = yield select(getUser);
+	if (!user?.id) {
+		return;
+	}
+	try {
+		yield call(retryErrorMessages);
+	} catch (e) {
+		log(e);
+	}
+};
+
+const root = function* root() {
+	yield takeEvery(METEOR.SUCCESS, retryErrorMessagesSaga);
+};
+
+export default root;


### PR DESCRIPTION
This PR adds a offline/sync flow to ensure messages don’t remain stuck after app restarts, crashes, or network changes.

* **Stuck TEMP messages**: On login, messages that have been in `TEMP` state for more than **5 minutes** are reconciled:

  * If the message exists on the server (via `chat.getMessage`), its status is updated to `SENT`.
  * Otherwise, the message is resent. If resend fails, it is moved to `ERROR`.

* **Auto-retry ERROR messages**: When the app reconnects (`METEOR.SUCCESS`), all messages in `ERROR` state are automatically retried so users don’t need to manually tap **Resend** after going back online.

* ** Details**:

  * Introduced `messageSync.ts` with `reconcileTempMessages()` and `retryErrorMessages()`.
  * Exported `changeMessageStatus` from `sendMessage.ts` for reuse.
  * TEMP reconciliation runs once on login success.
  * Added a `messageSync` saga that retries ERROR messages on connection success when the user is logged in.

---

## Issue(s)
Closes #6928, #4471



* Messages stuck in `TEMP` remained in a perpetual **Sending…** state after app crash or force kill.
* Messages in `ERROR` state were never retried automatically after network reconnection.

---

## How to Test / Reproduce

### Stuck TEMP Messages

1. Open a room and send a message.
2. Force close the app while the message is still in **Sending…** state.
3. Reopen the app and navigate back to the room.

**Expected result**:

* The message is reconciled:

  * Marked as `SENT` if it exists on the server, or
  * Resent automatically, or
  * Moved to `ERROR` if resend fails.

### Auto-retry ERROR Messages

1. Enable **Airplane Mode**.
2. Send a message (it moves to `ERROR`).
3. Disable **Airplane Mode** and wait for reconnection.

**result**:

* The message is retried automatically without tapping **Resend**.

---

## Screenshots/Videos

https://github.com/user-attachments/assets/421b330c-679d-411c-9752-b15c62cb9f96

---

## Types of Changes

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] Improvement (non-breaking change which improves a current function)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Documentation update

---

## Checklist

* [ ] I have read the CONTRIBUTING document
* [ ] I have signed the CLA
* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
* [ ] I have added necessary documentation (if applicable)
* [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TEMP messages older than 5 minutes are automatically reconciled with server state.
  * Messages that previously errored are retried automatically.
  * Message synchronization runs in the background after login and when the app reconnects, reducing stuck or failed sends.
  * Per-attempt retry attempts and outcomes are logged to aid visibility and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->