### PR TITLE
fix: add retry logic to loadThreadMessages to prevent missing thread …

### DIFF
--- a/app/lib/methods/loadThreadMessages.ts
+++ b/app/lib/methods/loadThreadMessages.ts
@@ -11,8 +11,9 @@ import { type TThreadMessageModel } from '../../definitions';
 import sdk from '../services/sdk';
 
 async function load({ tmid }: { tmid: string }) {
-	const MAX_RETRIES = 3;
-	for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+	const MAX_ATTEMPTS = 3;
+	/* eslint-disable no-await-in-loop */
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
 		try {
 			// RC 1.0
 			const result = await sdk.methodCallWrapper('getThreadMessages', { tmid });
@@ -21,13 +22,14 @@ async function load({ tmid }: { tmid: string }) {
 			}
 			return EJSON.fromJSONValue(result);
 		} catch (e) {
-			if (attempt < MAX_RETRIES) {
+			if (attempt < MAX_ATTEMPTS) {
 				await new Promise(resolve => setTimeout(resolve, attempt * 500));
 			} else {
 				throw e;
 			}
 		}
 	}
+	/* eslint-enable no-await-in-loop */
 }
 
 export function loadThreadMessages({ tmid, rid }: { tmid: string; rid: string }) {

--- a/app/lib/methods/loadThreadMessages.ts
+++ b/app/lib/methods/loadThreadMessages.ts
@@ -11,7 +11,7 @@ import { type TThreadMessageModel } from '../../definitions';
 import sdk from '../services/sdk';
 
 async function load({ tmid }: { tmid: string }) {
-	const MAX_ATTEMPTS = 3;
+	const MAX_ATTEMPTS = 4;
 	/* eslint-disable no-await-in-loop */
 	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
 		try {

--- a/app/lib/methods/loadThreadMessages.ts
+++ b/app/lib/methods/loadThreadMessages.ts
@@ -28,7 +28,6 @@ async function load({ tmid }: { tmid: string }) {
 			}
 		}
 	}
-	return [];
 }
 
 export function loadThreadMessages({ tmid, rid }: { tmid: string; rid: string }) {


### PR DESCRIPTION
When `loadThreadMessages` fails (due to network error, timeout, or server error), the `load()` function silently catches the error and returns an empty array `[]`.

This causes the thread view in the native app to display only a subset of messages.

Specifically, only messages that were:

* Already cached from channel history (messages with `tshow: true` / "Also send to channel")
* Received in real-time while the user was actively online in the room

The web client does not have this issue because it uses a different fetching strategy with proper error handling.

---

Cause

The `load()` function contains a silent catch block:

* Errors from `loadThreadMessages` are swallowed
* An empty array `[]` is returned
* No retry is attempted
* No error is propagated to the caller

This makes the failure invisible and results in incomplete thread data.

---

Closes #6311

Proposed changes

This PR improves reliability by:

1. **Adding retry logic**

   * 3 retry attempts
   * Backoff delays: 500ms → 1000ms → 1500ms
   * Handles transient network failures

2. **Propagating errors after retries fail**

   * Instead of returning `[]`, the error is thrown
   * Allows the caller (`RoomView.init()`) to trigger its own retry mechanism
   * Creates a two-layer retry system

3. **Removing silent error swallowing**

   * Eliminates the `catch { return []; }`
   * Prevents hidden data loss

---

## How to Test / Reproduce

1. Go to **Settings > Preferences > Also send thread message to channel behavior**.
2. Choose **"Selected by default"**.
3. Create a thread message.
4. Reply in that thread with **"Also send to channel" enabled**.
5. Reply in that thread with **"Also send to channel" disabled**.
6. Repeat with other preference settings:

   * "Selected for first reply, unselected for following replies"
   * "Unselected by default"
7. Compare the thread view in the native app vs the web version.

### Before Fix

* Some thread replies are missing in the native app.
* Especially replies sent without "Also send to channel".
* Happens when the initial `getThreadMessages` call fails.

### After Fix

* All thread messages are shown reliably.
* Retry logic handles transient failures.
* No silent data loss.

---

## Screenshots

N/A — No UI changes. This is a data-fetching reliability improvement.

---

## Type of Change

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] Improvement (non-breaking change which improves a current function)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Documentation update (if none of the other choices apply)

---

## Checklist

* [x] I have read the CONTRIBUTING doc
* [x] I have signed the CLA
* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
* [ ] I have added necessary documentation (if applicable)
* [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread message loading reliability by adding automatic retries with incremental backoff (up to 4 attempts), reducing transient failures and resulting in more consistent message delivery and fewer empty results for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->