### PR TITLE
fix(android): check pending notification before WebSocket connection guard

### DIFF
--- a/app/sagas/state.js
+++ b/app/sagas/state.js
@@ -19,6 +19,13 @@ const appHasComeBackToForeground = function* appHasComeBackToForeground() {
 	if (appRoot !== RootEnum.ROOT_INSIDE) {
 		return;
 	}
+	// Check for pending notification BEFORE connection check.
+	// This ensures notification taps during WebSocket reconnection are not lost.
+	// checkPendingNotification() dispatches deepLinkingOpen, and the deepLinking
+	// saga already waits for LOGIN.SUCCESS before navigating to the room.
+	checkPendingNotification().catch((e) => {
+		log('[state.js] Error checking pending notification:', e);
+	});
 	const isReady = yield isAuthAndConnected();
 	if (!isReady) {
 		return;
@@ -27,10 +34,6 @@ const appHasComeBackToForeground = function* appHasComeBackToForeground() {
 		const server = yield select(state => state.server.server);
 		yield localAuthenticate(server);
 		checkAndReopen();
-		// Check for pending notification when app comes to foreground (Android - notification tap while in background)
-		checkPendingNotification().catch((e) => {
-			log('[state.js] Error checking pending notification:', e);
-		});
 		return yield setUserPresenceOnline();
 	} catch (e) {
 		log(e);


### PR DESCRIPTION
## Proposed changes

On Android, when a user taps a push notification while the WebSocket is reconnecting, the app opens but does **not** navigate to the room. The notification tap is silently ignored.

**Root cause:** `checkPendingNotification()` in `app/sagas/state.js` was called inside the `isAuthAndConnected()` guard, which requires `meteor.connected === true`. During WebSocket reconnection, this returns `false`, so the function is never reached and the pending notification data in SharedPreferences is never processed.

**Fix:** Move `checkPendingNotification()` **before** the `isAuthAndConnected()` guard. This is safe because:
- `checkPendingNotification()` dispatches a `deepLinkingOpen` Redux action
- The `deepLinking` saga already has its own `yield take(LOGIN.SUCCESS)` mechanism to wait for reconnection before navigating
- No notification data is lost or duplicated — the native module clears SharedPreferences after reading

This is a minimal, targeted fix that leverages the existing reconnection-wait pattern used throughout the codebase.

## Issue(s)
Fixes #7013

## How to test or reproduce
1. Open the app and log into a server
2. Background the app
3. Send a message from another user/device to trigger a push notification
4. Enable airplane mode briefly to force WebSocket disconnect
5. Tap the notification
6. **Before fix:** App opens but stays on the last screen — no navigation
7. **After fix:** App opens and navigates to the correct room once connection re-establishes

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes

## Further comments
The `deepLinking.js` saga (which handles `deepLinkingOpen` actions) already correctly waits for `LOGIN.SUCCESS` before navigating to a room (see lines 172-178). By calling `checkPendingNotification()` before the connection guard, we ensure notification data is read from SharedPreferences and dispatched to the deep linking saga, which handles the reconnection wait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized notification handling by adjusting the sequence of operations during app startup to check for pending notifications earlier, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->