### PR TITLE
fix: prevent parser crash on app initialization push payload

### DIFF
--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -56,7 +56,7 @@ const restore = function* restore() {
 		yield put(appReady({}));
 		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');
 		if (pushNotification) {
-			const pushNotification = yield call(AsyncStorage.removeItem, 'pushNotification');
+			yield call(AsyncStorage.removeItem, 'pushNotification');
 			yield call(deepLinkingClickCallPush, JSON.parse(pushNotification));
 		}
 	} catch (e) {


### PR DESCRIPTION
## Proposed changes
Fixes a variable shadowing bug in `app/sagas/init.js` where the inner `pushNotification` constant reassignment resulted in a `SyntaxError: JSON.parse(undefined)` crash when `AsyncStorage.removeItem` returned `undefined`. This issue resulted in prematurely breaking the restore flow and occasionally looping or forcing a re-login.

Fixed by not reassigning the variable during the remove action and passing the correct outer tracked notification data to the parsing callback.

## Issue(s)
Fixes #7014

## How to test or reproduce
1. Verify the app restores from a cold boot correctly.
2. Confirm the `SyntaxError: JSON.parse(undefined)` crash no longer appears in logs natively.

## Screenshots
N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed a data restoration bug that was preventing stored preferences from being correctly loaded during app initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->