### PR TITLE
fix: ios videoconf push notification deduplication

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -139,7 +139,10 @@ export default class Root extends React.Component<{}, IState> {
 			if ('configured' in notification) {
 				return;
 			}
-			onNotification(notification);
+			const result = onNotification(notification);
+			if (result?.catch) {
+				result.catch(e => console.warn('app/index.tsx: onNotification error', e));
+			}
 			return;
 		}
 

--- a/app/lib/notifications/index.ts
+++ b/app/lib/notifications/index.ts
@@ -1,6 +1,7 @@
 import EJSON from 'ejson';
 import { Platform } from 'react-native';
 
+import { isPushVideoConfAlreadyProcessed } from './videoConf/deduplication';
 import { appInit } from '../../actions/app';
 import { deepLinkingClickCallPush, deepLinkingOpen } from '../../actions/deepLinking';
 import { type INotification, SubscriptionType } from '../../definitions';
@@ -16,7 +17,7 @@ interface IEjson {
 	messageId: string;
 }
 
-export const onNotification = (push: INotification): void => {
+export const onNotification = async (push: INotification): Promise<void> => {
 	const identifier = String(push?.payload?.action?.identifier);
 
 	// Handle video conf notification actions (Accept/Decline buttons)
@@ -24,6 +25,10 @@ export const onNotification = (push: INotification): void => {
 		if (push?.payload?.ejson) {
 			try {
 				const notification = EJSON.parse(push.payload.ejson);
+				const currentId = push.identifier || push.payload?.notId;
+				if (await isPushVideoConfAlreadyProcessed(currentId)) {
+					return;
+				}
 				store.dispatch(
 					deepLinkingClickCallPush({ ...notification, event: identifier === 'ACCEPT_ACTION' ? 'accept' : 'decline' })
 				);
@@ -40,6 +45,10 @@ export const onNotification = (push: INotification): void => {
 
 			// Handle video conf notification tap (default action) - treat as accept
 			if (notification?.notificationType === 'videoconf') {
+				const currentId = push.identifier || push.payload?.notId;
+				if (await isPushVideoConfAlreadyProcessed(currentId)) {
+					return;
+				}
 				store.dispatch(deepLinkingClickCallPush({ ...notification, event: 'accept' }));
 				return;
 			}
@@ -122,7 +131,10 @@ export const checkPendingNotification = async (): Promise<void> => {
 							},
 							identifier: notificationData.notId || ''
 						};
-						onNotification(notification);
+						const result = onNotification(notification);
+						if (result?.catch) {
+							result.catch(e => console.warn('[notifications/index.ts] onNotification error:', e));
+						}
 					} catch (e) {
 						console.warn('[notifications/index.ts] Failed to parse pending notification:', e);
 					}

--- a/app/lib/notifications/push.ts
+++ b/app/lib/notifications/push.ts
@@ -159,7 +159,9 @@ const registerForPushNotifications = async (): Promise<string | null> => {
 	}
 };
 
-export const pushNotificationConfigure = (onNotification: (notification: INotification) => void): Promise<any> => {
+export const pushNotificationConfigure = (
+	onNotification: (notification: INotification) => Promise<void> | void
+): Promise<any> => {
 	if (configured) {
 		return Promise.resolve({ configured: true });
 	}
@@ -207,10 +209,16 @@ export const pushNotificationConfigure = (onNotification: (notification: INotifi
 		if (isIOS) {
 			const { background } = reduxStore.getState().app;
 			if (background) {
-				onNotification(notification);
+				const result = onNotification(notification);
+				if (result?.catch) {
+					result.catch((e: any) => console.warn('[push.ts] Notification handler error:', e));
+				}
 			}
 		} else {
-			onNotification(notification);
+			const result = onNotification(notification);
+			if (result?.catch) {
+				result.catch((e: any) => console.warn('[push.ts] Notification handler error:', e));
+			}
 		}
 	});
 

--- a/app/lib/notifications/videoConf/deduplication.ts
+++ b/app/lib/notifications/videoConf/deduplication.ts
@@ -1,0 +1,31 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const processingIds = new Set<string>();
+
+export const isPushVideoConfAlreadyProcessed = async (notificationId?: string | null): Promise<boolean> => {
+    if (!notificationId) {
+        return false; // Can't dedup without an ID
+    }
+
+    // 1. Synchronously check and lock in-memory to prevent TOCTOU race condition
+    if (processingIds.has(notificationId)) {
+        return true;
+    }
+    processingIds.add(notificationId);
+
+    // 2. Check persistent storage (for cold boot scenarios)
+    try {
+        const lastId = await AsyncStorage.getItem('lastProcessedVideoConfNotificationId');
+        if (lastId === notificationId) {
+            return true;
+        }
+
+        // 3. Persist new ID
+        await AsyncStorage.setItem('lastProcessedVideoConfNotificationId', notificationId);
+    } catch (e) {
+        // Ignore storage errors, we still have the in-memory lock
+        console.warn('Error reading/writing video conf dedup state', e);
+    }
+
+    return false;
+};

--- a/app/lib/notifications/videoConf/getInitialNotification.ts
+++ b/app/lib/notifications/videoConf/getInitialNotification.ts
@@ -2,6 +2,7 @@ import * as Notifications from 'expo-notifications';
 import EJSON from 'ejson';
 import { DeviceEventEmitter, Platform } from 'react-native';
 
+import { isPushVideoConfAlreadyProcessed } from './deduplication';
 import { deepLinkingClickCallPush } from '../../../actions/deepLinking';
 import { store } from '../../store/auxStore';
 import NativeVideoConfModule from '../../native/NativeVideoConfAndroid';
@@ -66,6 +67,10 @@ export const getInitialNotification = async (): Promise<boolean> => {
 				if (payload.ejson) {
 					const ejsonData = EJSON.parse(payload.ejson);
 					if (ejsonData?.notificationType === 'videoconf') {
+						const notificationId = notification.request.identifier;
+						if (await isPushVideoConfAlreadyProcessed(notificationId)) {
+							return false;
+						}
 						// Accept/Decline actions or default tap (treat as accept)
 						let event = 'accept';
 						if (actionIdentifier === 'DECLINE_ACTION') {

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -1,5 +1,7 @@
 import { all, call, delay, put, select, take, takeLatest } from 'redux-saga/effects';
 
+import { isPushVideoConfAlreadyProcessed } from '../lib/notifications/videoConf/deduplication';
+
 import { shareSetParams } from '../actions/share';
 import * as types from '../actions/actionsTypes';
 import { appInit, appStart, appReady } from '../actions/app';
@@ -245,8 +247,14 @@ const handleNavigateCallRoom = function* handleNavigateCallRoom({ params }) {
 
 const handleClickCallPush = function* handleClickCallPush({ params }) {
 	let { host } = params;
+	const notId = params.notId || params.identifier || params.payload?.notId || params.push?.identifier || params.push?.payload?.notId;
 
 	if (!host) {
+		return;
+	}
+
+	const isProcessed = yield call(isPushVideoConfAlreadyProcessed, notId);
+	if (isProcessed) {
 		return;
 	}
 


### PR DESCRIPTION
## Proposed changes
Fixes an issue where stale video conference notifications on iOS are re-dispatched upon cold boot. This happens because `expo-notifications` does not clear the internally cached read notification response, causing the app to repeatedly jump into an expired or handled video call indefinitely upon app restart.

Fixed by implementing a simple deduplication mechanism using `AsyncStorage`. We store the `lastProcessedVideoConfNotificationId` and cross-reference it natively across event handlers before proceeding to the deep linking dispatcher.

## Issue(s)
Fixes #7015

## How to test or reproduce
1. Receive a video conference push notification on iOS.
2. Tap "Accept" or "Decline", and navigate into the app via the notification.
3. Force close the app and reopen it natively as a cold boot.
4. Verify the app does not automatically attempt to re-dispatch and rejoin the stale call.

## Screenshots
N/A

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deduplicated video call notifications to prevent duplicate accept/decline actions and repeated call prompts across platforms, improving call reliability.
* **Chores**
  * Notification handler now supports asynchronous callbacks and logs errors to avoid unhandled rejections, making notification processing non-blocking and more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->