### PR TITLE
fix: URL query parsing when values contain '='

### DIFF
--- a/app/lib/methods/helpers/parseQuery.test.ts
+++ b/app/lib/methods/helpers/parseQuery.test.ts
@@ -1,0 +1,18 @@
+import parseQuery from './parseQuery';
+
+describe('parseQuery', () => {
+	it('preserves query values that contain equals signs', () => {
+		expect(parseQuery('host=open.rocket.chat&token=abc==&type=auth')).toEqual({
+			host: 'open.rocket.chat',
+			token: 'abc==',
+			type: 'auth'
+		});
+	});
+
+	it('decodes plus signs and encoded equals signs in values', () => {
+		expect(parseQuery('fullURL=https%3A%2F%2Fgo.rocket.chat%2Fauth%3Ftoken%3Da%252Bb%253D%253D&message=hello+world')).toEqual({
+			fullURL: 'https://go.rocket.chat/auth?token=a%2Bb%3D%3D',
+			message: 'hello world'
+		});
+	});
+});

--- a/app/lib/methods/helpers/parseQuery.ts
+++ b/app/lib/methods/helpers/parseQuery.ts
@@ -15,7 +15,9 @@ export default function (query: string) {
 	}
 
 	return (/^[?#]/.test(query) ? query.slice(1) : query).split('&').reduce((params: { [key: string]: string }, param) => {
-		const [key, value] = param.split('=');
+		const separatorIndex = param.indexOf('=');
+		const key = separatorIndex >= 0 ? param.slice(0, separatorIndex) : param;
+		const value = separatorIndex >= 0 ? param.slice(separatorIndex + 1) : '';
 		params[key] = value ? decodeURIComponent(value.replace(/\+/g, ' ')) : '';
 		return params;
 	}, {});


### PR DESCRIPTION
This PR fixes a bug where URL query values could be cut off when they contained `=`

Example:
`parseQuery('host=open.rocket.chat&token=abc==&type=auth')`

Before:
`{ host: 'open.rocket.chat', token: 'abc', type: 'auth' }`

After:
`{ host: 'open.rocket.chat', token: 'abc==', type: 'auth' }`

I updated parseQuery to split only on the first `=`

I also added tests for these cases:
- a query value like token=abc== because that was the broken case
- an encoded URL value to make sure values with encoded `=` and `+` still decode correctly

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query parameter parsing to correctly handle values containing `=` characters and properly decode `+` signs and percent-encoded characters.

* **Tests**
  * Added comprehensive test coverage for query parameter parsing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->