### PR TITLE
feat: Refactor media session handling and improve disconnect logic

### DIFF
--- a/app/lib/methods/logout.ts
+++ b/app/lib/methods/logout.ts
@@ -6,6 +6,7 @@ import { isSsl } from './helpers';
 import { BASIC_AUTH_KEY } from './helpers/fetch';
 import database, { getDatabase } from '../database';
 import log from './helpers/log';
+import { disconnect } from '../services/connect';
 import sdk from '../services/sdk';
 import { CURRENT_SERVER, E2E_PRIVATE_KEY, E2E_PUBLIC_KEY, E2E_RANDOM_PASSWORD_KEY, TOKEN_KEY } from '../constants/keys';
 import UserPreferences from './userPreferences';
@@ -111,7 +112,7 @@ export async function logout({ server }: { server: string }): Promise<void> {
 	}
 
 	if (sdk.current) {
-		sdk.disconnect();
+		disconnect();
 	}
 
 	await removeServerData({ server });

--- a/app/lib/services/connect.ios.test.ts
+++ b/app/lib/services/connect.ios.test.ts
@@ -1,5 +1,9 @@
 import { determineAuthType } from './connect';
 
+jest.mock('./voip/MediaSessionInstance', () => ({
+	mediaSessionInstance: { reset: jest.fn(), init: jest.fn() }
+}));
+
 // Mock the isIOS helper to return true for iOS-specific tests
 jest.mock('../methods/helpers', () => ({
 	...jest.requireActual('../methods/helpers'),

--- a/app/lib/services/connect.test.ts
+++ b/app/lib/services/connect.test.ts
@@ -1,5 +1,9 @@
 import { determineAuthType } from './connect';
 
+jest.mock('./voip/MediaSessionInstance', () => ({
+	mediaSessionInstance: { reset: jest.fn(), init: jest.fn() }
+}));
+
 // Mock the isIOS helper
 jest.mock('../methods/helpers/deviceInfo', () => ({
 	...jest.requireActual('../methods/helpers/deviceInfo'),

--- a/app/lib/services/connect.ts
+++ b/app/lib/services/connect.ts
@@ -11,6 +11,7 @@ import { twoFactor } from './twoFactor';
 import { store } from '../store/auxStore';
 import { loginRequest, logout, setLoginServices, setUser } from '../../actions/login';
 import sdk from './sdk';
+import { mediaSessionInstance } from './voip/MediaSessionInstance';
 import I18n from '../../i18n';
 import { type ICredentials, type ILoggedUser, STATUSES } from '../../definitions';
 import { connectRequest, connectSuccess, disconnect as disconnectAction } from '../../actions/connect';
@@ -407,7 +408,9 @@ function checkAndReopen() {
 }
 
 function disconnect() {
-	return sdk.disconnect();
+	const result = sdk.disconnect();
+	mediaSessionInstance.reset();
+	return result;
 }
 
 async function getWebsocketInfo({

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -1,0 +1,159 @@
+import { mediaSessionStore } from './MediaSessionStore';
+import { mediaSessionInstance } from './MediaSessionInstance';
+
+const mockCallStoreReset = jest.fn();
+
+jest.mock('./useCallStore', () => ({
+	useCallStore: {
+		getState: jest.fn(() => ({
+			reset: mockCallStoreReset,
+			setCall: jest.fn(),
+			callId: null as string | null
+		}))
+	}
+}));
+
+const mockOnStreamDataStop = jest.fn();
+const mockOnStreamData = jest.fn(() => ({ stop: mockOnStreamDataStop }));
+const mockMethodCall = jest.fn();
+
+jest.mock('../sdk', () => ({
+	__esModule: true,
+	default: {
+		onStreamData: (...args: Parameters<typeof mockOnStreamData>) => mockOnStreamData(...args),
+		methodCall: (...args: unknown[]) => mockMethodCall(...args)
+	}
+}));
+
+jest.mock('../../store/auxStore', () => ({
+	store: {
+		getState: jest.fn(() => ({
+			settings: {
+				VoIP_TeamCollab_Ice_Servers: '',
+				VoIP_TeamCollab_Ice_Gathering_Timeout: 5000
+			}
+		})),
+		subscribe: jest.fn(() => jest.fn())
+	}
+}));
+
+jest.mock('react-native-webrtc', () => ({
+	registerGlobals: jest.fn(),
+	mediaDevices: { getUserMedia: jest.fn() }
+}));
+
+jest.mock('react-native-callkeep', () => ({}));
+
+jest.mock('react-native-device-info', () => ({
+	getUniqueId: jest.fn(() => 'test-device-id')
+}));
+
+jest.mock('../../native/NativeVoip', () => ({
+	__esModule: true,
+	default: { stopNativeDDPClient: jest.fn() }
+}));
+
+jest.mock('../../navigation/appNavigation', () => ({
+	__esModule: true,
+	default: { navigate: jest.fn() }
+}));
+
+type SessionRecord = { userId: string; endSession: jest.Mock };
+const createdSessions: SessionRecord[] = [];
+
+jest.mock('@rocket.chat/media-signaling', () => ({
+	MediaCallWebRTCProcessor: jest.fn().mockImplementation(function MediaCallWebRTCProcessor(this: unknown) {
+		return this;
+	}),
+	MediaSignalingSession: jest.fn().mockImplementation(function MockMediaSignalingSession(this: any, config: { userId: string }) {
+		const endSession = jest.fn();
+		createdSessions.push({ userId: config.userId, endSession });
+		this.userId = config.userId;
+		this.endSession = endSession;
+		this.on = jest.fn();
+		this.processSignal = jest.fn().mockResolvedValue(undefined);
+		this.setIceGatheringTimeout = jest.fn();
+		this.startCall = jest.fn().mockResolvedValue(undefined);
+		this.getMainCall = jest.fn();
+	})
+}));
+
+describe('MediaSessionInstance', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		createdSessions.length = 0;
+		mediaSessionInstance.reset();
+	});
+
+	afterEach(() => {
+		mediaSessionInstance.reset();
+	});
+
+	describe('init', () => {
+		it('should register stream-notify-user listener', () => {
+			mediaSessionInstance.init('user-1');
+			expect(mockOnStreamData).toHaveBeenCalledWith('stream-notify-user', expect.any(Function));
+		});
+
+		it('should create session with userId', () => {
+			mediaSessionInstance.init('user-abc');
+			expect(createdSessions).toHaveLength(1);
+			expect(createdSessions[0].userId).toBe('user-abc');
+		});
+
+		it('should route sendSignal through sdk.methodCall with user media-calls channel', () => {
+			const spy = jest.spyOn(mediaSessionStore, 'setSendSignalFn');
+			mediaSessionInstance.init('user-xyz');
+			expect(spy).toHaveBeenCalled();
+			const sendFn = spy.mock.calls[spy.mock.calls.length - 1][0] as (signal: { type: string }) => void;
+			sendFn({ type: 'register' });
+			expect(mockMethodCall).toHaveBeenCalledWith(
+				'stream-notify-user',
+				'user-xyz/media-calls',
+				expect.stringContaining('register')
+			);
+			spy.mockRestore();
+		});
+	});
+
+	describe('teardown and user switch', () => {
+		it('should call endSession on previous session when init with different userId', () => {
+			mediaSessionInstance.init('user-1');
+			const first = createdSessions[0];
+			mediaSessionInstance.init('user-2');
+			expect(first.endSession).toHaveBeenCalled();
+			expect(createdSessions[createdSessions.length - 1].userId).toBe('user-2');
+		});
+
+		it('should only have one active onChange handler after re-init (getInstance once per change emit)', () => {
+			mediaSessionInstance.init('user-1');
+			mediaSessionInstance.init('user-2');
+			const spy = jest.spyOn(mediaSessionStore, 'getInstance');
+			mediaSessionStore.emit('change');
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(spy).toHaveBeenCalledWith('user-2');
+			spy.mockRestore();
+		});
+
+		it('should throw existing makeInstance error when getInstance after reset without init', () => {
+			mediaSessionInstance.init('user-1');
+			mediaSessionInstance.reset();
+			expect(() => mediaSessionStore.getInstance('any')).toThrow('WebRTC processor factory and send signal function must be set');
+		});
+
+		it('should allow init after reset', () => {
+			mediaSessionInstance.init('user-1');
+			mediaSessionInstance.reset();
+			mediaSessionInstance.init('user-2');
+			expect(createdSessions[createdSessions.length - 1].userId).toBe('user-2');
+		});
+
+		it('should not throw when reset is called twice', () => {
+			mediaSessionInstance.init('user-1');
+			expect(() => {
+				mediaSessionInstance.reset();
+				mediaSessionInstance.reset();
+			}).not.toThrow();
+		});
+	});
+});

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -26,13 +26,13 @@ class MediaSessionInstance {
 	private iceServers: IceServer[] = [];
 	private iceGatheringTimeout: number = 5000;
 	private mediaSignalListener: { stop: () => void } | null = null;
-	private mediaSignalsListener: { stop: () => void } | null = null;
 	private instance: MediaSignalingSession | null = null;
+	private mediaSessionStoreChangeUnsubscribe: (() => void) | null = null;
 	private storeTimeoutUnsubscribe: (() => void) | null = null;
 	private storeIceServersUnsubscribe: (() => void) | null = null;
 
 	public init(userId: string): void {
-		this.stop();
+		this.reset();
 		registerGlobals();
 		this.configureIceServers();
 		// prevent JS and native DDP clients from interfering with each other
@@ -50,7 +50,9 @@ class MediaSessionInstance {
 			sdk.methodCall('stream-notify-user', `${userId}/media-calls`, JSON.stringify(signal));
 		});
 		this.instance = mediaSessionStore.getInstance(userId);
-		mediaSessionStore.onChange(() => (this.instance = mediaSessionStore.getInstance(userId)));
+		this.mediaSessionStoreChangeUnsubscribe = mediaSessionStore.onChange(() => {
+			this.instance = mediaSessionStore.getInstance(userId);
+		});
 
 		this.mediaSignalListener = sdk.onStreamData('stream-notify-user', (ddpMessage: IDDPMessage) => {
 			if (!this.instance) {
@@ -168,22 +170,26 @@ class MediaSessionInstance {
 		});
 	}
 
-	private stop() {
+	public reset() {
+		if (this.mediaSessionStoreChangeUnsubscribe) {
+			this.mediaSessionStoreChangeUnsubscribe();
+			this.mediaSessionStoreChangeUnsubscribe = null;
+		}
 		if (this.mediaSignalListener?.stop) {
 			this.mediaSignalListener.stop();
 		}
-		if (this.mediaSignalsListener?.stop) {
-			this.mediaSignalsListener.stop();
-		}
+		this.mediaSignalListener = null;
 		if (this.storeTimeoutUnsubscribe) {
 			this.storeTimeoutUnsubscribe();
+			this.storeTimeoutUnsubscribe = null;
 		}
 		if (this.storeIceServersUnsubscribe) {
 			this.storeIceServersUnsubscribe();
+			this.storeIceServersUnsubscribe = null;
 		}
-		if (this.instance) {
-			this.instance.endSession();
-		}
+		mediaSessionStore.dispose();
+		this.instance = null;
+		useCallStore.getState().reset();
 	}
 }
 

--- a/app/lib/services/voip/MediaSessionStore.ts
+++ b/app/lib/services/voip/MediaSessionStore.ts
@@ -93,6 +93,16 @@ class MediaSessionStore extends Emitter<{ change: void }> {
 	public getCurrentInstance(): MediaSignalingSession | null {
 		return this.sessionInstance;
 	}
+
+	public dispose(): void {
+		if (this.sessionInstance !== null) {
+			this.sessionInstance.endSession();
+			this.sessionInstance = null;
+		}
+		this.sendSignalFn = null;
+		this._webrtcProcessorFactory = null;
+		this.change();
+	}
 }
 
 // TODO: change name

--- a/app/sagas/login.js
+++ b/app/sagas/login.js
@@ -32,7 +32,7 @@ import { getSlashCommands } from '../lib/methods/getSlashCommands';
 import { getUserPresence, subscribeUsersPresence } from '../lib/methods/getUsersPresence';
 import { logout, removeServerData, removeServerDatabase } from '../lib/methods/logout';
 import { subscribeSettings } from '../lib/methods/getSettings';
-import { loginWithPassword, login } from '../lib/services/connect';
+import { disconnect, loginWithPassword, login } from '../lib/services/connect';
 import { saveUserProfile, registerPushToken, getUsersRoles } from '../lib/services/restApi';
 import { setUsersRoles } from '../actions/usersRoles';
 import { getServerById } from '../lib/database/services/Server';
@@ -234,6 +234,8 @@ const startVoipFork = function* startVoipFork() {
 		if (isVoipModuleAvailable() && (hasPermissions[0] || hasPermissions[1])) {
 			const userId = yield select(state => state.login.user.id);
 			mediaSessionInstance.init(userId);
+		} else {
+			mediaSessionInstance.reset();
 		}
 	} catch (e) {
 		log(e);
@@ -411,10 +413,10 @@ const handleDeleteAccount = function* handleDeleteAccount() {
 				}
 			}
 			// if there's no servers, go outside
-			sdk.disconnect();
+			disconnect();
 			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 		} catch (e) {
-			sdk.disconnect();
+			disconnect();
 			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 			log(e);
 		}

--- a/app/sagas/selectServer.ts
+++ b/app/sagas/selectServer.ts
@@ -39,6 +39,7 @@ import { setPermissions } from '../lib/methods/getPermissions';
 import { setRoles } from '../lib/methods/getRoles';
 import { connect, disconnect, getWebsocketInfo, getLoginServices } from '../lib/services/connect';
 import sdk from '../lib/services/sdk';
+import { mediaSessionInstance } from '../lib/services/voip/MediaSessionInstance';
 import { appSelector } from '../lib/hooks/useAppSelector';
 import { getServerById } from '../lib/database/services/Server';
 import { getLoggedUserById } from '../lib/database/services/LoggedUser';
@@ -150,6 +151,7 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 		yield put(inquiryReset());
 		yield put(encryptionStop());
 		yield put(clearActiveUsers());
+		mediaSessionInstance.reset();
 		const userId = UserPreferences.getString(`${TOKEN_KEY}-${server}`);
 		let user = null;
 		if (userId) {

--- a/app/views/NewServerView/hooks/useConnectServer.tsx
+++ b/app/views/NewServerView/hooks/useConnectServer.tsx
@@ -1,7 +1,7 @@
 import { Keyboard } from 'react-native';
 import { useDispatch } from 'react-redux';
 
-import sdk from '../../../lib/services/sdk';
+import { disconnect } from '../../../lib/services/connect';
 import { events, logEvent } from '../../../lib/methods/helpers/log';
 import { selectServerClear, serverRequest } from '../../../actions/server';
 import completeUrl from '../utils/completeUrl';
@@ -24,7 +24,7 @@ const useConnectServer = ({ workspaceUrl, certificate, previousServer }: TUseNew
 
 		// Clear the previous workspace to prevent being stuck on the previous server
 		if (!previousServer) {
-			sdk.disconnect();
+			disconnect();
 			dispatch(selectServerClear());
 		}
 		if (workspaceUrl || serverUrl) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

This PR tightens VoIP / media-signaling lifecycle so teardown matches SDK disconnect and server or permission changes.

- **`connect.disconnect()`** now calls **`mediaSessionInstance.reset()`** after `sdk.disconnect()`, so VoIP state and listeners are cleared whenever the app disconnects through the connect service.
- **Call sites** that previously used `sdk.disconnect()` directly (`logout`, delete-account flow in `login` saga, `useConnectServer`) now use **`disconnect()`** from `connect` so VoIP reset always runs.
- **`MediaSessionInstance`**: unsubscribe from **`mediaSessionStore.onChange`** on teardown (fixes stacked handlers on re-init), null out listener references after stop, and **`reset()`** / **`stop()`** call **`mediaSessionStore.dispose()`** and reset the call store.
- **`MediaSessionStore.dispose()`**: end the signaling session, clear send-signal and WebRTC factory, and notify subscribers.
- **`selectServer`**: reset the media session when switching workspace before reconnecting.
- **`startVoipFork`**: **`mediaSessionInstance.reset()`** when the user does not have VoIP permissions, so prior init is not left active after permission loss.
- **Tests**: mock `MediaSessionInstance` in `connect` / `connect.ios` tests; add **`MediaSessionInstance.test.ts`** for init, signal routing, user switch, reset, and idempotent teardown.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/VMUX-60

## How to test or reproduce

1. Log in on a server with VoIP enabled, then **log out** — confirm no duplicate or stale stream handlers after logging in again (e.g. repeated / unexpected signaling behavior).
2. **Switch servers** (multi-server) with VoIP — confirm VoIP re-initializes for the new workspace and does not keep state from the previous server.
3. **Connect to a new workspace** from New Server View (path that disconnects the previous session) — confirm a clean disconnect + reconnect.
4. If applicable: user **loses VoIP permissions** (or logs into a context without VoIP) after having had VoIP — confirm media session is torn down.
5. Run **`yarn test`** (including `MediaSessionInstance.test.ts` and connect tests).

## Screenshots

N/A — behavioral / lifecycle changes, no UI changes.

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`selectServer` calls `mediaSessionInstance.reset()` before `connect()`, and `connect()` still begins with `disconnect()`, which resets VoIP again — redundant but safe and idempotent. This can be simplified later to a single reset path if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disconnect and logout flow with proper media session cleanup
  * Enhanced VoIP session lifecycle management when switching servers or logging out
  * Better state handling during account deletion and connection teardown

* **Tests**
  * Added comprehensive test coverage for media session lifecycle behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->