### PR TITLE
fix: Server removal not triggering from ServersList Modal

### DIFF
--- a/app/views/RoomsListView/components/ServersList.tsx
+++ b/app/views/RoomsListView/components/ServersList.tsx
@@ -115,7 +115,7 @@ const ServersList = () => {
 		<ServerItem
 			item={item}
 			onPress={() => select(item.id, item.version)}
-			onDeletePress={() => item.id && remove(item.id)}
+			onDeletePress={() => remove(item.id)}
 			hasCheck={item.id === server}
 		/>
 	);


### PR DESCRIPTION
## Proposed changes

This PR fixes an issue where servers could not be deleted from the Servers List modal.

Previously, the `onDeletePress` handler used a short-circuit condition:

```js
onDeletePress={() => item.id === server || remove(item.id)}
```

This prevented the `remove` function from being called when the condition evaluated truthy, causing inconsistent or failed deletion behavior.

The fix ensures that deletion is always triggered correctly:

```js
onDeletePress={() => remove(item.id)}
```

This results in consistent and expected server removal behavior from the UI.

## Issue(s)

Fixes server not being deleted from Servers List modal (no existing issue linked)

## How to test or reproduce

1. Open the app
3. Tap on the header to open the **Servers List modal**
4. Swipe to delete any server

### Before fix:

* Deletion may fail or not trigger

### After fix:

* Server is deleted consistently as expected

## Screenshots

### Before

https://github.com/user-attachments/assets/b3d23d54-af7b-4b7d-a205-2fe04bd8cd24 

### After

 https://github.com/user-attachments/assets/af77e80d-7eb5-43a1-8445-a59b45e84fc3

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] Improvement (non-breaking change which improves a current function)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Documentation update (if none of the other choices apply)

## Checklist

* [x] I have read the CONTRIBUTING doc
* [x] I have signed the CLA
* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
* [ ] I have added necessary documentation (if applicable)
* [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The issue was caused by relying on JavaScript’s logical OR (`||`) for conditional execution, which unintentionally prevented the delete action from firing in certain cases. Removing this condition ensures predictable and explicit behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent server deletion behavior where the currently selected server was treated differently than others. Now all servers are deleted consistently using the same removal logic, ensuring uniform and predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->