### PR TITLE
fix: messages not marked as read when new message arrives in active room

### DIFF
--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -242,56 +242,82 @@ export default class RoomSubscription {
 		readMessages(this.rid, new Date());
 	}, 300);
 
-	updateMessage = (message: IMessage): Promise<void> =>
-		new Promise(async resolve => {
-			if (this.rid !== message.rid) {
-				return resolve();
+	updateMessage = async (message: IMessage): Promise<void> => {
+		if (this.rid !== message.rid) {
+			return;
+		}
+
+		const batch: TMessageModel[] | TThreadModel[] | TThreadMessageModel[] = [];
+		const db = database.active;
+		const msgCollection = db.get('messages');
+		const threadsCollection = db.get('threads');
+		const threadMessagesCollection = db.get('thread_messages');
+
+		// Decrypt the message if necessary
+		message = (await Encryption.decryptMessage(message)) as IMessage;
+
+		// Create or update message
+		try {
+			const messageRecord = await getMessageById(message._id);
+			if (messageRecord) {
+				if (messageRecord.t === 'e2e' && message.attachments) {
+					message.attachments = message.attachments?.map(att => {
+						const existing = messageRecord.attachments?.find(
+							a =>
+								(a.image_url && a.image_url === att.image_url) ||
+								(a.video_url && a.video_url === att.video_url) ||
+								(a.audio_url && a.audio_url === att.audio_url) ||
+								(a.thumb_url && a.thumb_url === att.thumb_url)
+						);
+
+						return {
+							...att,
+							e2e: existing?.e2e,
+							title_link: existing?.e2e === 'done' ? existing?.title_link : att.title_link
+						};
+					});
+				}
+				batch.push(
+					messageRecord.prepareUpdate(
+						protectedFunction((m: TMessageModel) => {
+							Object.assign(m, message);
+						})
+					)
+				);
+			} else {
+				batch.push(
+					msgCollection.prepareCreate(
+						protectedFunction((m: TMessageModel) => {
+							m._raw = sanitizedRaw({ id: message._id }, msgCollection.schema);
+							if (m.subscription) m.subscription.id = this.rid;
+							Object.assign(m, message);
+						})
+					)
+				);
 			}
+		} catch (e) {
+			log(e);
+		}
 
-			const batch: TMessageModel[] | TThreadModel[] | TThreadMessageModel[] = [];
-			const db = database.active;
-			const msgCollection = db.get('messages');
-			const threadsCollection = db.get('threads');
-			const threadMessagesCollection = db.get('thread_messages');
-
-			// Decrypt the message if necessary
-			message = (await Encryption.decryptMessage(message)) as IMessage;
-
-			// Create or update message
+		// Create or update thread
+		if (message.tlm) {
 			try {
-				const messageRecord = await getMessageById(message._id);
-				if (messageRecord) {
-					if (messageRecord.t === 'e2e' && message.attachments) {
-						message.attachments = message.attachments?.map(att => {
-							const existing = messageRecord.attachments?.find(
-								a =>
-									(a.image_url && a.image_url === att.image_url) ||
-									(a.video_url && a.video_url === att.video_url) ||
-									(a.audio_url && a.audio_url === att.audio_url) ||
-									(a.thumb_url && a.thumb_url === att.thumb_url)
-							);
-
-							return {
-								...att,
-								e2e: existing?.e2e,
-								title_link: existing?.e2e === 'done' ? existing?.title_link : att.title_link
-							};
-						});
-					}
+				const threadRecord = await getThreadById(message._id);
+				if (threadRecord) {
 					batch.push(
-						messageRecord.prepareUpdate(
-							protectedFunction((m: TMessageModel) => {
-								Object.assign(m, message);
+						threadRecord.prepareUpdate(
+							protectedFunction((t: TThreadModel) => {
+								Object.assign(t, message);
 							})
 						)
 					);
 				} else {
 					batch.push(
-						msgCollection.prepareCreate(
-							protectedFunction((m: TMessageModel) => {
-								m._raw = sanitizedRaw({ id: message._id }, msgCollection.schema);
-								if (m.subscription) m.subscription.id = this.rid;
-								Object.assign(m, message);
+						threadsCollection.prepareCreate(
+							protectedFunction((t: TThreadModel) => {
+								t._raw = sanitizedRaw({ id: message._id }, threadsCollection.schema);
+								if (t.subscription) t.subscription.id = this.rid;
+								Object.assign(t, message);
 							})
 						)
 					);
@@ -299,79 +325,50 @@ export default class RoomSubscription {
 			} catch (e) {
 				log(e);
 			}
+		}
 
-			// Create or update thread
-			if (message.tlm) {
-				try {
-					const threadRecord = await getThreadById(message._id);
-					if (threadRecord) {
-						batch.push(
-							threadRecord.prepareUpdate(
-								protectedFunction((t: TThreadModel) => {
-									Object.assign(t, message);
-								})
-							)
-						);
-					} else {
-						batch.push(
-							threadsCollection.prepareCreate(
-								protectedFunction((t: TThreadModel) => {
-									t._raw = sanitizedRaw({ id: message._id }, threadsCollection.schema);
-									if (t.subscription) t.subscription.id = this.rid;
-									Object.assign(t, message);
-								})
-							)
-						);
-					}
-				} catch (e) {
-					log(e);
+		// Create or update thread message
+		if (message.tmid) {
+			try {
+				const threadMessageRecord = await getThreadMessageById(message._id);
+				if (threadMessageRecord) {
+					batch.push(
+						threadMessageRecord.prepareUpdate(
+							protectedFunction((tm: TThreadMessageModel) => {
+								Object.assign(tm, message);
+								if (message.tmid) {
+									tm.rid = message.tmid;
+									delete tm.tmid;
+								}
+							})
+						)
+					);
+				} else {
+					batch.push(
+						threadMessagesCollection.prepareCreate(
+							protectedFunction((tm: TThreadMessageModel) => {
+								tm._raw = sanitizedRaw({ id: message._id }, threadMessagesCollection.schema);
+								Object.assign(tm, message);
+								if (tm.subscription) {
+									tm.subscription.id = this.rid;
+								}
+								if (message.tmid) {
+									tm.rid = message.tmid;
+									delete tm.tmid;
+								}
+							})
+						)
+					);
 				}
+			} catch (e) {
+				log(e);
 			}
+		}
 
-			// Create or update thread message
-			if (message.tmid) {
-				try {
-					const threadMessageRecord = await getThreadMessageById(message._id);
-					if (threadMessageRecord) {
-						batch.push(
-							threadMessageRecord.prepareUpdate(
-								protectedFunction((tm: TThreadMessageModel) => {
-									Object.assign(tm, message);
-									if (message.tmid) {
-										tm.rid = message.tmid;
-										delete tm.tmid;
-									}
-								})
-							)
-						);
-					} else {
-						batch.push(
-							threadMessagesCollection.prepareCreate(
-								protectedFunction((tm: TThreadMessageModel) => {
-									tm._raw = sanitizedRaw({ id: message._id }, threadMessagesCollection.schema);
-									Object.assign(tm, message);
-									if (tm.subscription) {
-										tm.subscription.id = this.rid;
-									}
-									if (message.tmid) {
-										tm.rid = message.tmid;
-										delete tm.tmid;
-									}
-								})
-							)
-						);
-					}
-				} catch (e) {
-					log(e);
-				}
-			}
-
-			await db.write(async () => {
-				await db.batch(...batch);
-			});
-
-			resolve();
+		await db.write(async () => {
+			await db.batch(...batch);
 		});
+	};
 
 	handleMessageReceived = async (ddpMessage: IDDPMessage) => {
 		try {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

When a new message arrived in a room the user was actively viewing, the unread count and read status were not being updated. The user had to leave and re-enter the room to trigger the read receipt.

This PR fixes a bug that caused this:
`updateMessage` promise never resolved `updateMessage` was written as `new Promise(async resolve => ...)` but only called` resolve()` in the **early-return** branch `(this.rid !== message.rid)`. On the happy path — when the message did belong to the current room — the function did all its DB work and then silently hung forever. This meant await `this.updateMessage(message)` in `handleMessageReceived` never completed, so `readMessages` was never reached.

> Fixed by converting `updateMessage` to a proper `async` function, eliminating the `antipattern` entirely.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

#7087

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Open a room with another user/device
2. Have the other user send a message while you are actively viewing the room
3. Before: unread badge/count does not clear; read receipt not sent until you navigate away and back
4. After: message is marked as read immediately upon arrival

## Screenshots

### Before
When a new message arrives in the currently subscribed room, the read status does not update

https://github.com/user-attachments/assets/5825671a-1ea0-4d1b-8dff-10526fb4aabc

### After

When a new message arrives in the currently subscribed room, the read status updates after a debounced interval

https://github.com/user-attachments/assets/303c3479-2b07-41f2-8e2c-df3c9d59007f

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of message subscription updates by preventing processing of messages for the wrong room and ensuring the update handler completes cleanly while preserving existing message write batching and attachment reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->