### PR TITLE
fix: use server URL instead of full server object in useSubscriptions dependency

### DIFF
--- a/app/views/RoomsListView/hooks/useSubscriptions.ts
+++ b/app/views/RoomsListView/hooks/useSubscriptions.ts
@@ -39,7 +39,7 @@ export const useSubscriptions = () => {
 	'use memo';
 
 	const useRealName = useAppSelector(state => state.settings.UI_Use_Real_Name);
-	const server = useAppSelector(state => state.server);
+	const serverUrl = useAppSelector(state => state.server.server);
 	const subscriptionRef = useRef<Subscription>(null);
 	const [subscriptions, setSubscriptions] = useState<TSubscriptionModel[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -124,7 +124,7 @@ export const useSubscriptions = () => {
 		return () => {
 			subscriptionRef.current?.unsubscribe();
 		};
-	}, [isGrouping, sortBy, useRealName, showUnread, showFavorites, groupByType, roles, server]);
+	}, [isGrouping, sortBy, useRealName, showUnread, showFavorites, groupByType, roles, serverUrl]);
 
 	return {
 		subscriptions,


### PR DESCRIPTION
`useSubscriptions.ts` was selecting the entire `server` Redux object and using it as a `useEffect` dependency. Redux reducers return a new object reference on every dispatch — even when only `connecting` or `loading` fields change — so the effect re-ran on every server connection lifecycle transition, not just when the actual server URL changed.

Each spurious fire called `setLoading(true)` (blanking the rooms list), unsubscribed the existing WatermelonDB observable, and created a brand new one. On a slow or unstable network, this causes the rooms list to flicker repeatedly.

The fix selects only `state.server.server` (a string) instead of `state.server` (an object). Strings are compared by value, so the effect now only fires when the server URL actually changes. This is the same pattern used throughout the rest of the codebase.

## Issue(s)

Closes #7093

## Screenshots

N/A — this is a behavioral fix, no UI changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the subscription hook to more efficiently track server URL changes, reducing unnecessary re-subscriptions and improving performance when the server connection is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->