### PR TITLE
feat(voip): android landscape layout for IncomingCallActivity

### DIFF
--- a/android/app/src/main/res/layout-land/activity_incoming_call.xml
+++ b/android/app/src/main/res/layout-land/activity_incoming_call.xml
@@ -19,6 +19,7 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_marginEnd="8dp"
+            android:importantForAccessibility="no"
             android:src="@drawable/ic_notification"
             android:tint="@color/incoming_call_header_icon" />
 
@@ -72,6 +73,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
+                android:accessibilityLiveRegion="polite"
                 android:ellipsize="end"
                 android:gravity="center"
                 android:maxLines="2"
@@ -109,6 +111,7 @@
                 android:layout_marginEnd="16dp"
                 android:background="?attr/selectableItemBackground"
                 android:clickable="true"
+                android:contentDescription="@string/incoming_call_reject"
                 android:focusable="true"
                 android:gravity="center"
                 android:orientation="vertical"
@@ -126,6 +129,7 @@
                         android:layout_height="36dp"
                         android:layout_gravity="center"
                         android:contentDescription="@string/incoming_call_reject"
+                        android:importantForAccessibility="no"
                         android:src="@drawable/ic_call_end" />
 
                 </FrameLayout>
@@ -135,6 +139,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:importantForAccessibility="no"
                     android:text="@string/incoming_call_reject"
                     android:textColor="@color/incoming_call_button_label"
                     android:textSize="14sp" />
@@ -148,6 +153,7 @@
                 android:layout_height="wrap_content"
                 android:background="?attr/selectableItemBackground"
                 android:clickable="true"
+                android:contentDescription="@string/incoming_call_accept"
                 android:focusable="true"
                 android:gravity="center"
                 android:orientation="vertical"
@@ -165,6 +171,7 @@
                         android:layout_height="36dp"
                         android:layout_gravity="center"
                         android:contentDescription="@string/incoming_call_accept"
+                        android:importantForAccessibility="no"
                         android:src="@drawable/ic_call" />
 
                 </FrameLayout>
@@ -174,6 +181,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:importantForAccessibility="no"
                     android:text="@string/incoming_call_accept"
                     android:textColor="@color/incoming_call_button_label"
                     android:textSize="14sp" />

--- a/android/app/src/main/res/layout-land/activity_incoming_call.xml
+++ b/android/app/src/main/res/layout-land/activity_incoming_call.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/incoming_call_background"
+    android:orientation="vertical">
+
+    <!-- Top: Incoming call status with icon -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:paddingTop="32dp">
+
+        <ImageView
+            android:id="@+id/header_icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="8dp"
+            android:src="@drawable/ic_notification"
+            android:tint="@color/incoming_call_header_icon" />
+
+        <TextView
+            android:id="@+id/header_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif"
+            android:text="@string/incoming_call_status"
+            android:textColor="@color/incoming_call_header_text"
+            android:textSize="18sp" />
+
+    </LinearLayout>
+
+    <!-- Content row: caller info left, action buttons right -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="44dp"
+        android:paddingEnd="44dp">
+
+        <!-- Left column: avatar + caller info -->
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:id="@+id/avatar_container"
+                android:layout_width="80dp"
+                android:layout_height="80dp"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone">
+
+                <ImageView
+                    android:id="@+id/avatar"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@string/incoming_call_avatar_description"
+                    android:scaleType="centerCrop" />
+
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/caller_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:ellipsize="end"
+                android:gravity="center"
+                android:maxLines="2"
+                android:textColor="@color/incoming_call_name"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                tools:text="Unknown caller" />
+
+            <TextView
+                android:id="@+id/host_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:gravity="center"
+                android:maxLines="1"
+                android:textColor="@color/incoming_call_host_name"
+                android:textSize="18sp"
+                tools:text="Unknown host" />
+
+        </LinearLayout>
+
+        <!-- Right column: decline + accept buttons side-by-side -->
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <!-- Decline button -->
+            <LinearLayout
+                android:id="@+id/btn_decline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <FrameLayout
+                    android:id="@+id/btn_reject_bg"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:background="@drawable/bg_btn_reject"
+                    android:gravity="center">
+
+                    <ImageView
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:layout_gravity="center"
+                        android:contentDescription="@string/incoming_call_reject"
+                        android:src="@drawable/ic_call_end" />
+
+                </FrameLayout>
+
+                <TextView
+                    android:id="@+id/incoming_call_reject_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/incoming_call_reject"
+                    android:textColor="@color/incoming_call_button_label"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <!-- Accept button -->
+            <LinearLayout
+                android:id="@+id/btn_accept"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <FrameLayout
+                    android:id="@+id/btn_accept_bg"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:background="@drawable/bg_btn_accept"
+                    android:gravity="center">
+
+                    <ImageView
+                        android:layout_width="36dp"
+                        android:layout_height="36dp"
+                        android:layout_gravity="center"
+                        android:contentDescription="@string/incoming_call_accept"
+                        android:src="@drawable/ic_call" />
+
+                </FrameLayout>
+
+                <TextView
+                    android:id="@+id/incoming_call_accept_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/incoming_call_accept"
+                    android:textColor="@color/incoming_call_button_label"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/activity_incoming_call.xml
+++ b/android/app/src/main/res/layout/activity_incoming_call.xml
@@ -19,6 +19,7 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_marginEnd="8dp"
+            android:importantForAccessibility="no"
             android:src="@drawable/ic_notification"
             android:tint="@color/incoming_call_header_icon" />
 
@@ -63,6 +64,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
+            android:accessibilityLiveRegion="polite"
             android:textColor="@color/incoming_call_name"
             android:textSize="22sp"
             android:textStyle="bold"
@@ -95,6 +97,7 @@
             android:layout_marginStart="44dp"
             android:background="?attr/selectableItemBackground"
             android:clickable="true"
+            android:contentDescription="@string/incoming_call_reject"
             android:focusable="true"
             android:gravity="center"
             android:orientation="vertical"
@@ -112,6 +115,7 @@
                     android:layout_height="36dp"
                     android:layout_gravity="center"
                     android:contentDescription="@string/incoming_call_reject"
+                    android:importantForAccessibility="no"
                     android:src="@drawable/ic_call_end" />
 
             </FrameLayout>
@@ -121,6 +125,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
+                android:importantForAccessibility="no"
                 android:text="@string/incoming_call_reject"
                 android:textColor="@color/incoming_call_button_label"
                 android:textSize="14sp" />
@@ -141,6 +146,7 @@
             android:layout_marginEnd="44dp"
             android:background="?attr/selectableItemBackground"
             android:clickable="true"
+            android:contentDescription="@string/incoming_call_accept"
             android:focusable="true"
             android:gravity="center"
             android:orientation="vertical"
@@ -158,6 +164,7 @@
                     android:layout_height="36dp"
                     android:layout_gravity="center"
                     android:contentDescription="@string/incoming_call_accept"
+                    android:importantForAccessibility="no"
                     android:src="@drawable/ic_call" />
 
             </FrameLayout>
@@ -167,6 +174,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
+                android:importantForAccessibility="no"
                 android:text="@string/incoming_call_accept"
                 android:textColor="@color/incoming_call_button_label"
                 android:textSize="14sp" />


### PR DESCRIPTION
## Proposed changes

Adds `android/app/src/main/res/layout-land/activity_incoming_call.xml` so Android auto-selects a two-column layout when the device is in landscape. Header stays centered near the top (32dp padding vs portrait's 108dp), caller info fills the left half, and decline/accept buttons sit side-by-side on the right half — matching the iOS landscape design shipped in #7110.

Zero changes to `IncomingCallActivity.kt`, `AndroidManifest.xml`, or the portrait layout. All 12 view IDs required by the Activity are preserved with the same widget types.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-69

## How to test or reproduce

Trigger an incoming VoIP call on an Android device/emulator while in landscape orientation. Easiest way without a real call: use the team's existing VoIP push debug harness, or `adb shell am start` against `IncomingCallActivity` with a test `VoipPayload` extra.

## Screenshots
<img width="2400" height="1080" alt="Screenshot_1775756262" src="https://github.com/user-attachments/assets/9885056f-bf43-4ef0-a212-00df505a3078" />



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Uses Android's built-in `layout-land/` resource qualifier — the idiomatic approach for orientation-specific layouts. No Kotlin changes needed; the Activity finds all views by ID after inflation regardless of which layout file was selected. Reversible by deleting one file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added landscape orientation support for the incoming call screen, displaying caller information and accept/decline action buttons optimized for wider screen layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->