### PR TITLE
fix: replace module-scoped ref registry with instance-local ref in UIKit Overflow

### DIFF
--- a/app/containers/UIKit/Overflow.tsx
+++ b/app/containers/UIKit/Overflow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { FlatList, StyleSheet, Text, type View } from 'react-native';
 import Popover from 'react-native-popover-view';
 
@@ -41,19 +41,11 @@ const Options = ({ options, onOptionPress, parser, theme }: IOptions) => (
 	/>
 );
 
-const touchable: { [key: string]: React.RefObject<View | null> } = {};
-
 export const Overflow = ({ element, loading, action, parser }: IOverflow) => {
 	const { theme } = useTheme();
 	const options = element?.options || [];
-	const blockId = element?.blockId || '';
 	const [show, onShow] = useState(false);
-
-	if (!touchable[blockId]) {
-		touchable[blockId] = React.createRef();
-	}
-
-	const touchableRef = touchable[blockId] as React.RefObject<any>;
+	const touchableRef = useRef<View>(null) as React.RefObject<any>;
 
 	const onOptionPress = ({ value }: any) => {
 		onShow(false);


### PR DESCRIPTION
The `Overflow` component was storing refs in a module-scoped `touchable` map keyed by `blockId`. Two issues with that:

1. The map only ever grew. Refs added during a session were never cleaned up, so every `blockId` ever rendered stayed in memory until the app shut down.
2. When `blockId` was missing or repeated across instances, multiple `Overflow` components ended up sharing the same ref, so the `Popover` would sometimes anchor to the wrong button.

Switched to an instance-local `useRef` so the ref's lifecycle is tied to the component. I kept the `as React.RefObject<any>` cast that was already in the original code, since `Touch`'s ref is a `RectButton` instance and `Popover.from` strictly wants a `RefObject<View>`. Same workaround, just no longer global.

## Issue(s)

Closes #7095

## How to test or reproduce

The bug shows up when multiple `Overflow` components are rendered on the same screen (e.g. UIKit messages with more than one overflow menu, or when an `Overflow` is re-rendered with an empty `blockId`). Tapping the kebab on one would sometimes pop the menu over a different button. With this fix each instance has its own ref, so the popover always anchors correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal reference management for improved component performance and maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->