### PR TITLE
feat(voip): migrate Android accept/reject from DDP to REST

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
@@ -1,0 +1,125 @@
+package chat.rocket.reactnative.voip
+
+import android.util.Log
+import chat.rocket.reactnative.notification.Ejson
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+
+/**
+ * REST client for `POST /api/v1/media-calls.answer` used by accept/reject flows.
+ *
+ * Mirrors the iOS [MediaCallsAnswerRequest.swift][ios/Shared/RocketChat/API/MediaCallsAnswerRequest.swift]
+ * and replaces the DDP `sendAcceptSignal` / `sendRejectSignal` / `queueAcceptSignal` / `queueRejectSignal`
+ * methods in [VoipNotification].
+ *
+ * Auth headers (`x-user-id` / `x-auth-token`) are resolved from [Ejson] at call time,
+ * matching the pattern used by [chat.rocket.reactnative.notification.ReplyBroadcast].
+ *
+ * @param callId       The call identifier from the VoIP payload.
+ * @param contractId   The device-unique contract identifier (`Settings.Secure.ANDROID_ID`).
+ * @param answer       Either `"accept"` or `"reject"`.
+ * @param supportedFeatures Optional list of supported features (e.g. `["audio"]`); sent only for accept.
+ */
+class MediaCallsAnswerRequest(
+    private val callId: String,
+    private val contractId: String,
+    private val answer: String,
+    private val supportedFeatures: List<String>? = null
+) {
+    companion object {
+        private const val TAG = "RocketChat.MediaCallsAnswerRequest"
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+
+        @JvmStatic
+        fun fetch(
+            context: android.content.Context,
+            host: String,
+            callId: String,
+            contractId: String,
+            answer: String,
+            supportedFeatures: List<String>? = null,
+            onResult: (Boolean) -> Unit
+        ) {
+            val request = MediaCallsAnswerRequest(callId, contractId, answer, supportedFeatures)
+            request.execute(context, host, onResult)
+        }
+    }
+
+    /**
+     * Builds the JSON body for the request:
+     * ```json
+     * {
+     *   "callId": "<callId>",
+     *   "contractId": "<contractId>",
+     *   "type": "answer",
+     *   "answer": "<accept|reject>",
+     *   "supportedFeatures": ["audio"]  // only when non-null for accept
+     * }
+     * ```
+     */
+    private fun buildBody(): JSONObject {
+        val json = JSONObject().apply {
+            put("callId", callId)
+            put("contractId", contractId)
+            put("type", "answer")
+            put("answer", answer)
+        }
+        supportedFeatures?.let { features ->
+            val arr = JSONArray()
+            features.forEach { arr.put(it) }
+            json.put("supportedFeatures", arr)
+        }
+        return json
+    }
+
+    private fun execute(
+        context: android.content.Context,
+        host: String,
+        onResult: (Boolean) -> Unit
+    ) {
+        val ejson = Ejson().apply { this.host = host }
+        val userId = ejson.userId()
+        val token = ejson.token()
+
+        if (userId.isNullOrEmpty() || token.isNullOrEmpty()) {
+            Log.w(TAG, "Missing credentials for $host — cannot send media-call answer")
+            onResult(false)
+            return
+        }
+
+        val serverUrl = host.removeSuffix("/")
+        val url = "$serverUrl/api/v1/media-calls.answer"
+
+        val body = buildBody().toString()
+        val requestBody = body.toRequestBody(JSON_MEDIA_TYPE)
+
+        val request = Request.Builder()
+            .header("x-user-id", userId)
+            .header("x-auth-token", token)
+            .url(url)
+            .post(requestBody)
+            .build()
+
+        val client = OkHttpClient()
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                Log.e(TAG, "MediaCallsAnswerRequest failed for callId=$callId: ${e.message}")
+                onResult(false)
+            }
+
+            override fun onResponse(call: Call, response: okhttp3.Response) {
+                val code = response.code
+                val success = code in 200..299
+                Log.d(TAG, "MediaCallsAnswerRequest response for callId=$callId: code=$code success=$success")
+                onResult(success)
+            }
+        })
+    }
+}

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -537,9 +537,8 @@ class VoipNotification(private val context: Context) {
         /**
          * Rejects an incoming call because the user is already on another call.
          *
-         * Uses [connectAndRejectBusy] — a lightweight DDP flow that only connects,
-         * logs in, sends the reject signal, and tears down the client. Unlike
-         * [startListeningForCallEnd] (used by the normal incoming-call path), this
+         * Uses [MediaCallsAnswerRequest] over REST to send the reject signal.
+         * Unlike [startListeningForCallEnd] (used by the normal incoming-call path), this
          * does NOT subscribe to `stream-notify-user` or install a collection-message
          * handler, because no incoming-call UI was ever shown and there is nothing
          * to dismiss if the caller hangs up or another device answers.
@@ -548,58 +547,15 @@ class VoipNotification(private val context: Context) {
         fun rejectBusyCall(context: Context, payload: VoipPayload) {
             Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
             cancelTimeout(payload.callId)
-            connectAndRejectBusy(context, payload)
-        }
-
-        /**
-         * Minimal DDP flow for busy-reject: connect → login → send reject → stop.
-         *
-         * Intentionally omits the `stream-notify-user` subscription and the
-         * `onCollectionMessage` handler that [startListeningForCallEnd] sets up,
-         * since the busy path never shows UI — there are no notifications to
-         * dismiss and no call-end events to observe.
-         */
-        private fun connectAndRejectBusy(context: Context, payload: VoipPayload) {
-            val ejson = Ejson()
-            ejson.host = payload.host
-            val userId = ejson.userId()
-            val token = ejson.token()
-
-            if (userId.isNullOrEmpty() || token.isNullOrEmpty()) {
-                Log.d(TAG, "No credentials for ${payload.host}, skipping busy-reject DDP")
-                return
-            }
-
-            val callId = payload.callId
-            val client = DDPClient()
-            ddpRegistry.putClient(callId, client)
-
-            Log.d(TAG, "Connecting DDP to send busy-reject for call $callId")
-
-            client.connect(payload.host) { connected ->
-                if (!isLiveClient(callId, client)) {
-                    return@connect
-                }
-                if (!connected) {
-                    Log.d(TAG, "DDP connection failed for busy-reject $callId")
-                    ddpRegistry.stopClient(callId)
-                    return@connect
-                }
-
-                client.login(token) { loggedIn ->
-                    if (!isLiveClient(callId, client)) {
-                        return@login
-                    }
-                    if (!loggedIn) {
-                        Log.d(TAG, "DDP login failed for busy-reject $callId")
-                        ddpRegistry.stopClient(callId)
-                        return@login
-                    }
-
-                    ddpRegistry.markLoggedIn(callId)
-                    sendRejectSignal(context, payload)
-                }
-            }
+            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            MediaCallsAnswerRequest.fetch(
+                context = context,
+                host = payload.host,
+                callId = payload.callId,
+                contractId = deviceId,
+                answer = "reject",
+                supportedFeatures = null
+            ) { _ -> }
         }
 
         // -- Native DDP Listener (Call End Detection) --

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -152,11 +152,15 @@ class VoipNotification(private val context: Context) {
         fun handleDeclineAction(context: Context, payload: VoipPayload) {
             Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
             cancelTimeout(payload.callId)
-            if (ddpRegistry.isLoggedIn(payload.callId)) {
-                sendRejectSignal(context, payload)
-            } else {
-                queueRejectSignal(context, payload)
-            }
+            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            MediaCallsAnswerRequest.fetch(
+                context = context,
+                host = payload.host,
+                callId = payload.callId,
+                contractId = deviceId,
+                answer = "reject",
+                supportedFeatures = null
+            ) { _ -> }
             rejectIncomingCall(payload.callId)
             cancelById(context, payload.notificationId)
             LocalBroadcastManager.getInstance(context).sendBroadcast(

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -70,8 +70,6 @@ class VoipNotification(private val context: Context) {
         private const val CALLKEEP_CONNECTION_SERVICE_CLASS = "io.wazo.callkeep.VoiceConnectionService"
         private const val DISCONNECT_REASON_MISSED = 6
 
-        private data class VoipMediaCallIdentity(val userId: String, val deviceId: String)
-
         /** Keep in sync with MediaSessionStore features (audio-only today). */
         private val SUPPORTED_VOIP_FEATURES = JSONArray().apply { put("audio") }
         private val timeoutHandler = Handler(Looper.getMainLooper())
@@ -253,7 +251,7 @@ class VoipNotification(private val context: Context) {
                     answerIncomingCall(payload.callId)
                     VoipModule.storeInitialEvents(payload)
                 } else {
-                    Log.d(TAG, "Native accept did not succeed over DDP for ${payload.callId}; opening app for JS recovery")
+                    Log.d(TAG, "Native accept did not succeed for ${payload.callId}; opening app for JS recovery")
                     disconnectIncomingCall(payload.callId, false)
                     VoipModule.storeAcceptFailureForJs(payload)
                 }
@@ -345,146 +343,6 @@ class VoipNotification(private val context: Context) {
             }
         }
 
-        private fun sendRejectSignal(context: Context, payload: VoipPayload) {
-            val client = ddpRegistry.clientFor(payload.callId)
-            if (client == null) {
-                Log.d(TAG, "Native DDP client unavailable, cannot send reject for ${payload.callId}")
-                return
-            }
-
-            val params = buildRejectSignalParams(context, payload) ?: return
-
-            client.callMethod("stream-notify-user", params) { success ->
-                Log.d(TAG, "Native reject signal result for ${payload.callId}: $success")
-                ddpRegistry.stopClient(payload.callId)
-            }
-        }
-
-        private fun queueRejectSignal(context: Context, payload: VoipPayload) {
-            val client = ddpRegistry.clientFor(payload.callId)
-            if (client == null) {
-                Log.d(TAG, "Native DDP client unavailable, cannot queue reject for ${payload.callId}")
-                return
-            }
-
-            val params = buildRejectSignalParams(context, payload) ?: return
-
-            client.queueMethodCall("stream-notify-user", params) { success ->
-                Log.d(TAG, "Queued native reject signal result for ${payload.callId}: $success")
-                ddpRegistry.stopClient(payload.callId)
-            }
-            Log.d(TAG, "Queued native reject signal for ${payload.callId}")
-        }
-
-        private fun flushPendingQueuedSignalsIfNeeded(callId: String): Boolean {
-            val client = ddpRegistry.clientFor(callId) ?: return false
-            if (!client.hasQueuedMethodCalls()) {
-                return false
-            }
-
-            client.flushQueuedMethodCalls()
-            return true
-        }
-
-        private fun sendAcceptSignal(
-            context: Context,
-            payload: VoipPayload,
-            onComplete: (Boolean) -> Unit
-        ) {
-            val client = ddpRegistry.clientFor(payload.callId)
-            if (client == null) {
-                Log.d(TAG, "Native DDP client unavailable, cannot send accept for ${payload.callId}")
-                onComplete(false)
-                return
-            }
-
-            val params = buildAcceptSignalParams(context, payload) ?: run {
-                onComplete(false)
-                return
-            }
-
-            client.callMethod("stream-notify-user", params) { success ->
-                Log.d(TAG, "Native accept signal result for ${payload.callId}: $success")
-                onComplete(success)
-            }
-        }
-
-        private fun queueAcceptSignal(
-            context: Context,
-            payload: VoipPayload,
-            onComplete: (Boolean) -> Unit
-        ) {
-            val client = ddpRegistry.clientFor(payload.callId)
-            if (client == null) {
-                Log.d(TAG, "Native DDP client unavailable, cannot queue accept for ${payload.callId}")
-                onComplete(false)
-                return
-            }
-
-            val params = buildAcceptSignalParams(context, payload) ?: run {
-                onComplete(false)
-                return
-            }
-
-            client.queueMethodCall("stream-notify-user", params) { success ->
-                Log.d(TAG, "Queued native accept signal result for ${payload.callId}: $success")
-                onComplete(success)
-            }
-            Log.d(TAG, "Queued native accept signal for ${payload.callId}")
-        }
-
-        /**
-         * Resolves user id for this host and Android [Settings.Secure.ANDROID_ID] as media-signaling contractId.
-         * Must match JS `getUniqueIdSync()` from react-native-device-info (iOS native code uses `DeviceUID`).
-         */
-        private fun resolveVoipMediaCallIdentity(context: Context, payload: VoipPayload): VoipMediaCallIdentity? {
-            val ejson = Ejson().apply {
-                host = payload.host
-            }
-            val userId = ejson.userId()
-            if (userId.isNullOrEmpty()) {
-                Log.d(TAG, "Missing userId, cannot build stream-notify-user params for ${payload.callId}")
-                ddpRegistry.stopClient(payload.callId)
-                return null
-            }
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
-            if (deviceId.isNullOrEmpty()) {
-                Log.d(TAG, "Missing deviceId, cannot build stream-notify-user params for ${payload.callId}")
-                ddpRegistry.stopClient(payload.callId)
-                return null
-            }
-            return VoipMediaCallIdentity(userId, deviceId)
-        }
-
-        private fun buildAcceptSignalParams(context: Context, payload: VoipPayload): JSONArray? {
-            val ids = resolveVoipMediaCallIdentity(context, payload) ?: return null
-            val signal = JSONObject().apply {
-                put("callId", payload.callId)
-                put("contractId", ids.deviceId)
-                put("type", "answer")
-                put("answer", "accept")
-                put("supportedFeatures", SUPPORTED_VOIP_FEATURES)
-            }
-            return JSONArray().apply {
-                put("${ids.userId}/media-calls")
-                put(signal.toString())
-            }
-        }
-
-        private fun buildRejectSignalParams(context: Context, payload: VoipPayload): JSONArray? {
-            val ids = resolveVoipMediaCallIdentity(context, payload) ?: return null
-            val signal = JSONObject().apply {
-                put("callId", payload.callId)
-                put("contractId", ids.deviceId)
-                put("type", "answer")
-                put("answer", "reject")
-            }
-            return JSONArray().apply {
-                put("${ids.userId}/media-calls")
-                put(signal.toString())
-            }
-        }
-
         /**
          * True when the user is already in a call: this app's Telecom connections (ringing, dialing,
          * active, hold — same idea as iOS CXCallObserver "any non-ended"), any system in-call state
@@ -532,6 +390,16 @@ class VoipNotification(private val context: Context) {
                 return true
             }
             return false
+        }
+
+        private fun flushPendingQueuedSignalsIfNeeded(callId: String): Boolean {
+            val client = ddpRegistry.clientFor(callId) ?: return false
+            if (!client.hasQueuedMethodCalls()) {
+                return false
+            }
+
+            client.flushQueuedMethodCalls()
+            return true
         }
 
         /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -275,21 +275,16 @@ class VoipNotification(private val context: Context) {
             timeoutRunnable = postedTimeout
             timeoutHandler.postDelayed(postedTimeout, 10_000L)
 
-            val client = ddpRegistry.clientFor(payload.callId)
-            if (client == null) {
-                Log.d(TAG, "Native DDP client unavailable for accept ${payload.callId}")
-                finish(false)
-                return
-            }
-
-            if (ddpRegistry.isLoggedIn(payload.callId)) {
-                sendAcceptSignal(context, payload) { success ->
-                    finish(success)
-                }
-            } else {
-                queueAcceptSignal(context, payload) { success ->
-                    finish(success)
-                }
+            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            MediaCallsAnswerRequest.fetch(
+                context = context,
+                host = payload.host,
+                callId = payload.callId,
+                contractId = deviceId,
+                answer = "accept",
+                supportedFeatures = listOf("audio")
+            ) { success ->
+                finish(success)
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Migrate the VoIP accept/reject signal path on **Android** from the DDP (WebSocket) transport to a synchronous REST call (`POST /api/v1/media-calls.answer`), matching the pattern already implemented on iOS.

### Slices (each independently committed)

| Slice | Description | Commit |
|-------|-------------|--------|
| 1 | New `MediaCallsAnswerRequest.kt` REST client | `9692a23c0` |
| 2 | `handleAcceptAction` → REST | `669c19105` |
| 3 | `handleDeclineAction` → REST | `01d119185` |
| 4 | `rejectBusyCall` → REST | `d0dc50874` |
| 5 | Remove dead DDP methods from `VoipNotification` | `8d543e45a` |

### PRD Coverage

- **US-1** Reliable accept/reject signals (Slices 1–4)
- **US-2** Understandable VoipNotification handlers (Slices 2–5)
- **US-3** Testable without WebSocket (Slices 1, 2, 3)
- **US-4** Same Ejson auth mechanism (Slice 1)
- **US-5** Immediate response — no DDP handshake (Slices 2, 3, 4)
- **US-6** Remove DDP from VoIP stack (Slice 5)
- **US-7** Independent from iOS (all slices)

### Deferred

- **Slice 6** — `startListeningForCallEnd` off DDP (still uses DDP; deferred)
- **Slice 7** — Delete `DDPClient.kt` / `VoipPerCallDdpRegistry.kt` (blocked by Slice 6)

## Issue(s)

N/A — pure refactor.

## How to test or reproduce

1. Receive an incoming VoIP call push notification on Android
2. Accept the call — verify the accept signal is sent over REST (check app logs for `MediaCallsAnswerRequest response`)
3. Decline the call from notification — same verification
4. Be on an active call and receive a second VoIP call — verify `rejectBusyCall` sends REST reject

## Types of changes

- [ ] Bugfix
- [ ] Improvement
- [x] New feature
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable) — N/A
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

---

## File: `MediaCallsAnswerRequest.kt` (Slice 1 — `9692a23c0`)

```kotlin
package chat.rocket.reactnative.voip

import android.util.Log
import chat.rocket.reactnative.notification.Ejson
import okhttp3.Call
import okhttp3.Callback
import okhttp3.MediaType.Companion.toMediaType
import okhttp3.OkHttpClient
import okhttp3.Request
import okhttp3.RequestBody.Companion.toRequestBody
import org.json.JSONArray
import org.json.JSONObject
import java.io.IOException

/**
 * REST client for `POST /api/v1/media-calls.answer` used by accept/reject flows.
 *
 * Mirrors the iOS [MediaCallsAnswerRequest.swift][ios/Shared/RocketChat/API/MediaCallsAnswerRequest.swift]
 * and replaces the DDP `sendAcceptSignal` / `sendRejectSignal` / `queueAcceptSignal` / `queueRejectSignal`
 * methods in [VoipNotification].
 *
 * Auth headers (`x-user-id` / `x-auth-token`) are resolved from [Ejson] at call time,
 * matching the pattern used by [chat.rocket.reactnative.notification.ReplyBroadcast].
 *
 * @param callId       The call identifier from the VoIP payload.
 * @param contractId   The device-unique contract identifier (`Settings.Secure.ANDROID_ID`).
 * @param answer       Either `"accept"` or `"reject"`.
 * @param supportedFeatures Optional list of supported features (e.g. `["audio"]`); sent only for accept.
 */
class MediaCallsAnswerRequest(
    private val callId: String,
    private val contractId: String,
    private val answer: String,
    private val supportedFeatures: List<String>? = null
) {
    companion object {
        private const val TAG = "RocketChat.MediaCallsAnswerRequest"
        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()

        @JvmStatic
        fun fetch(
            context: android.content.Context,
            host: String,
            callId: String,
            contractId: String,
            answer: String,
            supportedFeatures: List<String>? = null,
            onResult: (Boolean) -> Unit
        ) {
            val request = MediaCallsAnswerRequest(callId, contractId, answer, supportedFeatures)
            request.execute(context, host, onResult)
        }
    }

    private fun buildBody(): JSONObject {
        val json = JSONObject().apply {
            put("callId", callId)
            put("contractId", contractId)
            put("type", "answer")
            put("answer", answer)
        }
        supportedFeatures?.let { features ->
            val arr = JSONArray()
            features.forEach { arr.put(it) }
            json.put("supportedFeatures", arr)
        }
        return json
    }

    private fun execute(
        context: android.content.Context,
        host: String,
        onResult: (Boolean) -> Unit
    ) {
        val ejson = Ejson().apply { this.host = host }
        val userId = ejson.userId()
        val token = ejson.token()

        if (userId.isNullOrEmpty() || token.isNullOrEmpty()) {
            Log.w(TAG, "Missing credentials for $host — cannot send media-call answer")
            onResult(false)
            return
        }

        val serverUrl = host.removeSuffix("/")
        val url = "$serverUrl/api/v1/media-calls.answer"

        val body = buildBody().toString()
        val requestBody = body.toRequestBody(JSON_MEDIA_TYPE)

        val request = Request.Builder()
            .header("x-user-id", userId)
            .header("x-auth-token", token)
            .url(url)
            .post(requestBody)
            .build()

        val client = OkHttpClient()
        client.newCall(request).enqueue(object : Callback {
            override fun onFailure(call: Call, e: IOException) {
                Log.e(TAG, "MediaCallsAnswerRequest failed for callId=$callId: ${e.message}")
                onResult(false)
            }

            override fun onResponse(call: Call, response: okhttp3.Response) {
                val code = response.code
                val success = code in 200..299
                Log.d(TAG, "MediaCallsAnswerRequest response for callId=$callId: code=$code success=$success")
                onResult(success)
            }
        })
    }
}
```

---

## File: `VoipNotification.kt` changed methods

### `handleDeclineAction` (Slice 3 — `01d119185`)

```kotlin
@JvmStatic
fun handleDeclineAction(context: Context, payload: VoipPayload) {
    Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
    cancelTimeout(payload.callId)
    val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
    MediaCallsAnswerRequest.fetch(
        context = context,
        host = payload.host,
        callId = payload.callId,
        contractId = deviceId,
        answer = "reject",
        supportedFeatures = null
    ) { _ -> }
    rejectIncomingCall(payload.callId)
    cancelById(context, payload.notificationId)
    LocalBroadcastManager.getInstance(context).sendBroadcast(
        Intent(ACTION_DISMISS).apply {
            putExtras(payload.toBundle())
        }
    )
}
```

### `handleAcceptAction` (Slice 2 — `669c19105`)

```kotlin
@JvmStatic
@JvmOverloads
fun handleAcceptAction(context: Context, payload: VoipPayload, skipLaunchMainActivity: Boolean = false) {
    Log.d(TAG, "Accept action triggered for callId: ${payload.callId}")
    cancelTimeout(payload.callId)

    val appCtx = context.applicationContext
    val finished = AtomicBoolean(false)
    val timeoutHandler = Handler(Looper.getMainLooper())
    var timeoutRunnable: Runnable? = null

    fun finish(ddpSuccess: Boolean) {
        if (!finished.compareAndSet(false, true)) return
        timeoutRunnable?.let { timeoutHandler.removeCallbacks(it) }
        ddpRegistry.stopClient(payload.callId)
        if (ddpSuccess) {
            answerIncomingCall(payload.callId)
            VoipModule.storeInitialEvents(payload)
        } else {
            Log.d(TAG, "Native accept did not succeed for ${payload.callId}; opening app for JS recovery")
            disconnectIncomingCall(payload.callId, false)
            VoipModule.storeAcceptFailureForJs(payload)
        }
        cancelById(appCtx, payload.notificationId)
        LocalBroadcastManager.getInstance(appCtx).sendBroadcast(
            Intent(ACTION_DISMISS).apply {
                putExtras(payload.toBundle())
            }
        )
        if (!skipLaunchMainActivity) {
            launchMainActivityForVoip(context, payload)
        }
    }

    val postedTimeout = Runnable {
        Log.w(TAG, "Native accept timed out for ${payload.callId}; falling back to JS recovery")
        finish(false)
    }
    timeoutRunnable = postedTimeout
    timeoutHandler.postDelayed(postedTimeout, 10_000L)

    val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
    MediaCallsAnswerRequest.fetch(
        context = context,
        host = payload.host,
        callId = payload.callId,
        contractId = deviceId,
        answer = "accept",
        supportedFeatures = listOf("audio")
    ) { success ->
        finish(success)
    }
}
```

### `rejectBusyCall` (Slice 4 — `d0dc50874`)

```kotlin
/**
 * Rejects an incoming call because the user is already on another call.
 *
 * Uses [MediaCallsAnswerRequest] over REST to send the reject signal.
 * Unlike [startListeningForCallEnd] (used by the normal incoming-call path), this
 * does NOT subscribe to `stream-notify-user` or install a collection-message
 * handler, because no incoming-call UI was ever shown and there is nothing
 * to dismiss if the caller hangs up or another device answers.
 */
@JvmStatic
fun rejectBusyCall(context: Context, payload: VoipPayload) {
    Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
    cancelTimeout(payload.callId)
    val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
    MediaCallsAnswerRequest.fetch(
        context = context,
        host = payload.host,
        callId = payload.callId,
        contractId = deviceId,
        answer = "reject",
        supportedFeatures = null
    ) { _ -> }
}
```

---

## Further comments

`DDPClient.kt` and `VoipPerCallDdpRegistry.kt` are **not deleted** — they remain in use by `startListeningForCallEnd` (call-end subscription), which is deferred to a future PRD (Slice 6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced VoIP call handling with modernized backend communication for accept, reject, and busy-call scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->