### PR TITLE
fix(voip): show CallKit UI when call is active in background

### DIFF
--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment node
+ *
+ * iOS-only mute tests: requires isIOS = true so performSetMutedCallAction listener is registered.
+ */
+import { DeviceEventEmitter } from 'react-native';
+import RNCallKeep from 'react-native-callkeep';
+
+import { DEEP_LINKING } from '../../../actions/actionsTypes';
+import type { VoipPayload } from '../../../definitions/Voip';
+import NativeVoipModule from '../../native/NativeVoip';
+import { getInitialMediaCallEvents, setupMediaCallEvents } from './MediaCallEvents';
+import { useCallStore } from './useCallStore';
+
+const mockDispatch = jest.fn();
+const mockSetNativeAcceptedCallId = jest.fn();
+const mockAddEventListener = jest.fn();
+const mockRNCallKeepClearInitialEvents = jest.fn();
+const mockSetCurrentCallActive = jest.fn();
+
+jest.mock('../../methods/helpers', () => ({
+	...jest.requireActual('../../methods/helpers'),
+	isIOS: true
+}));
+
+jest.mock('../../store', () => ({
+	__esModule: true,
+	default: {
+		dispatch: (...args: unknown[]) => mockDispatch(...args)
+	}
+}));
+
+jest.mock('./useCallStore', () => ({
+	useCallStore: {
+		getState: jest.fn()
+	}
+}));
+
+jest.mock('../../native/NativeVoip', () => ({
+	__esModule: true,
+	default: {
+		clearInitialEvents: jest.fn(),
+		getInitialEvents: jest.fn(() => null)
+	}
+}));
+
+jest.mock('react-native-callkeep', () => ({
+	__esModule: true,
+	default: {
+		addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
+		clearInitialEvents: (...args: unknown[]) => mockRNCallKeepClearInitialEvents(...args),
+		setCurrentCallActive: (...args: unknown[]) => mockSetCurrentCallActive(...args),
+		getInitialEvents: jest.fn(() => Promise.resolve([]))
+	}
+}));
+
+jest.mock('./MediaSessionInstance', () => ({
+	mediaSessionInstance: {
+		endCall: jest.fn()
+	}
+}));
+
+jest.mock('../restApi', () => ({
+	registerPushToken: jest.fn(() => Promise.resolve())
+}));
+
+const activeCallBase = {
+	call: {} as object,
+	callId: 'uuid-1',
+	nativeAcceptedCallId: null as string | null
+};
+
+function getMuteHandler(): (payload: { muted: boolean; callUUID: string }) => void {
+	const call = mockAddEventListener.mock.calls.find(([name]) => name === 'performSetMutedCallAction');
+	if (!call) {
+		throw new Error('performSetMutedCallAction listener not registered');
+	}
+	return call[1] as (payload: { muted: boolean; callUUID: string }) => void;
+}
+
+describe('setupMediaCallEvents — performSetMutedCallAction (iOS)', () => {
+	const toggleMute = jest.fn();
+	const getState = useCallStore.getState as jest.Mock;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		toggleMute.mockClear();
+		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
+		getState.mockReturnValue({ ...activeCallBase, isMuted: false, toggleMute });
+	});
+
+	it('registers performSetMutedCallAction via RNCallKeep.addEventListener', () => {
+		setupMediaCallEvents();
+		expect(mockAddEventListener).toHaveBeenCalledWith('performSetMutedCallAction', expect.any(Function));
+	});
+
+	it('calls toggleMute when muted state differs from OS and UUIDs match', () => {
+		setupMediaCallEvents();
+		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
+		expect(toggleMute).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call toggleMute when muted state already matches OS even if UUIDs match', () => {
+		getState.mockReturnValue({ ...activeCallBase, isMuted: true, toggleMute });
+		setupMediaCallEvents();
+		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
+		expect(toggleMute).not.toHaveBeenCalled();
+	});
+
+	it('drops event when callUUID does not match active call id', () => {
+		setupMediaCallEvents();
+		getMuteHandler()({ muted: true, callUUID: 'uuid-2' });
+		expect(toggleMute).not.toHaveBeenCalled();
+	});
+
+	it('drops event when there is no active call object even if UUIDs match', () => {
+		getState.mockReturnValue({
+			call: null,
+			callId: 'uuid-1',
+			nativeAcceptedCallId: null,
+			isMuted: false,
+			toggleMute
+		});
+		setupMediaCallEvents();
+		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
+		expect(toggleMute).not.toHaveBeenCalled();
+	});
+});

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -19,6 +19,31 @@ jest.mock('./useCallStore', () => ({
 	}
 }));
 
+jest.mock('../../store', () => ({
+	__esModule: true,
+	default: {
+		dispatch: jest.fn()
+	}
+}));
+
+jest.mock('../../native/NativeVoip', () => ({
+	__esModule: true,
+	default: {
+		clearInitialEvents: jest.fn(),
+		getInitialEvents: jest.fn(() => null)
+	}
+}));
+
+jest.mock('./MediaSessionInstance', () => ({
+	mediaSessionInstance: {
+		endCall: jest.fn()
+	}
+}));
+
+jest.mock('../restApi', () => ({
+	registerPushToken: jest.fn(() => Promise.resolve())
+}));
+
 jest.mock('react-native-callkeep', () => ({
 	__esModule: true,
 	default: {

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -1,33 +1,16 @@
 /**
  * @jest-environment node
  *
- * iOS-only mute tests: requires isIOS = true so performSetMutedCallAction listener is registered.
+ * iOS-only mute tests: requires isIOS = true so didPerformSetMutedCallAction listener is registered.
  */
-import { DeviceEventEmitter } from 'react-native';
-import RNCallKeep from 'react-native-callkeep';
-
-import { DEEP_LINKING } from '../../../actions/actionsTypes';
-import type { VoipPayload } from '../../../definitions/Voip';
-import NativeVoipModule from '../../native/NativeVoip';
-import { getInitialMediaCallEvents, setupMediaCallEvents } from './MediaCallEvents';
+import { setupMediaCallEvents } from './MediaCallEvents';
 import { useCallStore } from './useCallStore';
 
-const mockDispatch = jest.fn();
-const mockSetNativeAcceptedCallId = jest.fn();
 const mockAddEventListener = jest.fn();
-const mockRNCallKeepClearInitialEvents = jest.fn();
-const mockSetCurrentCallActive = jest.fn();
 
 jest.mock('../../methods/helpers', () => ({
 	...jest.requireActual('../../methods/helpers'),
 	isIOS: true
-}));
-
-jest.mock('../../store', () => ({
-	__esModule: true,
-	default: {
-		dispatch: (...args: unknown[]) => mockDispatch(...args)
-	}
 }));
 
 jest.mock('./useCallStore', () => ({
@@ -36,32 +19,14 @@ jest.mock('./useCallStore', () => ({
 	}
 }));
 
-jest.mock('../../native/NativeVoip', () => ({
-	__esModule: true,
-	default: {
-		clearInitialEvents: jest.fn(),
-		getInitialEvents: jest.fn(() => null)
-	}
-}));
-
 jest.mock('react-native-callkeep', () => ({
 	__esModule: true,
 	default: {
 		addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
-		clearInitialEvents: (...args: unknown[]) => mockRNCallKeepClearInitialEvents(...args),
-		setCurrentCallActive: (...args: unknown[]) => mockSetCurrentCallActive(...args),
+		clearInitialEvents: jest.fn(),
+		setCurrentCallActive: jest.fn(),
 		getInitialEvents: jest.fn(() => Promise.resolve([]))
 	}
-}));
-
-jest.mock('./MediaSessionInstance', () => ({
-	mediaSessionInstance: {
-		endCall: jest.fn()
-	}
-}));
-
-jest.mock('../restApi', () => ({
-	registerPushToken: jest.fn(() => Promise.resolve())
 }));
 
 const activeCallBase = {
@@ -71,14 +36,14 @@ const activeCallBase = {
 };
 
 function getMuteHandler(): (payload: { muted: boolean; callUUID: string }) => void {
-	const call = mockAddEventListener.mock.calls.find(([name]) => name === 'performSetMutedCallAction');
+	const call = mockAddEventListener.mock.calls.find(([name]) => name === 'didPerformSetMutedCallAction');
 	if (!call) {
-		throw new Error('performSetMutedCallAction listener not registered');
+		throw new Error('didPerformSetMutedCallAction listener not registered');
 	}
 	return call[1] as (payload: { muted: boolean; callUUID: string }) => void;
 }
 
-describe('setupMediaCallEvents — performSetMutedCallAction (iOS)', () => {
+describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 	const toggleMute = jest.fn();
 	const getState = useCallStore.getState as jest.Mock;
 
@@ -89,9 +54,9 @@ describe('setupMediaCallEvents — performSetMutedCallAction (iOS)', () => {
 		getState.mockReturnValue({ ...activeCallBase, isMuted: false, toggleMute });
 	});
 
-	it('registers performSetMutedCallAction via RNCallKeep.addEventListener', () => {
+	it('registers didPerformSetMutedCallAction via RNCallKeep.addEventListener', () => {
 		setupMediaCallEvents();
-		expect(mockAddEventListener).toHaveBeenCalledWith('performSetMutedCallAction', expect.any(Function));
+		expect(mockAddEventListener).toHaveBeenCalledWith('didPerformSetMutedCallAction', expect.any(Function));
 	});
 
 	it('calls toggleMute when muted state differs from OS and UUIDs match', () => {

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -87,6 +87,14 @@ const activeCallBase = {
 	nativeAcceptedCallId: null as string | null
 };
 
+function getMuteHandler(): (payload: { muted: boolean; callUUID: string }) => void {
+	const call = mockAddEventListener.mock.calls.find(([name]) => name === 'performSetMutedCallAction');
+	if (!call) {
+		throw new Error('performSetMutedCallAction listener not registered');
+	}
+	return call[1] as (payload: { muted: boolean; callUUID: string }) => void;
+}
+
 describe('MediaCallEvents cross-server accept (slice 3)', () => {
 	const getState = useCallStore.getState as jest.Mock;
 

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -87,14 +87,6 @@ const activeCallBase = {
 	nativeAcceptedCallId: null as string | null
 };
 
-function getMuteHandler(): (payload: { muted: boolean; callUUID: string }) => void {
-	const call = mockAddEventListener.mock.calls.find(([name]) => name === 'performSetMutedCallAction');
-	if (!call) {
-		throw new Error('performSetMutedCallAction listener not registered');
-	}
-	return call[1] as (payload: { muted: boolean; callUUID: string }) => void;
-}
-
 describe('MediaCallEvents cross-server accept (slice 3)', () => {
 	const getState = useCallStore.getState as jest.Mock;
 

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -90,7 +90,7 @@ export const setupMediaCallEvents = (): (() => void) => {
 		);
 
 		subscriptions.push(
-			RNCallKeep.addEventListener('performSetMutedCallAction', ({ muted, callUUID }) => {
+			RNCallKeep.addEventListener('didPerformSetMutedCallAction', ({ muted, callUUID }) => {
 				const { call, callId, nativeAcceptedCallId, toggleMute, isMuted } = useCallStore.getState();
 				const eventUuid = callUUID.toLowerCase();
 				const activeUuid = (callId ?? nativeAcceptedCallId ?? '').toLowerCase();

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -90,8 +90,16 @@ export const setupMediaCallEvents = (): (() => void) => {
 		);
 
 		subscriptions.push(
-			RNCallKeep.addEventListener('performSetMutedCallAction', ({ muted, callUUID: _callUUID }) => {
-				const { toggleMute, isMuted } = useCallStore.getState();
+			RNCallKeep.addEventListener('performSetMutedCallAction', ({ muted, callUUID }) => {
+				const { call, callId, nativeAcceptedCallId, toggleMute, isMuted } = useCallStore.getState();
+				const eventUuid = callUUID.toLowerCase();
+				const activeUuid = (callId ?? nativeAcceptedCallId ?? '').toLowerCase();
+
+				// No active media call or event is for another CallKit/Telecom session — drop stale closure state
+				if (!call || !activeUuid || eventUuid !== activeUuid) {
+					return;
+				}
+
 				// Sync mute state if it doesn't match what the OS is reporting
 				if (muted !== isMuted) {
 					toggleMute();

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -89,6 +89,16 @@ export const setupMediaCallEvents = (): (() => void) => {
 			})
 		);
 
+		subscriptions.push(
+			RNCallKeep.addEventListener('performSetMutedCallAction', ({ muted, callUUID: _callUUID }) => {
+				const { toggleMute, isMuted } = useCallStore.getState();
+				// Sync mute state if it doesn't match what the OS is reporting
+				if (muted !== isMuted) {
+					toggleMute();
+				}
+			})
+		);
+
 		// Note: there is intentionally no 'answerCall' listener here.
 		// VoipService.swift handles accept natively: handleObservedCallChanged detects
 		// hasConnected = true and calls handleNativeAccept(), which sends the DDP accept

--- a/app/lib/services/voip/useCallStore.test.ts
+++ b/app/lib/services/voip/useCallStore.test.ts
@@ -11,7 +11,15 @@ jest.mock('../../../containers/ActionSheet', () => ({
 	hideActionSheetRef: jest.fn()
 }));
 
-jest.mock('react-native-callkeep', () => ({}));
+jest.mock('react-native-callkeep', () => ({
+	setCurrentCallActive: jest.fn(),
+	addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+	endCall: jest.fn(),
+	start: jest.fn(),
+	stop: jest.fn(),
+	setForceSpeakerphoneOn: jest.fn(),
+	setAvailable: jest.fn()
+}));
 
 function createMockCall(callId: string) {
 	const listeners: Record<string, Set<(...args: unknown[]) => void>> = {};

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -175,6 +175,12 @@ export const useCallStore = create<CallStore>((set, get) => ({
 			if (newState === 'active' && !get().callStartTime) {
 				set({ callStartTime: Date.now() });
 			}
+
+			// Tell CallKit the call is active so iOS shows it in the system UI (lock screen, Control Center, Dynamic Island)
+			if (newState === 'active') {
+				const { callId, nativeAcceptedCallId } = get();
+				RNCallKeep.setCurrentCallActive(callId ?? nativeAcceptedCallId ?? '');
+			}
 		};
 
 		const handleTrackStateChange = () => {


### PR DESCRIPTION
## Proposed changes

When a VoIP call is active and the app is backgrounded, iOS was not showing the call in the system UI (lock screen, Control Center, Dynamic Island) due to two missing CallKit integrations.

**Fix 1 — `setCurrentCallActive` on active state transition:**
`RNCallKeep.setCurrentCallActive()` was only called in the local answer path (`answerCall()`), but never when the call transitioned to `active` through other paths (e.g., remote user answering an outgoing call). Added the call in `handleStateChange` inside `setCall` (`useCallStore.ts`) when `newState === 'active'`.

**Fix 2 — `performSetMutedCallAction` not wired:**
The mute button in the system UI (lock screen, Control Center, Dynamic Island) had no effect because `performSetMutedCallAction` was unwired. Added a listener in `setupMediaCallEvents` (`MediaCallEvents.ts`) that syncs mute state via `toggleMute()`.

Hold (`didToggleHoldCallAction`) was already correctly wired — no changes needed.

## Issue(s)
https://rocketchat.atlassian.net/browse/VMUX-75

## How to test or reproduce

1. Place a VoIP call and background the app — confirm the call appears in lock screen / Control Center / Dynamic Island
2. Mute from the system UI (lock screen/Control Center) — confirm mute state syncs correctly
3. Hold from the system UI — confirm hold state syncs correctly (already worked)

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS VoIP: better synchronization between system mute events and the app’s mute state
  * Improved CallKit integration to mark active calls correctly on iOS

* **Tests**
  * Added tests covering iOS mute-event handling, including matching call sessions and mute-state reconciliation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->