### PR TITLE
chore: scope jest, lint, prettier, and tsc to ignore .worktrees directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ coverage
 e2e/docker
 android
 ios
+
+.worktrees/

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,8 @@ ios/
 patches/
 scripts/
 
+.worktrees/
+
 .bettercodehub.yml
 .buckconfig
 .gitattributes

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	testPathIgnorePatterns: ['/e2e/', '/node_modules/', '/(^|\\/)\\.worktrees\\//'],
+	testPathIgnorePatterns: ['e2e', 'node_modules', '.worktrees/'],
 	transformIgnorePatterns: [
 		'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@rocket.chat/ui-kit)'
 	],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	testPathIgnorePatterns: ['e2e', 'node_modules'],
+	testPathIgnorePatterns: ['/e2e/', '/node_modules/', '/(^|\\/)\\.worktrees\\//'],
 	transformIgnorePatterns: [
 		'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@rocket.chat/ui-kit)'
 	],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,5 +70,5 @@
 		"forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
 		"resolveJsonModule": true
 	},
-	"exclude": ["node_modules", "__mocks__"]
+	"exclude": ["node_modules", "__mocks__", "**/.worktrees/**"]
 }


### PR DESCRIPTION
## Proposed changes

Avoid running test/lint/typecheck commands on sibling git worktrees by ignoring the standard `.worktrees/` directory in all four tools:

- **jest**: Added `/(^|\\/)\.worktrees\\//` to `testPathIgnorePatterns`
- **eslint**: Added `.worktrees/` to `.eslintignore`
- **prettier**: Added `.worktrees/` to `.prettierignore`
- **tsc**: Added `**/.worktrees/**` to `tsconfig.json` exclude

## Issues

https://rocketchat.atlassian.net/browse/CORE-2098

## How to test or reproduce

Run any of the four commands from a worktree inside `.worktrees/` and verify only files from the current worktree are processed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] Lint and unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ESLint configured to ignore the .worktrees/ directory, excluding it from linting.
  * Prettier configured to skip formatting files within the .worktrees/ directory.
  * Jest updated to exclude the .worktrees/ directory from test discovery and execution.
  * TypeScript configuration updated to exclude the .worktrees/ directory from type checking and compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->