### PR TITLE
fix: add missing return in goRoom after failed DM creation

### DIFF
--- a/app/lib/methods/helpers/goRoom.ts
+++ b/app/lib/methods/helpers/goRoom.ts
@@ -110,6 +110,7 @@ export const goRoom = async ({
 			}
 		} catch (e: any) {
 			emitErrorCreateDirectMessage(e?.data);
+			return;
 		}
 	}
 


### PR DESCRIPTION
When a user taps a spotlight search result to open a DM and `createDirectMessage` fails (network error, invalid user, etc.), the catch block in `goRoom.ts` emits an error toast but doesn't return. Execution falls through to the navigation code below, which navigates to `RoomView` using the username string as the `rid` instead of a real room ID. The user ends up on a broken/empty RoomView.

Added a `return` statement in the catch block so navigation is skipped after a failed DM creation.

## Issue(s)

Closes #7098

## How to test or reproduce

1. Open the app and search for a user via spotlight
2. Simulate a DM creation failure (e.g. search for a deactivated user, or disconnect network before tapping the result)
3. Before fix: error toast appears AND you get navigated to a broken RoomView
4. After fix: error toast appears and you stay on the current screen

## Screenshots

N/A — logic-only change, no UI modifications.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules