### PR TITLE
fix: dismiss ringing notification when call answered on another device

### DIFF
--- a/app/sagas/videoConf.ts
+++ b/app/sagas/videoConf.ts
@@ -121,6 +121,9 @@ function* onDirectCallJoined(payload: ICallInfo) {
 		yield put(removeVideoConfCall(currentCall));
 		yield call(hideActionSheetRef);
 		videoConfJoin(payload.callId, false, true);
+	} else if (currentCall && currentCall.action === 'call') {
+		yield put(removeVideoConfCall(currentCall));
+		hideNotification();
 	}
 }
 


### PR DESCRIPTION
When a user receives a video call on both phone and desktop and picks up on desktop, the phone keeps ringing indefinitely. The `join` event fires on all clients via DDP, but `onDirectCallJoined` in `videoConf.ts` only handled calls in `accepted` or `calling` state. An unanswered incoming call sits in `call` state, so the condition never matched and the ringing notification was never dismissed.

Added an `else if` branch to handle the `call` state — removes the call from Redux state and hides the notification without joining the conference.

## Issue(s)

Closes #6177

## How to test or reproduce

1. Enable "Conference > Enable mobile ringing" on the Rocket.Chat server
2. Open the Rocket.Chat desktop app and the mobile app
3. Have another user call you via direct message video call
4. Verify both phone and desktop are ringing
5. Answer the call on desktop
6. Before fix: phone keeps ringing even though the call was answered
7. After fix: phone stops ringing and does not join the conference

## Screenshots

N/A — logic-only change, no UI modifications.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules