### PR TITLE
fix: show timestamp on system messages

### DIFF
--- a/app/containers/message/Message.tsx
+++ b/app/containers/message/Message.tsx
@@ -171,6 +171,7 @@ const Message = React.memo((props: IMessageTouchable & IMessage) => {
 						style={{ flex: 1 }}>
 						<View style={styles.messageContent}>
 							<Content {...props} />
+							{props.isInfo ? <MessageTime ts={props.ts} timeFormat={props.timeFormat} /> : null}
 							{props.isInfo && props.type === 'message_pinned' ? (
 								<View pointerEvents='none'>
 									<Attachments {...props} />


### PR DESCRIPTION
System messages (user added, user removed, room name changed, etc.) don't display a timestamp on mobile, even though the web client shows one. This is because the `isInfo` rendering path in `Message.tsx` takes an early return that skips the `MessageTime` component entirely. Regular messages get their timestamp through the `User` component header, but info messages never reach that code path.

Added `<MessageTime>` to the info message block so system messages show their timestamp alongside the message text.

## Issue(s)

Closes #3190

## How to test or reproduce

1. Open any channel
2. Perform actions that generate system messages (add a user, remove a user, change room topic, etc.)
3. Before fix: system messages show no timestamp
4. After fix: system messages display their timestamp

## Screenshots

N/A — will add if requested.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamps not displaying in certain message types, improving message readability and accessibility in information and special message contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->