### PR TITLE
refactor(voip): migrate DDP registration to REST + library upgrade to 0.2.0-rc.0

### DIFF
--- a/app/lib/services/restApi.test.ts
+++ b/app/lib/services/restApi.test.ts
@@ -54,4 +54,13 @@ describe('mediaCallsStateSignals', () => {
 		expect(result.signals).toEqual([]);
 		expect(result.success).toBe(false);
 	});
+
+	it('returns empty signals and success false when signals is not an array', async () => {
+		mockSdkGet.mockResolvedValueOnce({ signals: null, success: true });
+
+		const result = await mediaCallsStateSignals('device-id');
+
+		expect(result.signals).toEqual([]);
+		expect(result.success).toBe(false);
+	});
 });

--- a/app/lib/services/restApi.ts
+++ b/app/lib/services/restApi.ts
@@ -1,4 +1,5 @@
 import { getUniqueId } from 'react-native-device-info';
+import type { ServerMediaSignal } from '@rocket.chat/media-signaling';
 
 import {
 	type IAvatarSuggestion,
@@ -14,7 +15,6 @@ import {
 	type RoomType,
 	type SubscriptionType
 } from '../../definitions';
-import type { ServerMediaSignal } from '@rocket.chat/media-signaling';
 import { type TParams } from '../../definitions/ILivechatEditView';
 import { type ILivechatTag } from '../../definitions/ILivechatTag';
 import { type ISpotlight } from '../../definitions/ISpotlight';
@@ -1217,15 +1217,15 @@ export const getUsersRoles = async (): Promise<boolean | IRoleUser[]> => {
 export const getSupportedVersionsCloud = (uniqueId?: string, domain?: string) =>
 	fetch(`https://releases.rocket.chat/v2/server/supportedVersions?uniqueId=${uniqueId}&domain=${domain}&source=mobile`);
 
-export const mediaCallsStateSignals = async (
-	contractId: string
-): Promise<{ signals: ServerMediaSignal[]; success: boolean }> => {
+export const mediaCallsStateSignals = async (contractId: string): Promise<{ signals: ServerMediaSignal[]; success: boolean }> => {
 	try {
-		const result = await (sdk.get as unknown as (path: string, params?: object) => Promise<{ signals: ServerMediaSignal[]; success: boolean }>)(
-			'media-calls.stateSignals',
-			{ contractId }
-		);
-		return result;
+		const result = await (
+			sdk.get as unknown as (path: string, params?: object) => Promise<{ signals: ServerMediaSignal[]; success: boolean }>
+		)('media-calls.stateSignals', { contractId });
+		if (!result?.success || !Array.isArray(result.signals)) {
+			return { signals: [], success: false };
+		}
+		return { signals: result.signals, success: true };
 	} catch {
 		return { signals: [], success: false };
 	}

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -51,7 +51,7 @@ jest.mock('../sdk', () => ({
 	}
 }));
 
-const mockMediaCallsStateSignals = jest.fn(() => Promise.resolve({ signals: [] }));
+const mockMediaCallsStateSignals = jest.fn(() => Promise.resolve({ signals: [], success: true }));
 jest.mock('../../services/restApi', () => ({
 	mediaCallsStateSignals: (...args: unknown[]) => mockMediaCallsStateSignals(...args)
 }));
@@ -188,8 +188,12 @@ function buildClientMediaCall(options: {
 	role: 'caller' | 'callee';
 	hidden?: boolean;
 	reject?: jest.Mock;
+	accept?: jest.Mock;
+	contact?: { username: string; sipExtension: string };
 }): IClientMediaCall {
 	const reject = options.reject ?? jest.fn();
+	const accept = options.accept ?? jest.fn().mockResolvedValue(undefined);
+	const contact = options.contact ?? { id: 'u', displayName: 'U', username: 'u', sipExtension: '' };
 	const emitter = { on: jest.fn(), off: jest.fn(), emit: jest.fn() };
 	return {
 		callId: options.callId,
@@ -201,7 +205,7 @@ function buildClientMediaCall(options: {
 			role: options.role,
 			muted: false,
 			held: false,
-			contact: { id: 'u', displayName: 'U', username: 'u', sipExtension: '' },
+			contact,
 			getMediaStream: () => null,
 			setMuted: () => {},
 			setHeld: () => {}
@@ -210,6 +214,7 @@ function buildClientMediaCall(options: {
 		participants: [],
 		hidden: options.hidden ?? false,
 		reject,
+		accept,
 		emitter: emitter as unknown as IClientMediaCall['emitter']
 	} as unknown as IClientMediaCall;
 }
@@ -385,7 +390,7 @@ describe('MediaSessionInstance', () => {
 	describe('stream-notify-user (notification/accepted gated)', () => {
 		it('does not call answerCall when nativeAcceptedCallId is null', async () => {
 			const answerSpy = jest.spyOn(mediaSessionInstance, 'answerCall').mockResolvedValue(undefined);
-			mediaSessionInstance.init('user-1');
+			await mediaSessionInstance.init('user-1');
 			const streamHandler = getStreamNotifyHandler();
 			streamHandler({
 				msg: 'changed',
@@ -418,7 +423,7 @@ describe('MediaSessionInstance', () => {
 				nativeAcceptedCallId: 'from-signal',
 				roomId: null
 			});
-			mediaSessionInstance.init('user-1');
+			await mediaSessionInstance.init('user-1');
 			const streamHandler = getStreamNotifyHandler();
 			streamHandler({
 				msg: 'changed',
@@ -451,7 +456,7 @@ describe('MediaSessionInstance', () => {
 				nativeAcceptedCallId: 'sticky-only',
 				roomId: null
 			});
-			mediaSessionInstance.init('user-1');
+			await mediaSessionInstance.init('user-1');
 			const streamHandler = getStreamNotifyHandler();
 			streamHandler({
 				msg: 'changed',
@@ -484,7 +489,7 @@ describe('MediaSessionInstance', () => {
 				nativeAcceptedCallId: 'from-signal',
 				roomId: null
 			});
-			mediaSessionInstance.init('user-1');
+			await mediaSessionInstance.init('user-1');
 			const streamHandler = getStreamNotifyHandler();
 			streamHandler({
 				msg: 'changed',
@@ -547,9 +552,8 @@ describe('MediaSessionInstance', () => {
 			newCallHandler({
 				call: {
 					hidden: false,
-					role: 'caller',
 					callId: 'c1',
-					contact: { username: 'alice', sipExtension: '' },
+					localParticipant: { role: 'caller', contact: { username: 'alice', sipExtension: '' } },
 					emitter: { on: jest.fn(), off: jest.fn() }
 				} as unknown as IClientMediaCall
 			});
@@ -578,9 +582,8 @@ describe('MediaSessionInstance', () => {
 			newCallHandler({
 				call: {
 					hidden: false,
-					role: 'caller',
 					callId: 'c1',
-					contact: { username: 'alice', sipExtension: '' },
+					localParticipant: { role: 'caller', contact: { username: 'alice', sipExtension: '' } },
 					emitter: { on: jest.fn(), off: jest.fn() }
 				} as unknown as IClientMediaCall
 			});
@@ -599,9 +602,8 @@ describe('MediaSessionInstance', () => {
 			newCallHandler({
 				call: {
 					hidden: false,
-					role: 'caller',
 					callId: 'c1',
-					contact: { username: 'alice', sipExtension: '100' },
+					localParticipant: { role: 'caller', contact: { username: 'alice', sipExtension: '100' } },
 					emitter: { on: jest.fn(), off: jest.fn() }
 				} as unknown as IClientMediaCall
 			});
@@ -612,29 +614,24 @@ describe('MediaSessionInstance', () => {
 
 		it('answerCall resolves roomId from DM for non-SIP callee', async () => {
 			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-rid' } as any);
-			mediaSessionInstance.init('user-1');
-			const mainCall = {
-				callId: 'call-ans',
-				accept: jest.fn().mockResolvedValue(undefined),
-				localParticipant: {
-					contact: { username: 'bob', sipExtension: '' }
-				}
-			};
+			await mediaSessionInstance.init('user-1');
+			const incomingCall = buildClientMediaCall({ callId: 'call-ans', role: 'callee' });
+			(incomingCall.localParticipant.contact as any).username = 'bob';
+			(incomingCall.localParticipant.contact as any).sipExtension = '';
+			getNewCallHandler()({ call: incomingCall });
 
 			await mediaSessionInstance.answerCall('call-ans');
 
+			await waitFor(() => expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('bob'));
 			await waitFor(() => expect(mockSetRoomId).toHaveBeenCalledWith('dm-rid'));
 		});
 
 		it('answerCall skips DM lookup for SIP contact', async () => {
-			mediaSessionInstance.init('user-1');
-			const mainCall = {
-				callId: 'call-sip',
-				accept: jest.fn().mockResolvedValue(undefined),
-				localParticipant: {
-					contact: { username: 'bob', sipExtension: 'ext' }
-				}
-			};
+			await mediaSessionInstance.init('user-1');
+			const incomingCall = buildClientMediaCall({ callId: 'call-sip', role: 'callee' });
+			(incomingCall.localParticipant.contact as any).username = 'bob';
+			(incomingCall.localParticipant.contact as any).sipExtension = 'ext';
+			getNewCallHandler()({ call: incomingCall });
 
 			await mediaSessionInstance.answerCall('call-sip');
 

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -15,7 +15,7 @@ import { mediaSessionStore } from './MediaSessionStore';
 import { useCallStore } from './useCallStore';
 import { store } from '../../store/auxStore';
 import sdk from '../sdk';
-import { mediaCallsStateSignals } from '../../services/restApi';
+import { mediaCallsStateSignals } from '../restApi';
 import Navigation from '../../navigation/appNavigation';
 import { parseStringToIceServers } from './parseStringToIceServers';
 import type { IceServer } from '../../../definitions/Voip';
@@ -33,6 +33,7 @@ class MediaSessionInstance {
 	private mediaSessionStoreChangeUnsubscribe: (() => void) | null = null;
 	private storeTimeoutUnsubscribe: (() => void) | null = null;
 	private storeIceServersUnsubscribe: (() => void) | null = null;
+	private pendingCalls: Map<string, IClientMediaCall> = new Map();
 
 	public async init(userId: string): Promise<void> {
 		this.reset();
@@ -54,22 +55,12 @@ class MediaSessionInstance {
 		const instance = mediaSessionStore.getInstance(userId);
 		this.instance = instance;
 
-		if (instance) {
-			// Fetch initial call state via REST before DDP register fires
-			try {
-				const { signals } = await mediaCallsStateSignals(getUniqueIdSync());
-				for (const signal of signals) {
-					instance.processSignal(signal);
-				}
-			} catch (error) {
-				console.error('[VoIP] Failed to fetch initial state signals:', error);
-			}
-
-			instance.register(false);
-		}
-
 		this.mediaSessionStoreChangeUnsubscribe = mediaSessionStore.onChange(() => {
-			this.instance = mediaSessionStore.getInstance(userId);
+			try {
+				this.instance = mediaSessionStore.getInstance(userId);
+			} catch {
+				// factory cleared during dispose; instance is already null
+			}
 		});
 
 		this.mediaSignalListener = sdk.onStreamData('stream-notify-user', (ddpMessage: IDDPMessage) => {
@@ -100,25 +91,46 @@ class MediaSessionInstance {
 			}
 		});
 
-		this.instance?.on('newCall', ({ call }: { call: IClientMediaCall }) => {
-			if (call && !call.hidden) {
-				call.emitter.on('stateChange', () => {});
+		if (instance) {
+			// Attach newCall handler BEFORE REST replay so replayed calls are captured
+			instance.on('newCall', ({ call }: { call: IClientMediaCall }) => {
+				if (call && !call.hidden) {
+					call.emitter.on('stateChange', () => {});
 
-				if (call.localParticipant.role === 'caller') {
-					useCallStore.getState().setCall(call);
-					Navigation.navigate('CallView');
-					if (useCallStore.getState().roomId == null) {
-						this.resolveRoomIdFromContact(call.localParticipant.contact).catch(error => {
-							console.error('[VoIP] Error resolving room id from contact (newCall):', error);
-						});
+					// Store call for lookup by answerCall/endCall regardless of role
+					this.pendingCalls.set(call.callId, call);
+
+					if (call.localParticipant.role === 'caller') {
+						useCallStore.getState().setCall(call);
+						Navigation.navigate('CallView');
+						if (useCallStore.getState().roomId == null) {
+							this.resolveRoomIdFromContact(call.localParticipant.contact).catch(error => {
+								console.error('[VoIP] Error resolving room id from contact (newCall):', error);
+							});
+						}
 					}
-				}
 
-				call.emitter.on('ended', () => {
-					RNCallKeep.endCall(call.callId);
-				});
+					call.emitter.on('ended', () => {
+						RNCallKeep.endCall(call.callId);
+						this.pendingCalls.delete(call.callId);
+					});
+				}
+			});
+
+			// Fetch initial call state via REST before DDP register fires
+			let bootstrappedFromRest = false;
+			try {
+				const { signals } = await mediaCallsStateSignals(getUniqueIdSync());
+				for (const signal of signals) {
+					instance.processSignal(signal);
+				}
+				bootstrappedFromRest = true;
+			} catch (error) {
+				console.error('[VoIP] Failed to fetch initial state signals:', error);
 			}
-		});
+
+			instance.register(!bootstrappedFromRest);
+		}
 	}
 
 	public answerCall = async (callId: string) => {
@@ -127,9 +139,9 @@ class MediaSessionInstance {
 			return;
 		}
 
-		const call = useCallStore.getState().call;
+		const call = this.pendingCalls.get(callId);
 
-		if (call && call.callId === callId) {
+		if (call) {
 			await call.accept();
 			RNCallKeep.setCurrentCallActive(callId);
 			useCallStore.getState().setCall(call);
@@ -160,7 +172,7 @@ class MediaSessionInstance {
 	};
 
 	public endCall = (callId: string) => {
-		const call = useCallStore.getState().call;
+		const call = this.pendingCalls.get(callId) ?? useCallStore.getState().call;
 
 		if (call && call.callId === callId) {
 			if (call.state === 'ringing') {
@@ -234,6 +246,7 @@ class MediaSessionInstance {
 		}
 		mediaSessionStore.dispose();
 		this.instance = null;
+		this.pendingCalls.clear();
 		useCallStore.getState().reset();
 	}
 }

--- a/app/lib/services/voip/mockCall.ts
+++ b/app/lib/services/voip/mockCall.ts
@@ -1,25 +1,7 @@
 import type { CallState, IClientMediaCall } from '@rocket.chat/media-signaling';
 
+import Navigation from '../../navigation/appNavigation';
 import { useCallStore } from './useCallStore';
-
-jest.mock('../../navigation/appNavigation', () => ({
-	__esModule: true,
-	default: { navigate: jest.fn(), back: jest.fn() }
-}));
-
-jest.mock('../../../containers/ActionSheet', () => ({
-	hideActionSheetRef: jest.fn()
-}));
-
-jest.mock('react-native-callkeep', () => ({
-	setCurrentCallActive: jest.fn(),
-	addEventListener: jest.fn(() => ({ remove: jest.fn() })),
-	endCall: jest.fn(),
-	start: jest.fn(),
-	stop: jest.fn(),
-	setForceSpeakerphoneOn: jest.fn(),
-	setAvailable: jest.fn()
-}));
 
 export interface MockCallOverrides {
 	callState?: CallState;
@@ -28,6 +10,7 @@ export interface MockCallOverrides {
 	isSpeakerOn?: boolean;
 	callStartTime?: number | null;
 	roomId?: string | null;
+	role?: 'caller' | 'callee';
 	contact?: {
 		id?: string;
 		displayName?: string;

--- a/app/lib/services/voip/useCallStore.test.ts
+++ b/app/lib/services/voip/useCallStore.test.ts
@@ -45,10 +45,12 @@ function createMockCall(callId: string) {
 			setMuted: jest.fn(),
 			setHeld: jest.fn()
 		},
-		remoteParticipants: [{
-			muted: false,
-			held: false
-		}],
+		remoteParticipants: [
+			{
+				muted: false,
+				held: false
+			}
+		],
 		hidden: false,
 		role: 'callee',
 		emitter,


### PR DESCRIPTION
## Proposed changes

Migrate VoIP JS layer session initialization from DDP registration-with-signals to REST `GET /media-calls.stateSignals`, and upgrade `@rocket.chat/media-signaling` from 0.1.3 to 0.2.0-rc.0.

Changes (10 commits):
- **REST function**: `mediaCallsStateSignals(contractId)` in `restApi.ts`
- **Library upgrade**: 0.1.3 → 0.2.0-rc.0 tarball, `requestInitialStateSignals: false` in session config
- **Init orchestration**: fetch REST stateSignals → feed into `processSignal()` → call `register(false)` for side effects
- **Participant model migration**: `IClientMediaCall` type changed in 0.2.0 — migrate flat field access to `localParticipant.*` / `remoteParticipants[0].*`
- **Cleanup**: remove old 0.1.3 tarball, null guards, debug logs

DDP subscription (`stream-notify-user`) stays for real-time signals (offer/answer/ICE). DDP register stays with `requestSignals: false` for server-side side effects.

## Issue(s)
https://rocketchat.atlassian.net/browse/VMUX-67

## How to test or reproduce

Run `TZ=UTC yarn test -- --testPathPattern='app/lib/services/voip'` — all tests pass.

## Types of changes
- [x] Refactoring (no functional changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of media call state responses from the API; invalid or missing signal data is now safely normalized to prevent unexpected behavior.

* **Tests**
  * Extended test coverage for API response validation and updated media session initialization tests to align with refactored call lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->