### PR TITLE
feat(voip): iOS CallKit Recents integration

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -27,7 +27,15 @@ public class AppDelegate: ExpoAppDelegate {
     Bugsnag.start()
     ReplyNotification.configure()
     VoipService.voipRegistration()
-    RNCallKeep.setup(["appName": "Rocket.Chat"])
+    if !VoipRegion.isChina() {
+      RNCallKeep.setup([
+        "appName": "Rocket.Chat",
+        "supportsVideo": false,
+        "maximumCallGroups": 1,
+        "maximumCallsPerCallGroup": 1,
+        "includesCallsInRecents": true
+      ])
+    }
       
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)

--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -26,8 +26,8 @@ public class AppDelegate: ExpoAppDelegate {
     FirebaseApp.configure()
     Bugsnag.start()
     ReplyNotification.configure()
-    VoipService.voipRegistration()
     if !VoipRegion.isChina() {
+      VoipService.voipRegistration()
       RNCallKeep.setup([
         "appName": "Rocket.Chat",
         "supportsVideo": false,

--- a/ios/Libraries/AppDelegate+Voip.swift
+++ b/ios/Libraries/AppDelegate+Voip.swift
@@ -90,7 +90,7 @@ extension AppDelegate: PKPushRegistryDelegate {
         onReportComplete: { completion() }
       )
     } else {
-      completion()
+      reportPlaceholderCallAndEnd(callId, caller)
     }
   }
 }

--- a/ios/Libraries/AppDelegate+Voip.swift
+++ b/ios/Libraries/AppDelegate+Voip.swift
@@ -79,14 +79,18 @@ extension AppDelegate: PKPushRegistryDelegate {
       return
     }
 
-    VoipService.prepareIncomingCall(voipPayload, storeEventsForJs: true)
+    if !VoipRegion.isChina() {
+      VoipService.prepareIncomingCall(voipPayload, storeEventsForJs: true)
 
-    reportVoipIncomingCallToCallKit(
-      callUUID: callId,
-      handle: caller,
-      localizedCallerName: caller,
-      payload: payloadDict,
-      onReportComplete: { completion() }
-    )
+      reportVoipIncomingCallToCallKit(
+        callUUID: callId,
+        handle: caller,
+        localizedCallerName: caller,
+        payload: payloadDict,
+        onReportComplete: { completion() }
+      )
+    } else {
+      completion()
+    }
   }
 }

--- a/ios/Libraries/VoipRegion.swift
+++ b/ios/Libraries/VoipRegion.swift
@@ -1,0 +1,18 @@
+import Foundation
+import CoreTelephony
+
+enum VoipRegion {
+	/// Returns true when ANY active cellular subscriber reports MCC 460 (China),
+	/// or — when no SIM is present — when the device locale region is "CN".
+	/// MIIT gates on SIM identity, so dual-SIM devices with one CN SIM are gated.
+	static func isChina() -> Bool {
+		let info = CTTelephonyNetworkInfo()
+		if let providers = info.serviceSubscriberCellularProviders, !providers.isEmpty {
+			for (_, carrier) in providers {
+				if carrier.mobileCountryCode == "460" { return true }
+			}
+			return false
+		}
+		return NSLocale.current.regionCode == "CN"
+	}
+}

--- a/ios/Libraries/VoipRegion.swift
+++ b/ios/Libraries/VoipRegion.swift
@@ -1,18 +1,10 @@
 import Foundation
-import CoreTelephony
 
 enum VoipRegion {
-	/// Returns true when ANY active cellular subscriber reports MCC 460 (China),
-	/// or — when no SIM is present — when the device locale region is "CN".
-	/// MIIT gates on SIM identity, so dual-SIM devices with one CN SIM are gated.
 	static func isChina() -> Bool {
-		let info = CTTelephonyNetworkInfo()
-		if let providers = info.serviceSubscriberCellularProviders, !providers.isEmpty {
-			for (_, carrier) in providers {
-				if carrier.mobileCountryCode == "460" { return true }
-			}
-			return false
+		if #available(iOS 16, *) {
+			return Locale.current.region?.identifier == "CN"
 		}
-		return NSLocale.current.regionCode == "CN"
+		return Locale.current.regionCode == "CN"
 	}
 }

--- a/ios/RocketChatRN.xcodeproj/project.pbxproj
+++ b/ios/RocketChatRN.xcodeproj/project.pbxproj
@@ -307,6 +307,8 @@
 		7A1B58422F5F58FF002A6BDE /* VoipPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B58402F5F58FF002A6BDE /* VoipPayload.swift */; };
 		7A1B58442F5F63DB002A6BDE /* AppDelegate+Voip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B58432F5F63DB002A6BDE /* AppDelegate+Voip.swift */; };
 		7A1B58452F5F63DB002A6BDE /* AppDelegate+Voip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B58432F5F63DB002A6BDE /* AppDelegate+Voip.swift */; };
+		7AVR00012F5F5900002A6BDE /* VoipRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AVR00002F5F5900002A6BDE /* VoipRegion.swift */; };
+		7AVR00022F5F5900002A6BDE /* VoipRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AVR00002F5F5900002A6BDE /* VoipRegion.swift */; };
 		7A3704562F7DB36E009085FC /* VoipPerCallDdpRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3704552F7DB36E009085FC /* VoipPerCallDdpRegistry.swift */; };
 		7A3704572F7DB36E009085FC /* VoipPerCallDdpRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3704552F7DB36E009085FC /* VoipPerCallDdpRegistry.swift */; };
 		7A37D6FF2F896C360095EBA1 /* MediaCallsAnswerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F98EE33D91A93DF8E69F34 /* MediaCallsAnswerRequest.swift */; };
@@ -647,6 +649,7 @@
 		7A14FCF3257FEB59005BDCD4 /* Official.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Official.xcassets; sourceTree = "<group>"; };
 		7A1B58402F5F58FF002A6BDE /* VoipPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoipPayload.swift; sourceTree = "<group>"; };
 		7A1B58432F5F63DB002A6BDE /* AppDelegate+Voip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Voip.swift"; sourceTree = "<group>"; };
+		7AVR00002F5F5900002A6BDE /* VoipRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoipRegion.swift; sourceTree = "<group>"; };
 		7A3704552F7DB36E009085FC /* VoipPerCallDdpRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoipPerCallDdpRegistry.swift; sourceTree = "<group>"; };
 		7A610CD127ECE38100B8ABDD /* custom.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = custom.ttf; sourceTree = "<group>"; };
 		7A8B30742BCD9D3F00146A40 /* SSLPinning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SSLPinning.h; sourceTree = "<group>"; };
@@ -1161,6 +1164,7 @@
 			children = (
 				7A3704552F7DB36E009085FC /* VoipPerCallDdpRegistry.swift */,
 				7A1B58432F5F63DB002A6BDE /* AppDelegate+Voip.swift */,
+				7AVR00002F5F5900002A6BDE /* VoipRegion.swift */,
 				7A1B58402F5F58FF002A6BDE /* VoipPayload.swift */,
 				7A0000042F1BAFA700B6B4BD /* VoipModule.mm */,
 				7A0000032F1BAFA700B6B4BD /* VoipService.swift */,
@@ -2136,6 +2140,7 @@
 				1ED038C42B50A1F500C007D4 /* WatchMessage.swift in Sources */,
 				1E76CBD025152C6E0067298C /* URL+Extensions.swift in Sources */,
 				7A1B58442F5F63DB002A6BDE /* AppDelegate+Voip.swift in Sources */,
+				7AVR00012F5F5900002A6BDE /* VoipRegion.swift in Sources */,
 				1E068CFE24FD2DC700A0FFC1 /* AppGroup.swift in Sources */,
 				1E76CBCE25152C2F0067298C /* RoomKey.swift in Sources */,
 				1E76CBCC25152C290067298C /* Message.swift in Sources */,
@@ -2420,6 +2425,7 @@
 				1ED038C52B50A1F500C007D4 /* WatchMessage.swift in Sources */,
 				7AAB3E2C257E6A6E00707CF6 /* URL+Extensions.swift in Sources */,
 				7A1B58452F5F63DB002A6BDE /* AppDelegate+Voip.swift in Sources */,
+				7AVR00022F5F5900002A6BDE /* VoipRegion.swift in Sources */,
 				7AAB3E2D257E6A6E00707CF6 /* AppGroup.swift in Sources */,
 				7AAB3E2E257E6A6E00707CF6 /* RoomKey.swift in Sources */,
 				7AAB3E2F257E6A6E00707CF6 /* Message.swift in Sources */,


### PR DESCRIPTION
## Proposed changes

iOS-only: surface incoming Rocket.Chat VoIP calls in Phone.app Recents by enabling CallKit's `includesCallsInRecents` via a new region-gated `RNCallKeep.setup(...)` call in `AppDelegate.swift`. Gate every CallKit touchpoint behind `!VoipRegion.isChina()` — a new Swift helper that uses `Locale.current.region` (iOS 16+) / `Locale.current.regionCode` (iOS 15 fallback) to identify CN devices — to satisfy MIIT compliance. The pre-existing JS-side `RNCallKeep.setup` in `index.js:25` is gated `if (Platform.OS === 'android')` and is unchanged by this PR.

- `ios/Libraries/VoipRegion.swift` (new) — locale-based CN region detection
- `ios/AppDelegate.swift` — region-gated block: `VoipService.voipRegistration()` and `RNCallKeep.setup(... includesCallsInRecents: true ...)` both run only when `!VoipRegion.isChina()`. CN devices skip PushKit registration entirely, so the server never receives a CN VoIP token and never sends VoIP pushes that would otherwise be discarded on the device.
- `ios/Libraries/AppDelegate+Voip.swift` — guards `prepareIncomingCall` + `reportNewIncomingCall`; the gated CN branch reports a short-lived placeholder call to CallKit (via `reportPlaceholderCallAndEnd`) before `completion()` to honor the PushKit→CallKit contract. With registration gated, this is now defense-in-depth for any stray push that races registration.
- `ios/RocketChatRN.xcodeproj/project.pbxproj` — registers the new Swift file in both targets

No Android changes. No manifest, entitlement, or store-review surface changed.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-26

## How to test or reproduce

1. Non-CN iOS 15/17 device → place a Rocket.Chat VoIP call → after hangup, Phone.app Recents shows the entry with caller name.
2. iOS 16+ device with region=CN (Settings → General → Language & Region → Region: China) → `pushRegistry(_:didUpdate:for:)` does not fire after launch (no PushKit token issued, none POSTed to the server). No native CallKit setup, no real call UI. If a stray VoIP push ever did arrive, the CN branch reports a short-lived placeholder call so iOS does not throttle VoIP push delivery.
3. iPad/no-SIM with region=US → not gated; Recents entry present.

## Screenshots

N/A — native platform surface; no in-app UI change.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — native CallKit behavior requires device verification
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

**Why iOS `RNCallKeep.setup` is native-owned:** the JS-side `RNCallKeep.setup` in `index.js:25` is gated `if (Platform.OS === 'android')` and never ran for iOS, so native `AppDelegate.swift` is the only place to set CallKit's `includesCallsInRecents: true` on iOS. Doing the setup native-side also avoids a JS↔native bridge round-trip on cold start for a boot-time constant. `RNCallKeep.setup` before the RN bridge is ready is safe: it only mutates the `CXProviderConfiguration` singleton and is bridge-independent.

**Why guarding `prepareIncomingCall` too:** it transitively instantiates `CXCallObserver` (`VoipService.swift:149`), so it is itself a CallKit surface and must live inside the MIIT gate.

**Why CN devices skip `voipRegistration()`:** unconditional registration would request a PushKit token, post it to the server, and any VoIP push the server then sent would be discarded on the device. Gating registration aligns CN-device behavior with "VoIP unavailable" rather than "VoIP attempted-and-discarded", and removes wasted server→device push traffic.

**Why the CN PushKit branch still reports a placeholder:** defense-in-depth. iOS PushKit requires every VoIP payload that does reach the device to call `CXProvider.reportNewIncomingCall` before `completion()`; returning bare `completion()` causes iOS to throttle or disable VoIP push delivery. The `reportPlaceholderCallAndEnd` helper (also used for unparseable / expired payload cases) reports a short-lived call to CallKit and ends it immediately, satisfying the contract for any stray push that races the registration gate.

**Deferred:** outgoing-call Recents entries (`RNCallKeep.startCall` injection site unresolved alongside the `IClientMediaCall` trace).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region-aware incoming call behavior: devices identified as being in China skip native call reporting.
  * Calling configuration updated: explicit call grouping limits set, video disabled by default, and calls included in recent calls.

* **Improvements**
  * VoIP handling adjusted for region-specific behavior and carrier variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->