### PR TITLE
feat: add Enable Mobile Ringing toggle in user preferences

### DIFF
--- a/app/definitions/IUser.ts
+++ b/app/definitions/IUser.ts
@@ -112,6 +112,7 @@ export interface INotificationPreferences {
 	pushNotifications: TNotifications;
 	emailNotificationMode: 'mentions' | 'nothing';
 	language?: string;
+	enableMobileRinging?: boolean;
 }
 
 export interface IMessagePreferences {

--- a/app/i18n/locales/ar.json
+++ b/app/i18n/locales/ar.json
@@ -182,6 +182,7 @@
   "Emoji_selector": "محدد الرموز التعبيرية",
   "Enable_Auto_Translate": "تمكين الترجمة التلقائية",
   "Enable_encryption_button_label": "تمكين التشفير",
+  "Enable_Mobile_Ringing": "تمكين الرنين على الهاتف الجوال",
   "Encrypted": "مشفر",
   "Encrypted_message": "رسالة مشفرة",
   "encrypted_room_description": "أدخل كلمة المرور الخاصة بالتشفير من طرف إلى طرف للوصول.",
@@ -662,6 +663,5 @@
   "Your_invite_link_will_never_expire": "لن تنتهي صلاحية رابط الدعوة الخاص بك",
   "Your_password_is": "كلمة المرور الخاصة بك هي",
   "Your_Password_Must_Have": "يجب أن تحتوي كلمة المرور الخاصة بك على:",
-  "Your_workspace": "مساحة عملك",
-  "Enable_Mobile_Ringing": "تمكين الرنين على الهاتف الجوال"
+  "Your_workspace": "مساحة عملك"
 }

--- a/app/i18n/locales/ar.json
+++ b/app/i18n/locales/ar.json
@@ -662,5 +662,6 @@
   "Your_invite_link_will_never_expire": "لن تنتهي صلاحية رابط الدعوة الخاص بك",
   "Your_password_is": "كلمة المرور الخاصة بك هي",
   "Your_Password_Must_Have": "يجب أن تحتوي كلمة المرور الخاصة بك على:",
-  "Your_workspace": "مساحة عملك"
+  "Your_workspace": "مساحة عملك",
+  "Enable_Mobile_Ringing": "تمكين الرنين على الهاتف الجوال"
 }

--- a/app/i18n/locales/bn-IN.json
+++ b/app/i18n/locales/bn-IN.json
@@ -924,5 +924,6 @@
   "Your_invite_link_will_never_expire": "আপনার আমন্ত্রণ লিঙ্কটি কখনও মেয়াদ শেষ হবে না।",
   "Your_password_is": "আপনার পাসওয়ার্ড হল",
   "Your_Password_Must_Have": "আপনার পাসওয়ার্ড থাকতে হবে:",
-  "Your_workspace": "আপনার ওয়ার্কস্পেস"
+  "Your_workspace": "আপনার ওয়ার্কস্পেস",
+  "Enable_Mobile_Ringing": "মোবাইল রিংিং সক্ষম করুন"
 }

--- a/app/i18n/locales/bn-IN.json
+++ b/app/i18n/locales/bn-IN.json
@@ -282,6 +282,7 @@
   "Enable_Auto_Translate": "অটো-অনুবাদ সক্রিয় করুন",
   "Enable_encryption_button_label": "এনক্রিপশন সক্রিয় করুন",
   "Enable_Message_Parser": "বার্তা পার্সার সক্ষম করুন",
+  "Enable_Mobile_Ringing": "মোবাইল রিংিং সক্ষম করুন",
   "Enable_writing_in_room": "রুমে লেখা সক্ষম করুন",
   "Enabled_E2E_Encryption_for_this_room": "এই রুমের জন্য E2E এনক্রিপশন সক্রিয় করা হয়েছে",
   "Encrypted": "এনক্রিপ্টেড",
@@ -924,6 +925,5 @@
   "Your_invite_link_will_never_expire": "আপনার আমন্ত্রণ লিঙ্কটি কখনও মেয়াদ শেষ হবে না।",
   "Your_password_is": "আপনার পাসওয়ার্ড হল",
   "Your_Password_Must_Have": "আপনার পাসওয়ার্ড থাকতে হবে:",
-  "Your_workspace": "আপনার ওয়ার্কস্পেস",
-  "Enable_Mobile_Ringing": "মোবাইল রিংিং সক্ষম করুন"
+  "Your_workspace": "আপনার ওয়ার্কস্পেস"
 }

--- a/app/i18n/locales/cs.json
+++ b/app/i18n/locales/cs.json
@@ -300,6 +300,7 @@
   "Enable_Auto_Translate": "Povolit automatický překlad",
   "Enable_encryption_button_label": "Povolit šifrování",
   "Enable_Message_Parser": "Povolit analyzátor zpráv",
+  "Enable_Mobile_Ringing": "Povolení vyzvánění na mobilním telefonu",
   "Enable_writing_in_room": "Povolit psaní v místnosti",
   "Enabled_E2E_Encryption_for_this_room": "povoleno E2E šifrování pro tuto místnost",
   "Encrypted": "Zašifrováno",
@@ -998,6 +999,5 @@
   "Your_password_is": "Vaše heslo je",
   "Your_Password_Must_Have": "Vaše heslo musí mít:",
   "Your_push_was_sent_to_s_devices": "Vaše push byla odeslána do {{s}} zařízení",
-  "Your_workspace": "Váš pracovní prostor",
-  "Enable_Mobile_Ringing": "Povolení vyzvánění na mobilním telefonu"
+  "Your_workspace": "Váš pracovní prostor"
 }

--- a/app/i18n/locales/cs.json
+++ b/app/i18n/locales/cs.json
@@ -998,5 +998,6 @@
   "Your_password_is": "Vaše heslo je",
   "Your_Password_Must_Have": "Vaše heslo musí mít:",
   "Your_push_was_sent_to_s_devices": "Vaše push byla odeslána do {{s}} zařízení",
-  "Your_workspace": "Váš pracovní prostor"
+  "Your_workspace": "Váš pracovní prostor",
+  "Enable_Mobile_Ringing": "Povolení vyzvánění na mobilním telefonu"
 }

--- a/app/i18n/locales/de.json
+++ b/app/i18n/locales/de.json
@@ -914,5 +914,6 @@
   "Your_invite_link_will_never_expire": "Ihr Einladungs-Link wird niemals ablaufen.",
   "Your_password_is": "Ihr Passwort lautet",
   "Your_Password_Must_Have": "Ihr Passwort muss:",
-  "Your_workspace": "Ihr Arbeitsbereich"
+  "Your_workspace": "Ihr Arbeitsbereich",
+  "Enable_Mobile_Ringing": "Mobiles Klingeln aktivieren"
 }

--- a/app/i18n/locales/de.json
+++ b/app/i18n/locales/de.json
@@ -277,6 +277,7 @@
   "Enable_Auto_Translate": "Automatische Übersetzung aktivieren",
   "Enable_encryption_button_label": "Verschlüsselung aktivieren",
   "Enable_Message_Parser": "Nachrichtenparser aktivieren",
+  "Enable_Mobile_Ringing": "Mobiles Klingeln aktivieren",
   "Enabled_E2E_Encryption_for_this_room": "hat E2E-Verschlüsselung für diesen Raum aktiviert",
   "Encrypted": "Verschlüsselt",
   "Encrypted_message": "Verschlüsselte Nachricht",
@@ -914,6 +915,5 @@
   "Your_invite_link_will_never_expire": "Ihr Einladungs-Link wird niemals ablaufen.",
   "Your_password_is": "Ihr Passwort lautet",
   "Your_Password_Must_Have": "Ihr Passwort muss:",
-  "Your_workspace": "Ihr Arbeitsbereich",
-  "Enable_Mobile_Ringing": "Mobiles Klingeln aktivieren"
+  "Your_workspace": "Ihr Arbeitsbereich"
 }

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -1027,5 +1027,6 @@
   "Your_invite_link_will_never_expire": "Your invite link will never expire.",
   "Your_password_is": "Your password is",
   "Your_Password_Must_Have": "Your password must have:",
-  "Your_push_was_sent_to_s_devices": "Your push was sent to {{s}} devices"
+  "Your_push_was_sent_to_s_devices": "Your push was sent to {{s}} devices",
+  "Enable_Mobile_Ringing": "Enable Mobile Ringing"
 }

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -313,7 +313,7 @@
   "Enable_encryption_description": "Ensure conversations are kept private",
   "Enable_encryption_title": "Enable encryption",
   "Enable_Message_Parser": "Enable message parser",
-  "Enable_Mobile_Ringing": "Enable mobile ringing",
+  "Enable_Mobile_Ringing": "Enable Mobile Ringing",
   "Enable_writing_in_room": "Enable writing in room",
   "Enabled": "Enabled",
   "Enabled_E2E_Encryption_for_this_room": "enabled E2E encryption for this room",
@@ -1028,6 +1028,5 @@
   "Your_invite_link_will_never_expire": "Your invite link will never expire.",
   "Your_password_is": "Your password is",
   "Your_Password_Must_Have": "Your password must have:",
-  "Your_push_was_sent_to_s_devices": "Your push was sent to {{s}} devices",
-  "Enable_Mobile_Ringing": "Enable Mobile Ringing"
+  "Your_push_was_sent_to_s_devices": "Your push was sent to {{s}} devices"
 }

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -313,6 +313,7 @@
   "Enable_encryption_description": "Ensure conversations are kept private",
   "Enable_encryption_title": "Enable encryption",
   "Enable_Message_Parser": "Enable message parser",
+  "Enable_Mobile_Ringing": "Enable mobile ringing",
   "Enable_writing_in_room": "Enable writing in room",
   "Enabled": "Enabled",
   "Enabled_E2E_Encryption_for_this_room": "enabled E2E encryption for this room",

--- a/app/i18n/locales/es.json
+++ b/app/i18n/locales/es.json
@@ -153,6 +153,7 @@
   "Emoji_selector": "Selector de emojis",
   "Enable_Auto_Translate": "Permitir Auto-Translate",
   "Enable_encryption_button_label": "Activar cifrado",
+  "Enable_Mobile_Ringing": "Habilitar timbrado móvil",
   "Encryption_error_desc": "No fue posible descifrar tu clave de cifrado.",
   "Encryption_error_title": "Contraseña incorrecta",
   "Enter_E2EE_Password_description": "Ingrese su contraseña E2EE para ver y enviar mensajes cifrados.\n\nLa contraseña debe ingresarse en cada dispositivo.",
@@ -483,6 +484,5 @@
   "you_were_mentioned": "has sido mencionado",
   "You_will_not_be_able_to_recover_this_message": "¡No podrás recuperar este mensaje!",
   "Your_certificate": "Tu certificado",
-  "Your_Password_Must_Have": "Su contraseña debe tener:",
-  "Enable_Mobile_Ringing": "Habilitar timbrado móvil"
+  "Your_Password_Must_Have": "Su contraseña debe tener:"
 }

--- a/app/i18n/locales/es.json
+++ b/app/i18n/locales/es.json
@@ -483,5 +483,6 @@
   "you_were_mentioned": "has sido mencionado",
   "You_will_not_be_able_to_recover_this_message": "¡No podrás recuperar este mensaje!",
   "Your_certificate": "Tu certificado",
-  "Your_Password_Must_Have": "Su contraseña debe tener:"
+  "Your_Password_Must_Have": "Su contraseña debe tener:",
+  "Enable_Mobile_Ringing": "Habilitar timbrado móvil"
 }

--- a/app/i18n/locales/fi.json
+++ b/app/i18n/locales/fi.json
@@ -262,6 +262,7 @@
   "Enable_Auto_Translate": "Ota käyttöön automaattikäännös",
   "Enable_encryption_button_label": "Ota salaus käyttöön",
   "Enable_Message_Parser": "Ota käyttöön viestin jäsentäjä",
+  "Enable_Mobile_Ringing": "Ota soittoääni käyttöön matkapuhelimessa",
   "Enabled_E2E_Encryption_for_this_room": "otti täyden salauksen käyttöön tässä huoneessa",
   "Encrypted": "Salattu",
   "Encrypted_message": "Salattu viesti",
@@ -886,6 +887,5 @@
   "Your_invite_link_will_never_expire": "Kutsulinkkisi ei vanhene.",
   "Your_password_is": "Salasanasi on",
   "Your_Password_Must_Have": "Salasanasi on oltava:",
-  "Your_workspace": "Työtilasi",
-  "Enable_Mobile_Ringing": "Ota soittoääni käyttöön matkapuhelimessa"
+  "Your_workspace": "Työtilasi"
 }

--- a/app/i18n/locales/fi.json
+++ b/app/i18n/locales/fi.json
@@ -886,5 +886,6 @@
   "Your_invite_link_will_never_expire": "Kutsulinkkisi ei vanhene.",
   "Your_password_is": "Salasanasi on",
   "Your_Password_Must_Have": "Salasanasi on oltava:",
-  "Your_workspace": "Työtilasi"
+  "Your_workspace": "Työtilasi",
+  "Enable_Mobile_Ringing": "Ota soittoääni käyttöön matkapuhelimessa"
 }

--- a/app/i18n/locales/fr.json
+++ b/app/i18n/locales/fr.json
@@ -230,6 +230,7 @@
   "Enable_Auto_Translate": "Activer la traduction automatique",
   "Enable_encryption_button_label": "Activer le chiffrement",
   "Enable_Message_Parser": "Activer le parseur de messages",
+  "Enable_Mobile_Ringing": "Activer la sonnerie mobile",
   "Encrypted": "Crypté",
   "Encrypted_message": "Message crypté",
   "encrypted_room_description": "Entrez votre mot de passe de cryptage de bout en bout pour accéder.",
@@ -807,6 +808,5 @@
   "Your_invite_link_will_never_expire": "Votre lien d'invitation n'expirera jamais.",
   "Your_password_is": "Votre mot de passe est",
   "Your_Password_Must_Have": "Votre mot de passe doit avoir:",
-  "Your_workspace": "Votre espace de travail",
-  "Enable_Mobile_Ringing": "Activer la sonnerie mobile"
+  "Your_workspace": "Votre espace de travail"
 }

--- a/app/i18n/locales/fr.json
+++ b/app/i18n/locales/fr.json
@@ -807,5 +807,6 @@
   "Your_invite_link_will_never_expire": "Votre lien d'invitation n'expirera jamais.",
   "Your_password_is": "Votre mot de passe est",
   "Your_Password_Must_Have": "Votre mot de passe doit avoir:",
-  "Your_workspace": "Votre espace de travail"
+  "Your_workspace": "Votre espace de travail",
+  "Enable_Mobile_Ringing": "Activer la sonnerie mobile"
 }

--- a/app/i18n/locales/hi-IN.json
+++ b/app/i18n/locales/hi-IN.json
@@ -282,6 +282,7 @@
   "Enable_Auto_Translate": "स्वच्छता से अनुवाद सक्षम करें",
   "Enable_encryption_button_label": "एन्क्रिप्शन सक्षम करें",
   "Enable_Message_Parser": "संदेश पार्सर सक्षम करें",
+  "Enable_Mobile_Ringing": "मोबाइल रिंगिंग सक्षम करें",
   "Enable_writing_in_room": "कमरे में लेखन सक्षम करें",
   "Enabled_E2E_Encryption_for_this_room": "इस कक्ष के लिए ईटूई एन्क्रिप्शन सक्षम किया गया है",
   "Encrypted": "एन्क्रिप्टेड",
@@ -924,6 +925,5 @@
   "Your_invite_link_will_never_expire": "आपका आमंत्रण लिंक कभी समाप्त नहीं होगा।",
   "Your_password_is": "आपका पासवर्ड है",
   "Your_Password_Must_Have": "आपका पासवर्ड होना चाहिए:",
-  "Your_workspace": "आपका कार्यस्थान",
-  "Enable_Mobile_Ringing": "मोबाइल रिंगिंग सक्षम करें"
+  "Your_workspace": "आपका कार्यस्थान"
 }

--- a/app/i18n/locales/hi-IN.json
+++ b/app/i18n/locales/hi-IN.json
@@ -924,5 +924,6 @@
   "Your_invite_link_will_never_expire": "आपका आमंत्रण लिंक कभी समाप्त नहीं होगा।",
   "Your_password_is": "आपका पासवर्ड है",
   "Your_Password_Must_Have": "आपका पासवर्ड होना चाहिए:",
-  "Your_workspace": "आपका कार्यस्थान"
+  "Your_workspace": "आपका कार्यस्थान",
+  "Enable_Mobile_Ringing": "मोबाइल रिंगिंग सक्षम करें"
 }

--- a/app/i18n/locales/hu.json
+++ b/app/i18n/locales/hu.json
@@ -927,5 +927,6 @@
   "Your_invite_link_will_never_expire": "A meghívási hivatkozása sosem jár le.",
   "Your_password_is": "A jelszava a következő",
   "Your_Password_Must_Have": "A jelszavának rendelkeznie kell:",
-  "Your_workspace": "Az Ön munkaterülete"
+  "Your_workspace": "Az Ön munkaterülete",
+  "Enable_Mobile_Ringing": "Mobilos csengés engedélyezése"
 }

--- a/app/i18n/locales/hu.json
+++ b/app/i18n/locales/hu.json
@@ -282,6 +282,7 @@
   "Enable_Auto_Translate": "Automatikus fordítás engedélyezése",
   "Enable_encryption_button_label": "A titkosítás engedélyezése",
   "Enable_Message_Parser": "Üzenetelemző engedélyezése",
+  "Enable_Mobile_Ringing": "Mobilos csengés engedélyezése",
   "Enable_writing_in_room": "Írás engedélyezése a szobában",
   "Enabled_E2E_Encryption_for_this_room": "E2E engedélyezve ennél a szobánál",
   "Encrypted": "Titkosítva",
@@ -927,6 +928,5 @@
   "Your_invite_link_will_never_expire": "A meghívási hivatkozása sosem jár le.",
   "Your_password_is": "A jelszava a következő",
   "Your_Password_Must_Have": "A jelszavának rendelkeznie kell:",
-  "Your_workspace": "Az Ön munkaterülete",
-  "Enable_Mobile_Ringing": "Mobilos csengés engedélyezése"
+  "Your_workspace": "Az Ön munkaterülete"
 }

--- a/app/i18n/locales/it.json
+++ b/app/i18n/locales/it.json
@@ -206,6 +206,7 @@
   "Emoji_selector": "Selettore di emoji",
   "Enable_Auto_Translate": "Abilita traduzione automatica",
   "Enable_encryption_button_label": "Abilita crittografia",
+  "Enable_Mobile_Ringing": "Abilita suoneria mobile",
   "Encrypted": "Crittografato",
   "Encrypted_message": "Messaggio crittografato",
   "encrypted_room_description": "Inserisci la tua password di crittografia end-to-end per accedere.",
@@ -710,6 +711,5 @@
   "Your_invite_link_will_never_expire": "Il tuo link di invito non scadrà mai.",
   "Your_password_is": "La tua password è",
   "Your_Password_Must_Have": "La tua password deve avere:",
-  "Your_workspace": "Il tuo workspace",
-  "Enable_Mobile_Ringing": "Abilita suoneria mobile"
+  "Your_workspace": "Il tuo workspace"
 }

--- a/app/i18n/locales/it.json
+++ b/app/i18n/locales/it.json
@@ -710,5 +710,6 @@
   "Your_invite_link_will_never_expire": "Il tuo link di invito non scadrà mai.",
   "Your_password_is": "La tua password è",
   "Your_Password_Must_Have": "La tua password deve avere:",
-  "Your_workspace": "Il tuo workspace"
+  "Your_workspace": "Il tuo workspace",
+  "Enable_Mobile_Ringing": "Abilita suoneria mobile"
 }

--- a/app/i18n/locales/ja.json
+++ b/app/i18n/locales/ja.json
@@ -581,5 +581,6 @@
   "Your_invite_link_will_expire_on__date__": "招待リンクは{{date}}に使用できなくなります。",
   "Your_invite_link_will_expire_on__date__or_after__usesLeft__uses": "招待リンクは{{date}}までか、あと{{usesLeft}}回で使用できなくなります。",
   "Your_invite_link_will_never_expire": "招待リンクはずっと有効です。",
-  "Your_Password_Must_Have": "パスワードには次のことが必要です。"
+  "Your_Password_Must_Have": "パスワードには次のことが必要です。",
+  "Enable_Mobile_Ringing": "モバイル着信音を有効にする"
 }

--- a/app/i18n/locales/ja.json
+++ b/app/i18n/locales/ja.json
@@ -181,6 +181,7 @@
   "Emoji_selector": "絵文字セレクター",
   "Enable_Auto_Translate": "自動翻訳を有効にする",
   "Enable_encryption_button_label": "暗号化を有効にする",
+  "Enable_Mobile_Ringing": "モバイル着信音を有効にする",
   "Encrypted": "暗号化済み",
   "Encrypted_message": "暗号化されたメッセージ",
   "encrypted_room_description": "エンドツーエンドの暗号化パスワードを入力してアクセスしてください。",
@@ -581,6 +582,5 @@
   "Your_invite_link_will_expire_on__date__": "招待リンクは{{date}}に使用できなくなります。",
   "Your_invite_link_will_expire_on__date__or_after__usesLeft__uses": "招待リンクは{{date}}までか、あと{{usesLeft}}回で使用できなくなります。",
   "Your_invite_link_will_never_expire": "招待リンクはずっと有効です。",
-  "Your_Password_Must_Have": "パスワードには次のことが必要です。",
-  "Enable_Mobile_Ringing": "モバイル着信音を有効にする"
+  "Your_Password_Must_Have": "パスワードには次のことが必要です。"
 }

--- a/app/i18n/locales/nl.json
+++ b/app/i18n/locales/nl.json
@@ -230,6 +230,7 @@
   "Enable_Auto_Translate": "Automatisch vertalen inschakelen",
   "Enable_encryption_button_label": "Versleuteling inschakelen",
   "Enable_Message_Parser": "Berichtparser inschakelen",
+  "Enable_Mobile_Ringing": "Mobiele beltoon inschakelen",
   "Encrypted": "Versleuteld",
   "Encrypted_message": "Versleuteld bericht",
   "encrypted_room_description": "Voer uw end-to-end encryptiewachtwoord in om toegang te krijgen.",
@@ -807,6 +808,5 @@
   "Your_invite_link_will_never_expire": "Je uitnodigingslink zal nooit verlopen.",
   "Your_password_is": "Jouw wachtwoord is",
   "Your_Password_Must_Have": "Uw wachtwoord moet hebben:",
-  "Your_workspace": "Jouw werkruimte",
-  "Enable_Mobile_Ringing": "Mobiele beltoon inschakelen"
+  "Your_workspace": "Jouw werkruimte"
 }

--- a/app/i18n/locales/nl.json
+++ b/app/i18n/locales/nl.json
@@ -807,5 +807,6 @@
   "Your_invite_link_will_never_expire": "Je uitnodigingslink zal nooit verlopen.",
   "Your_password_is": "Jouw wachtwoord is",
   "Your_Password_Must_Have": "Uw wachtwoord moet hebben:",
-  "Your_workspace": "Jouw werkruimte"
+  "Your_workspace": "Jouw werkruimte",
+  "Enable_Mobile_Ringing": "Mobiele beltoon inschakelen"
 }

--- a/app/i18n/locales/nn.json
+++ b/app/i18n/locales/nn.json
@@ -148,6 +148,7 @@
   "Enable_encryption_button_label": "Aktiver kryptering",
   "Enable_encryption_description": "Sørg for at samtaler holdes private",
   "Enable_encryption_title": "Aktiver kryptering",
+  "Enable_Mobile_Ringing": "Aktiver mobilring",
   "Enabled": "aktivert",
   "Encrypted": "Kryptert",
   "Encrypted_message": "Kryptert melding",
@@ -431,6 +432,5 @@
   "You_will_not_be_able_to_recover_this_message": "Du vil ikke kunne gjenopprette denne meldingen!",
   "Your_invite_link_will_expire_after__usesLeft__uses": "Invitasjonslenken din utløper etter {{usesLeft}} anvendelser.",
   "Your_invite_link_will_expire_on__date__": "Invitasjonslenken din utløper {{date}}.",
-  "Your_invite_link_will_expire_on__date__or_after__usesLeft__uses": "Invitasjonskoblingen din utløper {{date}} eller etter  {{usesLeft}} anvendelser.",
-  "Enable_Mobile_Ringing": "Aktiver mobilring"
+  "Your_invite_link_will_expire_on__date__or_after__usesLeft__uses": "Invitasjonskoblingen din utløper {{date}} eller etter  {{usesLeft}} anvendelser."
 }

--- a/app/i18n/locales/nn.json
+++ b/app/i18n/locales/nn.json
@@ -431,5 +431,6 @@
   "You_will_not_be_able_to_recover_this_message": "Du vil ikke kunne gjenopprette denne meldingen!",
   "Your_invite_link_will_expire_after__usesLeft__uses": "Invitasjonslenken din utløper etter {{usesLeft}} anvendelser.",
   "Your_invite_link_will_expire_on__date__": "Invitasjonslenken din utløper {{date}}.",
-  "Your_invite_link_will_expire_on__date__or_after__usesLeft__uses": "Invitasjonskoblingen din utløper {{date}} eller etter  {{usesLeft}} anvendelser."
+  "Your_invite_link_will_expire_on__date__or_after__usesLeft__uses": "Invitasjonskoblingen din utløper {{date}} eller etter  {{usesLeft}} anvendelser.",
+  "Enable_Mobile_Ringing": "Aktiver mobilring"
 }

--- a/app/i18n/locales/no.json
+++ b/app/i18n/locales/no.json
@@ -300,6 +300,7 @@
   "Enable_encryption_description": "Sørg for at samtaler holdes private",
   "Enable_encryption_title": "Aktiver kryptering",
   "Enable_Message_Parser": "Aktiver meldingsparser",
+  "Enable_Mobile_Ringing": "Aktiver mobilring",
   "Enable_writing_in_room": "Tillat skriving i rommet",
   "Enabled": "Aktivert",
   "Enabled_E2E_Encryption_for_this_room": "aktivert E2E-kryptering for dette rommet",
@@ -974,6 +975,5 @@
   "Your_password_is": "Passordet ditt er",
   "Your_Password_Must_Have": "Passordet ditt må inneholde:",
   "Your_push_was_sent_to_s_devices": "Din push ble sendt til {{s}} enheter",
-  "Your_workspace": "Arbeidsområdet ditt",
-  "Enable_Mobile_Ringing": "Aktiver mobilring"
+  "Your_workspace": "Arbeidsområdet ditt"
 }

--- a/app/i18n/locales/no.json
+++ b/app/i18n/locales/no.json
@@ -974,5 +974,6 @@
   "Your_password_is": "Passordet ditt er",
   "Your_Password_Must_Have": "Passordet ditt må inneholde:",
   "Your_push_was_sent_to_s_devices": "Din push ble sendt til {{s}} enheter",
-  "Your_workspace": "Arbeidsområdet ditt"
+  "Your_workspace": "Arbeidsområdet ditt",
+  "Enable_Mobile_Ringing": "Aktiver mobilring"
 }

--- a/app/i18n/locales/pt-BR.json
+++ b/app/i18n/locales/pt-BR.json
@@ -308,6 +308,7 @@
   "Enable_encryption_description": "Garante a privacidade das suas conversas",
   "Enable_encryption_title": "Habilitar criptografia",
   "Enable_Message_Parser": "Habilita analisador de mensagem",
+  "Enable_Mobile_Ringing": "Habilitar toque de chamada móvel",
   "Enable_writing_in_room": "Permitir escrita na sala",
   "Enabled": "Habilitado",
   "Enabled_E2E_Encryption_for_this_room": "habilitou criptografia para essa sala",
@@ -1011,6 +1012,5 @@
   "Your_password_is": "Sua senha é",
   "Your_Password_Must_Have": "Sua senha deve conter:",
   "Your_push_was_sent_to_s_devices": "A sua notificação foi enviada para {{s}} dispositivos",
-  "Your_workspace": "Sua workspace",
-  "Enable_Mobile_Ringing": "Habilitar toque de chamada móvel"
+  "Your_workspace": "Sua workspace"
 }

--- a/app/i18n/locales/pt-BR.json
+++ b/app/i18n/locales/pt-BR.json
@@ -1011,5 +1011,6 @@
   "Your_password_is": "Sua senha é",
   "Your_Password_Must_Have": "Sua senha deve conter:",
   "Your_push_was_sent_to_s_devices": "A sua notificação foi enviada para {{s}} dispositivos",
-  "Your_workspace": "Sua workspace"
+  "Your_workspace": "Sua workspace",
+  "Enable_Mobile_Ringing": "Habilitar toque de chamada móvel"
 }

--- a/app/i18n/locales/pt-PT.json
+++ b/app/i18n/locales/pt-PT.json
@@ -177,6 +177,7 @@
   "Emoji_selector": "Seletor de emojis",
   "Enable_Auto_Translate": "Activar Auto-Tradução",
   "Enable_encryption_button_label": "Ativar encriptação",
+  "Enable_Mobile_Ringing": "Ativar toque de chamada móvel",
   "Encrypted": "Encriptado",
   "Encrypted_message": "Mensagem encriptada",
   "encrypted_room_description": "Insira a sua palavra-passe de encriptação de ponta a ponta para aceder.",
@@ -542,6 +543,5 @@
   "You_dont_have_account": "Não tem uma conta?",
   "you_were_mentioned": "você foi mencionado",
   "You_will_not_be_able_to_recover_this_message": "Você será incapaz de recuperar esta mensagem!",
-  "Your_Password_Must_Have": "Sua palavra-passe deve ter:",
-  "Enable_Mobile_Ringing": "Ativar toque de chamada móvel"
+  "Your_Password_Must_Have": "Sua palavra-passe deve ter:"
 }

--- a/app/i18n/locales/pt-PT.json
+++ b/app/i18n/locales/pt-PT.json
@@ -542,5 +542,6 @@
   "You_dont_have_account": "Não tem uma conta?",
   "you_were_mentioned": "você foi mencionado",
   "You_will_not_be_able_to_recover_this_message": "Você será incapaz de recuperar esta mensagem!",
-  "Your_Password_Must_Have": "Sua palavra-passe deve ter:"
+  "Your_Password_Must_Have": "Sua palavra-passe deve ter:",
+  "Enable_Mobile_Ringing": "Ativar toque de chamada móvel"
 }

--- a/app/i18n/locales/ru.json
+++ b/app/i18n/locales/ru.json
@@ -854,5 +854,6 @@
   "Your_invite_link_will_never_expire": "Ваша ссылка-приглашение никогда не будет просроченной.",
   "Your_password_is": "Ваш пароль",
   "Your_Password_Must_Have": "Ваш пароль должен иметь:",
-  "Your_workspace": "Ваш сервер"
+  "Your_workspace": "Ваш сервер",
+  "Enable_Mobile_Ringing": "Включить звонок на мобильном устройстве"
 }

--- a/app/i18n/locales/ru.json
+++ b/app/i18n/locales/ru.json
@@ -254,6 +254,7 @@
   "Enable_Auto_Translate": "Включить автоперевод",
   "Enable_encryption_button_label": "Включить шифрование",
   "Enable_Message_Parser": "Включить парсер сообщений",
+  "Enable_Mobile_Ringing": "Включить звонок на мобильном устройстве",
   "Encrypted": "Зашифрован",
   "Encrypted_message": "Зашифрованное сообщение",
   "encrypted_room_description": "Введите свой пароль для шифрования от конца к концу для доступа.",
@@ -854,6 +855,5 @@
   "Your_invite_link_will_never_expire": "Ваша ссылка-приглашение никогда не будет просроченной.",
   "Your_password_is": "Ваш пароль",
   "Your_Password_Must_Have": "Ваш пароль должен иметь:",
-  "Your_workspace": "Ваш сервер",
-  "Enable_Mobile_Ringing": "Включить звонок на мобильном устройстве"
+  "Your_workspace": "Ваш сервер"
 }

--- a/app/i18n/locales/sl-SI.json
+++ b/app/i18n/locales/sl-SI.json
@@ -240,6 +240,7 @@
   "Enable_Auto_Translate": "Omogoči samodejni prenos",
   "Enable_encryption_button_label": "Omogoči šifriranje",
   "Enable_Message_Parser": "Omogoči razčlenjevalnik sporočil",
+  "Enable_Mobile_Ringing": "Omogoči mobilni zvonjenje",
   "Encrypted": "Šifrirano",
   "Encrypted_message": "Šifrirano sporočilo",
   "encrypted_room_description": "Vnesite geslo za šifriranje od konca do konca za dostop.",
@@ -822,6 +823,5 @@
   "Your_invite_link_will_never_expire": "Vaša povezava za povabilo ne bo nikoli potekala.",
   "Your_password_is": "Vaše geslo je",
   "Your_Password_Must_Have": "Vaše geslo mora imeti:",
-  "Your_workspace": "Vaš delovni prostor",
-  "Enable_Mobile_Ringing": "Omogoči mobilni zvonjenje"
+  "Your_workspace": "Vaš delovni prostor"
 }

--- a/app/i18n/locales/sl-SI.json
+++ b/app/i18n/locales/sl-SI.json
@@ -822,5 +822,6 @@
   "Your_invite_link_will_never_expire": "Vaša povezava za povabilo ne bo nikoli potekala.",
   "Your_password_is": "Vaše geslo je",
   "Your_Password_Must_Have": "Vaše geslo mora imeti:",
-  "Your_workspace": "Vaš delovni prostor"
+  "Your_workspace": "Vaš delovni prostor",
+  "Enable_Mobile_Ringing": "Omogoči mobilni zvonjenje"
 }

--- a/app/i18n/locales/sv.json
+++ b/app/i18n/locales/sv.json
@@ -884,5 +884,6 @@
   "Your_invite_link_will_never_expire": "Inbjudningslänken upphör aldrig att gälla.",
   "Your_password_is": "Ditt lösenord är",
   "Your_Password_Must_Have": "Ditt lösenord måste ha:",
-  "Your_workspace": "Din arbetsyta"
+  "Your_workspace": "Din arbetsyta",
+  "Enable_Mobile_Ringing": "Aktivera mobilsamtal"
 }

--- a/app/i18n/locales/sv.json
+++ b/app/i18n/locales/sv.json
@@ -262,6 +262,7 @@
   "Enable_Auto_Translate": "Aktivera automatisk översättning",
   "Enable_encryption_button_label": "Aktivera kryptering",
   "Enable_Message_Parser": "Aktivera meddelandetolken",
+  "Enable_Mobile_Ringing": "Aktivera mobilsamtal",
   "Enabled_E2E_Encryption_for_this_room": "aktivera E2E-kryptering för det här rummet",
   "Encrypted": "Krypterat",
   "Encrypted_message": "Krypterat meddelande",
@@ -884,6 +885,5 @@
   "Your_invite_link_will_never_expire": "Inbjudningslänken upphör aldrig att gälla.",
   "Your_password_is": "Ditt lösenord är",
   "Your_Password_Must_Have": "Ditt lösenord måste ha:",
-  "Your_workspace": "Din arbetsyta",
-  "Enable_Mobile_Ringing": "Aktivera mobilsamtal"
+  "Your_workspace": "Din arbetsyta"
 }

--- a/app/i18n/locales/ta-IN.json
+++ b/app/i18n/locales/ta-IN.json
@@ -924,5 +924,6 @@
   "Your_invite_link_will_never_expire": "உங்கள் அழைத்துக்கொள்ளும் இணைய கணக்கு எப்போதும் காலாவதியாகின்றதுமில்லை.",
   "Your_password_is": "உங்கள் கடவுச்சொல் உள்ளது",
   "Your_Password_Must_Have": "உங்கள் கடவுச்சொல் இருக்க வேண்டும்:",
-  "Your_workspace": "உங்கள் பணிகள்"
+  "Your_workspace": "உங்கள் பணிகள்",
+  "Enable_Mobile_Ringing": "மொபைல் ரிங்கிங்கை இயக்கவும்"
 }

--- a/app/i18n/locales/ta-IN.json
+++ b/app/i18n/locales/ta-IN.json
@@ -282,6 +282,7 @@
   "Enable_Auto_Translate": "தானாக மொழிபெயர்க்க அனுமதிக்கவும்",
   "Enable_encryption_button_label": "என்க்ரிப்ஷனை இயக்கு",
   "Enable_Message_Parser": "செய்தி பார்சரை இயக்கு",
+  "Enable_Mobile_Ringing": "மொபைல் ரிங்கிங்கை இயக்கவும்",
   "Enable_writing_in_room": "அறையில் எழுதலை இயக்கு",
   "Enabled_E2E_Encryption_for_this_room": "இந்த அறைக்கு E2E குறியீடு செயல்படுத்தப்பட்டுள்ளது",
   "Encrypted": "என்கிரிப்டு",
@@ -924,6 +925,5 @@
   "Your_invite_link_will_never_expire": "உங்கள் அழைத்துக்கொள்ளும் இணைய கணக்கு எப்போதும் காலாவதியாகின்றதுமில்லை.",
   "Your_password_is": "உங்கள் கடவுச்சொல் உள்ளது",
   "Your_Password_Must_Have": "உங்கள் கடவுச்சொல் இருக்க வேண்டும்:",
-  "Your_workspace": "உங்கள் பணிகள்",
-  "Enable_Mobile_Ringing": "மொபைல் ரிங்கிங்கை இயக்கவும்"
+  "Your_workspace": "உங்கள் பணிகள்"
 }

--- a/app/i18n/locales/te-IN.json
+++ b/app/i18n/locales/te-IN.json
@@ -281,6 +281,7 @@
   "Enable_Auto_Translate": "స్వయం-అనువదించడం అనుమతించండి",
   "Enable_encryption_button_label": "గూఢీకరణను ప్రారంభించు",
   "Enable_Message_Parser": "సందేశ పార్సర్‌ను సక్రియం చేయండి",
+  "Enable_Mobile_Ringing": "మోబైల్ రింగింగ్‌ను ఆన్ చేయండి",
   "Enable_writing_in_room": "{{roomName}}లో రచన అనుమతించండి",
   "Enabled_E2E_Encryption_for_this_room": "ఈ రూమ్‌కు E2E ఎన్క్రిప్షన్ ప్రారంభించబడింది",
   "Encrypted": "ఎన్క్రిప్టెడ్",
@@ -923,6 +924,5 @@
   "Your_invite_link_will_never_expire": "మీ ఆహ్వాన లింక్ ఎప్పుడూ కనబడదు.",
   "Your_password_is": "మీ సంకేతపదం",
   "Your_Password_Must_Have": "మీ పాస్‌వర్డ్ తప్పనిసరిగా ఉండాలి:",
-  "Your_workspace": "మీ వర్క్‌స్పేస్",
-  "Enable_Mobile_Ringing": "మోబైల్ రింగింగ్‌ను ఆన్ చేయండి"
+  "Your_workspace": "మీ వర్క్‌స్పేస్"
 }

--- a/app/i18n/locales/te-IN.json
+++ b/app/i18n/locales/te-IN.json
@@ -923,5 +923,6 @@
   "Your_invite_link_will_never_expire": "మీ ఆహ్వాన లింక్ ఎప్పుడూ కనబడదు.",
   "Your_password_is": "మీ సంకేతపదం",
   "Your_Password_Must_Have": "మీ పాస్‌వర్డ్ తప్పనిసరిగా ఉండాలి:",
-  "Your_workspace": "మీ వర్క్‌స్పేస్"
+  "Your_workspace": "మీ వర్క్‌స్పేస్",
+  "Enable_Mobile_Ringing": "మోబైల్ రింగింగ్‌ను ఆన్ చేయండి"
 }

--- a/app/i18n/locales/tr.json
+++ b/app/i18n/locales/tr.json
@@ -195,6 +195,7 @@
   "Emoji_selector": "Emoji seçici",
   "Enable_Auto_Translate": "Otomatik Çeviriyi Etkinleştir",
   "Enable_encryption_button_label": "Şifrelemeyi etkinleştir",
+  "Enable_Mobile_Ringing": "Mobil Çalma Sesi Etkinleştir",
   "Encrypted": "Şifreli",
   "Encrypted_message": "Şifreli ileti",
   "encrypted_room_description": "Erişmek için uçtan uca şifreleme şifrenizi girin.",
@@ -693,6 +694,5 @@
   "Your_invite_link_will_never_expire": "Davet bağlantınızın geçerlilik süresi asla dolmayacak.",
   "Your_password_is": "Şifreniz",
   "Your_Password_Must_Have": "Şifreniz:",
-  "Your_workspace": "Çalışma alanınız",
-  "Enable_Mobile_Ringing": "Mobil Çalma Sesi Etkinleştir"
+  "Your_workspace": "Çalışma alanınız"
 }

--- a/app/i18n/locales/tr.json
+++ b/app/i18n/locales/tr.json
@@ -693,5 +693,6 @@
   "Your_invite_link_will_never_expire": "Davet bağlantınızın geçerlilik süresi asla dolmayacak.",
   "Your_password_is": "Şifreniz",
   "Your_Password_Must_Have": "Şifreniz:",
-  "Your_workspace": "Çalışma alanınız"
+  "Your_workspace": "Çalışma alanınız",
+  "Enable_Mobile_Ringing": "Mobil Çalma Sesi Etkinleştir"
 }

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -653,5 +653,6 @@
   "Your_invite_link_will_never_expire": "您的邀请链接永久有效。",
   "Your_password_is": "您的密码",
   "Your_Password_Must_Have": "您的密码必须具有：",
-  "Your_workspace": "您的工作区"
+  "Your_workspace": "您的工作区",
+  "Enable_Mobile_Ringing": "启用移动来电铃声"
 }

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -191,6 +191,7 @@
   "Emoji_selector": "表情符号选择器",
   "Enable_Auto_Translate": "开启自动翻译",
   "Enable_encryption_button_label": "启用加密",
+  "Enable_Mobile_Ringing": "启用移动来电铃声",
   "Encrypted": "已加密",
   "Encrypted_message": "加密信息",
   "encrypted_room_description": "输入您的端到端加密密码以访问。",
@@ -653,6 +654,5 @@
   "Your_invite_link_will_never_expire": "您的邀请链接永久有效。",
   "Your_password_is": "您的密码",
   "Your_Password_Must_Have": "您的密码必须具有：",
-  "Your_workspace": "您的工作区",
-  "Enable_Mobile_Ringing": "启用移动来电铃声"
+  "Your_workspace": "您的工作区"
 }

--- a/app/i18n/locales/zh-TW.json
+++ b/app/i18n/locales/zh-TW.json
@@ -682,5 +682,6 @@
   "Your_invite_link_will_never_expire": "您的邀請連結永久有效。",
   "Your_password_is": "您的密碼",
   "Your_Password_Must_Have": "您的密碼必須具有：",
-  "Your_workspace": "您的工作區"
+  "Your_workspace": "您的工作區",
+  "Enable_Mobile_Ringing": "啟用行動來電鈴聲"
 }

--- a/app/i18n/locales/zh-TW.json
+++ b/app/i18n/locales/zh-TW.json
@@ -197,6 +197,7 @@
   "Emoji_selector": "表情符號選擇器",
   "Enable_Auto_Translate": "開啟自動翻譯",
   "Enable_encryption_button_label": "啟用加密",
+  "Enable_Mobile_Ringing": "啟用行動來電鈴聲",
   "Encrypted": "已加密",
   "Encrypted_message": "加密訊息",
   "encrypted_room_description": "輸入您的端對端加密密碼以存取。",
@@ -682,6 +683,5 @@
   "Your_invite_link_will_never_expire": "您的邀請連結永久有效。",
   "Your_password_is": "您的密碼",
   "Your_Password_Must_Have": "您的密碼必須具有：",
-  "Your_workspace": "您的工作區",
-  "Enable_Mobile_Ringing": "啟用行動來電鈴聲"
+  "Your_workspace": "您的工作區"
 }

--- a/app/views/UserPreferencesView/index.tsx
+++ b/app/views/UserPreferencesView/index.tsx
@@ -27,6 +27,7 @@ const UserPreferencesView = ({ navigation }: IUserPreferencesViewProps): JSX.Ele
 	const serverVersion = useAppSelector(state => state.server.version);
 	const dispatch = useDispatch();
 	const convertAsciiEmoji = settings?.preferences?.convertAsciiEmoji;
+	const enableMobileRinging = settings?.preferences?.enableMobileRinging;
 
 	useEffect(() => {
 		navigation.setOptions({
@@ -53,6 +54,15 @@ const UserPreferencesView = ({ navigation }: IUserPreferencesViewProps): JSX.Ele
 		try {
 			dispatch(setUser({ settings: { ...settings, preferences: { convertAsciiEmoji: value } } } as Partial<IUser>));
 			await saveUserPreferences({ convertAsciiEmoji: value });
+		} catch (e) {
+			log(e);
+		}
+	};
+
+	const toggleEnableMobileRinging = async (value: boolean) => {
+		try {
+			dispatch(setUser({ settings: { ...settings, preferences: { enableMobileRinging: value } } } as Partial<IUser>));
+			await saveUserPreferences({ enableMobileRinging: value });
 		} catch (e) {
 			log(e);
 		}
@@ -125,6 +135,22 @@ const UserPreferencesView = ({ navigation }: IUserPreferencesViewProps): JSX.Ele
 						onPress={() => toggleConvertAsciiToEmoji(!convertAsciiEmoji)}
 					/>
 					<List.Separator />
+					{compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '6.10.0') ? (
+						<>
+							<List.Item
+								title='Enable_Mobile_Ringing'
+								right={() => (
+									<Switch
+										value={enableMobileRinging}
+										onValueChange={toggleEnableMobileRinging}
+										testID='preferences-view-enable-mobile-ringing'
+									/>
+								)}
+								onPress={() => toggleEnableMobileRinging(!enableMobileRinging)}
+							/>
+							<List.Separator />
+						</>
+					) : null}
 				</List.Section>
 			</List.Container>
 		</SafeAreaView>


### PR DESCRIPTION
## Proposed changes

Adds an **Enable Mobile Ringing** toggle to `UserPreferencesView`, matching the web client. When enabled, incoming video conference calls ring the device like a phone call. Server-side enterprise kill switch (`VideoConf_Mobile_Ringing`) is enforced silently by the server; no client-side check needed for MVP.

- `INotificationPreferences`: adds optional `enableMobileRinging?: boolean`
- `UserPreferencesView`: adds version-gated (server >= 6.10.0) `Switch` wired to `saveUserPreferences()` + `dispatch(setUser(...))`, following the existing `convertAsciiEmoji` pattern
- `en.json`: adds `Enable_Mobile_Ringing` key

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-72

## How to test or reproduce

1. Connect to a Rocket.Chat server with version >= 6.10.0.
2. Go to **Profile → Preferences**.
3. Verify the **Enable Mobile Ringing** toggle is visible in the preferences section.
4. Toggle it on/off and verify `users.setPreferences` is called with `enableMobileRinging: <value>`.
5. Connect to a server < 6.10.0 and verify the toggle is NOT visible.

## Screenshots

N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Targets `feat.voip-lib-new` (not `develop`) since this stacks on the VoIP feature branch. MVP scope per ~/plans/enable-mobile-ringing/plan.md — no enterprise kill switch check (server enforces silently), no test additions (deferred).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile ringing option with localized labels in 25+ languages (including EN, ES, FR, DE, PT, RU, ZH, JA).
  * New user preference toggle for mobile ringing exposed in Preferences (visible when running server 6.10.0+); changes persist to user settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->