### PR TITLE
fix(voip): prevent duplicate ringtone on Android incoming call

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -7,8 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.graphics.drawable.GradientDrawable
-import android.media.Ringtone
-import android.media.RingtoneManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -31,6 +29,9 @@ import chat.rocket.reactnative.notification.Ejson
 /**
  * Full-screen Activity displayed when an incoming VoIP call arrives.
  * Shows on lock screen and handles user actions (Accept/Decline).
+ *
+ * Ring audio is owned by [VoipNotification]'s NotificationChannel — do not
+ * play a ringtone here; a second source would double-ring on most Android versions.
  */
 class IncomingCallActivity : Activity() {
 
@@ -38,7 +39,6 @@ class IncomingCallActivity : Activity() {
         private const val TAG = "RocketChat.IncomingCall"
     }
 
-    private var ringtone: Ringtone? = null
     private var voipPayload: VoipPayload? = null
     private var isCallStateReceiverRegistered = false
     private val timeoutHandler = Handler(Looper.getMainLooper())
@@ -51,7 +51,6 @@ class IncomingCallActivity : Activity() {
             }
 
             clearTimeout()
-            stopRingtone()
             finish()
         }
     }
@@ -97,7 +96,6 @@ class IncomingCallActivity : Activity() {
         Log.d(TAG, "IncomingCallActivity created - callId: ${voipPayload.callId}, caller: ${voipPayload.caller}")
 
         updateUI(voipPayload)
-        startRingtone()
         setupButtons(voipPayload)
         scheduleTimeout(voipPayload)
         val intentFilter = IntentFilter().apply {
@@ -225,27 +223,6 @@ class IncomingCallActivity : Activity() {
         }
     }
 
-    private fun startRingtone() {
-        try {
-            val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
-            ringtone = RingtoneManager.getRingtone(applicationContext, ringtoneUri)
-            ringtone?.play()
-            Log.d(TAG, "Ringtone started")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to start ringtone", e)
-        }
-    }
-
-    private fun stopRingtone() {
-        try {
-            ringtone?.stop()
-            ringtone = null
-            Log.d(TAG, "Ringtone stopped")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to stop ringtone", e)
-        }
-    }
-
     private fun setupButtons(payload: VoipPayload) {
         findViewById<LinearLayout>(R.id.btn_accept)?.setOnClickListener {
             handleAccept(payload)
@@ -259,14 +236,12 @@ class IncomingCallActivity : Activity() {
     private fun scheduleTimeout(payload: VoipPayload) {
         val remainingLifetimeMs = payload.getRemainingLifetimeMs()
         if (remainingLifetimeMs == null || remainingLifetimeMs <= 0L) {
-            stopRingtone()
             finish()
             return
         }
 
         clearTimeout()
         timeoutRunnable = Runnable {
-            stopRingtone()
             VoipNotification.handleTimeout(this, payload)
             finish()
         }.also { timeoutHandler.postDelayed(it, remainingLifetimeMs) }
@@ -281,7 +256,6 @@ class IncomingCallActivity : Activity() {
         Log.d(TAG, "Call accepted - callId: ${payload.callId}")
         clearTimeout()
         VoipNotification.cancelTimeout(payload.callId)
-        stopRingtone()
         VoipNotification.handleAcceptAction(this, payload)
         // Activity finishes when ACTION_DISMISS is broadcast from handleAcceptAction (async DDP).
     }
@@ -290,7 +264,6 @@ class IncomingCallActivity : Activity() {
         Log.d(TAG, "Call declined - callId: ${payload.callId}")
         clearTimeout()
         VoipNotification.cancelTimeout(payload.callId)
-        stopRingtone()
         VoipNotification.handleDeclineAction(this, payload)
 
         finish()
@@ -303,7 +276,6 @@ class IncomingCallActivity : Activity() {
             LocalBroadcastManager.getInstance(this).unregisterReceiver(callStateReceiver)
             isCallStateReceiverRegistered = false
         }
-        stopRingtone()
     }
 
     override fun onBackPressed() {

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -977,6 +977,7 @@ class VoipNotification(private val context: Context) {
             setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             setAutoCancel(false)
             setOngoing(true)
+            setOnlyAlertOnce(true)
             setTimeoutAfter(remainingLifetimeMs)
             addAction(0, "Decline", declinePendingIntent)
             addAction(0, "Accept", acceptPendingIntent)


### PR DESCRIPTION
## Proposed changes

Android VoIP pushes currently play **two concurrent ringtones** on incoming calls:

1. `NotificationChannel` (IMPORTANCE_HIGH + default ringtone URI + `USAGE_NOTIFICATION_RINGTONE`) — plays when the notification posts.
2. `IncomingCallActivity.startRingtone()` — plays `RingtoneManager.getDefaultUri(...)` via `Ringtone.play()` in `onCreate`.

Both fire simultaneously because the full-screen-intent notification posts and launches the activity in parallel, so the user hears overlapping / phasing audio.

This PR makes the `NotificationChannel` the **sole ring source** and adds `setOnlyAlertOnce(true)` as a safety net against same-`notificationId` reposts (e.g. FCM retries).

### Design rationale

- Channel-owned ring is the Google-recommended pattern for call-style full-screen-intent notifications (matches Signal / WhatsApp).
- Channel sound still plays even on OEMs (MIUI, etc.) that silently block full-screen-intent activity launches — so dropping the activity-side ring does **not** regress reliability; it actually improves it.
- Accept/decline/timeout paths already call `cancelById(notificationId)` on every exit, so cancelling the notification reliably stops the channel audio.
- Pre-Android-O (API 24/25) keeps its existing `builder.setSound(ringtoneUri)` path (NotificationChannel doesn't exist on pre-O) — single source preserved there as well.

### Files changed

- [IncomingCallActivity.kt](android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt): remove `startRingtone`/`stopRingtone` methods, the `ringtone` field, all 7 call sites, and the now-unused `Ringtone` / `RingtoneManager` imports. Add a class-header KDoc noting that ring audio is owned by `VoipNotification` to prevent accidental reintroduction.
- [VoipNotification.kt](android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt): add `setOnlyAlertOnce(true)` to the incoming-call `NotificationCompat.Builder`.

Full analysis + acceptance criteria + design options are in `~/plans/voip-android-duplicate-ring/plan.md` (local-only, not committed).

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-76

## How to test or reproduce

Before this PR (reproduction):

1. Trigger an incoming VoIP call to a device running `feat.voip-lib-new`.
2. Listen carefully — two ringtones overlap (audible phasing / echo). Record audio for clearer comparison.

After this PR (verification):

1. **Smoke — locked screen**: device locked → trigger VoIP push → single clean ringtone. Android 10, 12, 14.
2. **Smoke — unlocked background**: app backgrounded → push arrives → heads-up + FSI → single ring during transition.
3. **Smoke — unlocked foreground**: push arrives while app open → single ring via heads-up.
4. **Accept stops audio**: tap accept → ring cuts within ~300 ms.
5. **Decline stops audio**: tap decline → ring cuts immediately.
6. **Timeout stops audio**: let `remainingLifetimeMs` expire → ring cuts, notification cancelled.
7. **Duplicate FCM push (same callId)**: re-send identical push → no re-alert (thanks to `setOnlyAlertOnce(true)`).
8. **Busy-call guard regression**: push while already in a call → `rejectBusyCall` fires, no ring (pre-existing behavior).
9. **Pre-O emulator (API 24)**: verify ring still works via `builder.setSound`.

## Screenshots

Not applicable — audio-only change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes — Android-only change; local Kotlin compile could not run in this worktree (metro/symlink env issue). CI will verify. Recommend running `yarn lint` + `./gradlew :app:compileOfficialDebugKotlin` on a full checkout.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — No Kotlin unit tests exist in this repo. Requires manual on-device verification per "How to test" above.
- [ ] I have added necessary documentation (if applicable) — Added class-header KDoc in `IncomingCallActivity.kt`.
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The change is net **-27 lines** (31 deletions, 4 insertions). No new logic added — all of the real work is removing redundant code and relying on the already-wired NotificationChannel audio path. No API changes, no state changes, no new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incoming call audio alert handling to prevent duplicate ringtone sounds and vibrations when call notifications update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->