### PR TITLE
fix(voip): set explicit snaps for NewMediaCall bottom sheet

### DIFF
--- a/app/lib/hooks/useNewMediaCall/useNewMediaCall.tsx
+++ b/app/lib/hooks/useNewMediaCall/useNewMediaCall.tsx
@@ -19,7 +19,11 @@ export const useNewMediaCall = (rid?: string) => {
 			}
 		}
 		showActionSheetRef({
-			children: <NewMediaCall />
+			children: <NewMediaCall />,
+			portraitSnaps: ['60%'],
+			landscapeSnaps: ['90%'],
+			enableContentPanningGesture: false,
+			fullContainer: true
 		});
 	};
 

--- a/app/views/NewMessageView/Item.tsx
+++ b/app/views/NewMessageView/Item.tsx
@@ -29,7 +29,11 @@ const Item = ({ userId, name, username, onPress, testID, onLongPress }: IItem) =
 		if (!userId) return;
 		usePeerAutocompleteStore.getState().setSelectedPeer({ type: 'user', value: userId, label: name, username });
 		showActionSheetRef({
-			children: <NewMediaCall />
+			children: <NewMediaCall />,
+			portraitSnaps: ['60%'],
+			landscapeSnaps: ['90%'],
+			enableContentPanningGesture: false,
+			fullContainer: true
 		});
 	};
 


### PR DESCRIPTION
## Summary

- Add `portraitSnaps: ['60%']`, `landscapeSnaps: ['90%']`, `enableContentPanningGesture: false`, and `fullContainer: true` to both `showActionSheetRef` call sites for `NewMediaCall`
- Fixes the bottom sheet rendering at incorrect height, cutting off the "New call" title, helper text, and Call button
- Matches the existing `StartACallActionSheet` (VideoConf) pattern

## Changes

- `app/lib/hooks/useNewMediaCall/useNewMediaCall.tsx` — explicit snaps when opening from sidebar/room
- `app/views/NewMessageView/Item.tsx` — explicit snaps when opening from contact list

## Test plan

- [ ] Android: Open "New call" from sidebar — title, search, helper text, and Call button all visible
- [ ] Android: Select a peer — chip + enabled Call button visible
- [ ] Android: Rotate to landscape — sheet expands to ~90%
- [ ] iOS: Same checks as above
- [ ] Unit tests pass (`NewMediaCall|useNewMediaCall|Item` — 85 tests, 16 suites)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized media call interface display across different screen orientations
  * Enhanced gesture controls for improved interaction with media call dialogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->