### PR TITLE
fix(voip): ship blockers for PushKit, licensing, outbound calls, push tokens

### DIFF
--- a/app/containers/NewMediaCall/CreateCall.test.tsx
+++ b/app/containers/NewMediaCall/CreateCall.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 
 import { CreateCall } from './CreateCall';
@@ -99,7 +99,7 @@ describe('CreateCall', () => {
 		expect(button.props.accessibilityState?.disabled).toBe(false);
 	});
 
-	it('should call startCall with user type when user peer is selected and pressed', () => {
+	it('should call startCall with user type when user peer is selected and pressed', async () => {
 		setStoreState(userPeer);
 		const { getByTestId } = render(
 			<Wrapper>
@@ -107,13 +107,15 @@ describe('CreateCall', () => {
 			</Wrapper>
 		);
 
-		fireEvent.press(getByTestId('new-media-call-button'));
+		await act(async () => {
+			fireEvent.press(getByTestId('new-media-call-button'));
+		});
 		expect(mockStartCall).toHaveBeenCalledTimes(1);
 		expect(mockStartCall).toHaveBeenCalledWith('user-1', 'user');
 		expect(mockHideActionSheet).toHaveBeenCalledTimes(1);
 	});
 
-	it('should call startCall when SIP peer is selected and pressed', () => {
+	it('should call startCall when SIP peer is selected and pressed', async () => {
 		setStoreState(sipPeer);
 		const { getByTestId } = render(
 			<Wrapper>
@@ -121,7 +123,9 @@ describe('CreateCall', () => {
 			</Wrapper>
 		);
 
-		fireEvent.press(getByTestId('new-media-call-button'));
+		await act(async () => {
+			fireEvent.press(getByTestId('new-media-call-button'));
+		});
 		expect(mockStartCall).toHaveBeenCalledTimes(1);
 		expect(mockStartCall).toHaveBeenCalledWith('+5511999999999', 'sip');
 		expect(mockHideActionSheet).toHaveBeenCalledTimes(1);

--- a/app/containers/NewMediaCall/CreateCall.test.tsx
+++ b/app/containers/NewMediaCall/CreateCall.test.tsx
@@ -107,9 +107,8 @@ describe('CreateCall', () => {
 			</Wrapper>
 		);
 
-		await act(async () => {
-			fireEvent.press(getByTestId('new-media-call-button'));
-		});
+		fireEvent.press(getByTestId('new-media-call-button'));
+		await act(() => Promise.resolve());
 		expect(mockStartCall).toHaveBeenCalledTimes(1);
 		expect(mockStartCall).toHaveBeenCalledWith('user-1', 'user');
 		expect(mockHideActionSheet).toHaveBeenCalledTimes(1);
@@ -123,9 +122,8 @@ describe('CreateCall', () => {
 			</Wrapper>
 		);
 
-		await act(async () => {
-			fireEvent.press(getByTestId('new-media-call-button'));
-		});
+		fireEvent.press(getByTestId('new-media-call-button'));
+		await act(() => Promise.resolve());
 		expect(mockStartCall).toHaveBeenCalledTimes(1);
 		expect(mockStartCall).toHaveBeenCalledWith('+5511999999999', 'sip');
 		expect(mockHideActionSheet).toHaveBeenCalledTimes(1);

--- a/app/containers/NewMediaCall/CreateCall.tsx
+++ b/app/containers/NewMediaCall/CreateCall.tsx
@@ -7,6 +7,7 @@ import { CustomIcon } from '../CustomIcon';
 import { usePeerAutocompleteStore } from '../../lib/services/voip/usePeerAutocompleteStore';
 import { mediaSessionInstance } from '../../lib/services/voip/MediaSessionInstance';
 import { hideActionSheetRef } from '../ActionSheet';
+import { showErrorAlert } from '../../lib/methods/helpers/info';
 import sharedStyles from '../../views/Styles';
 
 export const CreateCall = () => {
@@ -14,13 +15,18 @@ export const CreateCall = () => {
 
 	const selectedPeer = usePeerAutocompleteStore(state => state.selectedPeer);
 
-	const handleCall = () => {
+	const handleCall = async () => {
 		if (!selectedPeer) {
 			return;
 		}
 
-		mediaSessionInstance.startCall(selectedPeer.value, selectedPeer.type);
-		hideActionSheetRef();
+		try {
+			await mediaSessionInstance.startCall(selectedPeer.value, selectedPeer.type);
+			hideActionSheetRef();
+		} catch (e) {
+			const message = e instanceof Error && e.message ? e.message : I18n.t('VoIP_Call_Issue');
+			showErrorAlert(message, I18n.t('Oops'));
+		}
 	};
 
 	const isCallDisabled = !selectedPeer;

--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -428,9 +428,8 @@ describe('VoIP call lifecycle (integration)', () => {
 		//   → session.startCall('user', 'user-1') [args reversed for SDK]
 		//   → mock fires 'newCall' → MediaSessionInstance handler
 		//   → useCallStore.setCall + Navigation.navigate('CallView')
-		await act(async () => {
-			fireEvent.press(getByTestId('new-media-call-button'));
-		});
+		fireEvent.press(getByTestId('new-media-call-button'));
+		await act(() => Promise.resolve());
 
 		expect(session.startCall).toHaveBeenCalledWith('user', 'user-1');
 		expect(Navigation.navigate).toHaveBeenCalledWith('CallView');

--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -413,7 +413,7 @@ describe('VoIP call lifecycle (integration)', () => {
 
 	// ── Outgoing calls (button press path) ───────────────────────────────────
 
-	it('user peer: press Call → startCall fires newCall → navigates to CallView', () => {
+	it('user peer: press Call → startCall fires newCall → navigates to CallView', async () => {
 		setSelectedPeer({ type: 'user', value: 'user-1', label: 'Alice', username: 'alice' });
 		const session = createdSessions[createdSessions.length - 1];
 
@@ -428,7 +428,9 @@ describe('VoIP call lifecycle (integration)', () => {
 		//   → session.startCall('user', 'user-1') [args reversed for SDK]
 		//   → mock fires 'newCall' → MediaSessionInstance handler
 		//   → useCallStore.setCall + Navigation.navigate('CallView')
-		fireEvent.press(getByTestId('new-media-call-button'));
+		await act(async () => {
+			fireEvent.press(getByTestId('new-media-call-button'));
+		});
 
 		expect(session.startCall).toHaveBeenCalledWith('user', 'user-1');
 		expect(Navigation.navigate).toHaveBeenCalledWith('CallView');

--- a/app/lib/methods/enterpriseModules.test.ts
+++ b/app/lib/methods/enterpriseModules.test.ts
@@ -12,6 +12,10 @@ describe('isVoipModuleAvailable', () => {
 		mockedStore.dispatch(clearEnterpriseModules());
 	});
 
+	it('returns false when enterpriseModules is empty', () => {
+		expect(isVoipModuleAvailable()).toBe(false);
+	});
+
 	it('returns false when teams-voip is absent', () => {
 		mockedStore.dispatch(setEnterpriseModules(['omnichannel-mobile-enterprise']));
 		expect(isVoipModuleAvailable()).toBe(false);

--- a/app/lib/methods/enterpriseModules.test.ts
+++ b/app/lib/methods/enterpriseModules.test.ts
@@ -1,0 +1,24 @@
+import { clearEnterpriseModules, setEnterpriseModules } from '../../actions/enterpriseModules';
+import { initStore } from '../store/auxStore';
+import { mockedStore } from '../../reducers/mockedStore';
+import { isVoipModuleAvailable } from './enterpriseModules';
+
+describe('isVoipModuleAvailable', () => {
+	beforeAll(() => {
+		initStore(mockedStore);
+	});
+
+	beforeEach(() => {
+		mockedStore.dispatch(clearEnterpriseModules());
+	});
+
+	it('returns false when teams-voip is absent', () => {
+		mockedStore.dispatch(setEnterpriseModules(['omnichannel-mobile-enterprise']));
+		expect(isVoipModuleAvailable()).toBe(false);
+	});
+
+	it('returns true when teams-voip is present', () => {
+		mockedStore.dispatch(setEnterpriseModules(['teams-voip']));
+		expect(isVoipModuleAvailable()).toBe(true);
+	});
+});

--- a/app/lib/methods/enterpriseModules.ts
+++ b/app/lib/methods/enterpriseModules.ts
@@ -63,6 +63,6 @@ export function isOmnichannelModuleAvailable() {
 }
 
 export function isVoipModuleAvailable() {
-	// const { enterpriseModules } = reduxStore.getState();
-	return true; // enterpriseModules.includes('teams-voip');
+	const { enterpriseModules } = reduxStore.getState();
+	return enterpriseModules.includes('teams-voip');
 }

--- a/app/lib/services/restApi.ts
+++ b/app/lib/services/restApi.ts
@@ -1095,11 +1095,6 @@ export const registerPushToken = async (): Promise<void> => {
 		return;
 	}
 
-	// TODO: voice permission check and retry to avoid race condition
-	if (isIOS && (!token || !voipToken)) {
-		return;
-	}
-
 	let data: TRegisterPushTokenData = {
 		id: await getUniqueId(),
 		value: '',

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -170,14 +170,16 @@ class MediaSessionInstance {
 		useCallStore.getState().setRoomId(room.rid ?? null);
 		const otherUserId = getUidDirectMessage(room);
 		if (otherUserId) {
-			this.startCall(otherUserId, 'user');
+			this.startCall(otherUserId, 'user').catch(error => {
+				console.error('[VoIP] Error starting call from room:', error);
+			});
 		}
 	};
 
 	public startCall = async (userId: string, actor: CallActorType): Promise<void> => {
 		requestPhoneStatePermission();
 		console.log('[VoIP] Starting call:', userId);
-		await Promise.resolve(this.instance?.startCall(actor, userId));
+		await this.instance?.startCall(actor, userId);
 	};
 
 	public endCall = (callId: string) => {

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -174,10 +174,10 @@ class MediaSessionInstance {
 		}
 	};
 
-	public startCall = (userId: string, actor: CallActorType) => {
+	public startCall = async (userId: string, actor: CallActorType): Promise<void> => {
 		requestPhoneStatePermission();
 		console.log('[VoIP] Starting call:', userId);
-		this.instance?.startCall(actor, userId);
+		await Promise.resolve(this.instance?.startCall(actor, userId));
 	};
 
 	public endCall = (callId: string) => {

--- a/ios/Libraries/AppDelegate+Voip.swift
+++ b/ios/Libraries/AppDelegate+Voip.swift
@@ -86,8 +86,7 @@ extension AppDelegate: PKPushRegistryDelegate {
       handle: caller,
       localizedCallerName: caller,
       payload: payloadDict,
-      onReportComplete: {}
+      onReportComplete: { completion() }
     )
-    completion()
   }
 }

--- a/ios/Libraries/AppDelegate+Voip.swift
+++ b/ios/Libraries/AppDelegate+Voip.swift
@@ -2,6 +2,30 @@ import PushKit
 
 fileprivate let voipAppDelegateLogTag = "RocketChat.AppDelegate+Voip"
 
+/// Shared CallKit reporting for VoIP PushKit payloads (`handle` and `localizedCallerName` may differ; often both are the caller display name).
+fileprivate func reportVoipIncomingCallToCallKit(
+  callUUID: String,
+  handle: String,
+  localizedCallerName: String,
+  payload: [AnyHashable: Any],
+  onReportComplete: @escaping () -> Void
+) {
+  RNCallKeep.reportNewIncomingCall(
+    callUUID,
+    handle: handle,
+    handleType: "generic",
+    hasVideo: false,
+    localizedCallerName: localizedCallerName,
+    supportsHolding: true,
+    supportsDTMF: true,
+    supportsGrouping: false,
+    supportsUngrouping: false,
+    fromPushKit: true,
+    payload: payload,
+    withCompletionHandler: onReportComplete
+  )
+}
+
 // MARK: - PKPushRegistryDelegate
 
 extension AppDelegate: PKPushRegistryDelegate {
@@ -22,11 +46,26 @@ extension AppDelegate: PKPushRegistryDelegate {
   public func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
     let payloadDict = payload.dictionaryPayload
 
+    /// PushKit requires reporting to CallKit before `completion()`. For expired or unparseable payloads,
+    /// report a short-lived incoming call and end it so the system is not left without a CallKit update.
+    let reportPlaceholderCallAndEnd: (_ callUUID: String, _ displayName: String) -> Void = { callUUID, displayName in
+      reportVoipIncomingCallToCallKit(
+        callUUID: callUUID,
+        handle: displayName,
+        localizedCallerName: displayName,
+        payload: payloadDict,
+        onReportComplete: {
+          RNCallKeep.endCall(withUUID: callUUID, reason: 1)
+          completion()
+        }
+      )
+    }
+
     guard let voipPayload = VoipPayload.fromDictionary(payloadDict) else {
       #if DEBUG
       print("[\(voipAppDelegateLogTag)] Failed to parse incoming VoIP payload: \(payloadDict)")
       #endif
-      completion()
+      reportPlaceholderCallAndEnd(UUID().uuidString, "Rocket.Chat")
       return
     }
 
@@ -36,25 +75,18 @@ extension AppDelegate: PKPushRegistryDelegate {
       #if DEBUG
       print("[\(voipAppDelegateLogTag)] Skipping expired or invalid VoIP payload for callId: \(callId): \(voipPayload)")
       #endif
-      completion()
+      reportPlaceholderCallAndEnd(callId, caller)
       return
     }
 
     VoipService.prepareIncomingCall(voipPayload, storeEventsForJs: true)
 
-    RNCallKeep.reportNewIncomingCall(
-      callId,
+    reportVoipIncomingCallToCallKit(
+      callUUID: callId,
       handle: caller,
-      handleType: "generic",
-      hasVideo: false,
       localizedCallerName: caller,
-      supportsHolding: true,
-      supportsDTMF: true,
-      supportsGrouping: false,
-      supportsUngrouping: false,
-      fromPushKit: true,
       payload: payloadDict,
-      withCompletionHandler: {}
+      onReportComplete: {}
     )
     completion()
   }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

This change set lands the first slice of the VoIP hardening plan (pre–PR #6918 ship blockers).

- **iOS PushKit**: invalid or expired VoIP payloads now report a placeholder call to CallKit and end it immediately, preserving PushKit's entitlement contract. The happy path routes the PushKit `completion()` through CallKit's `reportNewIncomingCall` completion handler so PushKit is only marked done after CallKit has been notified (per Apple's iOS 13+ PushKit docs). A shared helper in `AppDelegate+Voip.swift` removes duplicated CallKit reporting.
- **Enterprise licensing**: the `teams-voip` module check is restored so VoIP stays gated by licensing. Unit tests cover `isVoipModuleAvailable` for present/absent/empty module lists.
- **Outbound calls (new-media call sheet)**: `startCall` is now awaited, failures surface via `showErrorAlert`, and the action sheet only dismisses on success. In `MediaSessionInstance`, `startCall` propagates the SDK's native `Promise<void>` (no redundant `Promise.resolve` wrap) and the fire-and-forget caller `startCallByRoom` attaches a `.catch` handler so rejections do not leak as unhandled promise rejections.
- **iOS push token registration**: `registerPushToken` no longer short-circuits when the VoIP token is missing on iOS, while still sending both tokens together when VoIP is available.

## Issue(s)

<!-- Note for AI: don't fill this section, it's for the human reviewer to fill. -->

## How to test or reproduce

- iOS: exercise PushKit with an expired or malformed VoIP payload; confirm CallKit briefly shows then ends and the app does not skip CallKit reporting. Verify `completion()` fires only after CallKit accepts the report on the happy path as well.
- Enterprise: with Redux modules excluding `teams-voip`, confirm VoIP entry points respect licensing; with `teams-voip` present, confirm VoIP remains available; with modules empty/cleared, confirm VoIP is unavailable.
- New media call: start a call from the action sheet; on failure (e.g. mocked rejection), confirm an error alert and that the sheet stays open; on success, confirm the sheet dismisses.
- `startCallByRoom` rejections: mock the SDK `startCall` to reject and confirm the error is logged without becoming an unhandled rejection.
- iOS push: on a simulator or device without a VoIP token, confirm `push.token` still registers when APNs token exists; after VoIP token arrives, confirm a follow-up registration includes both fields.
- Run `TZ=UTC yarn test --testPathPattern='enterpriseModules.test|MediaSessionInstance.test'`.

## Screenshots

N/A (behavioral and platform fixes).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Split from the VoIP review plan; targets `develop` as requested. No native project file edits beyond Swift in `ios/Libraries/`. Review follow-ups applied in this branch: PushKit `completion()` ordering on the happy path (CodeRabbit), `Promise.resolve` ceremony removed, `startCallByRoom` unhandled-rejection guard, and an additional empty-modules regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when initiating calls with user-friendly alerts.
  * Fixed VoIP availability check to respect configured modules.
  * Enhanced iOS VoIP push handling for more reliable incoming-call reporting.
  * Optimized iOS push token registration to correctly handle notification and VoIP tokens.

* **Refactor**
  * Call-start flow updated to handle async failures more robustly.

* **Tests**
  * Added and updated tests to validate VoIP availability and call-start behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->