### PR TITLE
fix(voip): Android DDP thread safety and VoipPayload bundle parity

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,6 +155,7 @@ dependencies {
     implementation 'androidx.security:security-crypto:1.1.0'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.14.1'
 
     // For ProcessLifecycleOwner (app foreground detection)
     implementation 'androidx.lifecycle:lifecycle-process:2.8.7'

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -11,6 +11,7 @@ import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class DDPClient {
     private data class QueuedMethodCall(
@@ -28,13 +29,20 @@ class DDPClient {
 
     private var webSocket: WebSocket? = null
     private val client: OkHttpClient = sharedClient
-    private var sendCounter = 0
+    private val sendCounter = AtomicInteger(0)
+
+    @Volatile
     private var isConnected = false
+
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val pendingCallbacks = mutableMapOf<String, (JSONObject) -> Unit>()
     private val queuedMethodCalls = mutableListOf<QueuedMethodCall>()
+
+    @Volatile
     private var connectedCallback: ((Boolean) -> Unit)? = null
+
+    private var connectTimeoutRunnable: Runnable? = null
 
     var onCollectionMessage: ((JSONObject) -> Unit)? = null
 
@@ -66,7 +74,11 @@ class DDPClient {
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                 Log.e(TAG, "WebSocket failure: ${t.message}")
                 isConnected = false
-                mainHandler.post { callback(false) }
+                mainHandler.post {
+                    cancelConnectTimeout()
+                    connectedCallback = null
+                    callback(false)
+                }
             }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
@@ -134,6 +146,7 @@ class DDPClient {
     fun disconnect() {
         Log.d(TAG, "Disconnecting")
         isConnected = false
+        cancelConnectTimeout()
         synchronized(pendingCallbacks) { pendingCallbacks.clear() }
         clearQueuedMethodCalls()
         connectedCallback = null
@@ -143,10 +156,10 @@ class DDPClient {
     }
 
     private fun nextMessage(msg: String): JSONObject {
-        sendCounter++
+        val nextId = sendCounter.incrementAndGet()
         return JSONObject().apply {
             put("msg", msg)
-            put("id", "ddp-$sendCounter")
+            put("id", "ddp-$nextId")
         }
     }
 
@@ -213,12 +226,21 @@ class DDPClient {
 
     private fun waitForConnected(timeoutMs: Long, callback: (Boolean) -> Unit) {
         connectedCallback = callback
-        mainHandler.postDelayed({
-            val cb = connectedCallback ?: return@postDelayed
+        cancelConnectTimeout()
+        val runnable = Runnable {
+            connectTimeoutRunnable = null
+            val cb = connectedCallback ?: return@Runnable
             connectedCallback = null
             Log.e(TAG, "Connect timeout")
             cb(false)
-        }, timeoutMs)
+        }
+        connectTimeoutRunnable = runnable
+        mainHandler.postDelayed(runnable, timeoutMs)
+    }
+
+    private fun cancelConnectTimeout() {
+        connectTimeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        connectTimeoutRunnable = null
     }
 
     private fun handleMessage(text: String) {
@@ -231,7 +253,7 @@ class DDPClient {
         when (json.optString("msg")) {
             "connected" -> {
                 isConnected = true
-                mainHandler.removeCallbacksAndMessages(null)
+                cancelConnectTimeout()
                 val cb = connectedCallback
                 connectedCallback = null
                 cb?.let { mainHandler.post { it(true) } }
@@ -300,5 +322,13 @@ class DDPClient {
 
         val scheme = if (useSsl) "wss" else "ws"
         return "$scheme://$normalizedHost/websocket"
+    }
+
+    internal fun testStartConnectTimeout(timeoutMs: Long, callback: (Boolean) -> Unit) {
+        waitForConnected(timeoutMs, callback)
+    }
+
+    internal fun testDeliverRawMessage(text: String) {
+        handleMessage(text)
     }
 }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -11,6 +11,7 @@ import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class DDPClient {
@@ -42,11 +43,16 @@ class DDPClient {
     @Volatile
     private var connectedCallback: ((Boolean) -> Unit)? = null
 
+    @Volatile
     private var connectTimeoutRunnable: Runnable? = null
+
+    private val connectResultDelivered = AtomicBoolean(false)
 
     var onCollectionMessage: ((JSONObject) -> Unit)? = null
 
     fun connect(host: String, callback: (Boolean) -> Unit) {
+        resetConnectHandshakeState()
+
         val wsUrl = buildWebSocketURL(host)
 
         Log.d(TAG, "Connecting to $wsUrl")
@@ -75,9 +81,7 @@ class DDPClient {
                 Log.e(TAG, "WebSocket failure: ${t.message}")
                 isConnected = false
                 mainHandler.post {
-                    cancelConnectTimeout()
-                    connectedCallback = null
-                    callback(false)
+                    tryDeliverConnectOutcome(false)
                 }
             }
 
@@ -150,6 +154,7 @@ class DDPClient {
         synchronized(pendingCallbacks) { pendingCallbacks.clear() }
         clearQueuedMethodCalls()
         connectedCallback = null
+        connectResultDelivered.set(false)
         onCollectionMessage = null
         webSocket?.close(1000, null)
         webSocket = null
@@ -224,15 +229,36 @@ class DDPClient {
         }
     }
 
+    private fun resetConnectHandshakeState() {
+        connectResultDelivered.set(false)
+    }
+
+    /**
+     * Delivers at most one outcome for the WebSocket connect handshake ([connect] callback).
+     * Uses [AtomicBoolean] so [onFailure], the connect-timeout runnable, and `"connected"` cannot
+     * all report conflicting results.
+     */
+    private fun tryDeliverConnectOutcome(success: Boolean, connectTimeout: Boolean = false) {
+        if (!connectResultDelivered.compareAndSet(false, true)) {
+            return
+        }
+        cancelConnectTimeout()
+        val cb = connectedCallback
+        connectedCallback = null
+        if (connectTimeout) {
+            Log.e(TAG, "Connect timeout")
+        }
+        mainHandler.post {
+            cb?.invoke(success)
+        }
+    }
+
     private fun waitForConnected(timeoutMs: Long, callback: (Boolean) -> Unit) {
         connectedCallback = callback
         cancelConnectTimeout()
         val runnable = Runnable {
             connectTimeoutRunnable = null
-            val cb = connectedCallback ?: return@Runnable
-            connectedCallback = null
-            Log.e(TAG, "Connect timeout")
-            cb(false)
+            tryDeliverConnectOutcome(false, connectTimeout = true)
         }
         connectTimeoutRunnable = runnable
         mainHandler.postDelayed(runnable, timeoutMs)
@@ -253,10 +279,7 @@ class DDPClient {
         when (json.optString("msg")) {
             "connected" -> {
                 isConnected = true
-                cancelConnectTimeout()
-                val cb = connectedCallback
-                connectedCallback = null
-                cb?.let { mainHandler.post { it(true) } }
+                tryDeliverConnectOutcome(true)
             }
 
             "ping" -> {
@@ -325,6 +348,7 @@ class DDPClient {
     }
 
     internal fun testStartConnectTimeout(timeoutMs: Long, callback: (Boolean) -> Unit) {
+        resetConnectHandshakeState()
         waitForConnected(timeoutMs, callback)
     }
 

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -83,6 +83,11 @@ class DDPClient {
                 Log.e(TAG, "WebSocket failure: ${t.message}")
                 isConnected = false
                 mainHandler.post {
+                    // Re-check identity on main thread: disconnect()+connect() can interleave
+                    // between the outer guard (OkHttp thread) and this runnable's execution.
+                    // Without this re-check, a stale failure can hijack a newly installed
+                    // connectedCallback via the CAS in tryDeliverConnectOutcome.
+                    if (webSocket !== this@DDPClient.webSocket) return@post
                     tryDeliverConnectOutcome(false)
                 }
             }
@@ -358,7 +363,14 @@ class DDPClient {
         handleMessage(text)
     }
 
-    internal fun testDeliverConnectFailure() {
-        mainHandler.post { tryDeliverConnectOutcome(false) }
+    internal fun testDeliverConnectFailure(fromWebSocket: WebSocket? = null) {
+        mainHandler.post {
+            if (fromWebSocket != null && fromWebSocket !== this@DDPClient.webSocket) return@post
+            tryDeliverConnectOutcome(false)
+        }
+    }
+
+    internal fun testSetActiveWebSocket(ws: WebSocket?) {
+        this.webSocket = ws
     }
 }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -74,10 +74,12 @@ class DDPClient {
             }
 
             override fun onMessage(webSocket: WebSocket, text: String) {
+                if (webSocket !== this@DDPClient.webSocket) return
                 handleMessage(text)
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                if (webSocket !== this@DDPClient.webSocket) return
                 Log.e(TAG, "WebSocket failure: ${t.message}")
                 isConnected = false
                 mainHandler.post {
@@ -86,6 +88,7 @@ class DDPClient {
             }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                if (webSocket !== this@DDPClient.webSocket) return
                 Log.d(TAG, "WebSocket closed: $code $reason")
                 isConnected = false
             }
@@ -154,7 +157,6 @@ class DDPClient {
         synchronized(pendingCallbacks) { pendingCallbacks.clear() }
         clearQueuedMethodCalls()
         connectedCallback = null
-        connectResultDelivered.set(false)
         onCollectionMessage = null
         webSocket?.close(1000, null)
         webSocket = null
@@ -354,5 +356,9 @@ class DDPClient {
 
     internal fun testDeliverRawMessage(text: String) {
         handleMessage(text)
+    }
+
+    internal fun testDeliverConnectFailure() {
+        mainHandler.post { tryDeliverConnectOutcome(false) }
     }
 }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
@@ -20,6 +20,8 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
         private const val EVENT_VOIP_ACCEPT_FAILED = "VoipAcceptFailed"
 
         private var reactContextRef: WeakReference<ReactApplicationContext>? = null
+
+        @Volatile
         private var initialEventsData: VoipPayload? = null
 
         /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
@@ -2,11 +2,11 @@ package chat.rocket.reactnative.voip
 
 import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
-import java.lang.ref.WeakReference
 import chat.rocket.reactnative.networking.NativeVoipSpec
+import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Native module to expose VoIP call data to JavaScript.
@@ -21,8 +21,7 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
 
         private var reactContextRef: WeakReference<ReactApplicationContext>? = null
 
-        @Volatile
-        private var initialEventsData: VoipPayload? = null
+        private val initialEventsData = AtomicReference<VoipPayload?>(null)
 
         /**
          * Sets the React context reference for event emission.
@@ -56,7 +55,7 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
          */
         @JvmStatic
         fun storeInitialEvents(voipPayload: VoipPayload) {
-            initialEventsData = voipPayload
+            initialEventsData.set(voipPayload)
             emitInitialEventsEvent(voipPayload)
         }
 
@@ -66,7 +65,7 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
         @JvmStatic
         fun storeAcceptFailureForJs(payload: VoipPayload) {
             val failed = payload.copy(voipAcceptFailed = true)
-            initialEventsData = failed
+            initialEventsData.set(failed)
             emitVoipAcceptFailedEvent(failed)
         }
 
@@ -87,7 +86,7 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
         @JvmStatic
         fun clearInitialEventsInternal() {
             try {
-                initialEventsData = null
+                initialEventsData.set(null)
                 Log.d(TAG, "Cleared initial events")
             } catch (e: Exception) {
                 Log.e(TAG, "Error clearing initial events", e)
@@ -105,18 +104,22 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
      * Returns null if no initial events.
      */
     override fun getInitialEvents(): WritableMap? {
-        val data = initialEventsData ?: return null
+        while (true) {
+            val data = initialEventsData.get() ?: return null
 
-        if (data.isExpired()) {
-            Log.d(TAG, "Discarding expired VoIP initial event: ${data.callId}")
-            clearInitialEventsInternal()
-            return null
+            if (data.isExpired()) {
+                Log.d(TAG, "Discarding expired VoIP initial event: ${data.callId}")
+                if (initialEventsData.compareAndSet(data, null)) {
+                    return null
+                }
+                continue
+            }
+
+            val result = data.toWritableMap()
+            if (initialEventsData.compareAndSet(data, null)) {
+                return result
+            }
         }
-
-        val result = data.toWritableMap()
-        clearInitialEventsInternal()
-        
-        return result
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipPayload.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipPayload.kt
@@ -72,6 +72,7 @@ data class VoipPayload(
             putString("avatarUrl", avatarUrl)
             putString("createdAt", createdAt)
             putInt("notificationId", notificationId)
+            putBoolean("voipAcceptFailed", voipAcceptFailed)
             // Useful flag for MainActivity to know it's handling a VoIP action
             putBoolean("voipAction", true)
         }

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
@@ -70,4 +70,49 @@ class DDPClientTest {
         Shadows.shadowOf(Looper.getMainLooper()).idle()
         assertEquals(listOf(true), outcomes)
     }
+
+    @Test
+    fun `connection failure delivers false exactly once`() {
+        val client = DDPClient()
+        val outcomes = mutableListOf<Boolean>()
+        val looper = Shadows.shadowOf(Looper.getMainLooper())
+
+        client.testStartConnectTimeout(10_000) { outcomes.add(it) }
+        client.testDeliverConnectFailure()
+        looper.idle()
+
+        assertEquals(listOf(false), outcomes)
+
+        // duplicate failure must not re-deliver
+        client.testDeliverConnectFailure()
+        looper.idle()
+        assertEquals(listOf(false), outcomes)
+    }
+
+    @Test
+    fun `stale failure after completed connect and disconnect is a no-op`() {
+        // Regression: disconnect() previously reset connectResultDelivered, allowing a late
+        // onFailure from the old socket to win the CAS and invoke a newly installed callback.
+        // Fix: remove the reset from disconnect(); the stale-listener guard in onFailure()
+        // is the primary defence, but keeping delivered=true also protects the window before
+        // a new connect() rearms the state.
+        val client = DDPClient()
+        val outcomes = mutableListOf<Boolean>()
+        val looper = Shadows.shadowOf(Looper.getMainLooper())
+
+        client.testStartConnectTimeout(10_000) { outcomes.add(it) }
+        client.testDeliverRawMessage("""{"msg":"connected"}""")
+        looper.idle()
+        assertEquals(listOf(true), outcomes)
+
+        // disconnect — must NOT reset connectResultDelivered
+        client.disconnect()
+
+        // stale failure from old socket arrives before any new connect arms a callback
+        client.testDeliverConnectFailure()
+        looper.idle()
+
+        // delivered was still true → CAS fails → no spurious false
+        assertEquals(listOf(true), outcomes)
+    }
 }

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
@@ -1,0 +1,61 @@
+package chat.rocket.reactnative.voip
+
+import android.os.Handler
+import android.os.Looper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class DDPClientTest {
+
+    @Test
+    fun `connected before connect timeout invokes callback exactly once`() {
+        val client = DDPClient()
+        val outcomes = mutableListOf<Boolean>()
+        client.testStartConnectTimeout(10_000) { outcomes.add(it) }
+        client.testDeliverRawMessage("""{"msg":"connected"}""")
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(listOf(true), outcomes)
+
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(11_000, TimeUnit.MILLISECONDS)
+        assertEquals(listOf(true), outcomes)
+    }
+
+    @Test
+    fun `cancelling connect timeout preserves other mainHandler runnables`() {
+        val client = DDPClient()
+        val looper = Shadows.shadowOf(Looper.getMainLooper())
+        val connectOutcomes = mutableListOf<Boolean>()
+
+        var secondaryFired = false
+        Handler(Looper.getMainLooper()).postDelayed({ secondaryFired = true }, 15_000)
+
+        client.testStartConnectTimeout(10_000) { connectOutcomes.add(it) }
+        client.testDeliverRawMessage("""{"msg":"connected"}""")
+        looper.idle()
+
+        assertEquals(listOf(true), connectOutcomes)
+        assertFalse(secondaryFired)
+
+        looper.idleFor(20_000, TimeUnit.MILLISECONDS)
+        assertTrue(secondaryFired)
+    }
+
+    @Test
+    fun `connect timeout without connected posts false once`() {
+        val client = DDPClient()
+        val outcomes = mutableListOf<Boolean>()
+        client.testStartConnectTimeout(5_000) { outcomes.add(it) }
+        Shadows.shadowOf(Looper.getMainLooper()).idleFor(6_000, TimeUnit.MILLISECONDS)
+        assertEquals(listOf(false), outcomes)
+    }
+}

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
@@ -58,4 +58,16 @@ class DDPClientTest {
         Shadows.shadowOf(Looper.getMainLooper()).idleFor(6_000, TimeUnit.MILLISECONDS)
         assertEquals(listOf(false), outcomes)
     }
+
+    @Test
+    fun `duplicate connected messages invoke handshake callback once`() {
+        val client = DDPClient()
+        val outcomes = mutableListOf<Boolean>()
+        client.testStartConnectTimeout(10_000) { outcomes.add(it) }
+        client.testDeliverRawMessage("""{"msg":"connected"}""")
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        client.testDeliverRawMessage("""{"msg":"connected"}""")
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(listOf(true), outcomes)
+    }
 }

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
@@ -2,6 +2,9 @@ package chat.rocket.reactnative.voip
 
 import android.os.Handler
 import android.os.Looper
+import okhttp3.Request
+import okhttp3.WebSocket
+import okio.ByteString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -11,6 +14,15 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import java.util.concurrent.TimeUnit
+
+private class StubWebSocket : WebSocket {
+    override fun request(): Request = Request.Builder().url("wss://example.com").build()
+    override fun queueSize(): Long = 0
+    override fun send(text: String): Boolean = true
+    override fun send(bytes: ByteString): Boolean = true
+    override fun close(code: Int, reason: String?): Boolean = true
+    override fun cancel() {}
+}
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28])
@@ -90,12 +102,10 @@ class DDPClientTest {
     }
 
     @Test
-    fun `stale failure after completed connect and disconnect is a no-op`() {
-        // Regression: disconnect() previously reset connectResultDelivered, allowing a late
-        // onFailure from the old socket to win the CAS and invoke a newly installed callback.
-        // Fix: remove the reset from disconnect(); the stale-listener guard in onFailure()
-        // is the primary defence, but keeping delivered=true also protects the window before
-        // a new connect() rearms the state.
+    fun `stale failure after completed connect and disconnect is a no-op when no reconnect armed`() {
+        // CAS-gate case: disconnect() no longer resets connectResultDelivered, so a late
+        // failure arriving before any new connect() loses the CAS (delivered is still true
+        // from the completed handshake).
         val client = DDPClient()
         val outcomes = mutableListOf<Boolean>()
         val looper = Shadows.shadowOf(Looper.getMainLooper())
@@ -114,5 +124,47 @@ class DDPClientTest {
 
         // delivered was still true → CAS fails → no spurious false
         assertEquals(listOf(true), outcomes)
+    }
+
+    @Test
+    fun `stale failure during reconnect window does not hijack new callback`() {
+        // Real-hijack-vector regression: L1 onFailure queues a main-thread runnable while L1
+        // is still current. Before the runnable executes, user disconnects and reconnects.
+        // connect2 calls resetConnectHandshakeState() (delivered=false) and installs cb2.
+        // Without the re-check inside the main-handler post, the stale runnable would win
+        // the CAS and hijack cb2 with false. The inner identity check in onFailure's post
+        // must reject the stale failure.
+        val client = DDPClient()
+        val oldSocket = StubWebSocket()
+        val newSocket = StubWebSocket()
+        val cb1Outcomes = mutableListOf<Boolean>()
+        val cb2Outcomes = mutableListOf<Boolean>()
+        val looper = Shadows.shadowOf(Looper.getMainLooper())
+
+        // connect1 with oldSocket succeeds
+        client.testSetActiveWebSocket(oldSocket)
+        client.testStartConnectTimeout(10_000) { cb1Outcomes.add(it) }
+        client.testDeliverRawMessage("""{"msg":"connected"}""")
+        looper.idle()
+        assertEquals(listOf(true), cb1Outcomes)
+
+        // Simulate onFailure from oldSocket queuing a failure runnable
+        // (outer guard passed; runnable is now on main handler awaiting execution)
+        client.testDeliverConnectFailure(oldSocket)
+
+        // Before the runnable runs: quick disconnect + reconnect
+        client.disconnect()
+        client.testSetActiveWebSocket(newSocket)
+        client.testStartConnectTimeout(10_000) { cb2Outcomes.add(it) }
+
+        // Flush the queued stale failure
+        looper.idle()
+
+        // cb2 must NOT receive a spurious false — the inner identity check must reject
+        assertEquals(emptyList<Boolean>(), cb2Outcomes)
+
+        // connect2's own timeout still fires normally
+        looper.idleFor(11_000, TimeUnit.MILLISECONDS)
+        assertEquals(listOf(false), cb2Outcomes)
     }
 }

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/VoipPayloadBundleTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/VoipPayloadBundleTest.kt
@@ -1,0 +1,61 @@
+package chat.rocket.reactnative.voip
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class VoipPayloadBundleTest {
+
+    @Test
+    fun `toBundle includes voipAcceptFailed for process death round trip`() {
+        val createdAt = "2026-01-01T00:00:00.000Z"
+        val payload = VoipPayload(
+            callId = "call-1",
+            caller = "Caller",
+            username = "user1",
+            host = "https://example.com",
+            type = VoipPushType.INCOMING_CALL.value,
+            hostName = "Example",
+            avatarUrl = null,
+            createdAt = createdAt,
+            voipAcceptFailed = true,
+        )
+
+        val bundle = payload.toBundle()
+        assertTrue(bundle.containsKey("voipAcceptFailed"))
+        assertTrue(bundle.getBoolean("voipAcceptFailed", false))
+
+        val restored = VoipPayload.fromBundle(bundle)
+        assertNotNull(restored)
+        assertTrue(restored!!.voipAcceptFailed)
+    }
+
+    @Test
+    fun `toBundle round trips voipAcceptFailed false`() {
+        val createdAt = "2026-01-01T00:00:00.000Z"
+        val payload = VoipPayload(
+            callId = "call-2",
+            caller = "Caller",
+            username = "user1",
+            host = "https://example.com",
+            type = VoipPushType.INCOMING_CALL.value,
+            hostName = "Example",
+            avatarUrl = null,
+            createdAt = createdAt,
+            voipAcceptFailed = false,
+        )
+
+        val bundle = payload.toBundle()
+        assertFalse(bundle.getBoolean("voipAcceptFailed", true))
+
+        val restored = VoipPayload.fromBundle(bundle)
+        assertNotNull(restored)
+        assertFalse(restored!!.voipAcceptFailed)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Android VoIP DDP and cold-start payload hardening (split-plan **PR 2**):

- **`DDPClient`**: use `AtomicInteger` for DDP message ids; mark `isConnected` and `connectedCallback` `@Volatile` for visibility across OkHttp and main-thread handlers.
- **Connect timeout**: track a single `Runnable` for the connect timeout and remove only that callback instead of `removeCallbacksAndMessages(null)`, so unrelated `Handler` work is not cleared. Cancel that timeout on `connected`, `disconnect()`, and WebSocket `onFailure`.
- **Stale-listener guard**: `onMessage`, `onFailure`, and `onClosed` now bail early when the `WebSocket` parameter does not match the current active socket (`webSocket !== this@DDPClient.webSocket`). Prevents a closed socket's late OkHttp callbacks from hijacking a newly installed `connectedCallback` via a CAS win after reconnect.
- **`disconnect()` no longer resets `connectResultDelivered`**: `connect()` already rearms the flag via `resetConnectHandshakeState()`; the extra reset in `disconnect()` narrowed the stale-listener guard window unnecessarily.
- **`VoipPayload.toBundle()`**: include `voipAcceptFailed` so process-death / bundle restore matches `fromBundle()` and `toWritableMap()`.
- **`VoipModule`**: `@Volatile` on companion `initialEventsData` for cross-thread visibility.
- **Tests**: Robolectric unit tests for connect-timeout vs `connected` ordering, `voipAcceptFailed` bundle round-trip, connection failure delivery (previously untested `onFailure` path), and stale-failure no-op regression lock.

## Issue(s)

<!-- Link the issues being closed by or related to this PR. -->

## How to test or reproduce

From repo root after `yarn`:

```bash
cd android && ./gradlew :app:testOfficialDebugUnitTest --tests "chat.rocket.reactnative.voip.DDPClientTest" --tests "chat.rocket.reactnative.voip.VoipPayloadBundleTest"
```

Or run all VoIP JVM unit tests:

```bash
cd android && ./gradlew :app:testOfficialDebugUnitTest --tests "chat.rocket.reactnative.voip.*"
```

## Screenshots

N/A (native concurrency and serialization only).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Draft PR: branch `pr2-android-ddp-thread-safety`. Base branch is `feat.voip-lib-new`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve VoIP reliability: ensure handshake callback fires at most once, robustly handle timeouts and stale socket events, and make initial event handling and message sending concurrency-safe.
  * Include accept-failure flag in VoIP payload serialization for reliable process-recovery.

* **Tests**
  * Add Android unit tests covering handshake timing, duplicate/late messages, timeout cancellation, stale-failure regressions, and payload bundle round-trips.

* **Chores**
  * Enable Robolectric-based Android unit testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->