### PR TITLE
fix(ios): serialize VoipService bridge statics

### DIFF
--- a/ios/Libraries/VoipService.swift
+++ b/ios/Libraries/VoipService.swift
@@ -6,6 +6,12 @@ import PushKit
  * VoipModuleSwift - Swift implementation for VoIP push notifications and initial events data.
  * This class provides static methods called by VoipModule.mm (the TurboModule bridge).
  *
+ * Threading:
+ * - `lastVoipToken` and `initialEventsData` are synchronized on `bridgeStateQueue` because they are
+ *   written on the main thread (PushKit, native call flows) and read from the React Native bridge thread.
+ * - **All other static state is main-thread-only** (PushKit registry on `.main`, `CXCallObserver` on
+ *   `.main`, and `trackIncomingCall` / `clearTrackedIncomingCall` already bounce work to main where needed).
+ *
  * This module:
  * - Manages PushKit VoIP registration
  * - Tracks VoIP push tokens
@@ -28,7 +34,9 @@ public final class VoipService: NSObject {
     private static let TAG = "RocketChat.VoipService"
     private static let voipTokenStorageKey = "RCVoipPushToken"
     private static let storage = MMKVBridge.build()
-    
+    /// Serializes access to `lastVoipToken` and `initialEventsData` (main-thread writers vs RN bridge readers).
+    private static let bridgeStateQueue = DispatchQueue(label: "chat.rocket.ios.voipService.bridgeState")
+
     // MARK: - Static Properties
     
     private static var initialEventsData: VoipPayload?
@@ -67,7 +75,8 @@ public final class VoipService: NSObject {
     public static func voipRegistration() {
         if isVoipRegistered {
             #if DEBUG
-            print("[\(TAG)] voipRegistration already registered. Returning lastVoipToken: \(lastVoipToken)")
+            let tokenSnapshot = bridgeStateQueue.sync { lastVoipToken }
+            print("[\(TAG)] voipRegistration already registered. Returning lastVoipToken: \(tokenSnapshot)")
             #endif
             return
         }
@@ -100,14 +109,21 @@ public final class VoipService: NSObject {
         // Convert token data to hex string
         let token = credentials.token.map { String(format: "%02x", $0) }.joined()
 
-        if lastVoipToken == token {
+        let tokenUnchanged = bridgeStateQueue.sync { () -> Bool in
+            if lastVoipToken == token {
+                return true
+            }
+            lastVoipToken = token
+            return false
+        }
+
+        if tokenUnchanged {
             #if DEBUG
             print("[\(TAG)] VoIP token unchanged")
             #endif
             return
         }
 
-        lastVoipToken = token
         persistVoipToken(token)
         
         #if DEBUG
@@ -126,7 +142,9 @@ public final class VoipService: NSObject {
     // TODO: remove voip token from all logged in workspaces, since they share the same token
     @objc
     public static func invalidatePushToken() {
-        lastVoipToken = ""
+        bridgeStateQueue.sync {
+            lastVoipToken = ""
+        }
         storage.removeValue(forKey: voipTokenStorageKey)
 
         #if DEBUG
@@ -161,39 +179,45 @@ public final class VoipService: NSObject {
     /// Stores initial events for JS to retrieve.
     @objc
     public static func storeInitialEvents(_ payload: VoipPayload) {
-        initialEventsData = payload
-        
-        #if DEBUG
-        print("[\(TAG)] Stored initial events: \(payload.callId)")
-        #endif
+        bridgeStateQueue.sync {
+            initialEventsData = payload
+
+            #if DEBUG
+            print("[\(TAG)] Stored initial events: \(payload.callId)")
+            #endif
+        }
     }
 
     /// Gets any initial events. Returns nil if no initial events.
     @objc
     public static func getInitialEvents() -> [String: Any]? {
-        guard let data = initialEventsData else {
-            return nil
+        bridgeStateQueue.sync {
+            guard let data = initialEventsData else {
+                return nil
+            }
+
+            if data.isExpired() {
+                clearInitialEventsUnlocked()
+                return nil
+            }
+
+            let result = data.toDictionary()
+            clearInitialEventsUnlocked()
+
+            return result
         }
-        
-        if data.isExpired() {
-            clearInitialEventsInternal()
-            return nil
-        }
-        
-        let result = data.toDictionary()
-        clearInitialEventsInternal()
-        
-        return result
     }
-    
+
     /// Clears any initial events
     @objc
     public static func clearInitialEvents() {
-        clearInitialEventsInternal()
+        bridgeStateQueue.sync {
+            clearInitialEventsUnlocked()
+        }
     }
-    
-    /// Clears initial events (internal)
-    private static func clearInitialEventsInternal() {
+
+    /// Clears initial events. Caller must already be running on `bridgeStateQueue`.
+    private static func clearInitialEventsUnlocked() {
         initialEventsData = nil
         #if DEBUG
         print("[\(TAG)] Cleared initial events")
@@ -205,10 +229,12 @@ public final class VoipService: NSObject {
     /// Returns the last registered VoIP token
     @objc
     public static func getLastVoipToken() -> String {
-        if lastVoipToken.isEmpty {
-            lastVoipToken = loadPersistedVoipToken()
+        bridgeStateQueue.sync {
+            if lastVoipToken.isEmpty {
+                lastVoipToken = loadPersistedVoipToken()
+            }
+            return lastVoipToken
         }
-        return lastVoipToken
     }
 
     private static func loadPersistedVoipToken() -> String {
@@ -502,8 +528,10 @@ public final class VoipService: NSObject {
         cancelIncomingCallTimeout(for: payload.callId)
         clearTrackedIncomingCall(for: payload.callUUID)
 
-        if initialEventsData?.callId == payload.callId {
-            clearInitialEventsInternal()
+        bridgeStateQueue.sync {
+            if initialEventsData?.callId == payload.callId {
+                clearInitialEventsUnlocked()
+            }
         }
 
         // End the just-reported CallKit call immediately (reason 2 = unanswered / declined).

--- a/ios/Libraries/VoipService.swift
+++ b/ios/Libraries/VoipService.swift
@@ -229,9 +229,14 @@ public final class VoipService: NSObject {
     /// Returns the last registered VoIP token
     @objc
     public static func getLastVoipToken() -> String {
-        bridgeStateQueue.sync {
+        let current = bridgeStateQueue.sync { lastVoipToken }
+        if !current.isEmpty {
+            return current
+        }
+        let persisted = loadPersistedVoipToken()
+        return bridgeStateQueue.sync {
             if lastVoipToken.isEmpty {
-                lastVoipToken = loadPersistedVoipToken()
+                lastVoipToken = persisted
             }
             return lastVoipToken
         }


### PR DESCRIPTION
## Proposed changes

In `ios/Libraries/VoipService.swift`, add a private serial `DispatchQueue` and route every read and write of **`lastVoipToken`** and **`initialEventsData`** through it so PushKit / main-thread updates cannot race the native module when JavaScript reads the last token or consumes initial incoming-call payload data.

Concretely:

- **`lastVoipToken`:** token comparison, in-memory update, and the early-return path for an unchanged token all happen inside one `sync` block on that queue; `invalidatePushToken` clears the in-memory value on the same queue; `getLastVoipToken` reloads from MMKV when empty and returns the value under the same queue. MMKV disk I/O is hoisted **outside** the critical section so a slow read cannot block main-thread token updates; the second `sync` block re-checks `lastVoipToken.isEmpty` to stay correct under concurrent reloaders.
- **`initialEventsData`:** `storeInitialEvents`, `getInitialEvents` (including expire / serialize / clear), `clearInitialEvents`, and the matching branch in `rejectBusyCall` all use the queue. Internal clearing uses **`clearInitialEventsUnlocked()`** so nothing calls `sync` on the same queue while already inside a `sync` block (avoids deadlock).

The file-level comment at the top of `VoipService.swift` explains which fields use the queue and states that the rest of the class's static state is still treated as main-thread-only by design—this PR does **not** add locks for those other fields.

**Explicitly out of scope here:** wiring an XCTest target or Thread Sanitizer CI for those races; Android or TypeScript changes; any change to unrelated VoIP statics. Follow-ups for tests and hardening are listed in local planning notes (`future.md` in the VoIP PR review folder).

## Issue(s)

<!-- For maintainers: link related issues if any. -->

## How to test or reproduce

- iOS: register for VoIP, confirm the token still reaches JavaScript and incoming-call / initial-events flows still work (`storeInitialEvents`, `getInitialEvents`, busy reject if you exercise that path).
- Optional: run under Thread Sanitizer while refreshing the token and reading it from the bridge.

## Screenshots

Not applicable (native concurrency fix only).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Base branch: `feat.voip-lib-new`. No dependency on other split-plan items beyond this file.

Rebased onto `feat.voip-lib-new` tip. CodeRabbit nit applied: MMKV read hoisted out of `getLastVoipToken` critical section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread safety and synchronization in VOIP push token and event data handling to prevent potential race conditions and improve service stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->