### PR TITLE
fix(voip): Phone account creation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -138,7 +138,7 @@
             android:label="Wazo"
             android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
             android:exported="true"
-            android:foregroundServiceType="microphone"
+            android:foregroundServiceType="microphone|phoneCall"
             >
             <intent-filter>
                 <action android:name="android.telecom.ConnectionService" />

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -674,8 +674,10 @@ class VoipNotification(private val context: Context) {
                     return
                 }
 
-            // Build the PhoneAccountHandle using the same (ComponentName, appName) pair that
-            // react-native-callkeep uses so JS-side and native-side accounts collide.
+            // Build the PhoneAccountHandle using the same (ComponentName, packageName) pair
+            // that react-native-callkeep uses (see patches/react-native-callkeep+4.3.16.patch)
+            // so the JS-side and native-side PhoneAccount registrations share one handle.
+            // The ID must be locale-stable; the localized label is only used for display below.
             val componentName = ComponentName(context.packageName, CALLKEEP_CONNECTION_SERVICE_CLASS)
             val phoneAccountHandle = PhoneAccountHandle(componentName, context.packageName)
 

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -663,8 +663,8 @@ class VoipNotification(private val context: Context) {
     private fun registerCallWithTelecomManager(callId: String, caller: String) {
         try {
             // Validate inputs
-            if (callId.isNullOrEmpty() || caller.isNullOrEmpty()) {
-                Log.e(TAG, "Cannot register call with TelecomManager: callId is null or empty")
+            if (callId.isEmpty() || caller.isEmpty()) {
+                Log.e(TAG, "Cannot register call with TelecomManager: callId='$callId' caller='$caller' — empty values rejected")
                 return
             }
 
@@ -677,13 +677,12 @@ class VoipNotification(private val context: Context) {
             // Build the PhoneAccountHandle using the same (ComponentName, appName) pair that
             // react-native-callkeep uses so JS-side and native-side accounts collide.
             val componentName = ComponentName(context.packageName, CALLKEEP_CONNECTION_SERVICE_CLASS)
-            val appName = getApplicationLabel()
-            val phoneAccountHandle = PhoneAccountHandle(componentName, appName)
+            val phoneAccountHandle = PhoneAccountHandle(componentName, context.packageName)
 
             // Ensure the self-managed PhoneAccount is registered. FCM pushes can arrive before
             // JS boots and calls RNCallKeep.setup, so we must register from native too.
             // registerPhoneAccount is idempotent for the same handle.
-            ensureSelfManagedPhoneAccountRegistered(telecomManager, phoneAccountHandle, appName)
+            ensureSelfManagedPhoneAccountRegistered(telecomManager, phoneAccountHandle, getApplicationLabel())
 
             // Create extras for the incoming call
             val extras = Bundle().apply {

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -674,17 +674,16 @@ class VoipNotification(private val context: Context) {
                     return
                 }
 
-            // Get react-native-callkeep's PhoneAccountHandle
+            // Build the PhoneAccountHandle using the same (ComponentName, appName) pair that
+            // react-native-callkeep uses so JS-side and native-side accounts collide.
             val componentName = ComponentName(context.packageName, CALLKEEP_CONNECTION_SERVICE_CLASS)
-            // react-native-callkeep typically uses the app package name as the account ID
-            val phoneAccountHandle = PhoneAccountHandle(componentName, context.packageName)
+            val appName = getApplicationLabel()
+            val phoneAccountHandle = PhoneAccountHandle(componentName, appName)
 
-            // Check if PhoneAccount is registered
-            val phoneAccount = telecomManager.getPhoneAccount(phoneAccountHandle)
-            if (phoneAccount == null) {
-                Log.w(TAG, "PhoneAccount not registered by react-native-callkeep yet. Call may not have full OS integration.")
-                return
-            }
+            // Ensure the self-managed PhoneAccount is registered. FCM pushes can arrive before
+            // JS boots and calls RNCallKeep.setup, so we must register from native too.
+            // registerPhoneAccount is idempotent for the same handle.
+            ensureSelfManagedPhoneAccountRegistered(telecomManager, phoneAccountHandle, appName)
 
             // Create extras for the incoming call
             val extras = Bundle().apply {
@@ -702,9 +701,34 @@ class VoipNotification(private val context: Context) {
             telecomManager.addNewIncomingCall(phoneAccountHandle, extras)
             Log.d(TAG, "Successfully registered incoming call with TelecomManager: $callId")
         } catch (e: SecurityException) {
-            Log.e(TAG, "SecurityException registering call with TelecomManager. MANAGE_OWN_CALLS permission may be missing.", e)
+            Log.e(TAG, "SecurityException registering call with TelecomManager. Check MANAGE_OWN_CALLS/READ_PHONE_STATE grants and PhoneAccount registration.", e)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to register call with TelecomManager", e)
+        }
+    }
+
+    private fun getApplicationLabel(): String {
+        val applicationInfo = context.applicationInfo
+        val stringId = applicationInfo.labelRes
+        return if (stringId == 0) applicationInfo.nonLocalizedLabel?.toString() ?: context.packageName
+        else context.getString(stringId)
+    }
+
+    private fun ensureSelfManagedPhoneAccountRegistered(
+        telecomManager: TelecomManager,
+        handle: PhoneAccountHandle,
+        label: String
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        try {
+            val account = PhoneAccount.builder(handle, label)
+                .setCapabilities(PhoneAccount.CAPABILITY_SELF_MANAGED)
+                .build()
+            telecomManager.registerPhoneAccount(account)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "SecurityException registering PhoneAccount. MANAGE_OWN_CALLS may be denied.", e)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to register self-managed PhoneAccount", e)
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
 		"@types/ejson": "^2.1.3",
 		"@types/i18n-js": "3.8.3",
 		"@types/invariant": "2.2.37",
-		"@types/jest": "^29.5.14",
+		"@types/jest": "29.5.14",
 		"@types/jsrsasign": "^10.5.8",
 		"@types/lodash": "^4.14.188",
 		"@types/react": "~19.1.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
 		"@types/ejson": "^2.1.3",
 		"@types/i18n-js": "3.8.3",
 		"@types/invariant": "2.2.37",
-		"@types/jest": "^29.5.13",
+		"@types/jest": "^29.5.14",
 		"@types/jsrsasign": "^10.5.8",
 		"@types/lodash": "^4.14.188",
 		"@types/react": "~19.1.0",

--- a/patches/react-native-callkeep+4.3.16.patch
+++ b/patches/react-native-callkeep+4.3.16.patch
@@ -1,7 +1,16 @@
 diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
-index 025480a..70a1305 100644
+index 025480a..6a66858 100644
 --- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
 +++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
+@@ -221,7 +221,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
+         ComponentName cName = new ComponentName(context, VoiceConnectionService.class);
+         String appName = this.getApplicationName(context);
+ 
+-        handle = new PhoneAccountHandle(cName, appName);
++        handle = new PhoneAccountHandle(cName, context.getPackageName());
+         telecomManager = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
+     }
+ 
 @@ -434,11 +434,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
          this.hasListeners = false;
      }
@@ -26,6 +35,24 @@ index 025480a..70a1305 100644
      @ReactMethod
      public void startCall(String uuid, String number, String callerName, boolean hasVideo) {
          this.startCall(uuid, number, callerName, hasVideo, null);
+@@ -1196,9 +1186,14 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
+             return true;
+         }
+ 
+-        return isConnectionServiceAvailable() && telecomManager != null &&
+-            hasPermissions() && telecomManager.getPhoneAccount(handle) != null &&
+-            telecomManager.getPhoneAccount(handle).isEnabled();
++        try {
++            return isConnectionServiceAvailable() && telecomManager != null &&
++                hasPermissions() && telecomManager.getPhoneAccount(handle) != null &&
++                telecomManager.getPhoneAccount(handle).isEnabled();
++        } catch (SecurityException e) {
++            Log.w(TAG, "[RNCallKeepModule] hasPhoneAccount: SecurityException querying phone account", e);
++            return false;
++        }
+     }
+ 
+     protected void registerReceiver() {
 diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
 index 5d58692..f4e4b1b 100644
 --- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java

--- a/patches/react-native-callkeep+4.3.16.patch
+++ b/patches/react-native-callkeep+4.3.16.patch
@@ -57,6 +57,15 @@ diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/ca
 index 5d58692..f4e4b1b 100644
 --- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
 +++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+@@ -317,7 +317,7 @@ public class VoiceConnectionService extends ConnectionService {
+         notificationBuilder.setOngoing(true)
+             .setContentTitle(foregroundSettings.getString("notificationTitle"))
+             .setPriority(NotificationManager.IMPORTANCE_MIN)
+             .setCategory(Notification.CATEGORY_SERVICE);
+ 
+-        Activity currentActivity = RNCallKeepModule.instance.getCurrentReactActivity();
++        Activity currentActivity = RNCallKeepModule.instance != null ? RNCallKeepModule.instance.getCurrentReactActivity() : null;
+         if (currentActivity != null) {
 @@ -459,18 +459,10 @@ public class VoiceConnectionService extends ConnectionService {
          connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
  

--- a/patches/react-native-callkeep+4.3.16.patch
+++ b/patches/react-native-callkeep+4.3.16.patch
@@ -26,11 +26,38 @@ index 025480a..70a1305 100644
      @ReactMethod
      public void startCall(String uuid, String number, String callerName, boolean hasVideo) {
          this.startCall(uuid, number, callerName, hasVideo, null);
+diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+index 5d58692..f4e4b1b 100644
+--- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
++++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+@@ -459,18 +459,10 @@ public class VoiceConnectionService extends ConnectionService {
+         connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
+ 
+         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+-            Context context = getApplicationContext();
+-            TelecomManager telecomManager = (TelecomManager) context.getSystemService(context.TELECOM_SERVICE);
+-            PhoneAccount phoneAccount = telecomManager.getPhoneAccount(request.getAccountHandle());
+-
+-            //If the phone account is self managed, then this connection must also be self managed.
+-            if((phoneAccount.getCapabilities() & PhoneAccount.CAPABILITY_SELF_MANAGED) == PhoneAccount.CAPABILITY_SELF_MANAGED) {
+-                Log.d(TAG, "[VoiceConnectionService] PhoneAccount is SELF_MANAGED, so connection will be too");
+-                connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
+-            }
+-            else {
+-                Log.d(TAG, "[VoiceConnectionService] PhoneAccount is not SELF_MANAGED, so connection won't be either");
+-            }
++            // This app always registers its PhoneAccount with CAPABILITY_SELF_MANAGED.
++            // Skip telecomManager.getPhoneAccount(...) which requires READ_PHONE_NUMBERS on
++            // Android 11+ and isn't grantable from an FCM background context.
++            connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
+         }
+ 
+         connection.setInitializing();
 diff --git a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
 index 786045f..a989d58 100644
 --- a/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
 +++ b/node_modules/react-native-callkeep/ios/RNCallKeep/RNCallKeep.m
-@@ -171,6 +171,8 @@ - (void)sendEventWithNameWrapper:(NSString *)name body:(id)body {
+@@ -171,6 +171,8 @@ RCT_EXPORT_MODULE()
              body, @"data",
              nil
          ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4591,7 +4591,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^29.5.14":
+"@types/jest@29.5.14":
   version "29.5.14"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
   integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4591,7 +4591,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^29.5.13":
+"@types/jest@^29.5.14":
   version "29.5.14"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
   integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==


### PR DESCRIPTION
## Proposed changes

Fixes Android VoIP incoming calls that failed from a cold state because the `PhoneAccount` was not yet registered with `TelecomManager` when the FCM push arrived. The app now registers a self-managed `PhoneAccount` natively (idempotently) before calling `addNewIncomingCall`, so calls work even before JS boots and runs `RNCallKeep.setup`.

Additional Android hardening via `react-native-callkeep` patches:
- Use `packageName` (locale-stable) instead of the localized app label as the `PhoneAccountHandle` ID, so the JS-side and native-side registrations share one handle.
- Always mark the connection as `PROPERTY_SELF_MANAGED` instead of querying `telecomManager.getPhoneAccount(...)`, which requires `READ_PHONE_NUMBERS` on Android 11+ and isn't grantable from an FCM background context.
- Wrap `hasPhoneAccount` in `try/catch` for `SecurityException`.
- Null-check `RNCallKeepModule.instance` in `startForegroundService` to avoid NPE when the service starts before the JS module initialises.

Android manifest: add `phoneCall` to the `VoiceConnectionService` `foregroundServiceType` so the foreground service is legal for a self-managed telecom connection.

iOS: initialise event storage eagerly inside `RCT_EXPORT_MODULE()` so events emitted before `setup` isn't called (cold-start CallKit) aren't dropped.

## Issue(s)

Related to the VoIP lib base branch (`feat.voip-lib-new`).

## How to test or reproduce

Android:
1. Force-stop the app so JS is not running.
2. Trigger an incoming call to the device.
3. The CallKeep incoming-call UI should appear and the call should be answerable without the app needing to launch first.
4. Repeat after a device reboot to cover the PhoneAccount-not-yet-registered path.

iOS:
1. Force-quit the app.
2. Trigger an incoming call; the CallKit UI should appear and no ringing/answer events should be dropped.

## Screenshots

N/A — native-only behavioural fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The `react-native-callkeep` changes live in `patches/react-native-callkeep+4.3.16.patch` (applied via `patch-package` at `postinstall`). The callkeep version is unchanged (`4.3.16`); only the patch grew. The `@types/jest` bump in `package.json` is an unrelated stray pin — harmless.