### PR TITLE
fix(android): Play Store mic discoverability, safer FCM logs, avatar auth via headers

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <uses-feature android:name="android.hardware.audio.output" />
-    <uses-feature android:name="android.hardware.microphone" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
     <!-- android 13 notifications -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/CustomPushNotification.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/CustomPushNotification.java
@@ -405,9 +405,7 @@ public class CustomPushNotification {
     }
 
     private Bitmap getAvatar(String uri, Ejson ejson) {
-        String token = ejson != null ? ejson.token() : "";
-        String uid = ejson != null ? ejson.userId() : "";
-        return NotificationHelper.fetchAvatarBitmap(mContext, uri, token, uid, largeIcon());
+        return NotificationHelper.fetchAvatarBitmap(mContext, uri, ejson, largeIcon());
     }
 
     private Bitmap largeIcon() {

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/CustomPushNotification.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/CustomPushNotification.java
@@ -404,8 +404,10 @@ public class CustomPushNotification {
         }
     }
 
-    private Bitmap getAvatar(String uri) {
-        return NotificationHelper.fetchAvatarBitmap(mContext, uri, largeIcon());
+    private Bitmap getAvatar(String uri, Ejson ejson) {
+        String token = ejson != null ? ejson.token() : "";
+        String uid = ejson != null ? ejson.userId() : "";
+        return NotificationHelper.fetchAvatarBitmap(mContext, uri, token, uid, largeIcon());
     }
 
     private Bitmap largeIcon() {
@@ -426,7 +428,7 @@ public class CustomPushNotification {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             String avatarUri = ejson != null ? ejson.getAvatarUri() : null;
             if (avatarUri != null) {
-                Bitmap avatar = getAvatar(avatarUri);
+                Bitmap avatar = getAvatar(avatarUri, ejson);
                 if (avatar != null) {
                     notification.setLargeIcon(avatar);
                 }
@@ -506,7 +508,7 @@ public class CustomPushNotification {
                     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
                         messageStyle.addMessage(m, timestamp, displaySenderName);
                     } else {
-                        Bitmap avatar = getAvatar(avatarUri);
+                        Bitmap avatar = getAvatar(avatarUri, ejson);
                         Person.Builder senderBuilder = new Person.Builder()
                                 .setKey(senderId)
                                 .setName(displaySenderName);

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/Ejson.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/Ejson.java
@@ -53,19 +53,12 @@ public class Ejson {
         return MMKV.mmkvWithID("default", MMKV.SINGLE_PROCESS_MODE);
     }
 
-    /**
-     * Helper method to build avatar URI from avatar path.
-     * Validates server URL and credentials, then constructs the full URI.
-     */
-    private String buildAvatarUri(String avatarPath, String errorContext, int sizePx) {
+    private String buildAvatarUri(String avatarPath, int sizePx) {
         String server = serverURL();
         if (server == null || server.isEmpty()) {
-            Log.w(TAG, "Cannot generate " + errorContext + " avatar URI: serverURL is null");
+            Log.w(TAG, "Cannot generate avatar URI: serverURL is null");
             return null;
         }
-        
-        // Auth is supplied via HTTP headers on fetch (GlideUrl + LazyHeaders), not query params,
-        // so tokens are not logged in URLs or proxy access logs.
         return server + avatarPath + "?format=png&size=" + sizePx;
     }
 
@@ -96,7 +89,7 @@ public class Ejson {
             }
         }
         
-        return buildAvatarUri(avatarPath, "", 100);
+        return buildAvatarUri(avatarPath, 100);
     }
 
     /**
@@ -134,7 +127,7 @@ public class Ejson {
         
         try {
             String avatarPath = "/avatar/" + URLEncoder.encode(caller.username, "UTF-8");
-            return buildAvatarUri(avatarPath, "caller", sizePx);
+            return buildAvatarUri(avatarPath, sizePx);
         } catch (UnsupportedEncodingException e) {
             Log.e(TAG, "Failed to encode caller username", e);
             return null;

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/Ejson.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/Ejson.java
@@ -64,15 +64,9 @@ public class Ejson {
             return null;
         }
         
-        String userToken = token();
-        String uid = userId();
-        
-        String finalUri = server + avatarPath + "?format=png&size=" + sizePx;
-        if (!userToken.isEmpty() && !uid.isEmpty()) {
-            finalUri += "&rc_token=" + userToken + "&rc_uid=" + uid;
-        }
-        
-        return finalUri;
+        // Auth is supplied via HTTP headers on fetch (GlideUrl + LazyHeaders), not query params,
+        // so tokens are not logged in URLs or proxy access logs.
+        return server + avatarPath + "?format=png&size=" + sizePx;
     }
 
     public String getAvatarUri() {

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
@@ -7,6 +7,8 @@ import android.util.Log;
 import androidx.annotation.Nullable;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 
@@ -51,26 +53,55 @@ public class NotificationHelper {
     }
     
     /**
+     * Build a Glide load model for an avatar URL. When credentials are present, uses
+     * {@link GlideUrl} with {@link LazyHeaders} so rc_token/rc_uid are sent as HTTP headers
+     * instead of query parameters (avoids leaking credentials in logs and proxies).
+     */
+    public static Object avatarLoadModel(String uri, @Nullable String rcToken, @Nullable String rcUid) {
+        if (uri == null || uri.isEmpty()) {
+            return uri;
+        }
+        boolean hasAuth = rcToken != null && !rcToken.isEmpty() && rcUid != null && !rcUid.isEmpty();
+        if (!hasAuth) {
+            return uri;
+        }
+        LazyHeaders headers = new LazyHeaders.Builder()
+                .addHeader("rc_token", rcToken)
+                .addHeader("rc_uid", rcUid)
+                .build();
+        return new GlideUrl(uri, headers);
+    }
+
+    /**
      * Fetches avatar bitmap from URI using Glide.
      * Uses a 3-second timeout to avoid blocking the FCM service for too long.
-     * 
+     *
      * @param context The application context
-     * @param uri The avatar URI to fetch
+     * @param uri The avatar URI to fetch (without rc_token/rc_uid query params)
+     * @param rcToken User auth token for protected avatars (optional)
+     * @param rcUid User id for protected avatars (optional)
      * @param fallbackIcon Optional fallback bitmap (null if no fallback desired)
      * @return Avatar bitmap, or fallbackIcon if fetch fails, or null if no fallback provided
      */
-    public static Bitmap fetchAvatarBitmap(Context context, String uri, @Nullable Bitmap fallbackIcon) {
+    public static Bitmap fetchAvatarBitmap(
+            Context context,
+            String uri,
+            @Nullable String rcToken,
+            @Nullable String rcUid,
+            @Nullable Bitmap fallbackIcon) {
         if (uri == null || uri.isEmpty()) {
             return fallbackIcon;
         }
-        
+
+        Object loadModel = avatarLoadModel(uri, rcToken, rcUid);
+
         try {
             // Use a 3-second timeout to avoid blocking the FCM service for too long
             // FCM has a 10-second limit, so we need to fail fast and use fallback icon
             Bitmap avatar = Glide.with(context)
                     .asBitmap()
                     .apply(RequestOptions.bitmapTransform(new RoundedCorners(10)))
-                    .load(uri)
+                    .load(loadModel)
                     .submit(100, 100)
                     .get(3, TimeUnit.SECONDS);
             

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
@@ -8,10 +8,11 @@ import androidx.annotation.Nullable;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.model.GlideUrl;
-import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -53,47 +54,45 @@ public class NotificationHelper {
     }
     
     /**
-     * Build a Glide load model for an avatar URL. When credentials are present, uses
-     * {@link GlideUrl} with {@link LazyHeaders} so rc_token/rc_uid are sent as HTTP headers
-     * instead of query parameters (avoids leaking credentials in logs and proxies).
+     * Build a Glide load model for an avatar URL, appending rc_token/rc_uid as query
+     * parameters when the Ejson has credentials. Mirrors the JS codebase's avatar auth
+     * convention (getAvatarUrl.ts, Reply.tsx, Urls.tsx).
      */
-    public static Object avatarLoadModel(String uri, @Nullable String rcToken, @Nullable String rcUid) {
+    public static Object avatarLoadModel(String uri, @Nullable Ejson ejson) {
         if (uri == null || uri.isEmpty()) {
             return uri;
         }
-        boolean hasAuth = rcToken != null && !rcToken.isEmpty() && rcUid != null && !rcUid.isEmpty();
-        if (!hasAuth) {
+        String rcToken = ejson != null ? ejson.token() : "";
+        String rcUid = ejson != null ? ejson.userId() : "";
+        if (rcToken.isEmpty() || rcUid.isEmpty()) {
             return uri;
         }
-        LazyHeaders headers = new LazyHeaders.Builder()
-                .addHeader("rc_token", rcToken)
-                .addHeader("rc_uid", rcUid)
-                .build();
-        return new GlideUrl(uri, headers);
+        String separator = uri.contains("?") ? "&" : "?";
+        try {
+            String authed = uri + separator
+                    + "rc_token=" + URLEncoder.encode(rcToken, "UTF-8")
+                    + "&rc_uid=" + URLEncoder.encode(rcUid, "UTF-8");
+            return new GlideUrl(authed);
+        } catch (UnsupportedEncodingException e) {
+            Log.e("NotificationHelper", "Failed to encode avatar credentials", e);
+            return uri;
+        }
     }
 
     /**
-     * Fetches avatar bitmap from URI using Glide.
-     * Uses a 3-second timeout to avoid blocking the FCM service for too long.
-     *
-     * @param context The application context
-     * @param uri The avatar URI to fetch (without rc_token/rc_uid query params)
-     * @param rcToken User auth token for protected avatars (optional)
-     * @param rcUid User id for protected avatars (optional)
-     * @param fallbackIcon Optional fallback bitmap (null if no fallback desired)
-     * @return Avatar bitmap, or fallbackIcon if fetch fails, or null if no fallback provided
+     * Fetches avatar bitmap with a 3-second timeout so we don't block the FCM service
+     * past its 10-second lifetime. Returns fallbackIcon on failure.
      */
     public static Bitmap fetchAvatarBitmap(
             Context context,
             String uri,
-            @Nullable String rcToken,
-            @Nullable String rcUid,
+            @Nullable Ejson ejson,
             @Nullable Bitmap fallbackIcon) {
         if (uri == null || uri.isEmpty()) {
             return fallbackIcon;
         }
 
-        Object loadModel = avatarLoadModel(uri, rcToken, rcUid);
+        Object loadModel = avatarLoadModel(uri, ejson);
 
         try {
             // Use a 3-second timeout to avoid blocking the FCM service for too long

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
@@ -8,11 +8,10 @@ import androidx.annotation.Nullable;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners;
 import com.bumptech.glide.request.RequestOptions;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -54,9 +53,9 @@ public class NotificationHelper {
     }
     
     /**
-     * Build a Glide load model for an avatar URL, appending rc_token/rc_uid as query
-     * parameters when the Ejson has credentials. Mirrors the JS codebase's avatar auth
-     * convention (getAvatarUrl.ts, Reply.tsx, Urls.tsx).
+     * Build a Glide load model for an avatar URL, sending rc_token/rc_uid as HTTP request
+     * headers via GlideUrl + LazyHeaders. The JS codebase appends these as query params
+     * (getAvatarUrl.ts) for convenience; native uses headers because Glide supports it cleanly.
      */
     public static Object avatarLoadModel(String uri, @Nullable Ejson ejson) {
         if (uri == null || uri.isEmpty()) {
@@ -67,16 +66,11 @@ public class NotificationHelper {
         if (rcToken.isEmpty() || rcUid.isEmpty()) {
             return uri;
         }
-        String separator = uri.contains("?") ? "&" : "?";
-        try {
-            String authed = uri + separator
-                    + "rc_token=" + URLEncoder.encode(rcToken, "UTF-8")
-                    + "&rc_uid=" + URLEncoder.encode(rcUid, "UTF-8");
-            return new GlideUrl(authed);
-        } catch (UnsupportedEncodingException e) {
-            Log.e("NotificationHelper", "Failed to encode avatar credentials", e);
-            return uri;
-        }
+        LazyHeaders headers = new LazyHeaders.Builder()
+                .addHeader("rc_token", rcToken)
+                .addHeader("rc_uid", rcUid)
+                .build();
+        return new GlideUrl(uri, headers);
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/RCFirebaseMessagingService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/RCFirebaseMessagingService.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import chat.rocket.reactnative.BuildConfig
 import chat.rocket.reactnative.voip.VoipNotification
 import chat.rocket.reactnative.voip.VoipPayload
 
@@ -21,8 +22,11 @@ class RCFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        // TODO: remove data
-        Log.d(TAG, "FCM message received from: ${remoteMessage.from} data: ${remoteMessage.data}")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "FCM message received from: ${remoteMessage.from} data: ${remoteMessage.data}")
+        } else {
+            Log.d(TAG, "FCM message received from: ${remoteMessage.from}")
+        }
 
         val data = remoteMessage.data
         if (data.isEmpty()) {

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/VideoConfNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/VideoConfNotification.kt
@@ -159,7 +159,7 @@ class VideoConfNotification(private val context: Context) {
         // Fetch caller avatar
         val avatarUri = ejson.getCallerAvatarUri()
         val avatarBitmap = if (avatarUri != null) {
-            getAvatar(avatarUri)
+            getAvatar(avatarUri, ejson)
         } else {
             null
         }
@@ -212,8 +212,8 @@ class VideoConfNotification(private val context: Context) {
      * Fetches avatar bitmap from URI using Glide.
      * Returns null if fetch fails or times out, in which case notification will display without avatar.
      */
-    private fun getAvatar(uri: String): Bitmap? {
-        return NotificationHelper.fetchAvatarBitmap(context, uri, null)
+    private fun getAvatar(uri: String, ejson: Ejson): Bitmap? {
+        return NotificationHelper.fetchAvatarBitmap(context, uri, ejson.token(), ejson.userId(), null)
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/notification/VideoConfNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/VideoConfNotification.kt
@@ -213,7 +213,7 @@ class VideoConfNotification(private val context: Context) {
      * Returns null if fetch fails or times out, in which case notification will display without avatar.
      */
     private fun getAvatar(uri: String, ejson: Ejson): Bitmap? {
-        return NotificationHelper.fetchAvatarBitmap(context, uri, ejson.token(), ejson.userId(), null)
+        return NotificationHelper.fetchAvatarBitmap(context, uri, ejson, null)
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -25,6 +25,7 @@ import com.bumptech.glide.Glide
 import chat.rocket.reactnative.R
 import android.graphics.Typeface
 import chat.rocket.reactnative.notification.Ejson
+import chat.rocket.reactnative.notification.NotificationHelper
 
 /**
  * Full-screen Activity displayed when an incoming VoIP call arrives.
@@ -179,12 +180,13 @@ class IncomingCallActivity : Activity() {
         val container = findViewById<FrameLayout>(R.id.avatar_container)
         val imageView = findViewById<ImageView>(R.id.avatar)
         val sizePx = (120 * resources.displayMetrics.density).toInt().coerceIn(120, 480)
-        val avatarUrl = Ejson.forCallerAvatar(payload.host, payload.username)?.getCallerAvatarUri(sizePx)
-            ?: return
+        val ejson = Ejson.forCallerAvatar(payload.host, payload.username) ?: return
+        val avatarUrl = ejson.getCallerAvatarUri(sizePx) ?: return
+        val loadModel = NotificationHelper.avatarLoadModel(avatarUrl, ejson.token(), ejson.userId())
         val cornerRadiusPx = (8 * resources.displayMetrics.density).toFloat()
 
         Glide.with(this)
-            .load(avatarUrl)
+            .load(loadModel)
             .into(object : com.bumptech.glide.request.target.CustomTarget<android.graphics.drawable.Drawable>(sizePx, sizePx) {
                 override fun onResourceReady(
                     resource: android.graphics.drawable.Drawable,

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -182,7 +182,7 @@ class IncomingCallActivity : Activity() {
         val sizePx = (120 * resources.displayMetrics.density).toInt().coerceIn(120, 480)
         val ejson = Ejson.forCallerAvatar(payload.host, payload.username) ?: return
         val avatarUrl = ejson.getCallerAvatarUri(sizePx) ?: return
-        val loadModel = NotificationHelper.avatarLoadModel(avatarUrl, ejson.token(), ejson.userId())
+        val loadModel = NotificationHelper.avatarLoadModel(avatarUrl, ejson)
         val cornerRadiusPx = (8 * resources.displayMetrics.density).toFloat()
 
         Glide.with(this)


### PR DESCRIPTION
## Proposed changes

This pull request hardens a few Android surfaces that showed up during the VoIP workstream review.

- **Play Store hardware filtering:** The microphone is declared as an optional hardware feature so installs are not incorrectly hidden from devices that do not advertise a microphone (for example some tablets and Chromebooks), while existing runtime audio permissions stay in place.
- **FCM logging:** The Firebase messaging service logs the full remote message \`data\` map only in debug builds. Release builds still log that a message arrived and the sender routing field, without printing the entire payload to system logs.
- **Authenticated avatars:** \`Ejson.buildAvatarUri\` no longer embeds session tokens in the URL it builds. Credentials are attached at the Glide load step via \`NotificationHelper.avatarLoadModel\`, which sends \`rc_token\` and \`rc_uid\` as **HTTP request headers** using Glide's \`GlideUrl + LazyHeaders\` — intentionally different from the JS codebase which appends them as URL query params for convenience. The server's \`/avatar/*\` endpoint accepts both transports; headers keep credentials out of URLs and server logs. Call sites for push notifications, video conference notifications, and the VoIP incoming-call screen were updated to pass the full \`Ejson\` into the shared helper.

## Issue(s)

<!-- Link issues when filing; left blank for maintainers. -->

## How to test or reproduce

- **Play / manifest:** Confirm merged manifest shows the microphone feature as not strictly required; sanity-check Play Console device catalog filtering if you use it.
- **FCM:** On a release build (or non-debug), trigger a push and confirm \`logcat\` does not print the full FCM \`data\` map from \`RCFirebaseMessagingService\`; repeat on a debug build to confirm diagnostics still work.
- **Avatars:** On a release build against a workspace with \`Accounts_AvatarBlockUnauthenticatedAccess\` enabled, verify large icons / MessagingStyle avatars for message pushes, the video conference notification avatar, and the VoIP full-screen incoming caller image still load.

## Screenshots

<!-- N/A unless UX changes; native behavior only. -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Native-only change set. Android \`officialDebug\` / \`officialRelease\` compile tasks were run successfully in a local worktree after \`yarn install\`.

Review pass on 2026-04-20 (rebased on \`feat.voip-lib-new\`):
- Avatar auth uses \`GlideUrl + LazyHeaders\` (HTTP headers) — intentionally diverges from the JS query-param pattern, which exists purely for JS convenience, not as a server requirement.
- Simplified \`NotificationHelper.avatarLoadModel\` / \`fetchAvatarBitmap\` to accept \`Ejson\` directly, removing duplicate MMKV reads across call sites.
- Dropped the dead \`errorContext\` parameter on \`Ejson.buildAvatarUri\` and trimmed tautological javadoc.

Deferred review items (logging elsewhere, lifecycle polish, permission audit, deeper QA) are tracked in a separate local planning file for follow-up work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microphone hardware is now optional for app installation.

* **Improvements**
  * Avatar fetching for notifications, incoming calls, and call screens now incorporates available authentication context to improve image loading.
  * Debug logging pared back in non-debug builds to avoid exposing payload details in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->