### PR TITLE
refactor(voip): decouple navigateToCallRoom from Redux and backfill REST/connect tests

### DIFF
--- a/app/containers/MediaCallHeader/components/Content.tsx
+++ b/app/containers/MediaCallHeader/components/Content.tsx
@@ -1,5 +1,6 @@
 import { Pressable, StyleSheet, View } from 'react-native';
 
+import { useAppSelector } from '../../../lib/hooks/useAppSelector';
 import { navigateToCallRoom } from '../../../lib/services/voip/navigateToCallRoom';
 import { useCallStore } from '../../../lib/services/voip/useCallStore';
 import Title from './Title';
@@ -19,6 +20,7 @@ const styles = StyleSheet.create({
 });
 
 export const Content = () => {
+	const isMasterDetail = useAppSelector(state => state.app.isMasterDetail);
 	const roomId = useCallStore(state => state.roomId);
 	const contact = useCallStore(state => state.contact);
 	const contentDisabled = Boolean(contact.sipExtension) || roomId == null;
@@ -29,7 +31,7 @@ export const Content = () => {
 			testID='media-call-header-content'
 			disabled={contentDisabled}
 			onPress={() => {
-				navigateToCallRoom().catch(() => undefined);
+				navigateToCallRoom({ isMasterDetail }).catch(() => undefined);
 			}}
 			style={pressableStyle}>
 			<View style={styles.container}>

--- a/app/lib/services/connect.ios.test.ts
+++ b/app/lib/services/connect.ios.test.ts
@@ -1,12 +1,11 @@
 import { determineAuthType } from './connect';
 
 jest.mock('./voip/MediaSessionInstance', () => ({
-	mediaSessionInstance: { reset: jest.fn(), init: jest.fn() }
+	mediaSessionInstance: { reset: jest.fn() }
 }));
 
-// Mock the isIOS helper to return true for iOS-specific tests
-jest.mock('../methods/helpers', () => ({
-	...jest.requireActual('../methods/helpers'),
+jest.mock('../methods/helpers/deviceInfo', () => ({
+	...jest.requireActual('../methods/helpers/deviceInfo'),
 	isIOS: true
 }));
 

--- a/app/lib/services/connect.test.ts
+++ b/app/lib/services/connect.test.ts
@@ -1,7 +1,8 @@
-import { determineAuthType } from './connect';
+import { determineAuthType, disconnect } from './connect';
+import { mediaSessionInstance } from './voip/MediaSessionInstance';
 
 jest.mock('./voip/MediaSessionInstance', () => ({
-	mediaSessionInstance: { reset: jest.fn(), init: jest.fn() }
+	mediaSessionInstance: { reset: jest.fn() }
 }));
 
 // Mock the isIOS helper
@@ -302,6 +303,13 @@ describe('determineAuthType', () => {
 			const result = determineAuthType(services);
 			expect(result).toBe('cas'); // Should return cas before checking for oauth
 		});
+	});
+});
+
+describe('VoIP media session lifecycle (disconnect)', () => {
+	it('calls mediaSessionInstance.reset when disconnect runs', () => {
+		disconnect();
+		expect(mediaSessionInstance.reset).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/app/lib/services/restApi.test.ts
+++ b/app/lib/services/restApi.test.ts
@@ -1,14 +1,60 @@
 import type { ServerMediaSignal } from '@rocket.chat/media-signaling';
+import { Platform } from 'react-native';
 
 import { mediaCallsStateSignals } from './restApi';
 
 const mockSdkGet = jest.fn();
+const mockSdkPost = jest.fn();
+
 jest.mock('./sdk', () => ({
 	__esModule: true,
 	default: {
-		get: (...args: unknown[]) => mockSdkGet(...args)
+		get: (...args: unknown[]) => mockSdkGet(...args),
+		post: (...args: unknown[]) => mockSdkPost(...args)
 	}
 }));
+
+jest.mock('../notifications', () => ({
+	getDeviceToken: jest.fn()
+}));
+
+jest.mock('../native/NativeVoip', () => ({
+	__esModule: true,
+	default: {
+		getLastVoipToken: jest.fn()
+	}
+}));
+
+jest.mock('react-native-device-info', () => {
+	const mock = require('react-native-device-info/jest/react-native-device-info-mock');
+	const getUniqueId = jest.fn(() => Promise.resolve('unique-device-id'));
+	const defaultExport = {
+		...mock,
+		getUniqueId
+	};
+	return {
+		__esModule: true,
+		default: defaultExport,
+		getUniqueId
+	};
+});
+
+function loadRegisterPushToken(platform: 'ios' | 'android' = 'android') {
+	jest.resetModules();
+	Object.defineProperty(Platform, 'OS', { configurable: true, writable: true, value: platform });
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const notifications = require('../notifications');
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const voipNative = require('../native/NativeVoip').default;
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { registerPushToken } = require('./restApi');
+	return {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+		registerPushToken: registerPushToken as typeof import('./restApi').registerPushToken,
+		getDeviceToken: jest.mocked(notifications.getDeviceToken),
+		getLastVoipToken: jest.mocked(voipNative.getLastVoipToken)
+	};
+}
 
 describe('mediaCallsStateSignals', () => {
 	beforeEach(() => {
@@ -53,5 +99,88 @@ describe('mediaCallsStateSignals', () => {
 
 		expect(result.signals).toEqual([]);
 		expect(result.success).toBe(false);
+	});
+});
+
+describe('registerPushToken', () => {
+	const platformOsAtSuiteStart = Platform.OS;
+
+	afterEach(() => {
+		Object.defineProperty(Platform, 'OS', { configurable: true, writable: true, value: platformOsAtSuiteStart });
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockSdkPost.mockResolvedValue(undefined);
+	});
+
+	it('returns early when there is no device push token', async () => {
+		const { registerPushToken, getDeviceToken: getToken } = loadRegisterPushToken();
+		getToken.mockReturnValue('');
+
+		await registerPushToken();
+
+		expect(mockSdkPost).not.toHaveBeenCalled();
+	});
+
+	it('on iOS returns early when push token exists but VoIP token is missing', async () => {
+		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios');
+		getToken.mockReturnValue('apns-token');
+		getVoip.mockReturnValue('');
+
+		await registerPushToken();
+
+		expect(mockSdkPost).not.toHaveBeenCalled();
+	});
+
+	it('on Android still registers when VoIP token is missing', async () => {
+		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('android');
+		getToken.mockReturnValue('fcm-token');
+		getVoip.mockReturnValue('');
+
+		await registerPushToken();
+
+		expect(mockSdkPost).toHaveBeenCalledTimes(1);
+		expect(mockSdkPost).toHaveBeenCalledWith(
+			'push.token',
+			expect.objectContaining({
+				id: 'unique-device-id',
+				value: 'fcm-token',
+				type: 'gcm',
+				appName: expect.any(String)
+			})
+		);
+		const payload = mockSdkPost.mock.calls[0][1] as Record<string, unknown>;
+		expect(Object.prototype.hasOwnProperty.call(payload, 'voipToken')).toBe(false);
+	});
+
+	it('dedupes when the same push and VoIP tokens are registered again', async () => {
+		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios');
+		getToken.mockReturnValue('apns-token');
+		getVoip.mockReturnValue('voip-token');
+
+		await registerPushToken();
+		await registerPushToken();
+
+		expect(mockSdkPost).toHaveBeenCalledTimes(1);
+	});
+
+	it('on iOS posts apn payload with voipToken when both tokens are present', async () => {
+		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios');
+		getToken.mockReturnValue('apns-token');
+		getVoip.mockReturnValue('voip-token');
+
+		await registerPushToken();
+
+		expect(mockSdkPost).toHaveBeenCalledWith(
+			'push.token',
+			expect.objectContaining({
+				id: 'unique-device-id',
+				value: 'apns-token',
+				type: 'apn',
+				appName: expect.any(String),
+				voipToken: 'voip-token'
+			})
+		);
 	});
 });

--- a/app/lib/services/restApi.test.ts
+++ b/app/lib/services/restApi.test.ts
@@ -123,14 +123,25 @@ describe('registerPushToken', () => {
 		expect(mockSdkPost).not.toHaveBeenCalled();
 	});
 
-	it('on iOS returns early when push token exists but VoIP token is missing', async () => {
+	it('on iOS registers apn payload without voipToken when VoIP token is missing', async () => {
 		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios');
 		getToken.mockReturnValue('apns-token');
 		getVoip.mockReturnValue('');
 
 		await registerPushToken();
 
-		expect(mockSdkPost).not.toHaveBeenCalled();
+		expect(mockSdkPost).toHaveBeenCalledTimes(1);
+		expect(mockSdkPost).toHaveBeenCalledWith(
+			'push.token',
+			expect.objectContaining({
+				id: 'unique-device-id',
+				value: 'apns-token',
+				type: 'apn',
+				appName: expect.any(String)
+			})
+		);
+		const payload = mockSdkPost.mock.calls[0][1] as Record<string, unknown>;
+		expect(Object.prototype.hasOwnProperty.call(payload, 'voipToken')).toBe(false);
 	});
 
 	it('on Android still registers when VoIP token is missing', async () => {

--- a/app/lib/services/voip/navigateToCallRoom.test.ts
+++ b/app/lib/services/voip/navigateToCallRoom.test.ts
@@ -1,6 +1,5 @@
 import { goRoom } from '../../methods/helpers/goRoom';
 import Navigation from '../../navigation/appNavigation';
-import { store } from '../../store/auxStore';
 import { useCallStore } from './useCallStore';
 import { navigateToCallRoom } from './navigateToCallRoom';
 import { SubscriptionType } from '../../../definitions';
@@ -15,12 +14,6 @@ jest.mock('../../methods/helpers/goRoom', () => ({
 	goRoom: jest.fn().mockResolvedValue(undefined)
 }));
 
-jest.mock('../../store/auxStore', () => ({
-	store: {
-		getState: jest.fn()
-	}
-}));
-
 jest.mock('../../navigation/appNavigation', () => ({
 	__esModule: true,
 	default: {
@@ -31,7 +24,6 @@ jest.mock('../../navigation/appNavigation', () => ({
 
 const mockGetState = jest.mocked(useCallStore.getState);
 const mockGoRoom = jest.mocked(goRoom);
-const mockStoreGetState = jest.mocked(store.getState);
 const mockNavigation = jest.mocked(Navigation);
 
 type CallStoreSnapshot = ReturnType<typeof useCallStore.getState>;
@@ -48,7 +40,6 @@ describe('navigateToCallRoom', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		mockStoreGetState.mockReturnValue({ app: { isMasterDetail: true } } as ReturnType<typeof store.getState>);
 		mockNavigation.getCurrentRoute.mockReturnValue({ name: 'RoomsListView' } as any);
 	});
 
@@ -62,7 +53,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(mockGoRoom).not.toHaveBeenCalled();
 		expect(toggleFocus).not.toHaveBeenCalled();
@@ -79,7 +70,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(mockGoRoom).not.toHaveBeenCalled();
 		expect(toggleFocus).not.toHaveBeenCalled();
@@ -96,7 +87,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(mockGoRoom).not.toHaveBeenCalled();
 		expect(toggleFocus).not.toHaveBeenCalled();
@@ -113,7 +104,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(toggleFocus).toHaveBeenCalledTimes(1);
 		expect(mockGoRoom).toHaveBeenCalledWith({
@@ -133,7 +124,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(toggleFocus).not.toHaveBeenCalled();
 		expect(mockGoRoom).toHaveBeenCalledWith({
@@ -153,7 +144,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(mockNavigation.navigate).toHaveBeenCalledWith('ChatsStackNavigator');
 		expect(mockGoRoom).toHaveBeenCalledWith({
@@ -174,7 +165,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(mockNavigation.navigate).toHaveBeenCalledWith('ChatsStackNavigator');
 		expect(mockGoRoom).toHaveBeenCalled();
@@ -192,7 +183,7 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(mockNavigation.navigate).toHaveBeenCalledWith('ChatsStackNavigator');
 		expect(mockGoRoom).toHaveBeenCalled();
@@ -210,9 +201,27 @@ describe('navigateToCallRoom', () => {
 			})
 		);
 
-		await navigateToCallRoom();
+		await navigateToCallRoom({ isMasterDetail: true });
 
 		expect(mockNavigation.navigate).not.toHaveBeenCalled();
 		expect(mockGoRoom).toHaveBeenCalled();
+	});
+
+	it('passes isMasterDetail from the caller into goRoom', async () => {
+		mockGetState.mockReturnValue(
+			mockCallStoreState({
+				roomId: 'rid-1',
+				contact: { username: 'alice', sipExtension: '' },
+				focused: false,
+				toggleFocus
+			})
+		);
+
+		await navigateToCallRoom({ isMasterDetail: false });
+
+		expect(mockGoRoom).toHaveBeenCalledWith({
+			item: { rid: 'rid-1', name: 'alice', t: SubscriptionType.DIRECT },
+			isMasterDetail: false
+		});
 	});
 });

--- a/app/lib/services/voip/navigateToCallRoom.ts
+++ b/app/lib/services/voip/navigateToCallRoom.ts
@@ -1,14 +1,13 @@
 import { SubscriptionType } from '../../../definitions';
 import { goRoom } from '../../methods/helpers/goRoom';
 import Navigation from '../../navigation/appNavigation';
-import { store } from '../../store/auxStore';
 import { useCallStore } from './useCallStore';
 
 /**
  * From the VoIP UI, open the DM for the active call: minimizes CallView when it is focused, then navigates.
  * No-ops for SIP calls or when room id or username is missing.
  */
-export async function navigateToCallRoom(): Promise<void> {
+export async function navigateToCallRoom({ isMasterDetail }: { isMasterDetail: boolean }): Promise<void> {
 	const { roomId, contact, focused, toggleFocus } = useCallStore.getState();
 
 	if (!roomId || contact.sipExtension) {
@@ -23,10 +22,6 @@ export async function navigateToCallRoom(): Promise<void> {
 	if (focused) {
 		toggleFocus();
 	}
-
-	const {
-		app: { isMasterDetail }
-	} = store.getState();
 
 	// If we're not in the chats navigator (e.g., in Profile/Settings/Accessibility screens),
 	// navigate to ChatsStackNavigator first to ensure goRoom works correctly

--- a/app/views/CallView/components/CallButtons.tsx
+++ b/app/views/CallView/components/CallButtons.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
 
 import I18n from '../../../i18n';
+import { useAppSelector } from '../../../lib/hooks/useAppSelector';
 import { navigateToCallRoom } from '../../../lib/services/voip/navigateToCallRoom';
 import { useCallStore, useControlsVisible } from '../../../lib/services/voip/useCallStore';
 import CallActionButton from './CallActionButton';
@@ -27,6 +28,7 @@ export const CallButtons = () => {
 	'use memo';
 
 	const { colors } = useTheme();
+	const isMasterDetail = useAppSelector(state => state.app.isMasterDetail);
 	const { layoutMode } = useCallLayoutMode();
 	const { width, height } = useResponsiveLayout();
 	const isLandscape = width > height;
@@ -55,7 +57,7 @@ export const CallButtons = () => {
 	const messageDisabled = Boolean(contact.sipExtension) || roomId == null;
 
 	const handleMessage = () => {
-		navigateToCallRoom().catch(() => undefined);
+		navigateToCallRoom({ isMasterDetail }).catch(() => undefined);
 	};
 
 	const handleDialpad = () => {


### PR DESCRIPTION
## Proposed changes

Removes the hidden Redux dependency from the VoIP `navigateToCallRoom` helper and backfills unit coverage around REST push-token registration, the `connect` → VoIP media-session lifecycle, and the iOS-specific `connect` branch.

- `app/lib/services/voip/navigateToCallRoom.ts` no longer reads `auxStore`; it now takes `{ isMasterDetail }` as an argument. Callers — `CallButtons` and `MediaCallHeader/Content` — read `state.app.isMasterDetail` via `useAppSelector` and pass it in.
- `app/lib/services/voip/navigateToCallRoom.test.ts` drops the `auxStore` mock and adds a case asserting that `isMasterDetail: false` is forwarded into `goRoom`.
- `app/lib/services/restApi.test.ts` adds coverage for `registerPushToken`: early return when there is no device token, iOS registers the apn payload without `voipToken` when the VoIP token is missing (matches current `feat.voip-lib-new` behavior after the guard drop), Android registration without a VoIP token (no `voipToken` in payload), dedup on repeated calls, and the iOS APNs payload shape when both tokens are present.
- `app/lib/services/connect.test.ts` now asserts `mediaSessionInstance.reset` is called exactly once when `disconnect()` runs.
- `app/lib/services/connect.ios.test.ts` mocks `../methods/helpers/deviceInfo` instead of `../methods/helpers` so the `isIOS` override matches the module `connect.ts` actually imports.

Branch was rebased onto `feat.voip-lib-new` to pick up the iOS early-return removal; the iOS-no-voip test was flipped accordingly.

No behavior change for end users: the navigation UX is identical, and the VoIP lifecycle assertions pin existing behavior that was previously untested.

## Issue(s)

Part of the `voip-lib-new` cleanup track (PR-3: service boundary + REST/connect test backfill).

## How to test or reproduce

```
TZ=UTC yarn test --testPathPattern='restApi.test|navigateToCallRoom.test|connect.test.ts|connect.ios.test'
```

Manual smoke: place/receive a VoIP call, tap the message/header button — it should still navigate to the call's DM on both phone and tablet (master-detail) layouts.

## Screenshots

N/A — refactor + tests only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — iOS `connect` test was mocking the wrong module path
- [x] Improvement (non-breaking change which improves a current function) — removes hidden Redux coupling in VoIP nav helper; adds missing unit coverage
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`navigateToCallRoom` was previously importable from anywhere but silently required the Redux `auxStore` to be populated. Injecting `isMasterDetail` makes the dependency explicit and matches how other navigation helpers already read layout state at the call site. The `connect.ios.test` mock fix is small but load-bearing — the previous mock targeted `../methods/helpers`, which re-exports `isIOS` from `./deviceInfo`, so the override never reached the copy imported by `connect.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved call navigation to better manage master detail layout state through explicit parameter passing.

* **Tests**
  * Expanded push token registration coverage with platform-specific iOS and Android behavior validation.
  * Enhanced VoIP service initialization and disconnect handling test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->