### PR TITLE
test(voip): tighten ringing endCall assertion and add VideoConf VoIP-lock saga coverage

### DIFF
--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -7,9 +7,9 @@
 //   - Hang up (UI endCall and MediaSessionInstance.endCall ringing/active branches)
 //   - In-call controls (mute, hold, trackStateChange sync)
 //
-// Seam: @rocket.chat/media-signaling is mocked at the SDK boundary. Everything
-// between the SDK and the UI — MediaSessionInstance, useCallStore, NewMediaCall,
-// CallView — runs as real code.
+// Seam: @rocket.chat/media-signaling is mocked at the SDK boundary (see block
+// comment on the jest.mock below). Everything between that mock and the UI —
+// MediaSessionInstance, useCallStore, NewMediaCall, CallView — runs as real code.
 
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
@@ -184,6 +184,11 @@ function mockCallEmitter() {
 }
 
 // ─── Media-signaling mock ─────────────────────────────────────────────────────
+//
+// @rocket.chat/media-signaling (WebRTC stack) is fully mocked here. These tests
+// exercise signaling orchestration, Zustand, and navigation — not real peer
+// connections, ICE, or media tracks. Catching regressions in WebRTC-specific
+// behavior still requires device or E2E coverage outside Jest.
 
 type MockMediaSignalingSession = {
 	userId: string;
@@ -647,15 +652,17 @@ describe('VoIP call lifecycle (integration)', () => {
 			expect(useCallStore.getState().call).toBeNull();
 		});
 
-		it('B3: MediaSessionInstance.endCall during ringing → same cleanup (reject branch)', () => {
+		it('B3: MediaSessionInstance.endCall during ringing → reject (not hangup) + RNCallKeep cleanup', () => {
 			const session = createdSessions[createdSessions.length - 1];
-			const ringingCall = makeCall({ callId: 'ringing-1', state: 'ringing' });
+			const ringingCall = makeCall({ callId: 'ringing-1' });
 			session.getCallData.mockReturnValue(ringingCall);
 
 			act(() => {
 				mediaSessionInstance.endCall('ringing-1');
 			});
 
+			expect(ringingCall.reject).toHaveBeenCalled();
+			expect(ringingCall.hangup).not.toHaveBeenCalled();
 			expect(RNCallKeep.endCall as jest.Mock).toHaveBeenCalledWith('ringing-1');
 			expect(useCallStore.getState().call).toBeNull();
 		});

--- a/app/sagas/__tests__/videoConf.voipBlock.test.ts
+++ b/app/sagas/__tests__/videoConf.voipBlock.test.ts
@@ -17,7 +17,8 @@ async function flushSagaMicrotasks(): Promise<void> {
 }
 
 describe('videoConf saga — VoIP / videoconf lock', () => {
-	// First DDP arg is the envelope object; rooms.ts names it `action` in the tuple destructure.
+	// Mirrors the first DDP arg destructured at app/lib/methods/subscriptions/rooms.ts
+	// and dispatched as `{ action, params }` into handleVideoConfIncomingWebsocketMessages.
 	const envelope = {
 		action: 'call' as const,
 		params: { callId: 'vc-1', uid: 'user-b', rid: 'room-1' }
@@ -35,18 +36,13 @@ describe('videoConf saga — VoIP / videoconf lock', () => {
 		return store;
 	}
 
-	function dispatchIncomingCallLikeRooms(store: ReturnType<typeof setupStoreWithVideoConfSaga>): void {
-		const [wsAction, wsParams] = [envelope, undefined] as const;
-		store.dispatch(handleVideoConfIncomingWebsocketMessages({ action: wsAction, params: wsParams }));
-	}
-
 	it('short-circuits incoming direct videoconf when voipBlocksIncomingVideoconf returns true', async () => {
 		jest.mocked(voipBlocksIncomingVideoconf).mockReturnValue(true);
 
 		const store = setupStoreWithVideoConfSaga();
 		const callsBefore = store.getState().videoConf.calls;
 
-		dispatchIncomingCallLikeRooms(store);
+		store.dispatch(handleVideoConfIncomingWebsocketMessages({ action: envelope, params: undefined }));
 		await flushSagaMicrotasks();
 
 		expect(voipBlocksIncomingVideoconf).toHaveBeenCalled();
@@ -57,7 +53,7 @@ describe('videoConf saga — VoIP / videoconf lock', () => {
 	it('handles incoming direct videoconf when VoIP does not block', async () => {
 		const store = setupStoreWithVideoConfSaga();
 
-		dispatchIncomingCallLikeRooms(store);
+		store.dispatch(handleVideoConfIncomingWebsocketMessages({ action: envelope, params: undefined }));
 		await flushSagaMicrotasks();
 
 		expect(voipBlocksIncomingVideoconf).toHaveBeenCalled();

--- a/app/sagas/__tests__/videoConf.voipBlock.test.ts
+++ b/app/sagas/__tests__/videoConf.voipBlock.test.ts
@@ -1,0 +1,72 @@
+jest.mock('../../lib/services/voip/voipBlocksIncomingVideoconf', () => ({
+	voipBlocksIncomingVideoconf: jest.fn(() => false)
+}));
+
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import { handleVideoConfIncomingWebsocketMessages } from '../../actions/videoConf';
+import reducers from '../../reducers';
+import videoConfRootSaga from '../videoConf';
+import { voipBlocksIncomingVideoconf } from '../../lib/services/voip/voipBlocksIncomingVideoconf';
+
+/** Drains pending saga microtasks (takeEvery → call(onDirectCall) completes synchronously today). */
+async function flushSagaMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe('videoConf saga — VoIP / videoconf lock', () => {
+	// First DDP arg is the envelope object; rooms.ts names it `action` in the tuple destructure.
+	const envelope = {
+		action: 'call' as const,
+		params: { callId: 'vc-1', uid: 'user-b', rid: 'room-1' }
+	};
+
+	beforeEach(() => {
+		jest.mocked(voipBlocksIncomingVideoconf).mockReset();
+		jest.mocked(voipBlocksIncomingVideoconf).mockReturnValue(false);
+	});
+
+	function setupStoreWithVideoConfSaga() {
+		const sagaMiddleware = createSagaMiddleware();
+		const store = createStore(reducers, applyMiddleware(sagaMiddleware));
+		sagaMiddleware.run(videoConfRootSaga);
+		return store;
+	}
+
+	function dispatchIncomingCallLikeRooms(store: ReturnType<typeof setupStoreWithVideoConfSaga>): void {
+		const [wsAction, wsParams] = [envelope, undefined] as const;
+		store.dispatch(handleVideoConfIncomingWebsocketMessages({ action: wsAction, params: wsParams }));
+	}
+
+	it('short-circuits incoming direct videoconf when voipBlocksIncomingVideoconf returns true', async () => {
+		jest.mocked(voipBlocksIncomingVideoconf).mockReturnValue(true);
+
+		const store = setupStoreWithVideoConfSaga();
+		const callsBefore = store.getState().videoConf.calls;
+
+		dispatchIncomingCallLikeRooms(store);
+		await flushSagaMicrotasks();
+
+		expect(voipBlocksIncomingVideoconf).toHaveBeenCalled();
+		expect(store.getState().videoConf.calls).toBe(callsBefore);
+		expect(store.getState().videoConf.calls).toHaveLength(0);
+	});
+
+	it('handles incoming direct videoconf when VoIP does not block', async () => {
+		const store = setupStoreWithVideoConfSaga();
+
+		dispatchIncomingCallLikeRooms(store);
+		await flushSagaMicrotasks();
+
+		expect(voipBlocksIncomingVideoconf).toHaveBeenCalled();
+		expect(store.getState().videoConf.calls).toHaveLength(1);
+		expect(store.getState().videoConf.calls[0]).toMatchObject({
+			callId: 'vc-1',
+			uid: 'user-b',
+			rid: 'room-1',
+			action: 'call'
+		});
+	});
+});


### PR DESCRIPTION
## Proposed changes

Strengthens the VoIP integration and saga test suites without touching production code.

**`app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx`**

- Tightens the ringing-state `MediaSessionInstance.endCall` case so it now asserts **`call.reject` was invoked** and **`call.hangup` was not**, matching the ringing-vs-active branching inside `MediaSessionInstance.endCall`. Existing `RNCallKeep.endCall` and `useCallStore` assertions are preserved.
- Documents that `@rocket.chat/media-signaling` is fully mocked at the SDK boundary, so these tests exercise signaling orchestration, Zustand state and navigation — not real WebRTC (peer connections, ICE, media tracks). Regressions in the real WebRTC stack still require device or E2E coverage.

**`app/sagas/__tests__/videoConf.voipBlock.test.ts`** (new)

Covers the interaction between VoIP and incoming direct videoconf rings:

- When `voipBlocksIncomingVideoconf()` returns **true**, an incoming videoconf `call` websocket message is short-circuited at `onDirectCall` and `state.videoConf.calls` is left unchanged (same array reference, length 0).
- When it returns **false**, the saga adds the expected call to `state.videoConf.calls` with `callId`, `uid`, `rid` and `action: 'call'`.
- Dispatches use the same envelope shape that the production DDP handler emits into `handleVideoConfIncomingWebsocketMessages`, so the test exercises the real action → saga → reducer path end-to-end.
- `beforeEach` resets the VoIP guard mock between cases.

## Issue(s)

<!-- For human reviewer -->

## How to test or reproduce

```bash
TZ=UTC yarn test --testPathPattern='VoipCallLifecycle.integration|videoConf.voipBlock'
```

## Screenshots

N/A (tests only)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

- Test-only change; no production behavior is modified.
- The negative assertion (`hangup` not called on ringing) guards against an accidental swap of the reject/hangup branches in `MediaSessionInstance.endCall`.
- The new saga test uses the real reducer graph and root saga so the VoIP guard, action payload shape and reducer storage stay in sync end-to-end.