### PR TITLE
refactor(voip): MediaCallEvents Redux adapter + resetVoipState (PR-5)

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -36,7 +36,7 @@ import { getInitialNotification, setupVideoConfActionListener } from './lib/noti
 import {
 	getInitialMediaCallEvents,
 	setupMediaCallEvents,
-	type MediaCallEventsAdapters
+	type MediaCallEventsRuntime
 } from './lib/services/voip/MediaCallEvents';
 import store from './lib/store';
 import { initStore } from './lib/store/auxStore';
@@ -47,6 +47,13 @@ import StatusBar from './containers/StatusBar';
 
 enableScreens();
 initStore(store);
+
+const mediaCallEventsRuntime: MediaCallEventsRuntime = {
+	getActiveWorkspaceServerUrl: () => store.getState().server.server,
+	onOpenDeepLink: params => {
+		store.dispatch(deepLinkingOpen(params));
+	}
+};
 
 interface IDimensions {
 	width: number;
@@ -113,13 +120,6 @@ export default class Root extends React.Component<{}, IState> {
 		setNativeTheme(theme);
 	}
 
-	private getMediaCallEventsAdapters(): MediaCallEventsAdapters {
-		return {
-			getActiveServerUrl: () => store.getState().server.server,
-			onOpenDeepLink: params => store.dispatch(deepLinkingOpen(params))
-		};
-	}
-
 	componentDidMount() {
 		this.listenerTimeout = setTimeout(() => {
 			Linking.addEventListener('url', ({ url }) => {
@@ -134,7 +134,7 @@ export default class Root extends React.Component<{}, IState> {
 		// Set up video conf action listener for background accept/decline
 		this.videoConfActionCleanup = setupVideoConfActionListener();
 		// Set up media call event listeners for incoming calls
-		this.mediaCallEventCleanup = setupMediaCallEvents(this.getMediaCallEventsAdapters());
+		this.mediaCallEventCleanup = setupMediaCallEvents(mediaCallEventsRuntime);
 	}
 
 	componentWillUnmount() {
@@ -164,7 +164,7 @@ export default class Root extends React.Component<{}, IState> {
 			return;
 		}
 
-		const voipInitialHandled = await getInitialMediaCallEvents(this.getMediaCallEventsAdapters());
+		const voipInitialHandled = await getInitialMediaCallEvents(mediaCallEventsRuntime);
 		if (voipInitialHandled) {
 			// VoIP path already dispatched navigation (or will via deep linking); do not call appInit() in parallel
 			return;

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -172,6 +172,7 @@ const activeCallBase = {
 describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 	const toggleMute = jest.fn();
 	const getState = useCallStore.getState as jest.Mock;
+	let cleanup: (() => void) | undefined;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -180,28 +181,34 @@ describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 		toggleMute.mockClear();
 		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
 		getState.mockReturnValue({ ...activeCallBase, isMuted: false, toggleMute });
+		cleanup = undefined;
+	});
+
+	afterEach(() => {
+		cleanup?.();
+		cleanup = undefined;
 	});
 
 	it('registers didPerformSetMutedCallAction via RNCallKeep.addEventListener', () => {
-		setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		expect(mockAddEventListener).toHaveBeenCalledWith('didPerformSetMutedCallAction', expect.any(Function));
 	});
 
 	it('calls toggleMute when muted state differs from OS and UUIDs match', () => {
-		setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
 		expect(toggleMute).toHaveBeenCalledTimes(1);
 	});
 
 	it('does not call toggleMute when muted state already matches OS even if UUIDs match', () => {
 		getState.mockReturnValue({ ...activeCallBase, isMuted: true, toggleMute });
-		setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
 		expect(toggleMute).not.toHaveBeenCalled();
 	});
 
 	it('drops event when callUUID does not match active call id', () => {
-		setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-2' });
 		expect(toggleMute).not.toHaveBeenCalled();
 	});
@@ -214,7 +221,7 @@ describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 			isMuted: false,
 			toggleMute
 		});
-		setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
 		expect(toggleMute).not.toHaveBeenCalled();
 	});
@@ -223,6 +230,7 @@ describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 describe('setupMediaCallEvents — VoipPushTokenRegistered (iOS)', () => {
 	const getState = useCallStore.getState as jest.Mock;
 	let addListenerSpy: jest.SpyInstance;
+	let cleanup: (() => void) | undefined;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -231,14 +239,17 @@ describe('setupMediaCallEvents — VoipPushTokenRegistered (iOS)', () => {
 		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
 		getState.mockReturnValue({ ...activeCallBase, isMuted: false, toggleMute: jest.fn() });
 		addListenerSpy = jest.spyOn(NativeEventEmitter.prototype, 'addListener');
+		cleanup = undefined;
 	});
 
 	afterEach(() => {
+		cleanup?.();
+		cleanup = undefined;
 		addListenerSpy.mockRestore();
 	});
 
 	it('registers VoIP token listener and calls registerPushToken when native emits token', async () => {
-		setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		const handler = getNativeEmitterHandler('VoipPushTokenRegistered', addListenerSpy);
 		handler({ token: 'voip-device-token' });
 		await Promise.resolve();
@@ -330,6 +341,7 @@ describe('getInitialMediaCallEvents — iOS cold start', () => {
 describe('setupMediaCallEvents — endCall clears accept dedupe (iOS)', () => {
 	const getState = useCallStore.getState as jest.Mock;
 	let addListenerSpy: jest.SpyInstance;
+	let cleanup: (() => void) | undefined;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -338,15 +350,18 @@ describe('setupMediaCallEvents — endCall clears accept dedupe (iOS)', () => {
 		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
 		getState.mockReturnValue({ setNativeAcceptedCallId: jest.fn() });
 		addListenerSpy = jest.spyOn(NativeEventEmitter.prototype, 'addListener');
+		cleanup = undefined;
 	});
 
 	afterEach(() => {
+		cleanup?.();
+		cleanup = undefined;
 		addListenerSpy.mockRestore();
 	});
 
 	it('allows a second VoipAcceptSucceeded after endCall for the same callId (dedupe reset)', () => {
 		const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
-		setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		const payload = buildIncomingPayload({ callId: 'dedupe-after-end' });
 		const handler = getNativeEmitterHandler('VoipAcceptSucceeded', addListenerSpy);
 

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -3,6 +3,7 @@
  *
  * iOS-only paths: isIOS = true, NativeEventEmitter for VoIP events, CallKit listeners.
  */
+import { NativeEventEmitter } from 'react-native';
 import RNCallKeep from 'react-native-callkeep';
 
 import type { VoipPayload } from '../../../definitions/Voip';
@@ -12,7 +13,7 @@ import {
 	getInitialMediaCallEvents,
 	resetMediaCallEventsStateForTesting,
 	setupMediaCallEvents,
-	type MediaCallEventsAdapters
+	type MediaCallEventsRuntime
 } from './MediaCallEvents';
 import { useCallStore } from './useCallStore';
 
@@ -57,6 +58,16 @@ jest.mock('react-native', () => ({
 	}
 }));
 
+const mockOnOpenDeepLink = jest.fn();
+const mockGetActiveWorkspaceServerUrl = jest.fn(() => 'https://active-ws.example.com');
+
+const testRuntime: MediaCallEventsRuntime = {
+	onOpenDeepLink: mockOnOpenDeepLink,
+	getActiveWorkspaceServerUrl: mockGetActiveWorkspaceServerUrl
+};
+
+const mockAddEventListener = jest.fn();
+
 jest.mock('../../methods/helpers', () => ({
 	isIOS: true,
 	normalizeDeepLinkingServerHost: jest.requireActual('../../methods/helpers/normalizeDeepLinkingServerHost')
@@ -73,7 +84,9 @@ jest.mock('../../native/NativeVoip', () => ({
 	__esModule: true,
 	default: {
 		clearInitialEvents: jest.fn(),
-		getInitialEvents: jest.fn(() => null)
+		getInitialEvents: jest.fn(() => null),
+		addListener: jest.fn(),
+		removeListeners: jest.fn()
 	}
 }));
 
@@ -97,8 +110,6 @@ jest.mock('./MediaCallLogger', () => ({
 	}
 }));
 
-const mockAddEventListener = jest.fn();
-
 jest.mock('react-native-callkeep', () => ({
 	__esModule: true,
 	default: {
@@ -108,16 +119,6 @@ jest.mock('react-native-callkeep', () => ({
 		getInitialEvents: jest.fn(() => Promise.resolve([]))
 	}
 }));
-
-const mockOnOpenDeepLink = jest.fn();
-const mockServerSelector = jest.fn(() => 'https://workspace-ios.example.com');
-
-function makeTestAdapters(): MediaCallEventsAdapters {
-	return {
-		getActiveServerUrl: () => mockServerSelector(),
-		onOpenDeepLink: mockOnOpenDeepLink
-	};
-}
 
 function emitNativeVoipEvent(eventType: string, payload: unknown): void {
 	mockNativeVoipListeners[eventType]?.forEach(fn => {
@@ -141,12 +142,20 @@ function getMuteHandler(): (p: { muted: boolean; callUUID: string }) => void {
 	return call[1] as (p: { muted: boolean; callUUID: string }) => void;
 }
 
+function getNativeEmitterHandler(event: string, addListenerSpy: jest.SpyInstance): (payload: unknown) => void {
+	const call = addListenerSpy.mock.calls.find(([name]) => name === event);
+	if (!call) {
+		throw new Error(`NativeEventEmitter listener for ${event} not registered`);
+	}
+	return call[1] as (payload: unknown) => void;
+}
+
 function buildIncomingPayload(overrides: Partial<VoipPayload> = {}): VoipPayload {
 	return {
-		callId: 'ios-call-uuid',
+		callId: 'ios-cold-call',
 		caller: 'caller-id',
 		username: 'caller',
-		host: 'https://other-server.example.com',
+		host: 'https://other-ws.example.com',
 		hostName: 'Other',
 		type: 'incoming_call',
 		notificationId: 1,
@@ -174,25 +183,25 @@ describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 	});
 
 	it('registers didPerformSetMutedCallAction via RNCallKeep.addEventListener', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		expect(mockAddEventListener).toHaveBeenCalledWith('didPerformSetMutedCallAction', expect.any(Function));
 	});
 
 	it('calls toggleMute when muted state differs from OS and UUIDs match', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
 		expect(toggleMute).toHaveBeenCalledTimes(1);
 	});
 
 	it('does not call toggleMute when muted state already matches OS even if UUIDs match', () => {
 		getState.mockReturnValue({ ...activeCallBase, isMuted: true, toggleMute });
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
 		expect(toggleMute).not.toHaveBeenCalled();
 	});
 
 	it('drops event when callUUID does not match active call id', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-2' });
 		expect(toggleMute).not.toHaveBeenCalled();
 	});
@@ -205,7 +214,7 @@ describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 			isMuted: false,
 			toggleMute
 		});
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		getMuteHandler()({ muted: true, callUUID: 'uuid-1' });
 		expect(toggleMute).not.toHaveBeenCalled();
 	});
@@ -213,26 +222,33 @@ describe('setupMediaCallEvents — didPerformSetMutedCallAction (iOS)', () => {
 
 describe('setupMediaCallEvents — VoipPushTokenRegistered (iOS)', () => {
 	const getState = useCallStore.getState as jest.Mock;
+	let addListenerSpy: jest.SpyInstance;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 		resetMediaCallEventsStateForTesting();
 		Object.keys(mockNativeVoipListeners).forEach(k => delete mockNativeVoipListeners[k]);
 		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
-		getState.mockReturnValue({});
+		getState.mockReturnValue({ ...activeCallBase, isMuted: false, toggleMute: jest.fn() });
+		addListenerSpy = jest.spyOn(NativeEventEmitter.prototype, 'addListener');
 	});
 
-	it('registers push token with no arguments when native emits VoipPushTokenRegistered', async () => {
-		setupMediaCallEvents(makeTestAdapters());
-		emitNativeVoipEvent('VoipPushTokenRegistered', { token: 'voip-token-xyz' });
+	afterEach(() => {
+		addListenerSpy.mockRestore();
+	});
+
+	it('registers VoIP token listener and calls registerPushToken when native emits token', async () => {
+		setupMediaCallEvents(testRuntime);
+		const handler = getNativeEmitterHandler('VoipPushTokenRegistered', addListenerSpy);
+		handler({ token: 'voip-device-token' });
 		await Promise.resolve();
-		expect(registerPushToken).toHaveBeenCalledWith();
+		expect(registerPushToken).toHaveBeenCalledTimes(1);
 	});
 });
 
 describe('getInitialMediaCallEvents — iOS cold start', () => {
-	const getState = useCallStore.getState as jest.Mock;
 	const mockSetNativeAcceptedCallId = jest.fn();
+	const getState = useCallStore.getState as jest.Mock;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -242,91 +258,107 @@ describe('getInitialMediaCallEvents — iOS cold start', () => {
 		(NativeVoipModule.getInitialEvents as jest.Mock).mockReset();
 		(RNCallKeep.getInitialEvents as jest.Mock).mockReset();
 		getState.mockReturnValue({ setNativeAcceptedCallId: mockSetNativeAcceptedCallId });
+		mockGetActiveWorkspaceServerUrl.mockReturnValue('https://active-ws.example.com');
 	});
 
-	it('returns true and applies REST signals when CallKit shows answered and host matches workspace', async () => {
-		const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
-		const callId = 'answered-ios-uuid';
-		mockServerSelector.mockReturnValue('https://same.example.com');
+	it('returns true and invokes onOpenDeepLink when CallKit shows answered action for same call UUID (different workspace)', async () => {
+		const callId = 'matching-uuid';
 		(NativeVoipModule.getInitialEvents as jest.Mock).mockReturnValue(
 			buildIncomingPayload({
 				callId,
-				host: 'https://same.example.com'
+				host: 'https://other-ws.example.com'
 			})
 		);
 		(RNCallKeep.getInitialEvents as jest.Mock).mockResolvedValue([
-			{ name: 'RNCallKeepPerformAnswerCallAction', data: { callUUID: callId } }
+			{
+				name: 'RNCallKeepPerformAnswerCallAction',
+				data: { callUUID: callId }
+			}
 		]);
 
-		const result = await getInitialMediaCallEvents(makeTestAdapters());
-
-		expect(result).toBe(true);
-		expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith(callId);
-		expect(mediaSessionInstance.applyRestStateSignals).toHaveBeenCalled();
-		expect(mockOnOpenDeepLink).not.toHaveBeenCalled();
-	});
-
-	it('returns true and opens deep link when answered on cold start but host differs from workspace', async () => {
-		const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
-		const callId = 'answered-cross-ws';
-		mockServerSelector.mockReturnValue('https://workspace-ios.example.com');
-		(NativeVoipModule.getInitialEvents as jest.Mock).mockReturnValue(
-			buildIncomingPayload({
-				callId,
-				host: 'https://foreign.example.com'
-			})
-		);
-		(RNCallKeep.getInitialEvents as jest.Mock).mockResolvedValue([
-			{ name: 'RNCallKeepPerformAnswerCallAction', data: { callUUID: callId } }
-		]);
-
-		const result = await getInitialMediaCallEvents(makeTestAdapters());
+		const result = await getInitialMediaCallEvents(testRuntime);
 
 		expect(result).toBe(true);
 		expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith(callId);
 		expect(mockOnOpenDeepLink).toHaveBeenCalledWith({
 			callId,
-			host: 'https://foreign.example.com'
+			host: 'https://other-ws.example.com'
 		});
-		expect(mediaSessionInstance.applyRestStateSignals).not.toHaveBeenCalled();
 	});
 
-	it('returns false when CallKit initial events have no RNCallKeepPerformAnswerCallAction', async () => {
-		const callId = 'unanswered-ios-uuid';
+	it('clears native VoIP stash when CallKit shows the call was not answered (avoid sticky replay)', async () => {
+		const callId = 'unanswered-uuid';
 		(NativeVoipModule.getInitialEvents as jest.Mock).mockReturnValue(
-			buildIncomingPayload({ callId, host: 'https://workspace-ios.example.com' })
+			buildIncomingPayload({
+				callId,
+				host: 'https://other-ws.example.com'
+			})
 		);
-		(RNCallKeep.getInitialEvents as jest.Mock).mockResolvedValue([
-			{ name: 'RNCallKeepDidDisplayIncomingCall', data: { callUUID: callId } }
-		]);
+		(RNCallKeep.getInitialEvents as jest.Mock).mockResolvedValue([]);
 
-		const result = await getInitialMediaCallEvents(makeTestAdapters());
+		const result = await getInitialMediaCallEvents(testRuntime);
 
 		expect(result).toBe(false);
-		expect(mockSetNativeAcceptedCallId).not.toHaveBeenCalled();
+		expect(NativeVoipModule.clearInitialEvents).toHaveBeenCalled();
+		expect(mockOnOpenDeepLink).not.toHaveBeenCalled();
+	});
+
+	it('returns true without onOpenDeepLink when host matches active workspace (same-workspace cold accept)', async () => {
+		const callId = 'same-ws-uuid';
+		(NativeVoipModule.getInitialEvents as jest.Mock).mockReturnValue(
+			buildIncomingPayload({
+				callId,
+				host: 'https://active-ws.example.com'
+			})
+		);
+		(RNCallKeep.getInitialEvents as jest.Mock).mockResolvedValue([
+			{
+				name: 'RNCallKeepPerformAnswerCallAction',
+				data: { callUUID: callId }
+			}
+		]);
+		const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
+
+		const result = await getInitialMediaCallEvents(testRuntime);
+
+		expect(result).toBe(true);
+		expect(mediaSessionInstance.applyRestStateSignals).toHaveBeenCalled();
 		expect(mockOnOpenDeepLink).not.toHaveBeenCalled();
 	});
 });
 
 describe('setupMediaCallEvents — endCall clears accept dedupe (iOS)', () => {
 	const getState = useCallStore.getState as jest.Mock;
-	const mockSetNativeAcceptedCallId = jest.fn();
+	let addListenerSpy: jest.SpyInstance;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 		resetMediaCallEventsStateForTesting();
 		Object.keys(mockNativeVoipListeners).forEach(k => delete mockNativeVoipListeners[k]);
 		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
-		getState.mockReturnValue({ setNativeAcceptedCallId: mockSetNativeAcceptedCallId });
+		getState.mockReturnValue({ setNativeAcceptedCallId: jest.fn() });
+		addListenerSpy = jest.spyOn(NativeEventEmitter.prototype, 'addListener');
 	});
 
-	it('allows a second VoipAcceptSucceeded with the same callId after endCall', () => {
-		setupMediaCallEvents(makeTestAdapters());
-		const payload = buildIncomingPayload({ callId: 'reuse-id', host: 'https://foreign.example.com' });
-		emitNativeVoipEvent('VoipAcceptSucceeded', payload);
+	afterEach(() => {
+		addListenerSpy.mockRestore();
+	});
+
+	it('allows a second VoipAcceptSucceeded after endCall for the same callId (dedupe reset)', () => {
+		const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
+		setupMediaCallEvents(testRuntime);
+		const payload = buildIncomingPayload({ callId: 'dedupe-after-end' });
+		const handler = getNativeEmitterHandler('VoipAcceptSucceeded', addListenerSpy);
+
+		handler(payload);
+		handler(payload);
 		expect(mockOnOpenDeepLink).toHaveBeenCalledTimes(1);
+
 		getEndCallHandler()({ callUUID: 'any' });
-		emitNativeVoipEvent('VoipAcceptSucceeded', payload);
-		expect(mockOnOpenDeepLink).toHaveBeenCalledTimes(2);
+		(mediaSessionInstance.endCall as jest.Mock).mockClear();
+		mockOnOpenDeepLink.mockClear();
+
+		handler(payload);
+		expect(mockOnOpenDeepLink).toHaveBeenCalledTimes(1);
 	});
 });

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -120,12 +120,6 @@ jest.mock('react-native-callkeep', () => ({
 	}
 }));
 
-function emitNativeVoipEvent(eventType: string, payload: unknown): void {
-	mockNativeVoipListeners[eventType]?.forEach(fn => {
-		fn(payload);
-	});
-}
-
 function getEndCallHandler(): (payload: { callUUID: string }) => void {
 	const call = mockAddEventListener.mock.calls.find(([name]) => name === 'endCall');
 	if (!call) {

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -7,11 +7,18 @@ import {
 	getInitialMediaCallEvents,
 	resetMediaCallEventsStateForTesting,
 	setupMediaCallEvents,
-	type MediaCallEventsAdapters
+	type MediaCallEventsRuntime
 } from './MediaCallEvents';
 import { useCallStore } from './useCallStore';
 
 const mockOnOpenDeepLink = jest.fn();
+const mockGetActiveWorkspaceServerUrl = jest.fn(() => 'https://workspace-a.example.com');
+
+const testRuntime: MediaCallEventsRuntime = {
+	onOpenDeepLink: mockOnOpenDeepLink,
+	getActiveWorkspaceServerUrl: mockGetActiveWorkspaceServerUrl
+};
+
 const mockSetNativeAcceptedCallId = jest.fn();
 const mockAddEventListener = jest.fn();
 const mockRNCallKeepClearInitialEvents = jest.fn();
@@ -21,15 +28,6 @@ jest.mock('../../methods/helpers', () => ({
 	...jest.requireActual('../../methods/helpers'),
 	isIOS: false
 }));
-
-const mockServerSelector = jest.fn(() => 'https://workspace-a.example.com');
-
-function makeTestAdapters(): MediaCallEventsAdapters {
-	return {
-		getActiveServerUrl: () => mockServerSelector(),
-		onOpenDeepLink: mockOnOpenDeepLink
-	};
-}
 
 jest.mock('./useCallStore', () => ({
 	useCallStore: {
@@ -115,7 +113,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 			mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
 			(NativeVoipModule.getInitialEvents as jest.Mock).mockReturnValue(null);
 			getState.mockReturnValue({ setNativeAcceptedCallId: mockSetNativeAcceptedCallId });
-			teardown = setupMediaCallEvents(makeTestAdapters());
+			teardown = setupMediaCallEvents(testRuntime);
 		});
 
 		afterEach(() => {
@@ -124,7 +122,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 		});
 
 		describe('VoipAcceptSucceeded', () => {
-			it('sets nativeAcceptedCallId and opens deep link with host and callId for incoming_call', () => {
+			it('sets nativeAcceptedCallId and invokes onOpenDeepLink with host and callId for incoming_call', () => {
 				const payload = buildIncomingPayload({
 					callId: 'workspace-b-call',
 					host: 'https://workspace-b.open.rocket.chat'
@@ -141,9 +139,9 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 				});
 			});
 
-			it('skips deep link open and replays REST state signals when host matches active workspace', () => {
+			it('skips onOpenDeepLink and replays REST state signals when host matches active workspace', () => {
 				const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
-				mockServerSelector.mockReturnValueOnce('https://workspace-a.example.com');
+				mockGetActiveWorkspaceServerUrl.mockReturnValueOnce('https://workspace-a.example.com');
 				const payload = buildIncomingPayload({
 					callId: 'same-ws-call',
 					host: 'https://workspace-a.example.com'
@@ -182,7 +180,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 		});
 
 		describe('VoipAcceptFailed', () => {
-			it('opens deep link with voipAcceptFailed after native failure event', () => {
+			it('invokes onOpenDeepLink with voipAcceptFailed after native failure event', () => {
 				DeviceEventEmitter.emit(
 					'VoipAcceptFailed',
 					buildIncomingPayload({
@@ -234,7 +232,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 			getState.mockReturnValue({ setNativeAcceptedCallId: mockSetNativeAcceptedCallId });
 		});
 
-		it('returns true and opens failure deep link when stash has voipAcceptFailed + host + callId', async () => {
+		it('returns true and invokes failure deep link when stash has voipAcceptFailed + host + callId', async () => {
 			(NativeVoipModule.getInitialEvents as jest.Mock).mockReturnValue({
 				voipAcceptFailed: true,
 				callId: 'cold-fail-call',
@@ -246,7 +244,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 				notificationId: 1
 			});
 
-			const result = await getInitialMediaCallEvents(makeTestAdapters());
+			const result = await getInitialMediaCallEvents(testRuntime);
 
 			expect(result).toBe(true);
 			expect(mockOnOpenDeepLink).toHaveBeenCalledWith({
@@ -260,7 +258,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 			expect(mockSetNativeAcceptedCallId).not.toHaveBeenCalled();
 		});
 
-		it('on Android cold start, opens success deep link when incoming payload is present (answered path)', async () => {
+		it('on Android cold start, invokes success deep link when incoming payload is present (answered path)', async () => {
 			(NativeVoipModule.getInitialEvents as jest.Mock).mockReturnValue(
 				buildIncomingPayload({
 					callId: 'android-cold-accept',
@@ -268,7 +266,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 				})
 			);
 
-			const result = await getInitialMediaCallEvents(makeTestAdapters());
+			const result = await getInitialMediaCallEvents(testRuntime);
 
 			expect(result).toBe(true);
 			expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith('android-cold-accept');
@@ -291,7 +289,7 @@ describe('VoipAcceptSucceeded sentinel-correctness (Android)', () => {
 	});
 
 	it('B1: outgoing_call with same callId does not poison sentinel for subsequent incoming_call', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 
 		// First emit: outgoing_call — type guard should bail before setting sentinel
 		DeviceEventEmitter.emit('VoipAcceptSucceeded', buildIncomingPayload({ callId: 'shared-id', type: 'outgoing_call' }));
@@ -307,7 +305,7 @@ describe('VoipAcceptSucceeded sentinel-correctness (Android)', () => {
 	});
 
 	it('B2: different callIds are both processed (not suppressed)', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 
 		DeviceEventEmitter.emit(
 			'VoipAcceptSucceeded',
@@ -323,19 +321,15 @@ describe('VoipAcceptSucceeded sentinel-correctness (Android)', () => {
 		expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith('call-B');
 	});
 
-	it('B3: getActiveServerUrl returning undefined falls through to deep-link path', () => {
-		const adapters: MediaCallEventsAdapters = {
-			getActiveServerUrl: () => undefined,
-			onOpenDeepLink: mockOnOpenDeepLink
-		};
-		setupMediaCallEvents(adapters);
+	it('B3: getActiveWorkspaceServerUrl returning undefined falls through to deep-link path', () => {
+		mockGetActiveWorkspaceServerUrl.mockReturnValueOnce(undefined);
+		setupMediaCallEvents(testRuntime);
 
 		DeviceEventEmitter.emit(
 			'VoipAcceptSucceeded',
 			buildIncomingPayload({ callId: 'any-call', host: 'https://server-b.example.com' })
 		);
 
-		// isVoipIncomingHostCurrentWorkspace returns false when active URL is falsy
 		expect(mockOnOpenDeepLink).toHaveBeenCalledTimes(1);
 		expect(mockOnOpenDeepLink).toHaveBeenCalledWith({
 			callId: 'any-call',
@@ -357,12 +351,12 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 	});
 
 	it('registers didToggleHoldCallAction via RNCallKeep.addEventListener', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		expect(mockAddEventListener).toHaveBeenCalledWith('didToggleHoldCallAction', expect.any(Function));
 	});
 
 	it('hold: true when isOnHold is false calls toggleHold once and does not setCurrentCallActive', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		getToggleHoldHandler()({ hold: true, callUUID: 'uuid-1' });
 		expect(toggleHold).toHaveBeenCalledTimes(1);
 		expect(mockSetCurrentCallActive).not.toHaveBeenCalled();
@@ -370,13 +364,13 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 
 	it('hold: true when isOnHold is true does not call toggleHold', () => {
 		getState.mockReturnValue({ ...activeCallBase, isOnHold: true, toggleHold });
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		getToggleHoldHandler()({ hold: true, callUUID: 'uuid-1' });
 		expect(toggleHold).not.toHaveBeenCalled();
 	});
 
 	it('hold: false after OS-initiated hold calls toggleHold once (auto-resume) and setCurrentCallActive', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		const handler = getToggleHoldHandler();
 		handler({ hold: true, callUUID: 'uuid-1' });
 		getState.mockReturnValue({ ...activeCallBase, isOnHold: true, toggleHold });
@@ -387,14 +381,14 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 	});
 
 	it('hold: false without prior OS-initiated hold does not call toggleHold or setCurrentCallActive', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		getToggleHoldHandler()({ hold: false, callUUID: 'uuid-1' });
 		expect(toggleHold).not.toHaveBeenCalled();
 		expect(mockSetCurrentCallActive).not.toHaveBeenCalled();
 	});
 
 	it('consecutive hold: true events call toggleHold only once', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		const handler = getToggleHoldHandler();
 		handler({ hold: true, callUUID: 'uuid-1' });
 		getState.mockReturnValue({ ...activeCallBase, isOnHold: true, toggleHold });
@@ -403,7 +397,7 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 	});
 
 	it('clears stale auto-hold when callUUID does not match current call id (e.g. new workspace / call)', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		const handler = getToggleHoldHandler();
 		handler({ hold: true, callUUID: 'uuid-1' });
 		expect(toggleHold).toHaveBeenCalledTimes(1);
@@ -423,7 +417,7 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 	});
 
 	it('does not toggle when there is no active call object even if ids match', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		const handler = getToggleHoldHandler();
 		getState.mockReturnValue({
 			call: null,
@@ -437,7 +431,7 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 	});
 
 	it('hold: false does not call toggleHold when user already manually resumed before OS unhold arrives', () => {
-		setupMediaCallEvents(makeTestAdapters());
+		setupMediaCallEvents(testRuntime);
 		const handler = getToggleHoldHandler();
 
 		// OS holds the call
@@ -461,8 +455,42 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 			}
 			return { remove: jest.fn() };
 		});
-		const cleanup = setupMediaCallEvents(makeTestAdapters());
+		const cleanup = setupMediaCallEvents(testRuntime);
 		cleanup();
 		expect(remove).toHaveBeenCalled();
+	});
+});
+
+describe('setupMediaCallEvents — endCall clears accept dedupe (Android)', () => {
+	const getState = useCallStore.getState as jest.Mock;
+
+	function getEndCallHandler(): (payload: { callUUID: string }) => void {
+		const call = mockAddEventListener.mock.calls.find(([name]) => name === 'endCall');
+		if (!call) {
+			throw new Error('endCall listener not registered');
+		}
+		return call[1] as (payload: { callUUID: string }) => void;
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		resetMediaCallEventsStateForTesting();
+		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
+		getState.mockReturnValue({ setNativeAcceptedCallId: mockSetNativeAcceptedCallId });
+	});
+
+	it('registers endCall on Android and resets VoipAcceptSucceeded dedupe after endCall', () => {
+		setupMediaCallEvents(testRuntime);
+		expect(mockAddEventListener).toHaveBeenCalledWith('endCall', expect.any(Function));
+
+		const payload = buildIncomingPayload({ callId: 'dedupe-android' });
+		DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+		DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+		expect(mockOnOpenDeepLink).toHaveBeenCalledTimes(1);
+
+		mockOnOpenDeepLink.mockClear();
+		getEndCallHandler()({ callUUID: 'uuid-any' });
+		DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+		expect(mockOnOpenDeepLink).toHaveBeenCalledTimes(1);
 	});
 });

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -341,6 +341,7 @@ describe('VoipAcceptSucceeded sentinel-correctness (Android)', () => {
 describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 	const toggleHold = jest.fn();
 	const getState = useCallStore.getState as jest.Mock;
+	let cleanup: (() => void) | undefined;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -348,6 +349,12 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 		toggleHold.mockClear();
 		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
 		getState.mockReturnValue({ ...activeCallBase, isOnHold: false, toggleHold });
+		cleanup = undefined;
+	});
+
+	afterEach(() => {
+		cleanup?.();
+		cleanup = undefined;
 	});
 
 	it('registers didToggleHoldCallAction via RNCallKeep.addEventListener', () => {
@@ -455,7 +462,7 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 			}
 			return { remove: jest.fn() };
 		});
-		const cleanup = setupMediaCallEvents(testRuntime);
+		cleanup = setupMediaCallEvents(testRuntime);
 		cleanup();
 		expect(remove).toHaveBeenCalled();
 	});

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -17,25 +17,28 @@ const mediaCallLogger = new MediaCallLogger();
 const EVENT_VOIP_ACCEPT_FAILED = 'VoipAcceptFailed';
 const EVENT_VOIP_ACCEPT_SUCCEEDED = 'VoipAcceptSucceeded';
 
-/** Params forwarded into the app deep-linking pipeline for VoIP-driven navigation. */
-export type VoipDeepLinkParams = {
+/** Params forwarded to app-level deep linking (Redux) without importing actions here. */
+export type VoipDeepLinkOpenParams = {
 	host?: string;
 	callId?: string;
 	username?: string;
 	voipAcceptFailed?: boolean;
+	path?: string;
+	rid?: string;
+	messageId?: string;
+	fullURL?: string;
+	type?: string;
+	token?: string;
 };
 
-export type MediaCallEventsAdapters = {
-	getActiveServerUrl: () => string | null | undefined;
-	onOpenDeepLink: (params: VoipDeepLinkParams) => void;
+export type MediaCallEventsRuntime = {
+	getActiveWorkspaceServerUrl: () => string | null | undefined;
+	onOpenDeepLink: (params: VoipDeepLinkOpenParams) => void;
 };
 
 /** True when normalized incoming host matches the active Redux workspace (no server switch needed). */
-function isVoipIncomingHostCurrentWorkspace(
-	incomingHost: string,
-	getActiveServerUrl: MediaCallEventsAdapters['getActiveServerUrl']
-): boolean {
-	const active = getActiveServerUrl();
+function isVoipIncomingHostCurrentWorkspace(runtime: MediaCallEventsRuntime, incomingHost: string): boolean {
+	const active = runtime.getActiveWorkspaceServerUrl();
 	if (!active || !incomingHost) {
 		return false;
 	}
@@ -47,20 +50,18 @@ let lastHandledVoipAcceptFailureCallId: string | null = null;
 /** Idempotent warm delivery of native accept success. */
 let lastHandledVoipAcceptSucceededCallId: string | null = null;
 
-export function clearVoipAcceptDedupeSentinels(): void {
+/** Test helper: clears accept dedupe sentinels (Jest module state). */
+export function resetMediaCallEventsStateForTesting(): void {
 	lastHandledVoipAcceptFailureCallId = null;
 	lastHandledVoipAcceptSucceededCallId = null;
 }
 
-/** Exported for tests only. Clears accept-dedupe sentinels between test cases. Production code calls clearVoipAcceptDedupeSentinels() directly. */
-export function resetMediaCallEventsStateForTesting(): void {
-	clearVoipAcceptDedupeSentinels();
+function clearVoipAcceptDedupSentinels(): void {
+	lastHandledVoipAcceptFailureCallId = null;
+	lastHandledVoipAcceptSucceededCallId = null;
 }
 
-function dispatchVoipAcceptFailureFromNative(
-	raw: VoipPayload & { voipAcceptFailed?: boolean },
-	onOpenDeepLink: MediaCallEventsAdapters['onOpenDeepLink']
-) {
+function dispatchVoipAcceptFailureFromNative(runtime: MediaCallEventsRuntime, raw: VoipPayload & { voipAcceptFailed?: boolean }) {
 	if (!raw.voipAcceptFailed) {
 		return;
 	}
@@ -68,8 +69,10 @@ function dispatchVoipAcceptFailureFromNative(
 	if (callId && lastHandledVoipAcceptFailureCallId === callId) {
 		return;
 	}
-	lastHandledVoipAcceptFailureCallId = callId ?? null;
-	onOpenDeepLink({
+	if (callId) {
+		lastHandledVoipAcceptFailureCallId = callId;
+	}
+	runtime.onOpenDeepLink({
 		host: raw.host,
 		callId: raw.callId,
 		username: raw.username,
@@ -77,8 +80,12 @@ function dispatchVoipAcceptFailureFromNative(
 	});
 }
 
-function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaCallEventsAdapters) {
+function handleVoipAcceptSucceededFromNative(runtime: MediaCallEventsRuntime, data: VoipPayload) {
 	const { callId } = data;
+	if (data.type !== 'incoming_call') {
+		mediaCallLogger.log(`${TAG} VoipAcceptSucceeded: not an incoming call`);
+		return;
+	}
 	if (callId && lastHandledVoipAcceptSucceededCallId === callId) {
 		return;
 	}
@@ -92,13 +99,13 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	mediaCallLogger.log(`${TAG} VoipAcceptSucceeded:`, data);
 	NativeVoipModule.clearInitialEvents();
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
-	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
+	if (data.host && isVoipIncomingHostCurrentWorkspace(runtime, data.host)) {
 		mediaSessionInstance.applyRestStateSignals().catch(error => {
 			mediaCallLogger.error(`${TAG} applyRestStateSignals failed:`, error);
 		});
 		return;
 	}
-	adapters.onOpenDeepLink({
+	runtime.onOpenDeepLink({
 		callId: data.callId,
 		host: data.host
 	});
@@ -108,25 +115,25 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
  * Sets up listeners for media call events.
  * @returns Cleanup function to remove listeners
  */
-export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => void) => {
+export const setupMediaCallEvents = (runtime: MediaCallEventsRuntime): (() => void) => {
 	const subscriptions: { remove: () => void }[] = [];
 
-	// iOS listens for VoIP push token registration and CallKeep events
+	subscriptions.push(
+		RNCallKeep.addEventListener('endCall', ({ callUUID }) => {
+			mediaCallLogger.log(`${TAG} End call event listener:`, callUUID);
+			mediaSessionInstance.endCall(callUUID);
+			clearVoipAcceptDedupSentinels();
+		})
+	);
+
+	// iOS listens for VoIP push token registration and CallKeep UI actions
 	if (isIOS) {
 		subscriptions.push(
 			Emitter.addListener('VoipPushTokenRegistered', ({ token }: { token: string }) => {
 				mediaCallLogger.log(`${TAG} Registered VoIP push token:`, token);
 				registerPushToken().catch(error => {
-					mediaCallLogger.warn(`${TAG} Failed to register push token after VoIP update:`, error);
+					mediaCallLogger.log(`${TAG} Failed to register push token after VoIP update:`, error);
 				});
-			})
-		);
-
-		subscriptions.push(
-			RNCallKeep.addEventListener('endCall', ({ callUUID }) => {
-				mediaCallLogger.log(`${TAG} End call event listener:`, callUUID);
-				clearVoipAcceptDedupeSentinels();
-				mediaSessionInstance.endCall(callUUID);
 			})
 		);
 
@@ -189,7 +196,7 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 	subscriptions.push(
 		Emitter.addListener(EVENT_VOIP_ACCEPT_SUCCEEDED, (data: VoipPayload) => {
 			try {
-				handleVoipAcceptSucceededFromNative(data, adapters);
+				handleVoipAcceptSucceededFromNative(runtime, data);
 			} catch (error) {
 				mediaCallLogger.error(`${TAG} Error handling VoipAcceptSucceeded:`, error);
 			}
@@ -199,7 +206,7 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 	subscriptions.push(
 		Emitter.addListener(EVENT_VOIP_ACCEPT_FAILED, (data: VoipPayload & { voipAcceptFailed?: boolean }) => {
 			mediaCallLogger.log(`${TAG} VoipAcceptFailed event:`, data);
-			dispatchVoipAcceptFailureFromNative({ ...data, voipAcceptFailed: true }, adapters.onOpenDeepLink);
+			dispatchVoipAcceptFailureFromNative(runtime, { ...data, voipAcceptFailed: true });
 			NativeVoipModule.clearInitialEvents();
 		})
 	);
@@ -213,7 +220,7 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
  * Handles initial media call events (cold start).
  * @returns true if startup should skip the default `appInit()` path (answered call, or accept failure handed to deep linking)
  */
-export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapters): Promise<boolean> => {
+export const getInitialMediaCallEvents = async (runtime: MediaCallEventsRuntime): Promise<boolean> => {
 	try {
 		const initialEvents = NativeVoipModule.getInitialEvents() as (VoipPayload & { voipAcceptFailed?: boolean }) | null;
 		if (!initialEvents) {
@@ -224,7 +231,7 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 		mediaCallLogger.log(`${TAG} Found initial events:`, initialEvents);
 
 		if (initialEvents.voipAcceptFailed && initialEvents.callId && initialEvents.host) {
-			dispatchVoipAcceptFailureFromNative(initialEvents, adapters.onOpenDeepLink);
+			dispatchVoipAcceptFailureFromNative(runtime, initialEvents);
 			RNCallKeep.clearInitialEvents();
 			NativeVoipModule.clearInitialEvents();
 			// Avoid racing `appInit()` with the deep-linking saga that handles the failure
@@ -234,6 +241,7 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 		if (!initialEvents.callId || !initialEvents.host || initialEvents.type !== 'incoming_call') {
 			mediaCallLogger.log(`${TAG} Missing required call data`);
 			RNCallKeep.clearInitialEvents();
+			NativeVoipModule.clearInitialEvents();
 			return false;
 		}
 
@@ -264,19 +272,21 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 		if (wasAnswered) {
 			useCallStore.getState().setNativeAcceptedCallId(initialEvents.callId);
 
-			if (initialEvents.host && isVoipIncomingHostCurrentWorkspace(initialEvents.host, adapters.getActiveServerUrl)) {
+			if (initialEvents.host && isVoipIncomingHostCurrentWorkspace(runtime, initialEvents.host)) {
 				mediaSessionInstance.applyRestStateSignals().catch(error => {
 					mediaCallLogger.error(`${TAG} applyRestStateSignals (initial) failed:`, error);
 				});
-				mediaCallLogger.log(`${TAG} Same workspace as VoIP host; skipped deepLinkingOpen`);
+				mediaCallLogger.log(`${TAG} Same workspace as VoIP host; skipped deep link open`);
 				return true;
 			}
 
-			adapters.onOpenDeepLink({
+			runtime.onOpenDeepLink({
 				callId: initialEvents.callId,
 				host: initialEvents.host
 			});
-			mediaCallLogger.log(`${TAG} Dispatched deepLinkingOpen for VoIP`);
+			mediaCallLogger.log(`${TAG} Dispatched deep link open for VoIP`);
+		} else if (isIOS) {
+			NativeVoipModule.clearInitialEvents();
 		}
 
 		return wasAnswered;

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -61,6 +61,15 @@ function clearVoipAcceptDedupSentinels(): void {
 	lastHandledVoipAcceptSucceededCallId = null;
 }
 
+/** Redact sensitive fields from a VoipPayload before logging. */
+function redactVoipPayload(data: VoipPayload): VoipPayload {
+	return {
+		...data,
+		username: '[redacted]',
+		caller: '[redacted]'
+	};
+}
+
 function dispatchVoipAcceptFailureFromNative(runtime: MediaCallEventsRuntime, raw: VoipPayload & { voipAcceptFailed?: boolean }) {
 	if (!raw.voipAcceptFailed) {
 		return;
@@ -89,26 +98,26 @@ function handleVoipAcceptSucceededFromNative(runtime: MediaCallEventsRuntime, da
 	if (callId && lastHandledVoipAcceptSucceededCallId === callId) {
 		return;
 	}
-	if (data.type !== 'incoming_call') {
-		mediaCallLogger.log(`${TAG} VoipAcceptSucceeded: not an incoming call`);
-		return;
-	}
 	if (callId) {
 		lastHandledVoipAcceptSucceededCallId = callId;
 	}
-	mediaCallLogger.log(`${TAG} VoipAcceptSucceeded:`, data);
-	NativeVoipModule.clearInitialEvents();
-	useCallStore.getState().setNativeAcceptedCallId(data.callId);
-	if (data.host && isVoipIncomingHostCurrentWorkspace(runtime, data.host)) {
-		mediaSessionInstance.applyRestStateSignals().catch(error => {
-			mediaCallLogger.error(`${TAG} applyRestStateSignals failed:`, error);
+	mediaCallLogger.log(`${TAG} VoipAcceptSucceeded:`, redactVoipPayload(data));
+	try {
+		NativeVoipModule.clearInitialEvents();
+		useCallStore.getState().setNativeAcceptedCallId(data.callId);
+		if (data.host && isVoipIncomingHostCurrentWorkspace(runtime, data.host)) {
+			mediaSessionInstance.applyRestStateSignals().catch(error => {
+				mediaCallLogger.error(`${TAG} applyRestStateSignals failed:`, error);
+			});
+			return;
+		}
+		runtime.onOpenDeepLink({
+			callId: data.callId,
+			host: data.host
 		});
-		return;
+	} catch (error) {
+		mediaCallLogger.error(`${TAG} handleVoipAcceptSucceededFromNative error:`, error);
 	}
-	runtime.onOpenDeepLink({
-		callId: data.callId,
-		host: data.host
-	});
 }
 
 /**
@@ -228,7 +237,7 @@ export const getInitialMediaCallEvents = async (runtime: MediaCallEventsRuntime)
 			RNCallKeep.clearInitialEvents();
 			return false;
 		}
-		mediaCallLogger.log(`${TAG} Found initial events:`, initialEvents);
+		mediaCallLogger.log(`${TAG} Found initial events:`, redactVoipPayload(initialEvents as VoipPayload));
 
 		if (initialEvents.voipAcceptFailed && initialEvents.callId && initialEvents.host) {
 			dispatchVoipAcceptFailureFromNative(runtime, initialEvents);
@@ -280,10 +289,16 @@ export const getInitialMediaCallEvents = async (runtime: MediaCallEventsRuntime)
 				return true;
 			}
 
-			runtime.onOpenDeepLink({
-				callId: initialEvents.callId,
-				host: initialEvents.host
-			});
+			try {
+				runtime.onOpenDeepLink({
+					callId: initialEvents.callId,
+					host: initialEvents.host
+				});
+			} catch (error) {
+				mediaCallLogger.error(`${TAG} getInitialMediaCallEvents onOpenDeepLink error:`, error);
+			} finally {
+				NativeVoipModule.clearInitialEvents();
+			}
 			mediaCallLogger.log(`${TAG} Dispatched deep link open for VoIP`);
 		} else if (isIOS) {
 			NativeVoipModule.clearInitialEvents();

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -10,8 +10,7 @@ import { registerPushToken } from '../restApi';
 import { MediaCallLogger } from './MediaCallLogger';
 
 const Emitter = isIOS ? new NativeEventEmitter(NativeVoipModule) : DeviceEventEmitter;
-const platform = isIOS ? 'iOS' : 'Android';
-const TAG = `[MediaCallEvents][${platform}]`;
+const TAG = isIOS ? '[MediaCallEvents][iOS]' : '[MediaCallEvents][Android]';
 const mediaCallLogger = new MediaCallLogger();
 
 const EVENT_VOIP_ACCEPT_FAILED = 'VoipAcceptFailed';
@@ -138,8 +137,8 @@ export const setupMediaCallEvents = (runtime: MediaCallEventsRuntime): (() => vo
 	// iOS listens for VoIP push token registration and CallKeep UI actions
 	if (isIOS) {
 		subscriptions.push(
-			Emitter.addListener('VoipPushTokenRegistered', ({ token }: { token: string }) => {
-				mediaCallLogger.log(`${TAG} Registered VoIP push token:`, token);
+			Emitter.addListener('VoipPushTokenRegistered', () => {
+				mediaCallLogger.log(`${TAG} Registered VoIP push token`);
 				registerPushToken().catch(error => {
 					mediaCallLogger.log(`${TAG} Failed to register push token after VoIP update:`, error);
 				});
@@ -214,7 +213,7 @@ export const setupMediaCallEvents = (runtime: MediaCallEventsRuntime): (() => vo
 
 	subscriptions.push(
 		Emitter.addListener(EVENT_VOIP_ACCEPT_FAILED, (data: VoipPayload & { voipAcceptFailed?: boolean }) => {
-			mediaCallLogger.log(`${TAG} VoipAcceptFailed event:`, data);
+			mediaCallLogger.log(`${TAG} VoipAcceptFailed event:`, redactVoipPayload(data));
 			dispatchVoipAcceptFailureFromNative(runtime, { ...data, voipAcceptFailed: true });
 			NativeVoipModule.clearInitialEvents();
 		})
@@ -286,6 +285,7 @@ export const getInitialMediaCallEvents = async (runtime: MediaCallEventsRuntime)
 					mediaCallLogger.error(`${TAG} applyRestStateSignals (initial) failed:`, error);
 				});
 				mediaCallLogger.log(`${TAG} Same workspace as VoIP host; skipped deep link open`);
+				NativeVoipModule.clearInitialEvents();
 				return true;
 			}
 

--- a/app/lib/services/voip/resetVoipState.ts
+++ b/app/lib/services/voip/resetVoipState.ts
@@ -1,9 +1,7 @@
 import { useCallStore } from './useCallStore';
-import { clearVoipAcceptDedupeSentinels } from './MediaCallEvents';
 
-/** Resets VoIP UI / native-call-id state after accept failure or similar teardown (deep linking saga). Also clears accept-dedupe sentinels so Android cold-start and re-delivery paths are not poisoned by a prior call. */
+/** Resets VoIP Zustand slice after native accept failure (deep-linking saga). */
 export function resetVoipState(): void {
-	clearVoipAcceptDedupeSentinels();
 	const { resetNativeCallId, reset } = useCallStore.getState();
 	resetNativeCallId();
 	reset();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

This PR decouples VoIP native event wiring from Redux: `MediaCallEvents` no longer imports the global `store` or `deepLinkingOpen`. Instead, `app/index.tsx` passes a small `MediaCallEventsRuntime` with `onOpenDeepLink` (dispatching `deepLinkingOpen`) and `getActiveWorkspaceServerUrl` (current workspace host for same-server accept shortcuts).

VoIP accept failure handling in `sagas/deepLinking.js` now calls `resetVoipState()`, which encapsulates `resetNativeCallId()` plus `reset()` on the VoIP Zustand slice.

Logging in `MediaCallEvents` uses `MediaCallLogger` instead of raw `console.log` / `console.error`.

**Behavior fixes (from review pass):**

- `VoipAcceptSucceeded` dedupe keys are only applied after confirming `type === 'incoming_call'`, so a non-incoming payload with the same `callId` cannot block a later real incoming success.
- `RNCallKeep` `endCall` listener (end session + clear accept dedupe sentinels) is registered on **all** platforms, not only iOS.
- `getInitialMediaCallEvents`: `NativeVoipModule.clearInitialEvents()` when required fields are missing; on iOS, when CallKit initial events show the call was **not** answered, the native VoIP stash is cleared to avoid sticky replay on the next launch.

**Tests:** `MediaCallEvents.test.ts` and `MediaCallEvents.ios.test.ts` were updated for runtime injection; added coverage for Android `endCall` dedupe reset, iOS `VoipPushTokenRegistered` → `registerPushToken`, iOS cold-start paths, unanswered cold-start stash clear, and existing hold/mute scenarios.

## Issue(s)

<!-- Note for AI: don't fill this section, it's for the human reviewer to fill. -->

## How to test or reproduce

Run unit tests:

`TZ=UTC yarn test --testPathPattern='MediaCallEvents'`

Smoke: cold start with VoIP stash (answered / failed accept), accept from another workspace, and decline/end call; confirm deep linking and same-workspace REST replay still behave as before.

## Screenshots

N/A (internal wiring).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`resetMediaCallEventsStateForTesting()` remains exported for tests that need to reset module-level dedupe state.

`DEEP_LINKING.OPEN` + `takeLatest` cancellation while a VoIP failure saga is in flight is unchanged from prior behavior; if we want stronger guarantees, that would be a separate saga change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter VoIP payload validation, safer deep-link dispatch (try/catch), and consistent end-call deduplication across platforms.
  * Cleared initial native events when required and redacted VoIP payloads from logs.
  * End-call listener now registered on all platforms.

* **Tests**
  * Refactored and expanded VoIP tests (cold-start, dedupe, Android end-call) with improved native event simulation and per-test cleanup.

* **Chores**
  * Added a test-only reset for VoIP dedupe state; removed that sentinel clearing from the general reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->