### PR TITLE
test(android): VoIP DDP WebSocket JVM tests and module smoke tests

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -155,6 +155,9 @@ dependencies {
     implementation 'androidx.security:security-crypto:1.1.0'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.14.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
+    testImplementation 'org.mockito:mockito-core:5.14.2'
 
     // For ProcessLifecycleOwner (app foreground detection)
     implementation 'androidx.lifecycle:lifecycle-process:2.8.7'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -156,6 +156,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.14.1'
+    // Align with react-native okhttp version (see node_modules/react-native/gradle/libs.versions.toml okhttp = 4.9.2)
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
     testImplementation 'org.mockito:mockito-core:5.14.2'
 

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
@@ -1,0 +1,198 @@
+package chat.rocket.reactnative.voip
+
+import android.os.Looper
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = VoipTestApplication::class)
+class DDPClientTest {
+
+    private lateinit var mockWebServer: MockWebServer
+
+    @Before
+    fun setup() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+    }
+
+    @After
+    fun tearDown() {
+        if (::mockWebServer.isInitialized) {
+            try {
+                mockWebServer.shutdown()
+            } catch (_: Exception) {
+                // OkHttp MockWebServer can throw if a WebSocket is still closing.
+            }
+        }
+    }
+
+    private fun httpHost(): String = "http://${mockWebServer.hostName}:${mockWebServer.port}/"
+
+    /** OkHttp posts DDP results to the main looper; pump until [latch] completes or timeout. */
+    private fun awaitMain(latch: CountDownLatch, timeoutMs: Long): Boolean {
+        val shadow = Shadows.shadowOf(Looper.getMainLooper())
+        val end = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < end) {
+            shadow.idleFor(25, TimeUnit.MILLISECONDS)
+            if (latch.count == 0L) {
+                return true
+            }
+        }
+        return latch.await(0, TimeUnit.MILLISECONDS)
+    }
+
+    private fun enqueueWebSocketEchoServer() {
+        mockWebServer.enqueue(
+            MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        val json = JSONObject(text)
+                        when (json.optString("msg")) {
+                            "connect" -> webSocket.send("""{"msg":"connected","session":"test-session"}""")
+                            "method" -> {
+                                val id = json.getString("id")
+                                val method = json.optString("method")
+                                if (method == "login") {
+                                    webSocket.send("""{"msg":"result","id":"$id","result":{}}""")
+                                } else {
+                                    webSocket.send("""{"msg":"result","id":"$id","result":{}}""")
+                                }
+                            }
+                            "sub" -> {
+                                val id = json.getString("id")
+                                webSocket.send("""{"msg":"ready","subs":["$id"]}""")
+                            }
+                            "pong" -> Unit
+                        }
+                    }
+                }
+            )
+        )
+    }
+
+    @Test
+    fun `connect completes after server sends connected`() {
+        enqueueWebSocketEchoServer()
+        val client = DDPClient()
+        val latch = CountDownLatch(1)
+        var ok: Boolean? = null
+        client.connect(httpHost()) { success ->
+            assertTrue(Looper.getMainLooper().isCurrentThread)
+            ok = success
+            latch.countDown()
+        }
+        assertTrue(awaitMain(latch, 20_000))
+        assertTrue(ok!!)
+        client.disconnect()
+    }
+
+    @Test
+    fun `login succeeds after connect`() {
+        enqueueWebSocketEchoServer()
+        val client = DDPClient()
+        val connectLatch = CountDownLatch(1)
+        client.connect(httpHost()) { connectLatch.countDown() }
+        assertTrue(awaitMain(connectLatch, 20_000))
+
+        val loginLatch = CountDownLatch(1)
+        var loginOk: Boolean? = null
+        client.login("resume-token") { success ->
+            loginOk = success
+            loginLatch.countDown()
+        }
+        assertTrue(awaitMain(loginLatch, 20_000))
+        assertTrue(loginOk!!)
+        client.disconnect()
+    }
+
+    @Test
+    fun `disconnect prevents further login`() {
+        enqueueWebSocketEchoServer()
+        val client = DDPClient()
+        val connectLatch = CountDownLatch(1)
+        client.connect(httpHost()) { connectLatch.countDown() }
+        assertTrue(awaitMain(connectLatch, 20_000))
+
+        client.disconnect()
+
+        val loginLatch = CountDownLatch(1)
+        var loginOk: Boolean? = null
+        client.login("resume-token") { success ->
+            loginOk = success
+            loginLatch.countDown()
+        }
+        assertTrue(awaitMain(loginLatch, 10_000))
+        assertFalse(loginOk!!)
+    }
+
+    @Test
+    fun `login with error result posts false`() {
+        mockWebServer.enqueue(
+            MockResponse().withWebSocketUpgrade(
+                object : WebSocketListener() {
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        val json = JSONObject(text)
+                        when (json.optString("msg")) {
+                            "connect" -> webSocket.send("""{"msg":"connected","session":"s"}""")
+                            "method" -> {
+                                val id = json.getString("id")
+                                webSocket.send(
+                                    """{"msg":"result","id":"$id","error":{"reason":"nope"}}"""
+                                )
+                            }
+                        }
+                    }
+                }
+            )
+        )
+        val client = DDPClient()
+        val connectLatch = CountDownLatch(1)
+        client.connect(httpHost()) { connectLatch.countDown() }
+        assertTrue(awaitMain(connectLatch, 20_000))
+
+        val loginLatch = CountDownLatch(1)
+        var loginOk: Boolean? = null
+        client.login("bad") { success ->
+            loginOk = success
+            loginLatch.countDown()
+        }
+        assertTrue(awaitMain(loginLatch, 20_000))
+        assertFalse(loginOk!!)
+        client.disconnect()
+    }
+
+    @Test
+    fun `subscribe receives ready`() {
+        enqueueWebSocketEchoServer()
+        val client = DDPClient()
+        val connectLatch = CountDownLatch(1)
+        client.connect(httpHost()) { connectLatch.countDown() }
+        assertTrue(awaitMain(connectLatch, 20_000))
+
+        val subLatch = CountDownLatch(1)
+        var subOk: Boolean? = null
+        client.subscribe("stream-notify-user", JSONArray().put("x")) { ok ->
+            subOk = ok
+            subLatch.countDown()
+        }
+        assertTrue(awaitMain(subLatch, 20_000))
+        assertTrue(subOk!!)
+        client.disconnect()
+    }
+}

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/DDPClientTest.kt
@@ -57,7 +57,11 @@ class DDPClientTest {
         return latch.await(0, TimeUnit.MILLISECONDS)
     }
 
-    private fun enqueueWebSocketEchoServer() {
+    /**
+     * Single DDP-over-WebSocket fake: answers `connect`, `method` (including login), and `sub` (ready).
+     * @param methodResultError when true, DDP `method` replies include an `error` field (e.g. failed login).
+     */
+    private fun enqueueDdpWebSocketMock(methodResultError: Boolean = false) {
         mockWebServer.enqueue(
             MockResponse().withWebSocketUpgrade(
                 object : WebSocketListener() {
@@ -67,9 +71,10 @@ class DDPClientTest {
                             "connect" -> webSocket.send("""{"msg":"connected","session":"test-session"}""")
                             "method" -> {
                                 val id = json.getString("id")
-                                val method = json.optString("method")
-                                if (method == "login") {
-                                    webSocket.send("""{"msg":"result","id":"$id","result":{}}""")
+                                if (methodResultError) {
+                                    webSocket.send(
+                                        """{"msg":"result","id":"$id","error":{"reason":"nope"}}"""
+                                    )
                                 } else {
                                     webSocket.send("""{"msg":"result","id":"$id","result":{}}""")
                                 }
@@ -78,7 +83,6 @@ class DDPClientTest {
                                 val id = json.getString("id")
                                 webSocket.send("""{"msg":"ready","subs":["$id"]}""")
                             }
-                            "pong" -> Unit
                         }
                     }
                 }
@@ -88,7 +92,7 @@ class DDPClientTest {
 
     @Test
     fun `connect completes after server sends connected`() {
-        enqueueWebSocketEchoServer()
+        enqueueDdpWebSocketMock()
         val client = DDPClient()
         val latch = CountDownLatch(1)
         var ok: Boolean? = null
@@ -104,7 +108,7 @@ class DDPClientTest {
 
     @Test
     fun `login succeeds after connect`() {
-        enqueueWebSocketEchoServer()
+        enqueueDdpWebSocketMock()
         val client = DDPClient()
         val connectLatch = CountDownLatch(1)
         client.connect(httpHost()) { connectLatch.countDown() }
@@ -123,7 +127,7 @@ class DDPClientTest {
 
     @Test
     fun `disconnect prevents further login`() {
-        enqueueWebSocketEchoServer()
+        enqueueDdpWebSocketMock()
         val client = DDPClient()
         val connectLatch = CountDownLatch(1)
         client.connect(httpHost()) { connectLatch.countDown() }
@@ -143,24 +147,7 @@ class DDPClientTest {
 
     @Test
     fun `login with error result posts false`() {
-        mockWebServer.enqueue(
-            MockResponse().withWebSocketUpgrade(
-                object : WebSocketListener() {
-                    override fun onMessage(webSocket: WebSocket, text: String) {
-                        val json = JSONObject(text)
-                        when (json.optString("msg")) {
-                            "connect" -> webSocket.send("""{"msg":"connected","session":"s"}""")
-                            "method" -> {
-                                val id = json.getString("id")
-                                webSocket.send(
-                                    """{"msg":"result","id":"$id","error":{"reason":"nope"}}"""
-                                )
-                            }
-                        }
-                    }
-                }
-            )
-        )
+        enqueueDdpWebSocketMock(methodResultError = true)
         val client = DDPClient()
         val connectLatch = CountDownLatch(1)
         client.connect(httpHost()) { connectLatch.countDown() }
@@ -179,7 +166,7 @@ class DDPClientTest {
 
     @Test
     fun `subscribe receives ready`() {
-        enqueueWebSocketEchoServer()
+        enqueueDdpWebSocketMock()
         val client = DDPClient()
         val connectLatch = CountDownLatch(1)
         client.connect(httpHost()) { connectLatch.countDown() }

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/StubReactApplicationContext.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/StubReactApplicationContext.kt
@@ -1,0 +1,65 @@
+package chat.rocket.reactnative.voip
+
+import android.app.Application
+import com.facebook.react.bridge.Callback
+import com.facebook.react.bridge.CatalystInstance
+import com.facebook.react.bridge.JavaScriptContextHolder
+import com.facebook.react.bridge.JavaScriptModule
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
+import org.mockito.Mockito
+
+/**
+ * Minimal [ReactApplicationContext] for JVM unit tests (RN 0.81 [com.facebook.react.bridge.ReactContext] is abstract).
+ */
+open class StubReactApplicationContext(
+    application: Application,
+    private val activeReactInstance: Boolean = false
+) : ReactApplicationContext(application) {
+
+    private val catalyst: CatalystInstance = Mockito.mock(CatalystInstance::class.java)
+
+    override fun <T : JavaScriptModule?> getJSModule(jsInterface: Class<T>): T {
+        val mockJs = Mockito.mock(jsInterface)
+        @Suppress("UNCHECKED_CAST")
+        return mockJs as T
+    }
+
+    override fun <T : NativeModule?> hasNativeModule(nativeModuleInterface: Class<T>): Boolean = false
+
+    override fun getNativeModules(): Collection<NativeModule> = emptyList()
+
+    override fun <T : NativeModule?> getNativeModule(nativeModuleInterface: Class<T>): T? = null
+
+    override fun getNativeModule(moduleName: String): NativeModule? = null
+
+    override fun getCatalystInstance(): CatalystInstance = catalyst
+
+    override fun hasActiveCatalystInstance(): Boolean = activeReactInstance
+
+    override fun hasActiveReactInstance(): Boolean = activeReactInstance
+
+    override fun hasCatalystInstance(): Boolean = false
+
+    override fun hasReactInstance(): Boolean = false
+
+    override fun destroy() {}
+
+    override fun handleException(e: Exception) {
+        throw AssertionError("Unexpected exception in stub context", e)
+    }
+
+    override fun isBridgeless(): Boolean = false
+
+    override fun getJavaScriptContextHolder(): JavaScriptContextHolder? = null
+
+    override fun getJSCallInvokerHolder(): CallInvokerHolder? = null
+
+    override fun getFabricUIManager(): UIManager? = null
+
+    override fun getSourceURL(): String? = null
+
+    override fun registerSegment(segmentId: Int, path: String?, callback: Callback?) {}
+}

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/StubReactApplicationContext.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/StubReactApplicationContext.kt
@@ -14,7 +14,7 @@ import org.mockito.Mockito
 /**
  * Minimal [ReactApplicationContext] for JVM unit tests (RN 0.81 [com.facebook.react.bridge.ReactContext] is abstract).
  */
-open class StubReactApplicationContext(
+class StubReactApplicationContext(
     application: Application,
     private val activeReactInstance: Boolean = false
 ) : ReactApplicationContext(application) {
@@ -35,15 +35,18 @@ open class StubReactApplicationContext(
 
     override fun getNativeModule(moduleName: String): NativeModule? = null
 
-    override fun getCatalystInstance(): CatalystInstance = catalyst
+    override fun getCatalystInstance(): CatalystInstance {
+        check(activeReactInstance) { "No catalyst when React instance is inactive" }
+        return catalyst
+    }
 
     override fun hasActiveCatalystInstance(): Boolean = activeReactInstance
 
     override fun hasActiveReactInstance(): Boolean = activeReactInstance
 
-    override fun hasCatalystInstance(): Boolean = false
+    override fun hasCatalystInstance(): Boolean = activeReactInstance
 
-    override fun hasReactInstance(): Boolean = false
+    override fun hasReactInstance(): Boolean = activeReactInstance
 
     override fun destroy() {}
 

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/VoipModuleStaticTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/VoipModuleStaticTest.kt
@@ -1,0 +1,63 @@
+package chat.rocket.reactnative.voip
+
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Smoke coverage for [VoipModule] companion paths that do not require React Native JNI ([WritableMap]).
+ * Cold-start [VoipModule.getInitialEvents] / full REST assertions belong in instrumentation tests (MMKV + SoLoader).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = VoipTestApplication::class)
+class VoipModuleStaticTest {
+
+    @After
+    fun tearDown() {
+        val ctx = StubReactApplicationContext(RuntimeEnvironment.getApplication())
+        VoipModule.setReactContext(ctx)
+        VoipModule(ctx).clearInitialEvents()
+    }
+
+    private fun isoUtcNow(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        sdf.timeZone = TimeZone.getTimeZone("UTC")
+        return sdf.format(Date())
+    }
+
+    private fun samplePayload(callId: String = "c1") = VoipPayload(
+        callId = callId,
+        caller = "Caller",
+        username = "caller",
+        host = "https://open.rocket.chat",
+        type = VoipPushType.INCOMING_CALL.value,
+        hostName = "Open",
+        avatarUrl = null,
+        createdAt = isoUtcNow(),
+        voipAcceptFailed = false
+    )
+
+    @Test
+    fun `storeInitialEvents and emitInitialEventsEvent do not throw when react instance inactive`() {
+        val ctx = StubReactApplicationContext(RuntimeEnvironment.getApplication())
+        VoipModule.setReactContext(ctx)
+        VoipModule(ctx).clearInitialEvents()
+        VoipModule.storeInitialEvents(samplePayload("s1"))
+        VoipModule.emitInitialEventsEvent(samplePayload("s2"))
+    }
+
+    @Test
+    fun `storeAcceptFailureForJs does not throw when react instance inactive`() {
+        val ctx = StubReactApplicationContext(RuntimeEnvironment.getApplication())
+        VoipModule.setReactContext(ctx)
+        VoipModule(ctx).clearInitialEvents()
+        VoipModule.storeAcceptFailureForJs(samplePayload("fail-1"))
+    }
+}

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/VoipModuleStaticTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/VoipModuleStaticTest.kt
@@ -1,37 +1,37 @@
 package chat.rocket.reactnative.voip
 
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
 
 /**
  * Smoke coverage for [VoipModule] companion paths that do not require React Native JNI ([WritableMap]).
- * Cold-start [VoipModule.getInitialEvents] / full REST assertions belong in instrumentation tests (MMKV + SoLoader).
+ * Cold-start [VoipModule.getInitialEvents] and REST assertions need instrumentation (MMKV + SoLoader).
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = VoipTestApplication::class)
 class VoipModuleStaticTest {
 
-    @After
-    fun tearDown() {
-        val ctx = StubReactApplicationContext(RuntimeEnvironment.getApplication())
+    private lateinit var ctx: StubReactApplicationContext
+
+    @Before
+    fun prepareContext() {
+        ctx = StubReactApplicationContext(RuntimeEnvironment.getApplication())
         VoipModule.setReactContext(ctx)
         VoipModule(ctx).clearInitialEvents()
     }
 
-    private fun isoUtcNow(): String {
-        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-        sdf.timeZone = TimeZone.getTimeZone("UTC")
-        return sdf.format(Date())
+    @After
+    fun tearDown() {
+        VoipModule.setReactContext(ctx)
+        VoipModule(ctx).clearInitialEvents()
     }
 
+    /** Fixed UTC timestamp valid for [VoipPayload] parsing and well inside the incoming-call lifetime window. */
     private fun samplePayload(callId: String = "c1") = VoipPayload(
         callId = callId,
         caller = "Caller",
@@ -40,24 +40,18 @@ class VoipModuleStaticTest {
         type = VoipPushType.INCOMING_CALL.value,
         hostName = "Open",
         avatarUrl = null,
-        createdAt = isoUtcNow(),
+        createdAt = "2030-06-01T12:00:00.000Z",
         voipAcceptFailed = false
     )
 
     @Test
     fun `storeInitialEvents and emitInitialEventsEvent do not throw when react instance inactive`() {
-        val ctx = StubReactApplicationContext(RuntimeEnvironment.getApplication())
-        VoipModule.setReactContext(ctx)
-        VoipModule(ctx).clearInitialEvents()
         VoipModule.storeInitialEvents(samplePayload("s1"))
         VoipModule.emitInitialEventsEvent(samplePayload("s2"))
     }
 
     @Test
     fun `storeAcceptFailureForJs does not throw when react instance inactive`() {
-        val ctx = StubReactApplicationContext(RuntimeEnvironment.getApplication())
-        VoipModule.setReactContext(ctx)
-        VoipModule(ctx).clearInitialEvents()
         VoipModule.storeAcceptFailureForJs(samplePayload("fail-1"))
     }
 }

--- a/android/app/src/test/java/chat/rocket/reactnative/voip/VoipTestApplication.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/voip/VoipTestApplication.kt
@@ -1,0 +1,6 @@
+package chat.rocket.reactnative.voip
+
+import android.app.Application
+
+/** Robolectric application so [org.robolectric.RuntimeEnvironment.getApplication] is non-null in @Before. */
+class VoipTestApplication : Application()


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

This PR adds JVM (Robolectric + MockWebServer) unit tests for the Android VoIP stack as outlined for PR-6 in the voip cleanup plan, with one deliberate scope gap:

- **`DDPClientTest`**: Mock WebSocket server exercises connect → `connected`, `login` → `result`, `subscribe` → `ready`, disconnect-then-login failure, and login error payloads. Callbacks are pumped on the main looper to match production `Handler` behavior.
- **`VoipModuleStaticTest`**: Smoke tests for `storeInitialEvents`, `emitInitialEventsEvent`, and `storeAcceptFailureForJs` when `hasActiveReactInstance()` is false (no JS bridge / no `WritableMap`).
- **`StubReactApplicationContext`**: Minimal concrete `ReactApplicationContext` for RN 0.81 (abstract `ReactContext` API).
- **`VoipTestApplication`**: Robolectric application so `RuntimeEnvironment.getApplication()` is non-null in `@Before`.
- **`android/app/build.gradle`**: `testImplementation` for JUnit, Robolectric, MockWebServer (pinned to OkHttp **4.9.2** to match React Native’s `libs.versions.toml`), and Mockito (stub catalyst).

**Not included (documented):** `MediaCallsAnswerRequest` / `Ejson` paths always call `MMKV.mmkvWithID`; JVM unit tests on the host JDK do not load `libmmkv` (`UnsatisfiedLinkError`). Full REST assertions for `media-calls.answer` belong in **instrumentation** or device E2E, or would require production test hooks. Cold-start `getInitialEvents` returning a `WritableMap` likewise needs JNI (`Arguments`).

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
<!-- Note for AI: don't fill this section, it's for the human reviewer to fill. -->

## How to test or reproduce

From repo root (with `node_modules` present):

```bash
cd android && ./gradlew :app:testOfficialDebugUnitTest --tests "chat.rocket.reactnative.voip.*"
```

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

- Follow-up (optional): align `MockWebServer` via the same Gradle version catalog / BOM as runtime OkHttp if the project centralizes that later.
- `VoipModuleStaticTest` intentionally stays smoke-level (no `WritableMap`); stricter assertions need instrumentation or a small test-only seam in production code.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test infrastructure for the Android platform with new testing dependencies and expanded test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->