### PR TITLE
fix(voip): null-check RNCallKeepModule.instance on killed-app incoming call (Android)

### DIFF
--- a/patches/react-native-callkeep+4.3.16.patch
+++ b/patches/react-native-callkeep+4.3.16.patch
@@ -57,6 +57,15 @@ diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/ca
 index 5d58692..f4e4b1b 100644
 --- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
 +++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+@@ -317,7 +317,7 @@ public class VoiceConnectionService extends ConnectionService {
+         notificationBuilder.setOngoing(true)
+             .setContentTitle(foregroundSettings.getString("notificationTitle"))
+             .setPriority(NotificationManager.IMPORTANCE_MIN)
+             .setCategory(Notification.CATEGORY_SERVICE);
+ 
+-        Activity currentActivity = RNCallKeepModule.instance.getCurrentReactActivity();
++        Activity currentActivity = RNCallKeepModule.instance != null ? RNCallKeepModule.instance.getCurrentReactActivity() : null;
+         if (currentActivity != null) {
 @@ -459,18 +459,10 @@ public class VoiceConnectionService extends ConnectionService {
          connection.setConnectionCapabilities(Connection.CAPABILITY_MUTE | Connection.CAPABILITY_SUPPORT_HOLD);
  


### PR DESCRIPTION
## Proposed changes

Fix fatal NPE crash when receiving a VoIP call with the app killed on Android.

`VoiceConnectionService.startForegroundService()` calls `RNCallKeepModule.instance.getCurrentReactActivity()` at line 322, but `instance` is null when the app has been killed — React Native hasn't initialized yet, so the static singleton is never set.

Patch adds a null-guard: if `instance` is null, `currentActivity` is null, and the existing `if (currentActivity != null)` block already handles that gracefully (skips attaching a PendingIntent to the notification).

## Issue(s)

Crash stack trace:
```
java.lang.NullPointerException: Attempt to invoke virtual method
'android.app.Activity io.wazo.callkeep.RNCallKeepModule.getCurrentReactActivity()'
on a null object reference
  at VoiceConnectionService.startForegroundService (line 322)
  at VoiceConnectionService.onCreateIncomingConnection (line 209)
```

## How to test or reproduce

1. Kill app completely on Android
2. Receive incoming VoIP call
3. Before fix: app crashes with NPE
4. After fix: incoming call UI appears without crash

## Screenshots

N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The `RNCallKeepModule.instance` static is set in `getInstance()` which is called during React Native module initialization. When Android's Telecom framework starts `VoiceConnectionService` in response to an incoming call on a killed app, the RN runtime hasn't started yet, so `instance` remains null.