### PR TITLE
fix(android): remove MediaProjectionService from merged manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -146,6 +146,15 @@
         </service>
 
         <service android:name="io.wazo.callkeep.RNCallKeepBackgroundMessagingService" />
+
+        <!-- react-native-webrtc ships MediaProjectionService (foregroundServiceType=mediaProjection)
+             for screen sharing. We don't use screen sharing, and Android 15+ forbids starting
+             restricted foreground service types from BOOT_COMPLETED receivers (expo-notifications
+             merges one in). Play Console flags this as a crash risk. Strip it from the merged
+             manifest. To re-enable, remove this block and set enableMediaProjectionService=true. -->
+        <service
+            android:name="com.oney.WebRTCModule.MediaProjectionService"
+            tools:node="remove" />
     </application>
 
     <queries>


### PR DESCRIPTION
## Proposed changes

Strips `com.oney.WebRTCModule.MediaProjectionService` from the merged Android manifest using `tools:node="remove"` to fix a Play Console crash warning on Android 15+.

`react-native-webrtc` declares `MediaProjectionService` with `foregroundServiceType="mediaProjection"` (screen sharing). `expo-notifications` merges a `BOOT_COMPLETED` receiver. Android 15+ (we target SDK 36) forbids starting restricted foreground service types from `BOOT_COMPLETED` receivers — Play static analysis flags this as a crash risk.

We don't use screen sharing (`getDisplayMedia` never called, `enableMediaProjectionService` never set), so the service is dead weight. Strip it.

## Issue(s)

N/A — Play Console pre-launch report.

## How to test or reproduce

1. `./gradlew :app:processDebugMainManifest`
2. `grep -i MediaProjection android/app/build/intermediates/merged_manifests/debug/processDebugMainManifest/AndroidManifest.xml` → no matches

## Screenshots

N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

To re-enable screen sharing in future: remove the `tools:node="remove"` block and set `WebRTCModuleOptions.getInstance().enableMediaProjectionService = true`.