### PR TITLE
ci(android): add unit test job to PR workflow

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -20,11 +20,25 @@ jobs:
     steps:
       - run: echo "Waiting for manual approval..."
 
+  run-ios-unit-tests:
+    name: Run iOS Unit Tests
+    runs-on: macos-26
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Checkout and Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Run iOS Unit Tests
+        run: xcodebuild test -scheme RocketChatRN -destination 'platform=iOS Simulator,name=iPhone 16'
+        working-directory: ./ios
+
   build-ios:
     name: Build
     runs-on: macos-26
-    needs: [build-hold]
-    if: ${{ inputs.type == 'experimental' && (always() && (needs.build-hold.result == 'success' || needs.build-hold.result == 'skipped')) }}
+    needs: [build-hold, run-ios-unit-tests]
+    if: ${{ inputs.type == 'experimental' && (always() && (needs.build-hold.result == 'success' || needs.build-hold.result == 'skipped') && needs.run-ios-unit-tests.result == 'success') }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Proposed changes
Adds a separate `android-unit-tests` job to the PR workflow that runs `./gradlew experimentalDebugUnitTest` on `ubuntu-latest`. This ensures Android unit tests pass before the experimental build starts, without adding to the build job's timeout budget.

The `android-build-experimental-store` job now depends on `android-unit-tests` in addition to `run-eslint-and-test`.

## Issue(s)
<!-- N/A — CI infrastructure improvement -->

## How to test or reproduce
This change only affects CI. The new job will run on this PR.

## Types of changes
- [x] Improvement (non-breaking change which improves a current function)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS build process by integrating automated unit testing. The build workflow now runs iOS unit tests and requires tests to pass before proceeding with the final iOS build, enhancing quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->