### PR TITLE
ci(android): add unit test job to PR workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,11 +19,22 @@ jobs:
     if: ${{ github.repository == 'RocketChat/Rocket.Chat.ReactNative' }}
     uses: ./.github/workflows/eslint.yml
 
+  android-unit-tests:
+    name: Android Unit Tests
+    runs-on: ubuntu-latest
+    needs: [run-eslint-and-test]
+    if: ${{ github.repository == 'RocketChat/Rocket.Chat.ReactNative' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node
+      - run: ./gradlew experimentalDebugUnitTest
+        working-directory: ./android
+
   android-build-experimental-store:
     name: Build Android Experimental
     if: ${{ github.repository == 'RocketChat/Rocket.Chat.ReactNative' }}
     uses: ./.github/workflows/build-android.yml
-    needs: [run-eslint-and-test]
+    needs: [run-eslint-and-test, android-unit-tests]
     secrets: inherit
     with:
       type: experimental


### PR DESCRIPTION
## Proposed changes
Adds a separate `android-unit-tests` job to the PR workflow that runs `./gradlew experimentalDebugUnitTest` on `ubuntu-latest`. This ensures Android unit tests pass before the experimental build starts, without adding to the build job's timeout budget.

The `android-build-experimental-store` job now depends on `android-unit-tests` in addition to `run-eslint-and-test`.

## Issue(s)

## How to test or reproduce
This change only affects CI. The new job will run on this PR.

## Types of changes
- [x] Improvement (non-breaking change which improves a current function)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened build quality assurance by adding unit test validation for experimental Android builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->