### PR TITLE
ci(ios): add unit test job to iOS build workflow

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -20,14 +20,28 @@ jobs:
     steps:
       - run: echo "Waiting for manual approval..."
 
+  run-ios-unit-tests:
+    name: Run iOS Unit Tests
+    runs-on: macos-26
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Checkout and Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Run iOS Unit Tests
+        run: xcodebuild test -scheme RocketChatRN -destination 'platform=iOS Simulator,name=iPhone 16'
+        working-directory: ./ios
+
   build-ios:
     name: Build
     runs-on: macos-26
-    needs: [build-hold]
-    if: ${{ inputs.type == 'experimental' && (always() && (needs.build-hold.result == 'success' || needs.build-hold.result == 'skipped')) }}
+    needs: [build-hold, run-ios-unit-tests]
+    if: ${{ inputs.type == 'experimental' && (always() && (needs.build-hold.result == 'success' || needs.build-hold.result == 'skipped') && needs.run-ios-unit-tests.result == 'success') }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
 
       - name: Checkout and Setup Node
         uses: ./.github/actions/setup-node
@@ -67,7 +81,7 @@ jobs:
     if: ${{ inputs.type == 'experimental' && (always() && (needs.build-ios.result == 'success')) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
 
       - name: Setup Node
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
## Proposed changes
Adds a `run-ios-unit-tests` job to the iOS build workflow that runs `xcodebuild test -scheme RocketChatRN -destination 'platform=iOS Simulator,name=iPhone 16'` on `macos-26`. The job is ungated (runs immediately without approval) and the `build-ios` job now waits for both the approval gate and unit tests to succeed.

This ensures iOS unit tests pass before the experimental build starts.

## Issue(s)

## How to test or reproduce
This change only affects CI. The new job will run on this PR.

> **Note:** The `RocketChatRN` Xcode scheme must exist for `xcodebuild test` to succeed. This scheme needs to be created/verified in Xcode if not already present.

## Types of changes
- [x] Improvement (non-breaking change which improves a current function)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated iOS unit testing in CI. Unit tests run on an iOS simulator and must complete successfully before the iOS build proceeds; the build now waits for both the prior hold and test job outcomes.
  * CI checkout behaviour pinned to a fixed release to improve build stability and reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->