### PR TITLE
fix: Emoji keyboard doesn't dismiss when tapping on message composer input

### DIFF
--- a/app/containers/MessageComposer/components/ComposerInput.tsx
+++ b/app/containers/MessageComposer/components/ComposerInput.tsx
@@ -3,6 +3,7 @@ import { TextInput, StyleSheet, type TextInputProps, InteractionManager } from '
 import { useDebouncedCallback } from 'use-debounce';
 import { useDispatch } from 'react-redux';
 import { type RouteProp, useFocusEffect, useRoute } from '@react-navigation/native';
+import { KeyboardController } from 'react-native-keyboard-controller';
 
 import { textInputDebounceTime } from '../../../lib/constants/debounceConfig';
 import I18n from '../../../i18n';
@@ -16,6 +17,7 @@ import {
 import { useAutocompleteParams, useFocused, useMessageComposerApi, useMicOrSend } from '../context';
 import { fetchIsAllOrHere, getMentionRegexp } from '../helpers';
 import { useAutoSaveDraft } from '../hooks';
+import { useEmojiKeyboard } from '../hooks/useEmojiKeyboard';
 import sharedStyles from '../../../views/Styles';
 import { useTheme } from '../../../theme';
 import { userTyping } from '../../../actions/room';
@@ -51,6 +53,7 @@ export const ComposerInput = memo(
 		const { rid, tmid, sharing, action, selectedMessages, setQuotesAndText, room } = useRoomContext();
 		const focused = useFocused();
 		const { setFocused, setMicOrSend, setAutocompleteParams } = useMessageComposerApi();
+		const { closeEmojiKeyboard, showEmojiPickerSharedValue } = useEmojiKeyboard();
 		const autocompleteType = useAutocompleteParams()?.type;
 		const textRef = React.useRef('');
 		const firstRender = React.useRef(true);
@@ -210,6 +213,10 @@ export const ComposerInput = memo(
 		};
 
 		const onTouchStart: TextInputProps['onTouchStart'] = () => {
+			if (showEmojiPickerSharedValue.value) {
+				closeEmojiKeyboard();
+				KeyboardController.setFocusTo('current');
+			}
 			setFocused(true);
 		};
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

When the emoji picker is open and the user taps on the text input field, the emoji picker should dismiss and the keyboard should appear - matching the standard UX in apps like WhatsApp and Telegram.                                                                       

Implemented this by adding an `onTouchStart` handler on the ComposerInput TextInput that:      
1. Checks if the emoji picker is open via `showEmojiPickerSharedValue.value`
2. Calls `closeEmojiKeyboard()` to close the emoji picker                                      
3. Calls `KeyboardController.setFocusTo('current')` to restore keyboard focus immediately

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
Emoji keyboard doesn't dismiss when tapping on message composer input

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Open any chat room
2. Tap the emoji button in the message composer toolbar to open the emoji picker
3. Tap directly on the text input field
5. Expected: Emoji picker dismisses, keyboard appears, cursor blinks                         
6. Before fix: Emoji picker remained open, required second tap on icon

## Screenshots

### Before
https://github.com/user-attachments/assets/51f7e848-14b2-4460-9de5-2d9ca2573b15

### After
https://github.com/user-attachments/assets/fd92e3cd-f6ff-4353-8405-9350117df9e5


## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
This fix ensures the emoji picker dismisses on TextInput tap using the onTouchStart event rather than onFocus, since onFocus only fires on focus changes whereas onTouchStart fires on every tap - matching the expected WhatsApp-like behavior where a single tap on the composer area closes the emoji picker and shows the keyboard.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji picker interaction: tapping the text input while the emoji picker is displayed now properly closes the picker and redirects focus to the message composer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->