### PR TITLE
fix(ios): cancel old URLSession/webSocketTask before reconnecting in DDPClient.connect

### DIFF
--- a/ios/Libraries/DDPClient.swift
+++ b/ios/Libraries/DDPClient.swift
@@ -46,7 +46,13 @@ final class DDPClient {
             #if DEBUG
             print("[\(Self.TAG)] Connecting to \(wsUrl)")
             #endif
-            
+
+            // Cancel any existing connection before creating a new one.
+            self.webSocketTask?.cancel(with: .normalClosure, reason: nil)
+            self.urlSession?.invalidateAndCancel()
+            self.webSocketTask = nil
+            self.urlSession = nil
+
             let session = URLSession(configuration: .default, delegate: DDPClientURLSessionChallengeDelegate(), delegateQueue: nil)
             let task = session.webSocketTask(with: url)
 


### PR DESCRIPTION
## Summary

Cancel any existing `webSocketTask` and `urlSession` at the top of `DDPClient.connect()` before creating new ones. Prevents URLSession leak on reconnect when `connect()` is called multiple times (e.g. on network change or call retry).

Fixes H18 (URLSession leak on DDP reconnect).

## Changes

- `ios/Libraries/DDPClient.swift`: Added explicit cleanup at the start of `connect()`:
  - Cancel old `webSocketTask` with normal closure
  - Invalidate old `urlSession`
  - Nil both references before creating new session

## Testing

- iOS build: `xcodebuild` compiles without errors (Watch App failures are pre-existing, unrelated to this change)
- Logic: The change mirrors the existing cleanup pattern in `disconnectOnStateQueue` for the reconnect path

## Merge Order

This is PR 2 of 6. Merge in this order:
1. **PR-2: fix(ios) DDP cleanup** — independent ← MERGE FIRST
2. PR-1: fix(ios) NSLock + timeout — independent
3. PR-3: feat(android) VoipCallService — independent
4. PR-4: fix(android) service integration — MUST merge after PR-3
5. PR-5: fix(both) null guard — independent, merge before PR-6
6. PR-6: chore(ts) cleanup — merge last (shares file with PR-5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network connection state management to ensure proper cleanup and handling during reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->