### PR TITLE
feat(android): create VoipCallService with FOREGROUND_SERVICE_MICROPHONE

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -147,6 +147,13 @@
 
         <service android:name="io.wazo.callkeep.RNCallKeepBackgroundMessagingService" />
 
+        <!-- VoIP foreground service for keeping audio calls alive in the background. -->
+        <service
+            android:name="chat.rocket.reactnative.voip.VoipCallService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
+
         <!-- react-native-webrtc ships MediaProjectionService (foregroundServiceType=mediaProjection)
              for screen sharing. We don't use screen sharing, and Android 15+ forbids starting
              restricted foreground service types from BOOT_COMPLETED receivers (expo-notifications

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -1,0 +1,156 @@
+package chat.rocket.reactnative.voip
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import chat.rocket.reactnative.MainActivity
+
+/**
+ * Foreground service that keeps the VoIP call alive when the app moves to the background.
+ * Required because Android terminates background processes without a foreground service,
+ * which would drop the active audio session.
+ *
+ * Started on call accept, stopped on hangup.
+ */
+class VoipCallService : Service() {
+
+    companion object {
+        private const val TAG = "RocketChat.VoipCallService"
+        private const val CHANNEL_ID = "voip-call-service"
+        private const val CHANNEL_NAME = "VoIP Call"
+        private const val NOTIFICATION_ID = 1
+
+        private const val ACTION_START = "chat.rocket.reactnative.voip.START_SERVICE"
+        private const val ACTION_STOP = "chat.rocket.reactnative.voip.STOP_SERVICE"
+        const val EXTRA_CALL_ID = "callId"
+
+        private var isRunning = false
+
+        @JvmStatic
+        fun startService(context: android.content.Context, callId: String) {
+            val intent = Intent(context, VoipCallService::class.java).apply {
+                action = ACTION_START
+                putExtra(EXTRA_CALL_ID, callId)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        @JvmStatic
+        fun stopService(context: android.content.Context) {
+            val intent = Intent(context, VoipCallService::class.java).apply {
+                action = ACTION_STOP
+            }
+            context.startService(intent)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        Log.d(TAG, "VoipCallService created")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                Log.d(TAG, "Stopping VoipCallService")
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            ACTION_START -> {
+                val callId = intent.getStringExtra(EXTRA_CALL_ID) ?: "unknown"
+                Log.d(TAG, "Starting VoipCallService for callId: $callId")
+                if (!isRunning) {
+                    isRunning = true
+                    startForegroundWithNotification(callId)
+                } else {
+                    Log.d(TAG, "Service already running, skipping duplicate start")
+                }
+                return START_STICKY
+            }
+            else -> {
+                Log.w(TAG, "Unknown action: ${intent?.action}")
+                return START_NOT_STICKY
+            }
+        }
+    }
+
+    private fun startForegroundWithNotification(callId: String) {
+        val notification = buildNotification(callId)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+
+        Log.d(TAG, "Started foreground with notification for callId: $callId")
+    }
+
+    private fun buildNotification(callId: String): Notification {
+        // Pending intent: tapping the notification opens the app.
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                PendingIntent.FLAG_IMMUTABLE
+            } else {
+                0
+            }
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("VoIP Call")
+            .setContentText("Call in progress")
+            .setSmallIcon(getApplicationInfo().icon)
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "VoIP call in progress"
+                setShowBadge(false)
+            }
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager?.createNotificationChannel(channel)
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        isRunning = false
+        Log.d(TAG, "VoipCallService destroyed")
+        super.onDestroy()
+    }
+}

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -52,7 +52,7 @@ class VoipCallService : Service() {
             val intent = Intent(context, VoipCallService::class.java).apply {
                 action = ACTION_STOP
             }
-            context.startService(intent)
+            context.stopService(intent)
         }
     }
 
@@ -66,7 +66,7 @@ class VoipCallService : Service() {
         when (intent?.action) {
             ACTION_STOP -> {
                 Log.d(TAG, "Stopping VoipCallService")
-                stopSelf()
+                stopSelf(startId)
                 return START_NOT_STICKY
             }
             ACTION_START -> {
@@ -78,10 +78,11 @@ class VoipCallService : Service() {
                 } else {
                     Log.d(TAG, "Service already running, skipping duplicate start")
                 }
-                return START_STICKY
+                return START_NOT_STICKY
             }
             else -> {
                 Log.w(TAG, "Unknown action: ${intent?.action}")
+                stopSelf(startId)
                 return START_NOT_STICKY
             }
         }


### PR DESCRIPTION
## Proposed changes

Create `VoipCallService` — an Android foreground `Service` with `foregroundServiceType="microphone"` — so VoIP audio calls keep running when the app is backgrounded. Without a foreground service, Android terminates the process and drops the active WebRTC audio session, which is the same problem iOS solves via CallKit audio retention.

### What this adds

- `VoipCallService.kt` — foreground service that starts/stops around the call lifecycle.
  - `startService(context, callId)`: starts in foreground with an ongoing notification.
  - `stopService(context)`: requests shutdown.
  - `ACTION_START` / `ACTION_STOP` intent actions for explicit control.
  - `ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE` on API 29+.
  - Low-priority notification channel and ongoing notification.
- `AndroidManifest.xml` — declares the service with `foregroundServiceType="microphone"`, `enabled="true"`, `exported="false"`.

### Review fixes applied

Addresses CodeRabbit review findings #1 (production crash) and #2 (start-command semantics):

1. `stopService()` helper now calls `context.stopService(intent)` instead of `context.startService(intent)`. On Android 8+ (API 26+), invoking `startService` from a background context throws `IllegalStateException` / `BackgroundServiceStartNotAllowedException` — which is exactly when a hangup from a backgrounded or headless-notification flow happens.
2. `onStartCommand` returns `START_NOT_STICKY` for `ACTION_START` (was `START_STICKY`). A redelivered null intent cannot recover the WebRTC peer connection, so sticky semantics would only log a warning and terminate anyway.
3. `stopSelf(startId)` replaces `stopSelf()` in the `ACTION_STOP` and unknown-action branches, so only the matching start token is released and no start counts are leaked.

## Issue(s)

N/A — internal VoIP work.

## How to test or reproduce

1. Place a VoIP call (`ACTION_START`), background the app, verify audio continues and the ongoing notification is visible.
2. Hang up from the notification (`ACTION_STOP`); verify the service stops without `IllegalStateException` in logs.
3. Send `ACTION_STOP` while the app is fully backgrounded; the service still tears down cleanly (this is the case the fix unblocks).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue) — for the review-fix commit on top

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A for foreground service lifecycle; covered by manual VoIP test plan above
- [ ] I have added necessary documentation — N/A
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

### Merge order

This is PR 3 of 6 in the VoIP Android integration series:

1. ~~PR-2: fix(ios) DDP cleanup — independent~~ (merged)
2. ~~PR-1: fix(ios) NSLock + timeout — independent~~ (merged)
3. **PR-3: feat(android) VoipCallService** ← this PR
4. PR-4: fix(android) service integration — depends on PR-3
5. PR-5: fix(both) null guard — independent, merge before PR-6
6. PR-6: chore(ts) cleanup — last (shares file with PR-5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VoIP calling now runs reliably in the background, allowing calls to persist when switching apps.
  * Active calls show a persistent notification so users are informed and can return to the app quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->