### PR TITLE
fix(android): start VoipCallService on accept, stop on hangup/timeout, install end-call listener

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -132,6 +132,7 @@ class VoipNotification(private val context: Context) {
         fun handleTimeout(context: Context, payload: VoipPayload) {
             cancelTimeout(payload.callId)
             disconnectTimedOutCall(payload.callId)
+            VoipCallService.stopService(context)
             cancelById(context, payload.notificationId)
             LocalBroadcastManager.getInstance(context).sendBroadcast(
                 Intent(ACTION_TIMEOUT).apply {
@@ -238,6 +239,13 @@ class VoipNotification(private val context: Context) {
         fun handleAcceptAction(context: Context, payload: VoipPayload, skipLaunchMainActivity: Boolean = false) {
             Log.d(TAG, "Accept action triggered for callId: ${payload.callId}")
             cancelTimeout(payload.callId)
+
+            // H3 fix: install DDP listener for call-end detection before accepting.
+            // Previously only called from showIncomingCall, so notification-accept path missed it.
+            startListeningForCallEnd(context, payload)
+
+            // Start foreground service to keep call alive in background.
+            VoipCallService.startService(context, payload.callId)
 
             val appCtx = context.applicationContext
             // Guard so finish() is called at most once, whether by the REST callback or the timeout.
@@ -481,6 +489,7 @@ class VoipNotification(private val context: Context) {
                                         }
                                         cancelTimeout(callId)
                                         disconnectIncomingCall(callId, false)
+                                        VoipCallService.stopService(appContext)
                                         cancelById(appContext, payload.notificationId)
                                         LocalBroadcastManager.getInstance(appContext).sendBroadcast(
                                             Intent(ACTION_DISMISS).apply {

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -240,8 +240,8 @@ class VoipNotification(private val context: Context) {
             Log.d(TAG, "Accept action triggered for callId: ${payload.callId}")
             cancelTimeout(payload.callId)
 
-            // H3 fix: install DDP listener for call-end detection before accepting.
-            // Previously only called from showIncomingCall, so notification-accept path missed it.
+            // Install the DDP end-call listener here so the notification-accept path
+            // also tears down on hangup; previously only showIncomingCall installed it.
             startListeningForCallEnd(context, payload)
 
             // Start foreground service to keep call alive in background.


### PR DESCRIPTION
## Summary

**Notification-accept DDP listener:** Call `startListeningForCallEnd` in `handleAcceptAction` before REST accept. Previously only `showIncomingCall` called it, so the notification-accept path (accept via heads-up notification or IncomingCallActivity) missed DDP end-call detection.

**Foreground service lifecycle:**
- `VoipCallService.startService()` called in `handleAcceptAction` on call accept
- `VoipCallService.stopService()` called on:
  - DDP hangup/other-device-accept detection (DDP listener)
  - Incoming call timeout (`handleTimeout`)

Note: `VoipCallService.kt` and `AndroidManifest.xml` service declaration landed in PR-3 (#7199) and are no longer part of this PR's diff.

## Changes

- `VoipNotification.kt`: Added `startListeningForCallEnd(context, payload)` call in `handleAcceptAction`
- `VoipNotification.kt`: Added `VoipCallService.stopService(context)` in DDP hangup handler and `handleTimeout`
- `VoipNotification.kt`: Added `VoipCallService.startService(context, payload.callId)` in `handleAcceptAction`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Merge Order

This is PR 4 of 6. **DEPENDS ON PR-3 (already merged).**
1. ~~PR-2: fix(ios) DDP cleanup — independent~~ ← merged
2. ~~PR-1: fix(ios) NSLock + timeout — independent~~ ← merged
3. ~~PR-3: feat(android) VoipCallService — independent~~ ← merged
4. **PR-4: fix(android) service integration** ← MERGE NEXT (depends on PR-3)
5. PR-5: fix(both) null guard — independent, merge before PR-6
6. PR-6: chore(ts) cleanup — merge last (shares file with PR-5)

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Accepting a call starts the foreground service | ✅ `VoipCallService.startService()` in `handleAcceptAction` |
| Hanging up stops the service | ✅ `VoipCallService.stopService()` in DDP listener + `handleTimeout` |
| Accepting from notification installs the DDP end-call listener | ✅ `startListeningForCallEnd` called in `handleAcceptAction` |
| Accepting from incoming UI still works (no regression) | ✅ All existing code paths unchanged |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VoIP call timeout now stops the foreground service to ensure complete cleanup.
  * Call acceptance flow now starts the VoIP foreground service and registers call-end listening before proceeding.
  * Remote call termination handling now stops the foreground service and dismisses notifications reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->