### PR TITLE
fix(android): handle null VoiceConnection in answerIncomingCall, notify JS

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -315,7 +315,7 @@ class VoipNotification(private val context: Context) {
             when (connection) {
                 is VoiceConnection -> connection.onAnswer()
                 null -> {
-                    // C3 fix: null return means Telecom connection is gone (system killed it).
+                    // Null means Telecom connection is gone (e.g. system killed it).
                     // Notify JS so the user sees an error instead of a hanging UI.
                     Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
                     val appCtx = context.applicationContext

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -258,7 +258,7 @@ class VoipNotification(private val context: Context) {
                 timeoutRunnable?.let { timeoutHandler.removeCallbacks(it) }
                 ddpRegistry.stopClient(payload.callId)
                 if (answerRequestSucceeded) {
-                    answerIncomingCall(payload.callId)
+                    answerIncomingCall(appCtx, payload.callId)
                     VoipModule.storeInitialEvents(payload)
                 } else {
                     Log.d(TAG, "media-calls.answer failed for ${payload.callId}; opening app for JS recovery")
@@ -310,11 +310,31 @@ class VoipNotification(private val context: Context) {
             context.startActivity(intent)
         }
 
-        private fun answerIncomingCall(callId: String) {
+        private fun answerIncomingCall(context: Context, callId: String) {
             val connection = VoiceConnectionService.getConnection(callId)
             when (connection) {
                 is VoiceConnection -> connection.onAnswer()
-                null -> Log.d(TAG, "No active VoiceConnection found for accepted call: $callId")
+                null -> {
+                    // C3 fix: null return means Telecom connection is gone (system killed it).
+                    // Notify JS so the user sees an error instead of a hanging UI.
+                    Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
+                    val appCtx = context.applicationContext
+                    disconnectIncomingCall(callId, false)
+                    cancelById(appCtx, 0)
+                    ddpRegistry.stopClient(callId)
+                    // Stash failure payload for JS: it will show error toast on getInitialEvents.
+                    VoipModule.storeAcceptFailureForJs(VoipPayload(
+                        callId = callId,
+                        caller = "",
+                        username = "",
+                        host = "",
+                        type = "",
+                        hostName = "",
+                        avatarUrl = null,
+                        createdAt = null,
+                        voipAcceptFailed = true
+                    ))
+                }
                 else -> Log.d(TAG, "Non-VoiceConnection for accept, callId: $callId")
             }
         }

--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -342,7 +342,7 @@ const flushMicrotasks = async () => {
 //   - 'is not a valid icon name' — CallView's CustomIcon reports missing
 //     glyph entries (e.g. 'pause-shape-unfilled') in the Jest env; glyph map
 //     is not loaded. Rendering succeeds, warning is cosmetic for tests.
-//   - '[VoIP] Call not found:' — deterministic expected branch output of
+//   - '[VoIP] Call not found after accept:' — deterministic expected branch output of
 //     answerCall when getCallData returns undefined (exercised by test A2).
 //     Production code warns intentionally; tests should not hide it, but it
 //     is not an unexpected error for the asserting test.
@@ -351,7 +351,7 @@ const CONSOLE_WARN_ALLOWLIST: string[] = [
 	'@expo/vector-icons',
 	'not wrapped in act',
 	'is not a valid icon name',
-	'[VoIP] Call not found:'
+	'[VoIP] Call not found after accept:'
 ];
 
 let consoleErrorSpy: jest.SpyInstance | undefined;
@@ -586,7 +586,7 @@ describe('VoIP call lifecycle (integration)', () => {
 			expect(Navigation.navigate).not.toHaveBeenCalled();
 			expect(useCallStore.getState().call).toBeNull();
 			// Tighten: confirm the known-noise allowlist entry was actually triggered.
-			expect(consoleWarnSpy).toHaveBeenCalledWith('[VoIP] Call not found:', 'missing-1');
+			expect(consoleWarnSpy).toHaveBeenCalledWith('[VoIP] Call not found after accept:', 'missing-1');
 		});
 
 		it('A3: idempotency — existing call matches callId, answerCall early-returns', async () => {

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -164,7 +164,7 @@ class MediaSessionInstance {
 			if (st.nativeAcceptedCallId === callId) {
 				st.resetNativeCallId();
 			}
-			console.warn('[VoIP] Call not found:', callId); // TODO: Show error message?
+			console.warn('[VoIP] Call not found after accept:', callId);
 		}
 	};
 


### PR DESCRIPTION
## Proposed changes

**Android null guard:** `answerIncomingCall` now handles the null `VoiceConnection` case (Telecom connection killed by the system). It cleans up Telecom (`disconnectIncomingCall`, `cancelById`), stops DDP (`ddpRegistry.stopClient`), and stashes a `voipAcceptFailed` payload via `VoipModule.storeAcceptFailureForJs` so JS shows a `VoIP_Call_Issue` toast instead of leaving the UI hanging.

**TS log cleanup:** Removed the `// TODO: Show error message?` comment from the "Call not found after accept" branch in `MediaSessionInstance.answerCall`. The toast is already wired through the `voipAcceptFailed` deep-link saga, so the TODO was stale.

## Issue(s)

N/A

## How to test or reproduce

1. Start an incoming VoIP call on Android.
2. Force a scenario where Telecom's `VoiceConnection` is gone by the time `answerIncomingCall` runs (e.g. system kills the connection under memory pressure, or the connection is canceled before accept completes).
3. Verify the user sees the `VoIP_Call_Issue` toast instead of a hanging call UI, and that DDP/Telecom state is cleaned up.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

### Files changed

- `android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt`
  - `answerIncomingCall` now takes a `Context` parameter.
  - Null-`VoiceConnection` branch: calls `disconnectIncomingCall`, `cancelById`, `ddpRegistry.stopClient`, and `VoipModule.storeAcceptFailureForJs` with `voipAcceptFailed = true` to notify JS.
- `app/lib/services/voip/MediaSessionInstance.ts`
  - Cleaned up the "Call not found after accept" log; removed stale TODO comment since the toast path is already wired through the deep-link saga.

### Acceptance criteria

| Criterion | Status |
|---|---|
| Android null return triggers Telecom + DDP cleanup | `disconnectIncomingCall`, `cancelById`, `ddpRegistry.stopClient` |
| Android null return notifies JS | `VoipModule.storeAcceptFailureForJs` with `voipAcceptFailed = true` |
| User sees error message (toast) | `storeAcceptFailureForJs` -> `VoipAcceptFailed` event -> deep-link saga -> `VoIP_Call_Issue` toast |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VoIP call acceptance error handling with recovery steps when calls fail to connect, including notification cancellation and call cleanup.
  * Enhanced error logging to surface warnings for failed accept flows.

* **Tests**
  * Updated integration test expectations to match revised VoIP warning messaging after accept failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->