### PR TITLE
fix(voip): enable DM nav for users with SIP extension

### DIFF
--- a/app/containers/MediaCallHeader/MediaCallHeader.test.tsx
+++ b/app/containers/MediaCallHeader/MediaCallHeader.test.tsx
@@ -226,7 +226,7 @@ describe('MediaCallHeader', () => {
 		expect(mockNavigateToCallRoom).toHaveBeenCalledTimes(1);
 	});
 
-	it('does not call navigateToCallRoom when content is pressed for SIP calls', () => {
+	it('calls navigateToCallRoom when contact has both username and sipExtension (RC user with extension)', () => {
 		setStoreState({
 			contact: {
 				id: 'user-1',
@@ -243,7 +243,7 @@ describe('MediaCallHeader', () => {
 		);
 
 		fireEvent.press(getByTestId('media-call-header-content'));
-		expect(mockNavigateToCallRoom).not.toHaveBeenCalled();
+		expect(mockNavigateToCallRoom).toHaveBeenCalledTimes(1);
 	});
 
 	it('does not call navigateToCallRoom when roomId is null', () => {

--- a/app/containers/MediaCallHeader/components/Content.tsx
+++ b/app/containers/MediaCallHeader/components/Content.tsx
@@ -22,8 +22,7 @@ const styles = StyleSheet.create({
 export const Content = () => {
 	const isMasterDetail = useAppSelector(state => state.app.isMasterDetail);
 	const roomId = useCallStore(state => state.roomId);
-	const contact = useCallStore(state => state.contact);
-	const contentDisabled = Boolean(contact.sipExtension) || roomId == null;
+	const contentDisabled = roomId == null;
 	const pressableStyle = contentDisabled ? [styles.button, { opacity: 0.5 }] : styles.button;
 
 	return (

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -614,7 +614,8 @@ describe('MediaSessionInstance', () => {
 			expect(mockGetDMSubscriptionByUsername).not.toHaveBeenCalled();
 		});
 
-		it('newCall caller skips DM lookup for SIP contact', async () => {
+		it('newCall caller resolves roomId from DM when contact has both username and sipExtension', async () => {
+			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-ext' } as any);
 			await mediaSessionInstance.init('user-1');
 			const session = createdSessions[0];
 			const newCallHandler = session.on.mock.calls.find((c: string[]) => c[0] === 'newCall')?.[1] as (p: {
@@ -631,8 +632,8 @@ describe('MediaSessionInstance', () => {
 				} as unknown as IClientMediaCall
 			});
 
-			await Promise.resolve();
-			expect(mockGetDMSubscriptionByUsername).not.toHaveBeenCalled();
+			await waitFor(() => expect(mockSetRoomId).toHaveBeenCalledWith('dm-ext'));
+			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('alice');
 		});
 
 		it('answerCall resolves roomId from DM for non-SIP callee', async () => {
@@ -652,7 +653,8 @@ describe('MediaSessionInstance', () => {
 			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('bob');
 		});
 
-		it('answerCall skips DM lookup for SIP contact', async () => {
+		it('answerCall resolves roomId from DM when contact has both username and sipExtension', async () => {
+			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-ext' } as any);
 			await mediaSessionInstance.init('user-1');
 			const session = createdSessions[0];
 			const mainCall = {
@@ -664,9 +666,8 @@ describe('MediaSessionInstance', () => {
 
 			await mediaSessionInstance.answerCall('call-sip');
 
-			await Promise.resolve();
-			expect(mockGetDMSubscriptionByUsername).not.toHaveBeenCalled();
-			expect(mockSetRoomId).not.toHaveBeenCalled();
+			await waitFor(() => expect(mockSetRoomId).toHaveBeenCalledWith('dm-ext'));
+			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('bob');
 		});
 	});
 });

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -202,7 +202,7 @@ class MediaSessionInstance {
 	};
 
 	private async resolveRoomIdFromContact(contact: CallContact | undefined): Promise<void> {
-		if (!contact || contact.sipExtension) {
+		if (!contact) {
 			return;
 		}
 		const { username } = contact;

--- a/app/lib/services/voip/navigateToCallRoom.test.ts
+++ b/app/lib/services/voip/navigateToCallRoom.test.ts
@@ -60,7 +60,7 @@ describe('navigateToCallRoom', () => {
 		expect(mockNavigation.navigate).not.toHaveBeenCalled();
 	});
 
-	it('does not navigate for SIP contact', async () => {
+	it('navigates when contact has both username and sipExtension (RC user with extension)', async () => {
 		mockGetState.mockReturnValue(
 			mockCallStoreState({
 				roomId: 'rid-1',
@@ -72,9 +72,10 @@ describe('navigateToCallRoom', () => {
 
 		await navigateToCallRoom({ isMasterDetail: true });
 
-		expect(mockGoRoom).not.toHaveBeenCalled();
-		expect(toggleFocus).not.toHaveBeenCalled();
-		expect(mockNavigation.navigate).not.toHaveBeenCalled();
+		expect(mockGoRoom).toHaveBeenCalledWith({
+			item: { rid: 'rid-1', name: 'u', t: SubscriptionType.DIRECT },
+			isMasterDetail: true
+		});
 	});
 
 	it('does not navigate when username is missing', async () => {

--- a/app/lib/services/voip/navigateToCallRoom.ts
+++ b/app/lib/services/voip/navigateToCallRoom.ts
@@ -5,12 +5,12 @@ import { useCallStore } from './useCallStore';
 
 /**
  * From the VoIP UI, open the DM for the active call: minimizes CallView when it is focused, then navigates.
- * No-ops for SIP calls or when room id or username is missing.
+ * No-ops when room id or username is missing (e.g. pure SIP-only peers).
  */
 export async function navigateToCallRoom({ isMasterDetail }: { isMasterDetail: boolean }): Promise<void> {
 	const { roomId, contact, focused, toggleFocus } = useCallStore.getState();
 
-	if (!roomId || contact.sipExtension) {
+	if (!roomId) {
 		return;
 	}
 

--- a/app/views/CallView/__snapshots__/index.test.tsx.snap
+++ b/app/views/CallView/__snapshots__/index.test.tsx.snap
@@ -559,7 +559,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -594,9 +594,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -1435,7 +1433,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -1470,9 +1468,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -2307,7 +2303,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -2342,9 +2338,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -3177,7 +3171,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -3212,9 +3206,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -4047,7 +4039,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -4082,9 +4074,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -4917,7 +4907,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -4952,9 +4942,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -5759,7 +5747,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -5794,9 +5782,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -6607,7 +6593,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -6642,9 +6628,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -7451,7 +7435,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -7486,9 +7470,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -8293,7 +8275,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -8328,9 +8310,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -9135,7 +9115,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -9170,9 +9150,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -9977,7 +9955,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -10012,9 +9990,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },

--- a/app/views/CallView/components/CallButtons.tsx
+++ b/app/views/CallView/components/CallButtons.tsx
@@ -39,7 +39,6 @@ export const CallButtons = () => {
 	const isOnHold = useCallStore(state => state.isOnHold);
 	const isSpeakerOn = useCallStore(state => state.isSpeakerOn);
 	const roomId = useCallStore(state => state.roomId);
-	const contact = useCallStore(state => state.contact);
 
 	const toggleMute = useCallStore(state => state.toggleMute);
 	const toggleHold = useCallStore(state => state.toggleHold);
@@ -54,7 +53,7 @@ export const CallButtons = () => {
 	}));
 
 	const isConnecting = callState === 'none' || callState === 'ringing' || callState === 'accepted';
-	const messageDisabled = Boolean(contact.sipExtension) || roomId == null;
+	const messageDisabled = roomId == null;
 
 	const handleMessage = () => {
 		navigateToCallRoom({ isMasterDetail }).catch(() => undefined);


### PR DESCRIPTION
## Proposed changes

A Rocket.Chat user can have both a DM and a `sipExtension`. The existing guards treat any truthy `sipExtension` as "no DM exists", which wrongly disables the Message button on `CallView` and the header-content tap target, and also prevents the incoming-call flow from resolving `roomId` for that user. Pure SIP-only peers (no RC `username`, hence no DM) remain correctly gated by `roomId == null`.

- `MediaSessionInstance.resolveRoomIdFromContact` — no longer early-returns when `sipExtension` is present; the existing `!username` short-circuit already covers SIP-only peers.
- `navigateToCallRoom` — drops the `sipExtension` guard; `!roomId` and `!username` are sufficient.
- `CallButtons.messageDisabled` → `roomId == null`.
- `MediaCallHeader/components/Content.contentDisabled` → `roomId == null`.

Flipped tests: "no-op for SIP contact" / "skips DM lookup for SIP" → now expect DM resolution and navigation when the contact has both `username` and `sipExtension`.

## Issue(s)
https://rocketchat.atlassian.net/browse/VMUX-95

## How to test or reproduce

Place a call to (or receive one from) a Rocket.Chat user whose profile has a `sipExtension` set. Before: Message button + header title row appear disabled. After: both are enabled and tapping them navigates to the DM for that user. Pure SIP-dialed peers (no RC user) still disable Message and header navigation.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SIP contacts with associated usernames now properly resolve to their direct message rooms, enabling navigation during active calls
  * Messaging functionality is now available during calls with SIP contacts that have usernames
  * Fixed room lookup behavior for SIP-based contacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->