### PR TITLE
feat(voip): disable header buttons during active call

### DIFF
--- a/app/containers/Avatar/Avatar.tsx
+++ b/app/containers/Avatar/Avatar.tsx
@@ -20,6 +20,7 @@ const Avatar = React.memo(
 		userId,
 		token,
 		onPress,
+		disabled,
 		emoji,
 		getCustomEmoji,
 		avatarETag,
@@ -97,7 +98,7 @@ const Avatar = React.memo(
 
 		if (onPress) {
 			image = (
-				<Touch accessible={accessible} accessibilityLabel={avatarAccessibilityLabel} onPress={onPress}>
+				<Touch accessible={accessible} accessibilityLabel={avatarAccessibilityLabel} onPress={onPress} disabled={disabled}>
 					{image}
 				</Touch>
 			);

--- a/app/containers/Avatar/interfaces.ts
+++ b/app/containers/Avatar/interfaces.ts
@@ -16,6 +16,7 @@ export interface IAvatar {
 	userId?: string;
 	token?: string;
 	onPress?: () => void;
+	disabled?: boolean;
 	getCustomEmoji?: TGetCustomEmoji;
 	avatarETag?: string;
 	isStatic?: boolean | string;

--- a/app/lib/hooks/useIsVoipCallActive.test.ts
+++ b/app/lib/hooks/useIsVoipCallActive.test.ts
@@ -1,0 +1,40 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { useIsVoipCallActive } from './useIsVoipCallActive';
+import { useCallStore } from '../services/voip/useCallStore';
+
+const mockCall = { callId: 'call-1' } as any;
+const mockNativeId = 'native-call-id';
+
+describe('useIsVoipCallActive', () => {
+	beforeEach(() => {
+		useCallStore.setState({ call: null, nativeAcceptedCallId: null });
+	});
+
+	afterEach(() => {
+		useCallStore.setState({ call: null, nativeAcceptedCallId: null });
+	});
+
+	it('returns false when both call and nativeAcceptedCallId are null', () => {
+		const { result } = renderHook(() => useIsVoipCallActive());
+		expect(result.current).toBe(false);
+	});
+
+	it('returns true when call is set and nativeAcceptedCallId is null', () => {
+		useCallStore.setState({ call: mockCall, nativeAcceptedCallId: null });
+		const { result } = renderHook(() => useIsVoipCallActive());
+		expect(result.current).toBe(true);
+	});
+
+	it('returns true when call is null and nativeAcceptedCallId is set', () => {
+		useCallStore.setState({ call: null, nativeAcceptedCallId: mockNativeId });
+		const { result } = renderHook(() => useIsVoipCallActive());
+		expect(result.current).toBe(true);
+	});
+
+	it('returns true when both call and nativeAcceptedCallId are set', () => {
+		useCallStore.setState({ call: mockCall, nativeAcceptedCallId: mockNativeId });
+		const { result } = renderHook(() => useIsVoipCallActive());
+		expect(result.current).toBe(true);
+	});
+});

--- a/app/lib/hooks/useIsVoipCallActive.test.ts
+++ b/app/lib/hooks/useIsVoipCallActive.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook } from '@testing-library/react-native';
 
 import { useIsVoipCallActive } from './useIsVoipCallActive';
 import { useCallStore } from '../services/voip/useCallStore';

--- a/app/lib/hooks/useIsVoipCallActive.ts
+++ b/app/lib/hooks/useIsVoipCallActive.ts
@@ -1,0 +1,7 @@
+import { useShallow } from 'zustand/react/shallow';
+
+import { useCallStore } from '../services/voip/useCallStore';
+
+/** Returns true when a VoIP call is active (either ringing/accepted natively or fully connected). */
+export const useIsVoipCallActive = () =>
+	useCallStore(useShallow(state => state.call != null || state.nativeAcceptedCallId != null));

--- a/app/views/RoomView/LeftButtons.tsx
+++ b/app/views/RoomView/LeftButtons.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, useWindowDimensions } from 'react-native';
 import Avatar from '../../containers/Avatar';
 import { useAppNavigation } from '../../lib/hooks/navigation';
 import { HeaderBackButton } from '../../containers/Header/components/HeaderBackButton';
+import { useIsVoipCallActive } from '../../lib/hooks/useIsVoipCallActive';
 
 const styles = StyleSheet.create({
 	avatar: {
@@ -39,6 +40,7 @@ const LeftButtons = ({
 	const { goBack } = useAppNavigation();
 	const onPress = () => goRoomActionsView();
 	const { fontScale } = useWindowDimensions();
+	const isVoipCallActive = useIsVoipCallActive();
 
 	if (!isMasterDetail || tmid) {
 		let label = ' ';
@@ -55,7 +57,9 @@ const LeftButtons = ({
 	}
 
 	if (baseUrl && userId && token) {
-		return <Avatar rid={rid} text={title} size={30} type={t} style={styles.avatar} onPress={onPress} />;
+		return (
+			<Avatar rid={rid} text={title} size={30} type={t} style={styles.avatar} onPress={onPress} disabled={isVoipCallActive} />
+		);
 	}
 	return null;
 };

--- a/app/views/RoomView/RightButtons.tsx
+++ b/app/views/RoomView/RightButtons.tsx
@@ -20,6 +20,7 @@ import { type ILivechatTag } from '../../definitions/ILivechatTag';
 import i18n from '../../i18n';
 import database from '../../lib/database';
 import { hasPermission, showConfirmationAlert, showErrorAlert } from '../../lib/methods/helpers';
+import { useIsVoipCallActive } from '../../lib/hooks/useIsVoipCallActive';
 import { closeLivechat as closeLivechatService } from '../../lib/methods/helpers/closeLivechat';
 import { events, logEvent } from '../../lib/methods/helpers/log';
 import { getDepartmentInfo, getTagsList, onHoldLivechat, returnLivechat } from '../../lib/services/restApi';
@@ -60,6 +61,7 @@ interface IRightButtonsProps extends Pick<ISubscription, 't'> {
 	notificationsDisabled?: boolean;
 	hasE2EEWarning: boolean;
 	toggleRoomE2EEncryptionPermission?: string[];
+	isVoipCallActive?: boolean;
 }
 
 interface IRigthButtonsState {
@@ -164,6 +166,9 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 			return true;
 		}
 		if (!dequal(nextProps.toggleRoomE2EEncryptionPermission, toggleRoomE2EEncryptionPermission)) {
+			return true;
+		}
+		if (nextProps.isVoipCallActive !== this.props.isVoipCallActive) {
 			return true;
 		}
 		return false;
@@ -468,7 +473,8 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 			userId,
 			isGroupChat,
 			status,
-			teamMain
+			teamMain,
+			isVoipCallActive
 		} = this.props;
 
 		const accessibilityRoomName =
@@ -487,7 +493,12 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 			if (!this.isOmnichannelPreview()) {
 				return (
 					<HeaderButton.Container>
-						<HeaderButton.Item iconName='kebab' onPress={this.showMoreActions} testID='room-view-header-omnichannel-kebab' />
+						<HeaderButton.Item
+							iconName='kebab'
+							onPress={this.showMoreActions}
+							testID='room-view-header-omnichannel-kebab'
+							disabled={isVoipCallActive}
+						/>
 					</HeaderButton.Container>
 				);
 			}
@@ -501,6 +512,7 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 						iconName={isFollowingThread ? 'notification' : 'notification-disabled'}
 						onPress={this.toggleFollowThread}
 						testID={isFollowingThread ? 'room-view-header-unfollow' : 'room-view-header-follow'}
+						disabled={isVoipCallActive}
 					/>
 				</HeaderButton.Container>
 			);
@@ -511,7 +523,7 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 					<HeaderButton.Item
 						iconName='encrypted'
 						onPress={this.goE2EEToggleRoomView}
-						disabled={!canToggleEncryption}
+						disabled={!canToggleEncryption || isVoipCallActive}
 						testID='room-view-header-encryption'
 					/>
 				) : null}
@@ -521,13 +533,13 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 						iconName='notification-disabled'
 						onPress={this.navigateToNotificationOrPushTroubleshoot}
 						testID='room-view-push-troubleshoot'
-						disabled={hasE2EEWarning}
+						disabled={hasE2EEWarning || isVoipCallActive}
 					/>
 				) : null}
 				<HeaderCallButton
 					accessibilityLabel={i18n.t('Call_room_name', { roomName: accessibilityRoomName })}
 					rid={rid}
-					disabled={hasE2EEWarning}
+					disabled={!!(hasE2EEWarning || isVoipCallActive)}
 				/>
 				{threadsEnabled ? (
 					<HeaderButton.Item
@@ -536,7 +548,7 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 						onPress={this.goThreadsView}
 						testID='room-view-header-threads'
 						badge={() => <HeaderButton.BadgeUnread tunread={tunread} tunreadUser={tunreadUser} tunreadGroup={tunreadGroup} />}
-						disabled={hasE2EEWarning}
+						disabled={hasE2EEWarning || isVoipCallActive}
 					/>
 				) : null}
 				<HeaderButton.Item
@@ -544,7 +556,7 @@ class RightButtonsContainer extends Component<IRightButtonsProps, IRigthButtonsS
 					iconName='search'
 					onPress={this.goSearchView}
 					testID='room-view-search'
-					disabled={hasE2EEWarning}
+					disabled={hasE2EEWarning || isVoipCallActive}
 				/>
 			</HeaderButton.Container>
 		);
@@ -560,4 +572,9 @@ const mapStateToProps = (state: IApplicationState) => ({
 	toggleRoomE2EEncryptionPermission: state.permissions['toggle-room-e2e-encryption']
 });
 
-export default connect(mapStateToProps)(withTheme(RightButtonsContainer));
+const RightButtonsWithVoip = (props: IRightButtonsProps) => {
+	const isVoipCallActive = useIsVoipCallActive();
+	return <RightButtonsContainer {...props} isVoipCallActive={isVoipCallActive} />;
+};
+
+export default connect(mapStateToProps)(withTheme(RightButtonsWithVoip));

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -34,6 +34,7 @@ export interface IRoomViewProps extends IActionSheetProvider, IBaseScreen<ChatsS
 	airGappedRestrictionRemainingDays: number | undefined;
 	isFederationEnabled: boolean;
 	isFederationModuleEnabled: boolean;
+	isVoipCallActive?: boolean;
 }
 
 export type TStateAttrsUpdate = keyof IRoomViewState;

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -109,6 +109,7 @@ import { type IRoomFederated, isRoomFederated, isRoomNativeFederated } from '../
 import { InvitedRoom } from './components/InvitedRoom';
 import { getInvitationData } from '../../lib/methods/getInvitationData';
 import { isInviteSubscription } from '../../lib/methods/isInviteSubscription';
+import { useIsVoipCallActive } from '../../lib/hooks/useIsVoipCallActive';
 
 class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 	private rid?: string;
@@ -259,6 +260,9 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 		const { state } = this;
 		const { roomUpdate, member, isOnHold, isAutocompleteVisible, showMissingE2EEKey, showE2EEDisabledRoom } = state;
 		const { theme, insets, route, encryptionEnabled, airGappedRestrictionRemainingDays } = this.props;
+		if (this.props.isVoipCallActive !== nextProps.isVoipCallActive) {
+			return true;
+		}
 		if (theme !== nextProps.theme) {
 			return true;
 		}
@@ -464,7 +468,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 			showMissingE2EEKey,
 			showE2EEDisabledRoom
 		} = this.state;
-		const { navigation, isMasterDetail, baseUrl, user, route } = this.props;
+		const { navigation, isMasterDetail, baseUrl, user, route, isVoipCallActive } = this.props;
 		const { rid, tmid } = this;
 
 		if (!rid) {
@@ -548,7 +552,7 @@ class RoomView extends React.Component<IRoomViewProps, IRoomViewState> {
 					testID={`room-view-title-${title}`}
 					sourceType={sourceType}
 					abacAttributes={iSubRoom.abacAttributes}
-					disabled={isInviteSubscription(iSubRoom)}
+					disabled={isInviteSubscription(iSubRoom) || isVoipCallActive}
 				/>
 			),
 			headerRight: () => (
@@ -1710,4 +1714,9 @@ const mapStateToProps = (state: IApplicationState) => ({
 	isFederationModuleEnabled: state.enterpriseModules.includes('federation') as boolean
 });
 
-export default connect(mapStateToProps)(withDimensions(withTheme(withSafeAreaInsets(withActionSheet(RoomView)))));
+const ConnectedRoomView = connect(mapStateToProps)(withDimensions(withTheme(withSafeAreaInsets(withActionSheet(RoomView)))));
+const RoomViewWithVoip = (props: any) => {
+	const isVoipCallActive = useIsVoipCallActive();
+	return <ConnectedRoomView {...props} isVoipCallActive={isVoipCallActive} />;
+};
+export default RoomViewWithVoip;

--- a/app/views/RoomsListView/components/Header.tsx
+++ b/app/views/RoomsListView/components/Header.tsx
@@ -47,7 +47,6 @@ const RoomsListHeaderView = ({ search, searchEnabled }: { search: (text: string)
 	const isVoipCallActive = useIsVoipCallActive();
 
 	const onPress = () => {
-		if (isVoipCallActive) return;
 		showActionSheetRef({ children: <ServersList />, enableContentPanningGesture: false });
 	};
 

--- a/app/views/RoomsListView/components/Header.tsx
+++ b/app/views/RoomsListView/components/Header.tsx
@@ -70,7 +70,7 @@ const RoomsListHeaderView = ({ search, searchEnabled }: { search: (text: string)
 	}
 	return (
 		<View style={styles.container} accessibilityLabel={`${serverName} ${subtitle}`} accessibilityRole='header' accessible>
-			<TouchableOpacity onPress={onPress} testID='rooms-list-header-servers-list-button'>
+			<TouchableOpacity onPress={onPress} disabled={isVoipCallActive} testID='rooms-list-header-servers-list-button'>
 				<View style={styles.button}>
 					<Text style={[styles.title, { color: colors.fontTitlesLabels }]} numberOfLines={1}>
 						{serverName}

--- a/app/views/RoomsListView/components/Header.tsx
+++ b/app/views/RoomsListView/components/Header.tsx
@@ -6,6 +6,7 @@ import { showActionSheetRef } from '../../../containers/ActionSheet';
 import SearchHeader from '../../../containers/SearchHeader';
 import I18n from '../../../i18n';
 import { useAppSelector } from '../../../lib/hooks/useAppSelector';
+import { useIsVoipCallActive } from '../../../lib/hooks/useIsVoipCallActive';
 import { useTheme } from '../../../theme';
 import sharedStyles from '../../Styles';
 import ServersList from './ServersList';
@@ -43,8 +44,10 @@ const RoomsListHeaderView = ({ search, searchEnabled }: { search: (text: string)
 	const { status: supportedVersionsStatus } = useAppSelector(state => state.supportedVersions);
 	const { colors } = useTheme();
 	const { fontScale } = useWindowDimensions();
+	const isVoipCallActive = useIsVoipCallActive();
 
 	const onPress = () => {
+		if (isVoipCallActive) return;
 		showActionSheetRef({ children: <ServersList />, enableContentPanningGesture: false });
 	};
 

--- a/app/views/RoomsListView/hooks/useHeader.tsx
+++ b/app/views/RoomsListView/hooks/useHeader.tsx
@@ -4,6 +4,7 @@ import { useCallback, useContext, useLayoutEffect, useState } from 'react';
 import * as HeaderButton from '../../../containers/Header/components/HeaderButton';
 import i18n from '../../../i18n';
 import { useAppSelector } from '../../../lib/hooks/useAppSelector';
+import { useIsVoipCallActive } from '../../../lib/hooks/useIsVoipCallActive';
 import { usePermissions } from '../../../lib/hooks/usePermissions';
 import { isTablet } from '../../../lib/methods/helpers';
 import { events, logEvent } from '../../../lib/methods/helpers/log';
@@ -40,7 +41,9 @@ export const useHeader = () => {
 			createDiscussionPermission
 		].filter((r: boolean) => r === true).length > 0;
 
-	const disabled = supportedVersionsStatus === 'expired' || requirePasswordChange;
+	const isVoipCallActive = useIsVoipCallActive();
+
+	const disabled = supportedVersionsStatus === 'expired' || requirePasswordChange || isVoipCallActive;
 
 	const getBadge = useCallback(() => {
 		if (supportedVersionsStatus === 'warn') {
@@ -120,6 +123,7 @@ export const useHeader = () => {
 							onPress={navigateToPushTroubleshootView}
 							testID='rooms-list-view-push-troubleshoot'
 							color={colors.fontDanger}
+							disabled={disabled}
 						/>
 					) : null}
 					{canCreateRoom ? (
@@ -156,6 +160,7 @@ export const useHeader = () => {
 	}, [
 		disabled,
 		issuesWithNotifications,
+		isVoipCallActive,
 		navigation,
 		isMasterDetail,
 		colors,


### PR DESCRIPTION
## Summary

Disables all header buttons in RoomView and RoomsListView during an active VoIP call (except back button). Additionally gates the three navigation entry points into `RoomActionsView`. Uses the existing `disabled` prop on `HeaderButton.Item` to visually dim (`opacity: 0.5`) and block touch interaction.

- **New hook**: `useIsVoipCallActive` — reads `call != null || nativeAcceptedCallId != null` from `useCallStore` (Zustand), reactive to state changes
- **RoomsListView header buttons**: 5 buttons disabled (drawer, notification-troubleshoot, create, search, directory). Notification-troubleshoot button also gains missing `disabled` prop for pre-existing gating conditions.
- **RoomView RightButtons**: functional wrapper injects `isVoipCallActive` into the class component; all 3 render branches covered:
  - Livechat kebab (`disabled={isVoipCallActive}`)
  - Thread follow/unfollow (`disabled={isVoipCallActive}`)
  - Main 5 buttons (E2EE, notification troubleshoot, call, threads, search) — OR'd with existing `hasE2EEWarning` logic
- **Entry-point gating** (slice 4):
  - `RoomsListView` workspace switcher — `onPress` early-returns during call
  - `RoomView` title tap — `RoomHeader` `disabled` OR's `isInviteSubscription` with `isVoipCallActive`
  - Master-detail `Avatar` — gains `disabled` prop, `LeftButtons` wires it to `useIsVoipCallActive`

## Merge Order

Single PR — all 4 slices are on one branch targeting `feat.voip-lib-new`.

## Test plan

- [x] `TZ=UTC yarn test` — 1214 tests pass, 146 suites, 0 failed
- [x] `yarn lint` — 0 errors / 0 warnings on all changed files
- [ ] Manual: accept VoIP call → observe all header buttons dim and non-interactive; end call → buttons re-enable
- [ ] Manual (tablet): accept call → tap avatar → no navigation → end call → avatar tap opens RoomActionsView
- [ ] Manual (phone): accept call → tap room title → no navigation → end call → tap opens RoomActionsView
- [ ] Manual (rooms list): accept call → tap server name → no action sheet → end call → action sheet opens
- [ ] Back button remains functional during call

## Follow-ups (out of scope)

- ThreadMessagesView header buttons
- TeamChannelsView header buttons
- DirectoryView header buttons

## Related

Follows the same active-call detection pattern as `voipBlocksIncomingVideoconf.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now detects active VoIP calls and disables related room controls (encryption toggle, notifications, search, threads, call button, server actions, and header buttons).
  * Avatars can be rendered disabled to prevent avatar interactions while a call is active.

* **Tests**
  * Added tests validating VoIP call active detection and the resulting UI disabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->