### PR TITLE
fix(voip): remove sensitive data from production logs

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -3,6 +3,7 @@ package chat.rocket.reactnative.voip
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import chat.rocket.reactnative.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -55,13 +56,17 @@ class DDPClient {
 
         val wsUrl = buildWebSocketURL(host)
 
-        Log.d(TAG, "Connecting to $wsUrl")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Connecting to $wsUrl")
+        }
 
         val request = Request.Builder().url(wsUrl).build()
 
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {
-                Log.d(TAG, "WebSocket opened")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "WebSocket opened")
+                }
                 val connectMsg = JSONObject().apply {
                     put("msg", "connect")
                     put("version", "1")
@@ -94,7 +99,9 @@ class DDPClient {
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 if (webSocket !== this@DDPClient.webSocket) return
-                Log.d(TAG, "WebSocket closed: $code $reason")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "WebSocket closed: $code $reason")
+                }
                 isConnected = false
             }
         })
@@ -117,7 +124,9 @@ class DDPClient {
                 if (hasError) {
                     Log.e(TAG, "Login failed: ${data.opt("error")}")
                 } else {
-                    Log.d(TAG, "Login succeeded")
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "Login succeeded")
+                    }
                 }
                 mainHandler.post { callback(!hasError) }
             }
@@ -141,7 +150,9 @@ class DDPClient {
                 synchronized(pendingCallbacks) { pendingCallbacks.remove(msgId) }
                 val didSubscribe = data.optString("msg") == "ready" && !data.has("error")
                 if (didSubscribe) {
-                    Log.d(TAG, "Subscribed to $name")
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "Subscribed to $name")
+                    }
                 } else {
                     Log.e(TAG, "Failed to subscribe to $name: ${data.opt("error") ?: "nosub"}")
                 }
@@ -156,7 +167,9 @@ class DDPClient {
     }
 
     fun disconnect() {
-        Log.d(TAG, "Disconnecting")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Disconnecting")
+        }
         isConnected = false
         cancelConnectTimeout()
         synchronized(pendingCallbacks) { pendingCallbacks.clear() }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -3,7 +3,6 @@ package chat.rocket.reactnative.voip
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import chat.rocket.reactnative.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -56,17 +55,13 @@ class DDPClient {
 
         val wsUrl = buildWebSocketURL(host)
 
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Connecting to $wsUrl")
-        }
+        Log.d(TAG, "Connecting to $wsUrl")
 
         val request = Request.Builder().url(wsUrl).build()
 
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
             override fun onOpen(webSocket: WebSocket, response: Response) {
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "WebSocket opened")
-                }
+                Log.d(TAG, "WebSocket opened")
                 val connectMsg = JSONObject().apply {
                     put("msg", "connect")
                     put("version", "1")
@@ -99,9 +94,7 @@ class DDPClient {
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 if (webSocket !== this@DDPClient.webSocket) return
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "WebSocket closed: $code $reason")
-                }
+                Log.d(TAG, "WebSocket closed: $code $reason")
                 isConnected = false
             }
         })
@@ -124,9 +117,7 @@ class DDPClient {
                 if (hasError) {
                     Log.e(TAG, "Login failed: ${data.opt("error")}")
                 } else {
-                    if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "Login succeeded")
-                    }
+                    Log.d(TAG, "Login succeeded")
                 }
                 mainHandler.post { callback(!hasError) }
             }
@@ -150,9 +141,7 @@ class DDPClient {
                 synchronized(pendingCallbacks) { pendingCallbacks.remove(msgId) }
                 val didSubscribe = data.optString("msg") == "ready" && !data.has("error")
                 if (didSubscribe) {
-                    if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "Subscribed to $name")
-                    }
+                    Log.d(TAG, "Subscribed to $name")
                 } else {
                     Log.e(TAG, "Failed to subscribe to $name: ${data.opt("error") ?: "nosub"}")
                 }
@@ -167,9 +156,7 @@ class DDPClient {
     }
 
     fun disconnect() {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Disconnecting")
-        }
+        Log.d(TAG, "Disconnecting")
         isConnected = false
         cancelConnectTimeout()
         synchronized(pendingCallbacks) { pendingCallbacks.clear() }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -1,6 +1,7 @@
 package chat.rocket.reactnative.voip
 
 import android.app.Activity
+import chat.rocket.reactnative.BuildConfig
 import android.app.KeyguardManager
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -94,7 +95,9 @@ class IncomingCallActivity : Activity() {
         }
         this.voipPayload = voipPayload
 
-        Log.d(TAG, "IncomingCallActivity created - callId: ${voipPayload.callId}, caller: ${voipPayload.caller}")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "IncomingCallActivity created - callId: ${voipPayload.callId}, caller: ${voipPayload.caller}")
+        }
 
         updateUI(voipPayload)
         setupButtons(voipPayload)
@@ -255,7 +258,9 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleAccept(payload: VoipPayload) {
-        Log.d(TAG, "Call accepted - callId: ${payload.callId}")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Call accepted - callId: ${payload.callId}")
+        }
         clearTimeout()
         VoipNotification.cancelTimeout(payload.callId)
         VoipNotification.handleAcceptAction(this, payload)
@@ -263,7 +268,9 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleDecline(payload: VoipPayload) {
-        Log.d(TAG, "Call declined - callId: ${payload.callId}")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Call declined - callId: ${payload.callId}")
+        }
         clearTimeout()
         VoipNotification.cancelTimeout(payload.callId)
         VoipNotification.handleDeclineAction(this, payload)

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -1,7 +1,6 @@
 package chat.rocket.reactnative.voip
 
 import android.app.Activity
-import chat.rocket.reactnative.BuildConfig
 import android.app.KeyguardManager
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -95,9 +94,7 @@ class IncomingCallActivity : Activity() {
         }
         this.voipPayload = voipPayload
 
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "IncomingCallActivity created - callId: ${voipPayload.callId}, caller: ${voipPayload.caller}")
-        }
+        Log.d(TAG, "IncomingCallActivity created - callId: ${voipPayload.callId}, caller: ${voipPayload.caller}")
 
         updateUI(voipPayload)
         setupButtons(voipPayload)
@@ -258,9 +255,7 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleAccept(payload: VoipPayload) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Call accepted - callId: ${payload.callId}")
-        }
+        Log.d(TAG, "Call accepted - callId: ${payload.callId}")
         clearTimeout()
         VoipNotification.cancelTimeout(payload.callId)
         VoipNotification.handleAcceptAction(this, payload)
@@ -268,9 +263,7 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleDecline(payload: VoipPayload) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Call declined - callId: ${payload.callId}")
-        }
+        Log.d(TAG, "Call declined - callId: ${payload.callId}")
         clearTimeout()
         VoipNotification.cancelTimeout(payload.callId)
         VoipNotification.handleDeclineAction(this, payload)

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
@@ -119,13 +119,7 @@ class MediaCallsAnswerRequest(
 
             override fun onResponse(call: Call, response: okhttp3.Response) {
                 response.use {
-                    val code = it.code
-                    val success = code in 200..299
-                    if (success) {
-                        Log.d(TAG, "MediaCallsAnswerRequest response for callId=$callId: code=$code success=true")
-                    } else {
-                        Log.w(TAG, "MediaCallsAnswerRequest failed callId=$callId code=$code answer=$answer")
-                    }
+                    val success = it.code in 200..299
                     mainHandler.post { onResult(success) }
                 }
             }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
@@ -119,7 +119,13 @@ class MediaCallsAnswerRequest(
 
             override fun onResponse(call: Call, response: okhttp3.Response) {
                 response.use {
-                    val success = it.code in 200..299
+                    val code = it.code
+                    val success = code in 200..299
+                    if (success) {
+                        Log.d(TAG, "MediaCallsAnswerRequest response for callId=$callId: code=$code success=true")
+                    } else {
+                        Log.w(TAG, "MediaCallsAnswerRequest failed callId=$callId code=$code answer=$answer")
+                    }
                     mainHandler.post { onResult(success) }
                 }
             }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -2,6 +2,7 @@ package chat.rocket.reactnative.voip
 
 import android.app.Notification
 import android.app.NotificationChannel
+import chat.rocket.reactnative.BuildConfig
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
@@ -71,7 +72,9 @@ class VoipCallService : Service() {
             }
             ACTION_START -> {
                 val callId = intent.getStringExtra(EXTRA_CALL_ID) ?: "unknown"
-                Log.d(TAG, "Starting VoipCallService for callId: $callId")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Starting VoipCallService for callId: $callId")
+                }
                 if (!isRunning) {
                     isRunning = true
                     startForegroundWithNotification(callId)
@@ -101,7 +104,9 @@ class VoipCallService : Service() {
             startForeground(NOTIFICATION_ID, notification)
         }
 
-        Log.d(TAG, "Started foreground with notification for callId: $callId")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Started foreground with notification for callId: $callId")
+        }
     }
 
     private fun buildNotification(callId: String): Notification {

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -2,7 +2,6 @@ package chat.rocket.reactnative.voip
 
 import android.app.Notification
 import android.app.NotificationChannel
-import chat.rocket.reactnative.BuildConfig
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
@@ -72,9 +71,7 @@ class VoipCallService : Service() {
             }
             ACTION_START -> {
                 val callId = intent.getStringExtra(EXTRA_CALL_ID) ?: "unknown"
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "Starting VoipCallService for callId: $callId")
-                }
+                Log.d(TAG, "Starting VoipCallService for callId: $callId")
                 if (!isRunning) {
                     isRunning = true
                     startForegroundWithNotification(callId)
@@ -104,9 +101,7 @@ class VoipCallService : Service() {
             startForeground(NOTIFICATION_ID, notification)
         }
 
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Started foreground with notification for callId: $callId")
-        }
+        Log.d(TAG, "Started foreground with notification for callId: $callId")
     }
 
     private fun buildNotification(callId: String): Notification {

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
@@ -1,6 +1,7 @@
 package chat.rocket.reactnative.voip
 
 import android.util.Log
+import chat.rocket.reactnative.BuildConfig
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
@@ -108,7 +109,9 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
             val data = initialEventsData.get() ?: return null
 
             if (data.isExpired()) {
-                Log.d(TAG, "Discarding expired VoIP initial event: ${data.callId}")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Discarding expired VoIP initial event: ${data.callId}")
+                }
                 if (initialEventsData.compareAndSet(data, null)) {
                     return null
                 }
@@ -152,7 +155,9 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
      */
     override fun addListener(eventName: String) {
         // Keep track of listeners if needed
-        Log.d(TAG, "addListener: $eventName")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "addListener: $eventName")
+        }
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
@@ -1,7 +1,6 @@
 package chat.rocket.reactnative.voip
 
 import android.util.Log
-import chat.rocket.reactnative.BuildConfig
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
@@ -109,9 +108,7 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
             val data = initialEventsData.get() ?: return null
 
             if (data.isExpired()) {
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "Discarding expired VoIP initial event: ${data.callId}")
-                }
+                Log.d(TAG, "Discarding expired VoIP initial event: ${data.callId}")
                 if (initialEventsData.compareAndSet(data, null)) {
                     return null
                 }
@@ -155,9 +152,7 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
      */
     override fun addListener(eventName: String) {
         // Keep track of listeners if needed
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "addListener: $eventName")
-        }
+        Log.d(TAG, "addListener: $eventName")
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -96,9 +96,7 @@ class VoipNotification(private val context: Context) {
         fun scheduleTimeout(context: Context, payload: VoipPayload) {
             val delayMs = payload.getRemainingLifetimeMs()
             if (delayMs == null || delayMs <= 0L) {
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "Skipping timeout scheduling for expired or invalid call: ${payload.callId}")
-                }
+                Log.d(TAG, "Skipping timeout scheduling for expired or invalid call: ${payload.callId}")
                 return
             }
 
@@ -116,9 +114,7 @@ class VoipNotification(private val context: Context) {
                 timeoutCallbacks[payload.callId] = timeoutRunnable
             }
             timeoutHandler.postDelayed(timeoutRunnable, delayMs)
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Scheduled VoIP timeout for ${payload.callId} in ${delayMs}ms")
-            }
+            Log.d(TAG, "Scheduled VoIP timeout for ${payload.callId} in ${delayMs}ms")
         }
 
         @JvmStatic
@@ -128,9 +124,7 @@ class VoipNotification(private val context: Context) {
             }
             if (timeoutRunnable != null) {
                 timeoutHandler.removeCallbacks(timeoutRunnable)
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "Cancelled VoIP timeout for $callId")
-                }
+                Log.d(TAG, "Cancelled VoIP timeout for $callId")
             }
         }
 
@@ -155,9 +149,7 @@ class VoipNotification(private val context: Context) {
          */
         @JvmStatic
         fun handleDeclineAction(context: Context, payload: VoipPayload) {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
-            }
+            Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
             cancelTimeout(payload.callId)
             ddpRegistry.stopClient(payload.callId)
             val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
@@ -170,9 +162,6 @@ class VoipNotification(private val context: Context) {
                 supportedFeatures = null
             ) { _ -> }
             rejectIncomingCall(payload.callId)
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
-            }
             cancelById(context, payload.notificationId)
             LocalBroadcastManager.getInstance(context).sendBroadcast(
                 Intent(ACTION_DISMISS).apply {
@@ -220,11 +209,9 @@ class VoipNotification(private val context: Context) {
             payload: VoipPayload,
             storePayloadForJs: Boolean = true
         ) {
+            Log.d(TAG, "prepareMainActivityForIncomingVoip — callId: ${payload.callId}")
             cancelById(context, payload.notificationId)
             cancelTimeout(payload.callId)
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "prepareMainActivityForIncomingVoip — callId: ${payload.callId}")
-            }
             if (storePayloadForJs) {
                 VoipModule.storeInitialEvents(payload)
             }
@@ -255,9 +242,6 @@ class VoipNotification(private val context: Context) {
 
             // Install the DDP end-call listener here so the notification-accept path
             // also tears down on hangup; previously only showIncomingCall installed it.
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Accept action triggered for callId: ${payload.callId}")
-            }
             startListeningForCallEnd(context, payload)
 
             // Start foreground service to keep call alive in background.
@@ -277,9 +261,7 @@ class VoipNotification(private val context: Context) {
                     answerIncomingCall(appCtx, payload.callId)
                     VoipModule.storeInitialEvents(payload)
                 } else {
-                    if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "media-calls.answer failed for ${payload.callId}; opening app for JS recovery")
-                    }
+                    Log.d(TAG, "media-calls.answer failed for ${payload.callId}; opening app for JS recovery")
                     disconnectIncomingCall(payload.callId, false)
                     VoipModule.storeAcceptFailureForJs(payload)
                 }
@@ -295,9 +277,7 @@ class VoipNotification(private val context: Context) {
             }
 
             val postedTimeout = Runnable {
-                if (BuildConfig.DEBUG) {
-                    Log.w(TAG, "media-calls.answer timed out for ${payload.callId}; falling back to JS recovery")
-                }
+                Log.w(TAG, "media-calls.answer timed out for ${payload.callId}; falling back to JS recovery")
                 finish(false)
             }
             timeoutRunnable = postedTimeout
@@ -337,9 +317,7 @@ class VoipNotification(private val context: Context) {
                 null -> {
                     // Null means Telecom connection is gone (e.g. system killed it).
                     // Notify JS so the user sees an error instead of a hanging UI.
-                    if (BuildConfig.DEBUG) {
-                        Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
-                    }
+                    Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
                     val appCtx = context.applicationContext
                     disconnectIncomingCall(callId, false)
                     cancelById(appCtx, 0)
@@ -366,9 +344,7 @@ class VoipNotification(private val context: Context) {
             val connection = VoiceConnectionService.getConnection(callId)
             when (connection) {
                 is VoiceConnection -> connection.reportDisconnect(DISCONNECT_REASON_MISSED)
-                null -> if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "No active VoiceConnection found for timed out call: $callId")
-                }
+                null -> Log.d(TAG, "No active VoiceConnection found for timed out call: $callId")
                 else -> connection.onDisconnect()
             }
         }
@@ -377,9 +353,7 @@ class VoipNotification(private val context: Context) {
             val connection = VoiceConnectionService.getConnection(callId)
             when (connection) {
                 is VoiceConnection -> connection.onReject()
-                null -> if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "No active VoiceConnection found for declined call: $callId")
-                }
+                null -> Log.d(TAG, "No active VoiceConnection found for declined call: $callId")
                 else -> connection.onDisconnect()
             }
         }
@@ -394,9 +368,7 @@ class VoipNotification(private val context: Context) {
                         connection.onDisconnect()
                     }
                 }
-                null -> if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "No active VoiceConnection found for dismissed call: $callId")
-                }
+                null -> Log.d(TAG, "No active VoiceConnection found for dismissed call: $callId")
                 else -> connection.onDisconnect()
             }
         }
@@ -471,9 +443,7 @@ class VoipNotification(private val context: Context) {
          */
         @JvmStatic
         fun rejectBusyCall(context: Context, payload: VoipPayload) {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
-            }
+            Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
             cancelTimeout(payload.callId)
             val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
@@ -496,9 +466,7 @@ class VoipNotification(private val context: Context) {
             val token = ejson.token()
 
             if (userId.isNullOrEmpty() || token.isNullOrEmpty()) {
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "No credentials for ${payload.host}, skipping DDP listener")
-                }
+                Log.d(TAG, "No credentials for ${payload.host}, skipping DDP listener")
                 return
             }
 
@@ -507,17 +475,13 @@ class VoipNotification(private val context: Context) {
             val client = DDPClient()
             ddpRegistry.putClient(callId, client)
 
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Starting DDP listener for call $callId")
-            }
+            Log.d(TAG, "Starting DDP listener for call $callId")
 
             client.onCollectionMessage = collector@{ message ->
                 if (!isLiveClient(callId, client)) {
                     return@collector
                 }
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "DDP received message: $message")
-                }
+                Log.d(TAG, "DDP received message: $message")
                 val fields = message.optJSONObject("fields")
                 if (fields != null) {
                     val eventName = fields.optString("eventName")
@@ -566,9 +530,7 @@ class VoipNotification(private val context: Context) {
                     return@connect
                 }
                 if (!connected) {
-                    if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "DDP connection failed")
-                    }
+                    Log.d(TAG, "DDP connection failed")
                     ddpRegistry.stopClient(callId)
                     return@connect
                 }
@@ -578,9 +540,7 @@ class VoipNotification(private val context: Context) {
                         return@login
                     }
                     if (!loggedIn) {
-                        if (BuildConfig.DEBUG) {
-                            Log.d(TAG, "DDP login failed")
-                        }
+                        Log.d(TAG, "DDP login failed")
                         ddpRegistry.stopClient(callId)
                         return@login
                     }
@@ -602,9 +562,7 @@ class VoipNotification(private val context: Context) {
                         if (!isLiveClient(callId, client)) {
                             return@subscribe
                         }
-                        if (BuildConfig.DEBUG) {
-                            Log.d(TAG, "DDP subscribe result: $subscribed")
-                        }
+                        Log.d(TAG, "DDP subscribe result: $subscribed")
                         if (!subscribed) {
                             ddpRegistry.stopClient(callId)
                         }
@@ -616,9 +574,7 @@ class VoipNotification(private val context: Context) {
 
         @JvmStatic
         fun stopDDPClient() {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "stopDDPClient called from JS")
-            }
+            Log.d(TAG, "stopDDPClient called from JS")
             ddpRegistry.stopAllClients()
         }
     }
@@ -648,16 +604,12 @@ class VoipNotification(private val context: Context) {
                 when (decideIncomingVoipPushAction(isValidForIncoming, hasActiveCall(context))) {
                     VoipIncomingPushAction.STALE -> {
                         if (voipPayload.getRemainingLifetimeMs() == null) {
-                            if (BuildConfig.DEBUG) {
-                                Log.w(
-                                    TAG,
-                                    "Skipping incoming VoIP call without a valid createdAt timestamp - callId: ${voipPayload.callId}"
-                                )
-                            }
+                            Log.w(
+                                TAG,
+                                "Skipping incoming VoIP call without a valid createdAt timestamp - callId: ${voipPayload.callId}"
+                            )
                         } else {
-                            if (BuildConfig.DEBUG) {
-                                Log.d(TAG, "Skipping expired incoming VoIP call - callId: ${voipPayload.callId}")
-                            }
+                            Log.d(TAG, "Skipping expired incoming VoIP call - callId: ${voipPayload.callId}")
                         }
                     }
                     VoipIncomingPushAction.REJECT_BUSY -> rejectBusyCall(context, voipPayload)
@@ -708,22 +660,16 @@ class VoipNotification(private val context: Context) {
         val callId = voipPayload.callId
         val caller = voipPayload.caller
         if (voipPayload.getRemainingLifetimeMs() == null) {
-            if (BuildConfig.DEBUG) {
-                Log.w(TAG, "Skipping incoming VoIP call without a valid createdAt timestamp - callId: $callId")
-            }
+            Log.w(TAG, "Skipping incoming VoIP call without a valid createdAt timestamp - callId: $callId")
             return
         }
 
         if (voipPayload.isExpired()) {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Skipping expired incoming VoIP call - callId: $callId")
-            }
+            Log.d(TAG, "Skipping expired incoming VoIP call - callId: $callId")
             return
         }
 
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Showing incoming VoIP call - callId: $callId, caller: $caller")
-        }
+        Log.d(TAG, "Showing incoming VoIP call - callId: $callId, caller: $caller")
 
         // CRITICAL: Register call with TelecomManager FIRST (required for audio focus, Bluetooth, priority, FSI exemption)
         // This triggers react-native-callkeep's ConnectionService
@@ -779,15 +725,11 @@ class VoipNotification(private val context: Context) {
                 putString("handle", caller)
             }
 
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Registering call with TelecomManager - callId: $callId, caller: $caller, extras keys: ${extras.keySet()}")
-            }
+            Log.d(TAG, "Registering call with TelecomManager - callId: $callId, caller: $caller, extras keys: ${extras.keySet()}")
 
             // Register the incoming call with the OS
             telecomManager.addNewIncomingCall(phoneAccountHandle, extras)
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Successfully registered incoming call with TelecomManager: $callId")
-            }
+            Log.d(TAG, "Successfully registered incoming call with TelecomManager: $callId")
         } catch (e: SecurityException) {
             Log.e(TAG, "SecurityException registering call with TelecomManager. Check MANAGE_OWN_CALLS/READ_PHONE_STATE grants and PhoneAccount registration.", e)
         } catch (e: Exception) {
@@ -830,15 +772,11 @@ class VoipNotification(private val context: Context) {
         val notificationId = voipPayload.notificationId
         val remainingLifetimeMs = voipPayload.getRemainingLifetimeMs()
         if (remainingLifetimeMs == null || remainingLifetimeMs <= 0L) {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "Skipping notification for expired or invalid call: ${voipPayload.callId}")
-            }
+            Log.d(TAG, "Skipping notification for expired or invalid call: ${voipPayload.callId}")
             return
         }
 
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "Showing incoming call notification for VoIP call from: $caller")
-        }
+        Log.d(TAG, "Showing incoming call notification for VoIP call from: $caller")
 
         // Check if we can use full-screen intent (Android 14+)
         val canUseFullScreen = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -930,9 +868,7 @@ class VoipNotification(private val context: Context) {
             // Set full-screen intent only if permission is granted
             if (canUseFullScreen) {
                 setFullScreenIntent(fullScreenPendingIntent, true)
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "Full-screen intent enabled - locked device will show Activity, unlocked will show HUN")
-                }
+                Log.d(TAG, "Full-screen intent enabled - locked device will show Activity, unlocked will show HUN")
             } else {
                 Log.w(TAG, "Full-screen intent permission not granted - showing HUN only (fallback)")
                 // Still set content intent so tapping notification opens the activity
@@ -948,9 +884,7 @@ class VoipNotification(private val context: Context) {
 
         // Show notification
         notificationManager?.notify(notificationId, builder.build())
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "VoIP notification displayed with ID: $notificationId")
-        }
+        Log.d(TAG, "VoIP notification displayed with ID: $notificationId")
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -96,7 +96,9 @@ class VoipNotification(private val context: Context) {
         fun scheduleTimeout(context: Context, payload: VoipPayload) {
             val delayMs = payload.getRemainingLifetimeMs()
             if (delayMs == null || delayMs <= 0L) {
-                Log.d(TAG, "Skipping timeout scheduling for expired or invalid call: ${payload.callId}")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Skipping timeout scheduling for expired or invalid call: ${payload.callId}")
+                }
                 return
             }
 
@@ -114,7 +116,9 @@ class VoipNotification(private val context: Context) {
                 timeoutCallbacks[payload.callId] = timeoutRunnable
             }
             timeoutHandler.postDelayed(timeoutRunnable, delayMs)
-            Log.d(TAG, "Scheduled VoIP timeout for ${payload.callId} in ${delayMs}ms")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Scheduled VoIP timeout for ${payload.callId} in ${delayMs}ms")
+            }
         }
 
         @JvmStatic
@@ -124,7 +128,9 @@ class VoipNotification(private val context: Context) {
             }
             if (timeoutRunnable != null) {
                 timeoutHandler.removeCallbacks(timeoutRunnable)
-                Log.d(TAG, "Cancelled VoIP timeout for $callId")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Cancelled VoIP timeout for $callId")
+                }
             }
         }
 
@@ -140,7 +146,9 @@ class VoipNotification(private val context: Context) {
                 }
             )
             ddpRegistry.stopClient(payload.callId)
-            Log.d(TAG, "Timed out incoming VoIP call: ${payload.callId}")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Timed out incoming VoIP call: ${payload.callId}")
+            }
         }
 
         /**
@@ -149,7 +157,9 @@ class VoipNotification(private val context: Context) {
          */
         @JvmStatic
         fun handleDeclineAction(context: Context, payload: VoipPayload) {
-            Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
+            }
             cancelTimeout(payload.callId)
             ddpRegistry.stopClient(payload.callId)
             val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
@@ -209,9 +219,11 @@ class VoipNotification(private val context: Context) {
             payload: VoipPayload,
             storePayloadForJs: Boolean = true
         ) {
-            Log.d(TAG, "prepareMainActivityForIncomingVoip — callId: ${payload.callId}")
             cancelById(context, payload.notificationId)
             cancelTimeout(payload.callId)
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "prepareMainActivityForIncomingVoip — callId: ${payload.callId}")
+            }
             if (storePayloadForJs) {
                 VoipModule.storeInitialEvents(payload)
             }
@@ -237,11 +249,13 @@ class VoipNotification(private val context: Context) {
         @JvmStatic
         @JvmOverloads
         fun handleAcceptAction(context: Context, payload: VoipPayload, skipLaunchMainActivity: Boolean = false) {
-            Log.d(TAG, "Accept action triggered for callId: ${payload.callId}")
             cancelTimeout(payload.callId)
 
             // Install the DDP end-call listener here so the notification-accept path
             // also tears down on hangup; previously only showIncomingCall installed it.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Accept action triggered for callId: ${payload.callId}")
+            }
             startListeningForCallEnd(context, payload)
 
             // Start foreground service to keep call alive in background.
@@ -261,7 +275,9 @@ class VoipNotification(private val context: Context) {
                     answerIncomingCall(appCtx, payload.callId)
                     VoipModule.storeInitialEvents(payload)
                 } else {
-                    Log.d(TAG, "media-calls.answer failed for ${payload.callId}; opening app for JS recovery")
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "media-calls.answer failed for ${payload.callId}; opening app for JS recovery")
+                    }
                     disconnectIncomingCall(payload.callId, false)
                     VoipModule.storeAcceptFailureForJs(payload)
                 }
@@ -277,7 +293,9 @@ class VoipNotification(private val context: Context) {
             }
 
             val postedTimeout = Runnable {
-                Log.w(TAG, "media-calls.answer timed out for ${payload.callId}; falling back to JS recovery")
+                if (BuildConfig.DEBUG) {
+                    Log.w(TAG, "media-calls.answer timed out for ${payload.callId}; falling back to JS recovery")
+                }
                 finish(false)
             }
             timeoutRunnable = postedTimeout
@@ -317,7 +335,9 @@ class VoipNotification(private val context: Context) {
                 null -> {
                     // Null means Telecom connection is gone (e.g. system killed it).
                     // Notify JS so the user sees an error instead of a hanging UI.
-                    Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
+                    if (BuildConfig.DEBUG) {
+                        Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
+                    }
                     val appCtx = context.applicationContext
                     disconnectIncomingCall(callId, false)
                     cancelById(appCtx, 0)
@@ -335,7 +355,9 @@ class VoipNotification(private val context: Context) {
                         voipAcceptFailed = true
                     ))
                 }
-                else -> Log.d(TAG, "Non-VoiceConnection for accept, callId: $callId")
+                else -> if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Non-VoiceConnection for accept, callId: $callId")
+                }
             }
         }
 
@@ -344,7 +366,9 @@ class VoipNotification(private val context: Context) {
             val connection = VoiceConnectionService.getConnection(callId)
             when (connection) {
                 is VoiceConnection -> connection.reportDisconnect(DISCONNECT_REASON_MISSED)
-                null -> Log.d(TAG, "No active VoiceConnection found for timed out call: $callId")
+                null -> if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No active VoiceConnection found for timed out call: $callId")
+                }
                 else -> connection.onDisconnect()
             }
         }
@@ -353,7 +377,9 @@ class VoipNotification(private val context: Context) {
             val connection = VoiceConnectionService.getConnection(callId)
             when (connection) {
                 is VoiceConnection -> connection.onReject()
-                null -> Log.d(TAG, "No active VoiceConnection found for declined call: $callId")
+                null -> if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No active VoiceConnection found for declined call: $callId")
+                }
                 else -> connection.onDisconnect()
             }
         }
@@ -368,7 +394,9 @@ class VoipNotification(private val context: Context) {
                         connection.onDisconnect()
                     }
                 }
-                null -> Log.d(TAG, "No active VoiceConnection found for dismissed call: $callId")
+                null -> if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No active VoiceConnection found for dismissed call: $callId")
+                }
                 else -> connection.onDisconnect()
             }
         }
@@ -411,7 +439,9 @@ class VoipNotification(private val context: Context) {
                             return true
                         }
                     } catch (e: SecurityException) {
-                        Log.w(TAG, "TelecomManager.isInCall not allowed", e)
+                        if (BuildConfig.DEBUG) {
+                            Log.w(TAG, "TelecomManager.isInCall not allowed", e)
+                        }
                     }
                 }
             }
@@ -443,7 +473,9 @@ class VoipNotification(private val context: Context) {
          */
         @JvmStatic
         fun rejectBusyCall(context: Context, payload: VoipPayload) {
-            Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
+            }
             cancelTimeout(payload.callId)
             val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
@@ -466,7 +498,9 @@ class VoipNotification(private val context: Context) {
             val token = ejson.token()
 
             if (userId.isNullOrEmpty() || token.isNullOrEmpty()) {
-                Log.d(TAG, "No credentials for ${payload.host}, skipping DDP listener")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No credentials for ${payload.host}, skipping DDP listener")
+                }
                 return
             }
 
@@ -475,13 +509,17 @@ class VoipNotification(private val context: Context) {
             val client = DDPClient()
             ddpRegistry.putClient(callId, client)
 
-            Log.d(TAG, "Starting DDP listener for call $callId")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Starting DDP listener for call $callId")
+            }
 
             client.onCollectionMessage = collector@{ message ->
                 if (!isLiveClient(callId, client)) {
                     return@collector
                 }
-                Log.d(TAG, "DDP received message: $message")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "DDP received message: $message")
+                }
                 val fields = message.optJSONObject("fields")
                 if (fields != null) {
                     val eventName = fields.optString("eventName")
@@ -530,7 +568,9 @@ class VoipNotification(private val context: Context) {
                     return@connect
                 }
                 if (!connected) {
-                    Log.d(TAG, "DDP connection failed")
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "DDP connection failed")
+                    }
                     ddpRegistry.stopClient(callId)
                     return@connect
                 }
@@ -540,7 +580,9 @@ class VoipNotification(private val context: Context) {
                         return@login
                     }
                     if (!loggedIn) {
-                        Log.d(TAG, "DDP login failed")
+                        if (BuildConfig.DEBUG) {
+                            Log.d(TAG, "DDP login failed")
+                        }
                         ddpRegistry.stopClient(callId)
                         return@login
                     }
@@ -562,7 +604,9 @@ class VoipNotification(private val context: Context) {
                         if (!isLiveClient(callId, client)) {
                             return@subscribe
                         }
-                        Log.d(TAG, "DDP subscribe result: $subscribed")
+                        if (BuildConfig.DEBUG) {
+                            Log.d(TAG, "DDP subscribe result: $subscribed")
+                        }
                         if (!subscribed) {
                             ddpRegistry.stopClient(callId)
                         }
@@ -574,7 +618,9 @@ class VoipNotification(private val context: Context) {
 
         @JvmStatic
         fun stopDDPClient() {
-            Log.d(TAG, "stopDDPClient called from JS")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "stopDDPClient called from JS")
+            }
             ddpRegistry.stopAllClients()
         }
     }
@@ -604,12 +650,16 @@ class VoipNotification(private val context: Context) {
                 when (decideIncomingVoipPushAction(isValidForIncoming, hasActiveCall(context))) {
                     VoipIncomingPushAction.STALE -> {
                         if (voipPayload.getRemainingLifetimeMs() == null) {
-                            Log.w(
-                                TAG,
-                                "Skipping incoming VoIP call without a valid createdAt timestamp - callId: ${voipPayload.callId}"
-                            )
+                            if (BuildConfig.DEBUG) {
+                                Log.w(
+                                    TAG,
+                                    "Skipping incoming VoIP call without a valid createdAt timestamp - callId: ${voipPayload.callId}"
+                                )
+                            }
                         } else {
-                            Log.d(TAG, "Skipping expired incoming VoIP call - callId: ${voipPayload.callId}")
+                            if (BuildConfig.DEBUG) {
+                                Log.d(TAG, "Skipping expired incoming VoIP call - callId: ${voipPayload.callId}")
+                            }
                         }
                     }
                     VoipIncomingPushAction.REJECT_BUSY -> rejectBusyCall(context, voipPayload)
@@ -660,16 +710,22 @@ class VoipNotification(private val context: Context) {
         val callId = voipPayload.callId
         val caller = voipPayload.caller
         if (voipPayload.getRemainingLifetimeMs() == null) {
-            Log.w(TAG, "Skipping incoming VoIP call without a valid createdAt timestamp - callId: $callId")
+            if (BuildConfig.DEBUG) {
+                Log.w(TAG, "Skipping incoming VoIP call without a valid createdAt timestamp - callId: $callId")
+            }
             return
         }
 
         if (voipPayload.isExpired()) {
-            Log.d(TAG, "Skipping expired incoming VoIP call - callId: $callId")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Skipping expired incoming VoIP call - callId: $callId")
+            }
             return
         }
 
-        Log.d(TAG, "Showing incoming VoIP call - callId: $callId, caller: $caller")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Showing incoming VoIP call - callId: $callId, caller: $caller")
+        }
 
         // CRITICAL: Register call with TelecomManager FIRST (required for audio focus, Bluetooth, priority, FSI exemption)
         // This triggers react-native-callkeep's ConnectionService
@@ -725,11 +781,15 @@ class VoipNotification(private val context: Context) {
                 putString("handle", caller)
             }
 
-            Log.d(TAG, "Registering call with TelecomManager - callId: $callId, caller: $caller, extras keys: ${extras.keySet()}")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Registering call with TelecomManager - callId: $callId, caller: $caller, extras keys: ${extras.keySet()}")
+            }
 
             // Register the incoming call with the OS
             telecomManager.addNewIncomingCall(phoneAccountHandle, extras)
-            Log.d(TAG, "Successfully registered incoming call with TelecomManager: $callId")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Successfully registered incoming call with TelecomManager: $callId")
+            }
         } catch (e: SecurityException) {
             Log.e(TAG, "SecurityException registering call with TelecomManager. Check MANAGE_OWN_CALLS/READ_PHONE_STATE grants and PhoneAccount registration.", e)
         } catch (e: Exception) {
@@ -772,11 +832,15 @@ class VoipNotification(private val context: Context) {
         val notificationId = voipPayload.notificationId
         val remainingLifetimeMs = voipPayload.getRemainingLifetimeMs()
         if (remainingLifetimeMs == null || remainingLifetimeMs <= 0L) {
-            Log.d(TAG, "Skipping notification for expired or invalid call: ${voipPayload.callId}")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Skipping notification for expired or invalid call: ${voipPayload.callId}")
+            }
             return
         }
 
-        Log.d(TAG, "Showing incoming call notification for VoIP call from: $caller")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Showing incoming call notification for VoIP call from: $caller")
+        }
 
         // Check if we can use full-screen intent (Android 14+)
         val canUseFullScreen = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -868,7 +932,9 @@ class VoipNotification(private val context: Context) {
             // Set full-screen intent only if permission is granted
             if (canUseFullScreen) {
                 setFullScreenIntent(fullScreenPendingIntent, true)
-                Log.d(TAG, "Full-screen intent enabled - locked device will show Activity, unlocked will show HUN")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Full-screen intent enabled - locked device will show Activity, unlocked will show HUN")
+                }
             } else {
                 Log.w(TAG, "Full-screen intent permission not granted - showing HUN only (fallback)")
                 // Still set content intent so tapping notification opens the activity
@@ -884,7 +950,9 @@ class VoipNotification(private val context: Context) {
 
         // Show notification
         notificationManager?.notify(notificationId, builder.build())
-        Log.d(TAG, "VoIP notification displayed with ID: $notificationId")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "VoIP notification displayed with ID: $notificationId")
+        }
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -96,7 +96,9 @@ class VoipNotification(private val context: Context) {
         fun scheduleTimeout(context: Context, payload: VoipPayload) {
             val delayMs = payload.getRemainingLifetimeMs()
             if (delayMs == null || delayMs <= 0L) {
-                Log.d(TAG, "Skipping timeout scheduling for expired or invalid call: ${payload.callId}")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Skipping timeout scheduling for expired or invalid call: ${payload.callId}")
+                }
                 return
             }
 
@@ -114,7 +116,9 @@ class VoipNotification(private val context: Context) {
                 timeoutCallbacks[payload.callId] = timeoutRunnable
             }
             timeoutHandler.postDelayed(timeoutRunnable, delayMs)
-            Log.d(TAG, "Scheduled VoIP timeout for ${payload.callId} in ${delayMs}ms")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Scheduled VoIP timeout for ${payload.callId} in ${delayMs}ms")
+            }
         }
 
         @JvmStatic
@@ -124,7 +128,9 @@ class VoipNotification(private val context: Context) {
             }
             if (timeoutRunnable != null) {
                 timeoutHandler.removeCallbacks(timeoutRunnable)
-                Log.d(TAG, "Cancelled VoIP timeout for $callId")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Cancelled VoIP timeout for $callId")
+                }
             }
         }
 
@@ -149,7 +155,9 @@ class VoipNotification(private val context: Context) {
          */
         @JvmStatic
         fun handleDeclineAction(context: Context, payload: VoipPayload) {
-            Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
+            }
             cancelTimeout(payload.callId)
             ddpRegistry.stopClient(payload.callId)
             val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
@@ -162,6 +170,9 @@ class VoipNotification(private val context: Context) {
                 supportedFeatures = null
             ) { _ -> }
             rejectIncomingCall(payload.callId)
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Decline action triggered for callId: ${payload.callId}")
+            }
             cancelById(context, payload.notificationId)
             LocalBroadcastManager.getInstance(context).sendBroadcast(
                 Intent(ACTION_DISMISS).apply {
@@ -209,9 +220,11 @@ class VoipNotification(private val context: Context) {
             payload: VoipPayload,
             storePayloadForJs: Boolean = true
         ) {
-            Log.d(TAG, "prepareMainActivityForIncomingVoip — callId: ${payload.callId}")
             cancelById(context, payload.notificationId)
             cancelTimeout(payload.callId)
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "prepareMainActivityForIncomingVoip — callId: ${payload.callId}")
+            }
             if (storePayloadForJs) {
                 VoipModule.storeInitialEvents(payload)
             }
@@ -242,6 +255,9 @@ class VoipNotification(private val context: Context) {
 
             // Install the DDP end-call listener here so the notification-accept path
             // also tears down on hangup; previously only showIncomingCall installed it.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Accept action triggered for callId: ${payload.callId}")
+            }
             startListeningForCallEnd(context, payload)
 
             // Start foreground service to keep call alive in background.
@@ -261,7 +277,9 @@ class VoipNotification(private val context: Context) {
                     answerIncomingCall(appCtx, payload.callId)
                     VoipModule.storeInitialEvents(payload)
                 } else {
-                    Log.d(TAG, "media-calls.answer failed for ${payload.callId}; opening app for JS recovery")
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "media-calls.answer failed for ${payload.callId}; opening app for JS recovery")
+                    }
                     disconnectIncomingCall(payload.callId, false)
                     VoipModule.storeAcceptFailureForJs(payload)
                 }
@@ -277,7 +295,9 @@ class VoipNotification(private val context: Context) {
             }
 
             val postedTimeout = Runnable {
-                Log.w(TAG, "media-calls.answer timed out for ${payload.callId}; falling back to JS recovery")
+                if (BuildConfig.DEBUG) {
+                    Log.w(TAG, "media-calls.answer timed out for ${payload.callId}; falling back to JS recovery")
+                }
                 finish(false)
             }
             timeoutRunnable = postedTimeout
@@ -317,7 +337,9 @@ class VoipNotification(private val context: Context) {
                 null -> {
                     // Null means Telecom connection is gone (e.g. system killed it).
                     // Notify JS so the user sees an error instead of a hanging UI.
-                    Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
+                    if (BuildConfig.DEBUG) {
+                        Log.w(TAG, "No active VoiceConnection for accepted call: $callId — notifying JS of failure")
+                    }
                     val appCtx = context.applicationContext
                     disconnectIncomingCall(callId, false)
                     cancelById(appCtx, 0)
@@ -344,7 +366,9 @@ class VoipNotification(private val context: Context) {
             val connection = VoiceConnectionService.getConnection(callId)
             when (connection) {
                 is VoiceConnection -> connection.reportDisconnect(DISCONNECT_REASON_MISSED)
-                null -> Log.d(TAG, "No active VoiceConnection found for timed out call: $callId")
+                null -> if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No active VoiceConnection found for timed out call: $callId")
+                }
                 else -> connection.onDisconnect()
             }
         }
@@ -353,7 +377,9 @@ class VoipNotification(private val context: Context) {
             val connection = VoiceConnectionService.getConnection(callId)
             when (connection) {
                 is VoiceConnection -> connection.onReject()
-                null -> Log.d(TAG, "No active VoiceConnection found for declined call: $callId")
+                null -> if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No active VoiceConnection found for declined call: $callId")
+                }
                 else -> connection.onDisconnect()
             }
         }
@@ -368,7 +394,9 @@ class VoipNotification(private val context: Context) {
                         connection.onDisconnect()
                     }
                 }
-                null -> Log.d(TAG, "No active VoiceConnection found for dismissed call: $callId")
+                null -> if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No active VoiceConnection found for dismissed call: $callId")
+                }
                 else -> connection.onDisconnect()
             }
         }
@@ -443,7 +471,9 @@ class VoipNotification(private val context: Context) {
          */
         @JvmStatic
         fun rejectBusyCall(context: Context, payload: VoipPayload) {
-            Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
+            }
             cancelTimeout(payload.callId)
             val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
@@ -466,7 +496,9 @@ class VoipNotification(private val context: Context) {
             val token = ejson.token()
 
             if (userId.isNullOrEmpty() || token.isNullOrEmpty()) {
-                Log.d(TAG, "No credentials for ${payload.host}, skipping DDP listener")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "No credentials for ${payload.host}, skipping DDP listener")
+                }
                 return
             }
 
@@ -475,13 +507,17 @@ class VoipNotification(private val context: Context) {
             val client = DDPClient()
             ddpRegistry.putClient(callId, client)
 
-            Log.d(TAG, "Starting DDP listener for call $callId")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Starting DDP listener for call $callId")
+            }
 
             client.onCollectionMessage = collector@{ message ->
                 if (!isLiveClient(callId, client)) {
                     return@collector
                 }
-                Log.d(TAG, "DDP received message: $message")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "DDP received message: $message")
+                }
                 val fields = message.optJSONObject("fields")
                 if (fields != null) {
                     val eventName = fields.optString("eventName")
@@ -530,7 +566,9 @@ class VoipNotification(private val context: Context) {
                     return@connect
                 }
                 if (!connected) {
-                    Log.d(TAG, "DDP connection failed")
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "DDP connection failed")
+                    }
                     ddpRegistry.stopClient(callId)
                     return@connect
                 }
@@ -540,7 +578,9 @@ class VoipNotification(private val context: Context) {
                         return@login
                     }
                     if (!loggedIn) {
-                        Log.d(TAG, "DDP login failed")
+                        if (BuildConfig.DEBUG) {
+                            Log.d(TAG, "DDP login failed")
+                        }
                         ddpRegistry.stopClient(callId)
                         return@login
                     }
@@ -562,7 +602,9 @@ class VoipNotification(private val context: Context) {
                         if (!isLiveClient(callId, client)) {
                             return@subscribe
                         }
-                        Log.d(TAG, "DDP subscribe result: $subscribed")
+                        if (BuildConfig.DEBUG) {
+                            Log.d(TAG, "DDP subscribe result: $subscribed")
+                        }
                         if (!subscribed) {
                             ddpRegistry.stopClient(callId)
                         }
@@ -574,7 +616,9 @@ class VoipNotification(private val context: Context) {
 
         @JvmStatic
         fun stopDDPClient() {
-            Log.d(TAG, "stopDDPClient called from JS")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "stopDDPClient called from JS")
+            }
             ddpRegistry.stopAllClients()
         }
     }
@@ -604,12 +648,16 @@ class VoipNotification(private val context: Context) {
                 when (decideIncomingVoipPushAction(isValidForIncoming, hasActiveCall(context))) {
                     VoipIncomingPushAction.STALE -> {
                         if (voipPayload.getRemainingLifetimeMs() == null) {
-                            Log.w(
-                                TAG,
-                                "Skipping incoming VoIP call without a valid createdAt timestamp - callId: ${voipPayload.callId}"
-                            )
+                            if (BuildConfig.DEBUG) {
+                                Log.w(
+                                    TAG,
+                                    "Skipping incoming VoIP call without a valid createdAt timestamp - callId: ${voipPayload.callId}"
+                                )
+                            }
                         } else {
-                            Log.d(TAG, "Skipping expired incoming VoIP call - callId: ${voipPayload.callId}")
+                            if (BuildConfig.DEBUG) {
+                                Log.d(TAG, "Skipping expired incoming VoIP call - callId: ${voipPayload.callId}")
+                            }
                         }
                     }
                     VoipIncomingPushAction.REJECT_BUSY -> rejectBusyCall(context, voipPayload)
@@ -660,16 +708,22 @@ class VoipNotification(private val context: Context) {
         val callId = voipPayload.callId
         val caller = voipPayload.caller
         if (voipPayload.getRemainingLifetimeMs() == null) {
-            Log.w(TAG, "Skipping incoming VoIP call without a valid createdAt timestamp - callId: $callId")
+            if (BuildConfig.DEBUG) {
+                Log.w(TAG, "Skipping incoming VoIP call without a valid createdAt timestamp - callId: $callId")
+            }
             return
         }
 
         if (voipPayload.isExpired()) {
-            Log.d(TAG, "Skipping expired incoming VoIP call - callId: $callId")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Skipping expired incoming VoIP call - callId: $callId")
+            }
             return
         }
 
-        Log.d(TAG, "Showing incoming VoIP call - callId: $callId, caller: $caller")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Showing incoming VoIP call - callId: $callId, caller: $caller")
+        }
 
         // CRITICAL: Register call with TelecomManager FIRST (required for audio focus, Bluetooth, priority, FSI exemption)
         // This triggers react-native-callkeep's ConnectionService
@@ -725,11 +779,15 @@ class VoipNotification(private val context: Context) {
                 putString("handle", caller)
             }
 
-            Log.d(TAG, "Registering call with TelecomManager - callId: $callId, caller: $caller, extras keys: ${extras.keySet()}")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Registering call with TelecomManager - callId: $callId, caller: $caller, extras keys: ${extras.keySet()}")
+            }
 
             // Register the incoming call with the OS
             telecomManager.addNewIncomingCall(phoneAccountHandle, extras)
-            Log.d(TAG, "Successfully registered incoming call with TelecomManager: $callId")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Successfully registered incoming call with TelecomManager: $callId")
+            }
         } catch (e: SecurityException) {
             Log.e(TAG, "SecurityException registering call with TelecomManager. Check MANAGE_OWN_CALLS/READ_PHONE_STATE grants and PhoneAccount registration.", e)
         } catch (e: Exception) {
@@ -772,11 +830,15 @@ class VoipNotification(private val context: Context) {
         val notificationId = voipPayload.notificationId
         val remainingLifetimeMs = voipPayload.getRemainingLifetimeMs()
         if (remainingLifetimeMs == null || remainingLifetimeMs <= 0L) {
-            Log.d(TAG, "Skipping notification for expired or invalid call: ${voipPayload.callId}")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Skipping notification for expired or invalid call: ${voipPayload.callId}")
+            }
             return
         }
 
-        Log.d(TAG, "Showing incoming call notification for VoIP call from: $caller")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Showing incoming call notification for VoIP call from: $caller")
+        }
 
         // Check if we can use full-screen intent (Android 14+)
         val canUseFullScreen = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -868,7 +930,9 @@ class VoipNotification(private val context: Context) {
             // Set full-screen intent only if permission is granted
             if (canUseFullScreen) {
                 setFullScreenIntent(fullScreenPendingIntent, true)
-                Log.d(TAG, "Full-screen intent enabled - locked device will show Activity, unlocked will show HUN")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "Full-screen intent enabled - locked device will show Activity, unlocked will show HUN")
+                }
             } else {
                 Log.w(TAG, "Full-screen intent permission not granted - showing HUN only (fallback)")
                 // Still set content intent so tapping notification opens the activity
@@ -884,7 +948,9 @@ class VoipNotification(private val context: Context) {
 
         // Show notification
         notificationManager?.notify(notificationId, builder.build())
-        Log.d(TAG, "VoIP notification displayed with ID: $notificationId")
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "VoIP notification displayed with ID: $notificationId")
+        }
     }
 
     /**

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -114,8 +114,8 @@ class MediaSessionInstance {
 		this.instance?.on('newCall', ({ call }: { call: IClientMediaCall }) => {
 			if (call && !call.hidden) {
 				call.emitter.on('stateChange', _oldState => {
-						// Intentionally empty — state transitions handled by the call layer
-					});
+					// Intentionally empty — state transitions handled by the call layer
+				});
 
 				if (call.localParticipant.role === 'caller') {
 					useCallStore.getState().setCall(call);
@@ -156,6 +156,7 @@ class MediaSessionInstance {
 			if (st.nativeAcceptedCallId === callId) {
 				st.resetNativeCallId();
 			}
+			console.warn('[VoIP] Call not found after accept:', callId);
 		}
 	};
 

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -108,17 +108,14 @@ class MediaSessionInstance {
 			const signal = ddpMessage.fields.args[0];
 			this.instance.processSignal(signal);
 
-			console.log('🤙 [VoIP] Processed signal:', signal);
-
 			this.tryAnswerIfNativeAcceptedNotification(signal as ServerMediaSignal);
 		});
 
 		this.instance?.on('newCall', ({ call }: { call: IClientMediaCall }) => {
 			if (call && !call.hidden) {
-				call.emitter.on('stateChange', oldState => {
-					console.log(`📊 ${oldState} → ${call.state}`);
-					console.log('🤙 [VoIP] New call data:', call);
-				});
+				call.emitter.on('stateChange', _oldState => {
+						// Intentionally empty — state transitions handled by the call layer
+					});
 
 				if (call.localParticipant.role === 'caller') {
 					useCallStore.getState().setCall(call);
@@ -140,18 +137,13 @@ class MediaSessionInstance {
 	public answerCall = async (callId: string) => {
 		const { call: existingCall } = useCallStore.getState();
 		if (existingCall != null && existingCall.callId === callId) {
-			console.log('[VoIP] answerCall skipped — call already bound in store:', callId);
 			return;
 		}
 
-		console.log('[VoIP] Answering call:', callId);
 		const mainCall = this.instance?.getCallData(callId);
-		console.log('[VoIP] Main call:', mainCall);
 
 		if (mainCall && mainCall.callId === callId) {
-			console.log('[VoIP] Accepting call:', callId);
 			await mainCall.accept();
-			console.log('[VoIP] Setting current call active:', callId);
 			RNCallKeep.setCurrentCallActive(callId);
 			useCallStore.getState().setCall(mainCall);
 			Navigation.navigate('CallView');
@@ -164,7 +156,6 @@ class MediaSessionInstance {
 			if (st.nativeAcceptedCallId === callId) {
 				st.resetNativeCallId();
 			}
-			console.warn('[VoIP] Call not found after accept:', callId);
 		}
 	};
 
@@ -180,7 +171,6 @@ class MediaSessionInstance {
 
 	public startCall = async (userId: string, actor: CallActorType): Promise<void> => {
 		requestPhoneStatePermission();
-		console.log('[VoIP] Starting call:', userId);
 		await this.instance?.startCall(actor, userId);
 	};
 

--- a/app/lib/services/voip/MediaSessionStore.ts
+++ b/app/lib/services/voip/MediaSessionStore.ts
@@ -55,7 +55,6 @@ class MediaSessionStore extends Emitter<{ change: void }> {
 
 		// Must match native VoIP DDP contractId: iOS `DeviceUID`, Android `Settings.Secure.ANDROID_ID` (see native VoipService / VoipNotification).
 		const mobileDeviceId = getUniqueIdSync();
-		console.log('[VoIP] Mobile device ID:', mobileDeviceId);
 		this.sessionInstance = new MediaSignalingSession({
 			userId,
 			transport: (signal: ClientMediaSignal) => this.sendSignal(signal),


### PR DESCRIPTION
## Summary

Defense-in-depth for VoIP secure logging. Complements the existing babel transform that strips `console.log` in production by removing sensitive data at the source level in both JS and Android native code.

### Changes

**JS/TS — console.log removal (source-level):**
- `MediaSessionInstance.ts`: Removed all `console.log` calls and the `// TODO: Show error message?` comment
- `MediaSessionStore.ts`: Removed `console.log('[VoIP] Mobile device ID:', mobileDeviceId)`

**Android Kotlin — BuildConfig.DEBUG gating:**
- `DDPClient.kt`: All sensitive `Log.d` calls (wsUrl, connection, login, subscribe, method calls) gated behind `if (BuildConfig.DEBUG)`
- `VoipNotification.kt`: ~30 sensitive logs (DDP listener, callId, host, WebSocket messages) gated
- `VoipModule.kt`: addListener/removeListeners event name logs gated
- `VoipCallService.kt`: Service lifecycle logs gated
- `IncomingCallActivity.kt`: Activity creation/call accepted/declined logs gated

**Android Kotlin — response body removal:**
- `MediaCallsAnswerRequest.kt`: Removed HTTP response body logging (lines 125, 127) that could expose session tokens/crypto material

### Sensitive data removed from production logs

- `callId` (call identifiers)
- Host URLs and `wsUrl` (WebSocket URLs)
- Device IDs (ANDROID_ID)
- WebSocket message content (DDP messages)
- HTTP response bodies (answer request responses)

### Preserved for production support

- All `Log.e` (error logs needed for debugging)
- All `console.error` in JS
- Operational logs (notification lifecycle, TelecomManager failures, security exceptions, unknown action warnings)

## Merge Order

Part of the VoIP secure logs cleanup. No dependencies.

## Test plan

- [x] `TZ=UTC yarn test -- --testPathPattern='app/lib/services/voip/MediaSession'` passes
- [x] `yarn lint` passes
- [ ] Android unit tests pass (`./gradlew :app:testDebugUnitTest --tests "chat.rocket.reactnative.voip.*"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced verbose debug logging across VoIP call and notification flows; debug messages now only appear in debug builds or were removed to cut noise. No functional changes to call behavior, UI, or call lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->