### PR TITLE
fix(android): VoIP SSL pinning integration for DDPClient + MediaCallsAnswerRequest

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/networking/SSLPinningTurboModule.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/networking/SSLPinningTurboModule.java
@@ -41,6 +41,30 @@ public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyCh
     private Promise promise;
     private static String alias;
     private static ReactApplicationContext reactContext;
+    private static OkHttpClient sharedClient;
+
+    public static OkHttpClient getSharedOkHttpClient() {
+        if (sharedClient != null) {
+            return sharedClient;
+        }
+        if (alias != null) {
+            OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                    .connectTimeout(0, TimeUnit.MILLISECONDS)
+                    .readTimeout(0, TimeUnit.MILLISECONDS)
+                    .writeTimeout(0, TimeUnit.MILLISECONDS)
+                    .cookieJar(new ReactCookieJarContainer());
+
+            SSLSocketFactory sslSocketFactory = getSSLFactory(alias);
+            X509TrustManager trustManager = getTrustManagerFactory();
+            if (sslSocketFactory != null) {
+                builder.sslSocketFactory(sslSocketFactory, trustManager);
+            }
+
+            sharedClient = builder.build();
+            return sharedClient;
+        }
+        return null;
+    }
 
     public SSLPinningTurboModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -61,6 +85,10 @@ public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyCh
     }
 
     protected OkHttpClient getOkHttpClient() {
+        OkHttpClient shared = getSharedOkHttpClient();
+        if (shared != null) {
+            return shared;
+        }
         OkHttpClient.Builder builder = new OkHttpClient.Builder()
                 .connectTimeout(0, TimeUnit.MILLISECONDS)
                 .readTimeout(0, TimeUnit.MILLISECONDS)

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -10,6 +10,7 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
+import chat.rocket.reactnative.networking.SSLPinningTurboModule
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -23,9 +24,11 @@ class DDPClient {
 
     companion object {
         private const val TAG = "RocketChat.DDPClient"
-        private val sharedClient = OkHttpClient.Builder()
-            .pingInterval(30, TimeUnit.SECONDS)
-            .build()
+        private val sharedClient: OkHttpClient by lazy {
+            SSLPinningTurboModule.getSharedOkHttpClient() ?: OkHttpClient.Builder()
+                .pingInterval(30, TimeUnit.SECONDS)
+                .build()
+        }
     }
 
     private var webSocket: WebSocket? = null
@@ -342,8 +345,7 @@ class DDPClient {
                 normalizedHost = normalizedHost.removePrefix("https://")
             }
             normalizedHost.startsWith("http://") -> {
-                useSsl = false
-                normalizedHost = normalizedHost.removePrefix("http://")
+                throw IllegalStateException("DDPClient does not support plaintext http:// servers — use https://")
             }
             else -> {
                 useSsl = true

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
@@ -12,6 +12,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
+import chat.rocket.reactnative.networking.SSLPinningTurboModule
 import java.io.IOException
 
 /**
@@ -40,7 +41,9 @@ class MediaCallsAnswerRequest(
     companion object {
         private const val TAG = "RocketChat.MediaCallsAnswerRequest"
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
-        private val httpClient = OkHttpClient()
+        private val httpClient: OkHttpClient by lazy {
+            SSLPinningTurboModule.getSharedOkHttpClient() ?: OkHttpClient()
+        }
         private val mainHandler = Handler(Looper.getMainLooper())
 
         @JvmStatic


### PR DESCRIPTION
## Summary
- Add `SSLPinningTurboModule.getSharedOkHttpClient()` static factory for SSL-pinned OkHttpClient
- Update `DDPClient` and `MediaCallsAnswerRequest` to use the shared SSL-pinned client
- Fail closed on `http://` server URLs (throw instead of falling back to `ws://`)

## Security Fix
VoIP WebSocket and REST traffic was using bare `OkHttpClient` instances that bypass SSL certificate validation. Auth tokens (DDPLogin, MediaCallsAnswerRequest) were exposed to MITM attacks on compromised networks.

## Merge Order
- Part of PR #6918 (feat/voip-lib-new branch)
- Depends on: feat.voip-lib-new (this PR's base)
- No follow-up PRs required

## Test Plan
- [ ] Android build passes (`yarn android`)
- [ ] Unit tests pass (`TZ=UTC yarn test`)
- [ ] ESLint passes (`yarn lint`)