### PR TITLE
fix(voip): resolve closure capture ordering in handleNativeAccept

### DIFF
--- a/ios/Libraries/VoipService.swift
+++ b/ios/Libraries/VoipService.swift
@@ -486,6 +486,7 @@ public final class VoipService: NSObject {
                     createdAt: payload.createdAt,
                     voipAcceptFailed: true
                 )
+                storeInitialEvents(failedPayload)
                 NotificationCenter.default.post(
                     name: NSNotification.Name("VoipAcceptFailed"),
                     object: nil,

--- a/ios/Libraries/VoipService.swift
+++ b/ios/Libraries/VoipService.swift
@@ -457,21 +457,11 @@ public final class VoipService: NSObject {
 
         cancelIncomingCallTimeout(for: payload.callId)
 
-        // 10-second timeout guard: if REST hasn't completed by then, call finishAccept(false).
-        let timeoutWorkItem = DispatchWorkItem { [weak payload] in
+        var finishAcceptInvoked = false
+        let finishAccept: (Bool) -> Void = { [weak payload] success in
+            guard !finishAcceptInvoked else { return }
+            finishAcceptInvoked = true
             guard let payload else { return }
-            // Check the callId is still tracked (not already cleaned up).
-            nativeAcceptLock.lock()
-            let isStillTracked = nativeAcceptHandledCallIds.contains(payload.callId)
-            nativeAcceptLock.unlock()
-            if isStillTracked {
-                finishAccept(false)
-            }
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: timeoutWorkItem)
-
-        let finishAccept: (Bool) -> Void = { [weak timeoutWorkItem] success in
-            timeoutWorkItem?.cancel()
             stopDDPClientInternal(callId: payload.callId)
             if success {
                 storeInitialEvents(payload)
@@ -496,30 +486,27 @@ public final class VoipService: NSObject {
                     createdAt: payload.createdAt,
                     voipAcceptFailed: true
                 )
-                storeInitialEvents(failedPayload)
-                var acceptFailedUserInfo: [String: Any] = [
-                    "callId": failedPayload.callId,
-                    "caller": failedPayload.caller,
-                    "username": failedPayload.username,
-                    "host": failedPayload.host,
-                    "type": failedPayload.type,
-                    "hostName": failedPayload.hostName,
-                    "notificationId": failedPayload.notificationId,
-                    "voipAcceptFailed": true
-                ]
-                if let avatarUrl = failedPayload.avatarUrl {
-                    acceptFailedUserInfo["avatarUrl"] = avatarUrl
-                }
-                if let createdAt = failedPayload.createdAt {
-                    acceptFailedUserInfo["createdAt"] = createdAt
-                }
                 NotificationCenter.default.post(
                     name: NSNotification.Name("VoipAcceptFailed"),
                     object: nil,
-                    userInfo: acceptFailedUserInfo
+                    userInfo: failedPayload.toDictionary()
                 )
             }
         }
+
+        // 10-second timeout guard: if REST hasn't completed by then, call finishAccept(false).
+        let timeoutWorkItem = DispatchWorkItem { [weak payload, finishAcceptInvoked] in
+            guard let payload else { return }
+            guard !finishAcceptInvoked else { return }
+            // Check the callId is still tracked (not already cleaned up).
+            nativeAcceptLock.lock()
+            let isStillTracked = nativeAcceptHandledCallIds.contains(payload.callId)
+            nativeAcceptLock.unlock()
+            if isStillTracked {
+                finishAccept(false)
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: timeoutWorkItem)
 
         guard let api = API(server: payload.host) else {
             #if DEBUG


### PR DESCRIPTION
## Proposed changes

Fixes two issues in `handleNativeAccept`:

1. **Swift compiler error**: Resolves "Closure captures 'finishAccept' before it is declared" by reordering `finishAccept` declaration before `timeoutWorkItem`.
2. **Cold-start accept failures**: Ensures iOS correctly reports accept failures when the app is not running at call accept time. Without this fix, cold-started apps misclassify accept failures as unanswered incoming calls.

## Issue(s)

N/A

## How to test or reproduce

1. Start a VoIP call to a user
2. Accept the call on iOS while the app is in the background or killed
3. Simulate REST failure (e.g. network timeout or server error)
4. Launch the app — verify the accept failure is correctly reported instead of being treated as a missed incoming call

## Screenshots

N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A