### PR TITLE
fix(voip): backwards compatibility

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/notification/VideoConfNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/VideoConfNotification.kt
@@ -112,7 +112,7 @@ class VideoConfNotification(private val context: Context) {
             putString("rid", rid ?: "")
             putString("notificationType", "videoconf")
             putString("callerId", callerId)
-            putString("callerName", callerName)
+            putString("caller", callerName)
             putString("host", ejson.host ?: "")
             putString("callId", ejson.callId ?: "")
             putString("ejson", bundle.getString("ejson", "{}"))

--- a/app/definitions/rest/v1/push.ts
+++ b/app/definitions/rest/v1/push.ts
@@ -6,7 +6,7 @@ type TPushInfo = {
 
 export type PushEndpoints = {
 	'push.token': {
-		POST: (params: { id: string; value: string; type: string; appName: string; voipToken?: string }) => {
+		POST: (params: { id?: string; value: string; type: string; appName: string; voipToken?: string }) => {
 			result: {
 				id: string;
 				token: string;

--- a/app/lib/services/restApi.test.ts
+++ b/app/lib/services/restApi.test.ts
@@ -39,9 +39,18 @@ jest.mock('react-native-device-info', () => {
 	};
 });
 
-function loadRegisterPushToken(platform: 'ios' | 'android' = 'android') {
+function loadRegisterPushToken(platform: 'ios' | 'android' = 'android', mockServerVersion = '8.0.0') {
 	jest.resetModules();
 	Object.defineProperty(Platform, 'OS', { configurable: true, writable: true, value: platform });
+
+	jest.doMock('../store/auxStore', () => ({
+		store: {
+			getState: () => ({
+				server: { version: mockServerVersion }
+			})
+		}
+	}));
+
 	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	const notifications = require('../notifications');
 	// eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -177,7 +186,7 @@ describe('registerPushToken', () => {
 	});
 
 	it('on iOS posts apn payload with voipToken when both tokens are present', async () => {
-		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios');
+		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios', '8.4.0');
 		getToken.mockReturnValue('apns-token');
 		getVoip.mockReturnValue('voip-token');
 
@@ -193,5 +202,43 @@ describe('registerPushToken', () => {
 				voipToken: 'voip-token'
 			})
 		);
+	});
+
+	it('on RC < 8.0 does not send id field', async () => {
+		const { registerPushToken, getDeviceToken: getToken } = loadRegisterPushToken('ios', '7.5.0');
+		getToken.mockReturnValue('apns-token');
+
+		await registerPushToken();
+
+		const payload = mockSdkPost.mock.calls[0][1] as Record<string, unknown>;
+		expect(Object.prototype.hasOwnProperty.call(payload, 'id')).toBe(false);
+	});
+
+	it('on RC < 8.0 does not send voipToken field even when present', async () => {
+		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios', '7.5.0');
+		getToken.mockReturnValue('apns-token');
+		getVoip.mockReturnValue('voip-token');
+
+		await registerPushToken();
+
+		const payload = mockSdkPost.mock.calls[0][1] as Record<string, unknown>;
+		expect(Object.prototype.hasOwnProperty.call(payload, 'voipToken')).toBe(false);
+	});
+
+	it('on RC 8.0-8.3 sends id but not voipToken', async () => {
+		const { registerPushToken, getDeviceToken: getToken, getLastVoipToken: getVoip } = loadRegisterPushToken('ios', '8.2.0');
+		getToken.mockReturnValue('apns-token');
+		getVoip.mockReturnValue('voip-token');
+
+		await registerPushToken();
+
+		expect(mockSdkPost).toHaveBeenCalledWith(
+			'push.token',
+			expect.objectContaining({
+				id: 'unique-device-id'
+			})
+		);
+		const payload = mockSdkPost.mock.calls[0][1] as Record<string, unknown>;
+		expect(Object.prototype.hasOwnProperty.call(payload, 'voipToken')).toBe(false);
 	});
 });

--- a/app/lib/services/restApi.ts
+++ b/app/lib/services/restApi.ts
@@ -1076,7 +1076,7 @@ let lastToken = '';
 let lastVoipToken = '';
 
 type TRegisterPushTokenData = {
-	id: string;
+	id?: string;
 	value: string;
 	type: string;
 	appName: string;
@@ -1095,12 +1095,15 @@ export const registerPushToken = async (): Promise<void> => {
 		return;
 	}
 
+	const serverVersion = reduxStore.getState().server.version;
 	let data: TRegisterPushTokenData = {
-		id: await getUniqueId(),
 		value: '',
 		type: '',
 		appName: getBundleId
 	};
+	if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '8.0.0')) {
+		data.id = await getUniqueId();
+	}
 	if (token) {
 		const type = isIOS ? 'apn' : 'gcm';
 		data = {
@@ -1109,7 +1112,7 @@ export const registerPushToken = async (): Promise<void> => {
 			type
 		};
 	}
-	if (voipToken) {
+	if (voipToken && compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '8.4.0')) {
 		data.voipToken = voipToken;
 	}
 


### PR DESCRIPTION
## Summary

Fix 3 regressions introduced by PR #6918 (feat: Voice support / VoIP) that break non-VoIP functionality on Rocket.Chat servers 3.11 and earlier.

## Changes

### Gate push.token `id` field behind RC >= 8.0.0
`registerPushToken` in `restApi.ts` conditionally sends the `id` field only when `compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '8.0.0')` is true. Pre-8.0 servers may reject the unknown field and silently fail token registration.

### Fix VideoConf caller intent extra name mismatch
`VideoConfNotification.kt` changed `putString("callerName", callerName)` to `putString("caller", callerName)`. This aligns with `NotificationIntentHandler` which reads `caller`, fixing VideoConf notification taps that were receiving an empty caller name.

### Gate `voipToken` behind RC >= 8.4.0
`voipToken` field is now only sent when `compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '8.4.0')` is true. Pre-VoIP servers may reject the unknown field.

## Issue(s)

<!-- Link the issues being closed by or related to this PR. -->

## How to test or reproduce

Run the `registerPushToken` tests: `TZ=UTC yarn test app/lib/services/restApi.test.ts`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/.github/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This PR must be merged after the base branch `feat.voip-lib-new` (PR #6918).

Related: #6918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Push notification token registration now adapts to different server versions, ensuring proper payload handling across versions pre-8.0, 8.0–8.3, and 8.4+.

* **Tests**
  * Added version-specific test coverage for push token registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->