### PR TITLE
fix(voip): Android lock-screen accept — silent audio + subsequent-call blank screen

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -66,6 +66,7 @@ class VoipCallService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_STOP -> {
+                isRunning = false
                 Log.d(TAG, "Stopping VoipCallService")
                 stopSelf(startId)
                 return START_NOT_STICKY

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
@@ -149,6 +149,15 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
         VoipNotification.stopDDPClient()
     }
 
+    override fun stopVoipCallService() {
+        try {
+            VoipCallService.stopService(reactApplicationContext)
+            Log.d(TAG, "stopVoipCallService: service stopped")
+        } catch (e: Exception) {
+            Log.e(TAG, "stopVoipCallService: failed to stop service", e)
+        }
+    }
+
     /**
      * Required for NativeEventEmitter in TurboModules.
      * Called when JS starts listening to events.

--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -53,7 +53,8 @@ jest.mock('../../lib/methods/helpers/helpers', () => ({
 }));
 jest.mock('../../lib/navigation/appNavigation', () => ({
 	__esModule: true,
-	default: { navigate: jest.fn(), back: jest.fn() }
+	default: { navigate: jest.fn(), back: jest.fn() },
+	waitForNavigationReady: jest.fn().mockResolvedValue(undefined)
 }));
 jest.mock('../../lib/services/sdk', () => ({
 	__esModule: true,

--- a/app/lib/native/NativeVoip.ts
+++ b/app/lib/native/NativeVoip.ts
@@ -35,6 +35,11 @@ export interface Spec extends TurboModule {
 	 */
 	stopNativeDDPClient(): void;
 
+	/**
+	 * Stops the VoIP foreground call service.
+	 * iOS: No-op.
+	 * Android: Sends ACTION_STOP to VoipCallService, releasing the mic-type foreground hold.
+	 */
 	stopVoipCallService(): void;
 
 	/**

--- a/app/lib/native/NativeVoip.ts
+++ b/app/lib/native/NativeVoip.ts
@@ -35,6 +35,8 @@ export interface Spec extends TurboModule {
 	 */
 	stopNativeDDPClient(): void;
 
+	stopVoipCallService(): void;
+
 	/**
 	 * Required for NativeEventEmitter in TurboModules.
 	 * Called when JS starts listening to events.
@@ -58,6 +60,7 @@ const NativeVoipModule =
 		clearInitialEvents: () => undefined,
 		getLastVoipToken: () => '',
 		stopNativeDDPClient: () => undefined,
+		stopVoipCallService: () => undefined,
 		addListener: () => undefined,
 		removeListeners: () => undefined
 	} as Spec);

--- a/app/lib/navigation/appNavigation.ts
+++ b/app/lib/navigation/appNavigation.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CommonActions, type NavigationContainerRef, StackActions } from '@react-navigation/native';
 
-import { emitter } from '../../methods/helpers/emitter';
+import { emitter } from '../methods/helpers';
 
 // TODO: we need change this any to the correctly types from our stacks
 const navigationRef = React.createRef<NavigationContainerRef<any>>();

--- a/app/lib/navigation/appNavigation.ts
+++ b/app/lib/navigation/appNavigation.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CommonActions, type NavigationContainerRef, StackActions } from '@react-navigation/native';
 
-import { emitter } from '../../methods/helpers';
+import { emitter } from '../../methods/helpers/emitter';
 
 // TODO: we need change this any to the correctly types from our stacks
 const navigationRef = React.createRef<NavigationContainerRef<any>>();

--- a/app/lib/navigation/appNavigation.ts
+++ b/app/lib/navigation/appNavigation.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { CommonActions, type NavigationContainerRef, StackActions } from '@react-navigation/native';
 
+import { emitter } from '../../methods/helpers';
+
 // TODO: we need change this any to the correctly types from our stacks
 const navigationRef = React.createRef<NavigationContainerRef<any>>();
 const routeNameRef: React.MutableRefObject<NavigationContainerRef<any> | null> = React.createRef();
@@ -72,6 +74,19 @@ function getCurrentRoute() {
 
 function setParams(params: any) {
 	navigationRef.current?.setParams(params);
+}
+
+export function waitForNavigationReady(): Promise<void> {
+	if (navigationRef.current) {
+		return Promise.resolve();
+	}
+	return new Promise(resolve => {
+		const listener = () => {
+			emitter.off('navigationReady', listener);
+			resolve();
+		};
+		emitter.on('navigationReady', listener);
+	});
 }
 
 export default {

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -265,8 +265,15 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 			useCallStore.getState().setNativeAcceptedCallId(initialEvents.callId);
 
 			if (initialEvents.host && isVoipIncomingHostCurrentWorkspace(initialEvents.host, adapters.getActiveServerUrl)) {
-				mediaCallLogger.log(`${TAG} Same workspace as VoIP host; continuing appInit for cold-start handoff`);
-				return false;
+				if (!isIOS) {
+					mediaCallLogger.log(`${TAG} Same workspace as VoIP host; continuing appInit for cold-start handoff`);
+					return false;
+				}
+				mediaSessionInstance.applyRestStateSignals().catch(error => {
+					mediaCallLogger.error(`${TAG} applyRestStateSignals (initial) failed:`, error);
+				});
+				mediaCallLogger.log(`${TAG} Same workspace as VoIP host; skipped deepLinkingOpen`);
+				return true;
 			}
 
 			adapters.onOpenDeepLink({

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -265,11 +265,8 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 			useCallStore.getState().setNativeAcceptedCallId(initialEvents.callId);
 
 			if (initialEvents.host && isVoipIncomingHostCurrentWorkspace(initialEvents.host, adapters.getActiveServerUrl)) {
-				mediaSessionInstance.applyRestStateSignals().catch(error => {
-					mediaCallLogger.error(`${TAG} applyRestStateSignals (initial) failed:`, error);
-				});
-				mediaCallLogger.log(`${TAG} Same workspace as VoIP host; skipped deepLinkingOpen`);
-				return true;
+				mediaCallLogger.log(`${TAG} Same workspace as VoIP host; continuing appInit for cold-start handoff`);
+				return false;
 			}
 
 			adapters.onOpenDeepLink({

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -84,8 +84,16 @@ jest.mock('react-native-callkeep', () => ({
 }));
 
 jest.mock('react-native-device-info', () => ({
+	default: {
+		getUniqueId: jest.fn(() => 'test-device-id'),
+		getUniqueIdSync: jest.fn(() => 'test-device-id'),
+		hasNotch: jest.fn(() => false),
+		getReadableVersion: jest.fn(() => '1.0.0')
+	},
 	getUniqueId: jest.fn(() => 'test-device-id'),
-	getUniqueIdSync: jest.fn(() => 'test-device-id')
+	getUniqueIdSync: jest.fn(() => 'test-device-id'),
+	hasNotch: jest.fn(() => false),
+	getReadableVersion: jest.fn(() => '1.0.0')
 }));
 
 jest.mock('../../native/NativeVoip', () => ({
@@ -95,7 +103,8 @@ jest.mock('../../native/NativeVoip', () => ({
 
 jest.mock('../../navigation/appNavigation', () => ({
 	__esModule: true,
-	default: { navigate: jest.fn() }
+	default: { navigate: jest.fn() },
+	waitForNavigationReady: jest.fn().mockResolvedValue(undefined)
 }));
 
 const mockRequestPhoneStatePermission = jest.fn();

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -13,6 +13,7 @@ import { registerGlobals } from 'react-native-webrtc';
 import { getUniqueIdSync } from 'react-native-device-info';
 
 import { mediaSessionStore } from './MediaSessionStore';
+import { terminateNativeCall } from './terminateNativeCall';
 import { useCallStore } from './useCallStore';
 import { store } from '../../store/auxStore';
 import sdk from '../sdk';
@@ -128,7 +129,7 @@ class MediaSessionInstance {
 				}
 
 				call.emitter.on('ended', () => {
-					RNCallKeep.endCall(call.callId);
+					terminateNativeCall(call.callId);
 				});
 			}
 		});
@@ -152,7 +153,7 @@ class MediaSessionInstance {
 				console.error('[VoIP] Error resolving room id from contact (answerCall):', error);
 			});
 		} else {
-			RNCallKeep.endCall(callId);
+			terminateNativeCall(callId);
 			const st = useCallStore.getState();
 			if (st.nativeAcceptedCallId === callId) {
 				st.resetNativeCallId();
@@ -186,7 +187,7 @@ class MediaSessionInstance {
 				mainCall.hangup();
 			}
 		}
-		RNCallKeep.endCall(callId);
+		terminateNativeCall(callId);
 		RNCallKeep.setCurrentCallActive('');
 		RNCallKeep.setAvailable(true);
 		useCallStore.getState().resetNativeCallId();

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -17,7 +17,7 @@ import { useCallStore } from './useCallStore';
 import { store } from '../../store/auxStore';
 import sdk from '../sdk';
 import { mediaCallsStateSignals } from '../restApi';
-import Navigation from '../../navigation/appNavigation';
+import Navigation, { waitForNavigationReady } from '../../navigation/appNavigation';
 import { parseStringToIceServers } from './parseStringToIceServers';
 import type { IceServer } from '../../../definitions/Voip';
 import type { IDDPMessage } from '../../../definitions/IDDPMessage';
@@ -146,6 +146,7 @@ class MediaSessionInstance {
 			await mainCall.accept();
 			RNCallKeep.setCurrentCallActive(callId);
 			useCallStore.getState().setCall(mainCall);
+			await waitForNavigationReady();
 			Navigation.navigate('CallView');
 			this.resolveRoomIdFromContact(mainCall.remoteParticipants[0]?.contact).catch(error => {
 				console.error('[VoIP] Error resolving room id from contact (answerCall):', error);

--- a/app/lib/services/voip/terminateNativeCall.ts
+++ b/app/lib/services/voip/terminateNativeCall.ts
@@ -4,7 +4,11 @@ import RNCallKeep from 'react-native-callkeep';
 import NativeVoipModule from '../../native/NativeVoip';
 
 export function terminateNativeCall(callId: string): void {
-	RNCallKeep.endCall(callId);
+	try {
+		RNCallKeep.endCall(callId);
+	} catch {
+		// CallKeep may be unavailable; still attempt to stop the Android service below
+	}
 	if (Platform.OS === 'android') {
 		try {
 			NativeVoipModule.stopVoipCallService();

--- a/app/lib/services/voip/terminateNativeCall.ts
+++ b/app/lib/services/voip/terminateNativeCall.ts
@@ -1,0 +1,15 @@
+import RNCallKeep from 'react-native-callkeep';
+
+import { isAndroid } from '../../methods/helpers';
+import NativeVoipModule from '../../native/NativeVoip';
+
+export function terminateNativeCall(callId: string): void {
+	RNCallKeep.endCall(callId);
+	if (isAndroid) {
+		try {
+			NativeVoipModule.stopVoipCallService();
+		} catch {
+			// bridge unavailable pre-boot
+		}
+	}
+}

--- a/app/lib/services/voip/terminateNativeCall.ts
+++ b/app/lib/services/voip/terminateNativeCall.ts
@@ -1,11 +1,11 @@
+import { Platform } from 'react-native';
 import RNCallKeep from 'react-native-callkeep';
 
-import { isAndroid } from '../../methods/helpers';
 import NativeVoipModule from '../../native/NativeVoip';
 
 export function terminateNativeCall(callId: string): void {
 	RNCallKeep.endCall(callId);
-	if (isAndroid) {
+	if (Platform.OS === 'android') {
 		try {
 			NativeVoipModule.stopVoipCallService();
 		} catch {

--- a/app/lib/services/voip/useCallStore.test.ts
+++ b/app/lib/services/voip/useCallStore.test.ts
@@ -233,9 +233,9 @@ describe('useCallStore native accepted + stale timer', () => {
 		expect(s.callId).toBeNull();
 	});
 
-	it('after 15s unbound, clears nativeAcceptedCallId when id still matches scheduled token', () => {
+	it('after 60s unbound, clears nativeAcceptedCallId when id still matches scheduled token', () => {
 		useCallStore.getState().setNativeAcceptedCallId('stale');
-		jest.advanceTimersByTime(15_000);
+		jest.advanceTimersByTime(60_000);
 		const s = useCallStore.getState();
 		expect(s.nativeAcceptedCallId).toBeNull();
 		expect(s.callId).toBeNull();
@@ -244,16 +244,16 @@ describe('useCallStore native accepted + stale timer', () => {
 	it('setCall clears native id and cancels stale timer so advance does not clear bound call context', () => {
 		useCallStore.getState().setNativeAcceptedCallId('x');
 		useCallStore.getState().setCall(createMockCall('x').call);
-		jest.advanceTimersByTime(15_000);
+		jest.advanceTimersByTime(60_000);
 		expect(useCallStore.getState().call).not.toBeNull();
 		expect(useCallStore.getState().nativeAcceptedCallId).toBeNull();
 	});
 
-	it('reset() preserves id and restarts 15s window from last reset', () => {
+	it('reset() preserves id and restarts 60s window from last reset', () => {
 		useCallStore.getState().setNativeAcceptedCallId('keep');
-		jest.advanceTimersByTime(14_000);
+		jest.advanceTimersByTime(59_000);
 		useCallStore.getState().reset();
-		jest.advanceTimersByTime(14_000);
+		jest.advanceTimersByTime(59_000);
 		expect(useCallStore.getState().nativeAcceptedCallId).toBe('keep');
 		jest.advanceTimersByTime(1_000);
 		expect(useCallStore.getState().nativeAcceptedCallId).toBeNull();
@@ -261,9 +261,9 @@ describe('useCallStore native accepted + stale timer', () => {
 
 	it('replacing native id restarts timer so old deadline does not clear new id', () => {
 		useCallStore.getState().setNativeAcceptedCallId('a');
-		jest.advanceTimersByTime(14_000);
+		jest.advanceTimersByTime(59_000);
 		useCallStore.getState().setNativeAcceptedCallId('b');
-		jest.advanceTimersByTime(14_000);
+		jest.advanceTimersByTime(59_000);
 		expect(useCallStore.getState().nativeAcceptedCallId).toBe('b');
 		jest.advanceTimersByTime(1_000);
 		expect(useCallStore.getState().nativeAcceptedCallId).toBeNull();

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -7,7 +7,7 @@ import Navigation from '../../navigation/appNavigation';
 import { hideActionSheetRef } from '../../../containers/ActionSheet';
 import { useIsScreenReaderEnabled } from '../../hooks/useIsScreenReaderEnabled';
 
-const STALE_NATIVE_MS = 15_000;
+const STALE_NATIVE_MS = 60_000;
 
 let callListenersCleanup: (() => void) | null = null;
 let staleNativeTimer: ReturnType<typeof setTimeout> | null = null;

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -3,6 +3,7 @@ import type { CallState, CallContact, IClientMediaCall } from '@rocket.chat/medi
 import RNCallKeep from 'react-native-callkeep';
 import InCallManager from 'react-native-incall-manager';
 
+import { terminateNativeCall } from './terminateNativeCall';
 import Navigation from '../../navigation/appNavigation';
 import { hideActionSheetRef } from '../../../containers/ActionSheet';
 import { useIsScreenReaderEnabled } from '../../hooks/useIsScreenReaderEnabled';
@@ -282,7 +283,7 @@ export const useCallStore = create<CallStore>((set, get) => ({
 		}
 
 		if (callUuid) {
-			RNCallKeep.endCall(callUuid);
+			terminateNativeCall(callUuid);
 		}
 
 		get().resetNativeCallId();

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -15,7 +15,7 @@ import database from '../lib/database';
 import { getServerById } from '../lib/database/services/Server';
 import { canOpenRoom } from '../lib/methods/canOpenRoom';
 import { getServerInfo } from '../lib/methods/getServerInfo';
-import { emitter, getUidDirectMessage, normalizeDeepLinkingServerHost } from '../lib/methods/helpers';
+import { getUidDirectMessage, normalizeDeepLinkingServerHost } from '../lib/methods/helpers';
 import EventEmitter from '../lib/methods/helpers/events';
 import { goRoom, navigateToRoom } from '../lib/methods/helpers/goRoom';
 import { localAuthenticate } from '../lib/methods/helpers/localAuthentication';
@@ -26,7 +26,7 @@ import { videoConfJoin } from '../lib/methods/videoConf';
 import { loginOAuthOrSso } from '../lib/services/connect';
 import { notifyUser } from '../lib/services/restApi';
 import sdk from '../lib/services/sdk';
-import Navigation from '../lib/navigation/appNavigation';
+import Navigation, { waitForNavigationReady } from '../lib/navigation/appNavigation';
 import { resetVoipState } from '../lib/services/voip/resetVoipState';
 
 const roomTypes = {
@@ -45,20 +45,6 @@ const handleInviteLink = function* handleInviteLink({ params, requireLogin = fal
 			yield put(inviteLinksRequest(token));
 		}
 	}
-};
-
-const waitForNavigation = () => {
-	if (Navigation.navigationRef.current) {
-		return Promise.resolve();
-	}
-	return new Promise(resolve => {
-		const listener = () => {
-			emitter.off('navigationReady', listener);
-			resolve();
-		};
-
-		emitter.on('navigationReady', listener);
-	});
 };
 
 const navigate = function* navigate({ params }) {
@@ -82,7 +68,7 @@ const navigate = function* navigate({ params }) {
 
 				const isMasterDetail = yield select(state => state.app.isMasterDetail);
 				const jumpToMessageId = params.messageId;
-				yield waitForNavigation();
+				yield waitForNavigationReady();
 				yield goRoom({ item, isMasterDetail, jumpToMessageId, jumpToThreadId });
 			}
 		} else {
@@ -104,7 +90,7 @@ const handleVoipAcceptFailed = function* handleVoipAcceptFailed(params) {
 			RNCallKeep.endCall(callId);
 		}
 
-		yield call(waitForNavigation);
+		yield call(waitForNavigationReady);
 
 		const navigateParams = {
 			...params,


### PR DESCRIPTION
## Proposed changes

Fixes two VoIP bugs on Android when accepting an incoming call from the lock screen while the app is not running:

1. **Silent audio on first call** — The Android same-workspace branch of `getInitialMediaCallEvents` returned `true`, which skipped `appInit()`. This prevented the login saga from running, so `mediaSessionInstance.init()` never fired, `applyRestStateSignals()` never processed the offer SDP, and audio never routed. Fix: return `false` on Android so the normal boot path runs (gated to Android-only — iOS retains existing behavior).

2. **Blank screen on subsequent calls** — The Android `VoipCallService` foreground service was never stopped from JS-driven hangup paths. Its static `isRunning` flag blocked re-initialization on the next incoming call. Fix: new `stopVoipCallService` bridge method + `terminateNativeCall` JS helper that wraps `RNCallKeep.endCall` + Android service stop at every call termination site.

Additional hardening:
- **Navigator readiness guard**: `answerCall` now awaits `waitForNavigationReady()` before navigating to `CallView`, preventing silent navigation drops during cold-start boot.
- **Stale timer extension**: `STALE_NATIVE_MS` raised from 15s to 60s to cover worst-case cold-boot handoff on slow devices/networks.
- **Eager `isRunning` reset**: `VoipCallService.onStartCommand(ACTION_STOP)` now resets `isRunning` before `stopSelf()` to prevent race conditions with rapid call cycling.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-99

## How to test or reproduce

1. **Cold-start lock-screen accept**: Kill the Rocket.Chat app on an Android device (Pixel 6 / Android 16). Initiate a VoIP call from the web client. Accept from the device lock screen. Expected: CallView renders and audio routes within 5–8 seconds.
2. **Subsequent calls**: End the first call. Initiate a second VoIP call. Accept from lock screen. Expected: identical behavior — no blank screen, no force-close needed.
3. **Warm-start regression**: With the app already running, accept an incoming VoIP call. Expected: unchanged behavior.
4. **iOS regression**: Accept a VoIP call from iOS lock screen. Expected: unchanged behavior.
5. **Different-workspace deep-link**: Accept a call hosted on a different workspace. Expected: workspace switch + call connect as before.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

## Merge Order

This PR targets `feat.voip-lib-new` (PR #6918). It should be merged into `feat.voip-lib-new` before #6918 is merged into `develop`.

## Further comments

**Files changed:**
- `android/.../voip/VoipModule.kt` — new `stopVoipCallService` bridge method
- `android/.../voip/VoipCallService.kt` — eager `isRunning` reset on `ACTION_STOP`
- `app/lib/native/NativeVoip.ts` — TurboModule spec + fallback for `stopVoipCallService`
- `app/lib/services/voip/terminateNativeCall.ts` — new helper wrapping `endCall` + service stop
- `app/lib/services/voip/MediaCallEvents.ts` — Android same-workspace branch returns `false`
- `app/lib/services/voip/MediaSessionInstance.ts` — `waitForNavigationReady` guard + `terminateNativeCall` migration
- `app/lib/services/voip/useCallStore.ts` — `STALE_NATIVE_MS` 15s → 60s + `terminateNativeCall` migration
- `app/lib/navigation/appNavigation.ts` — extracted `waitForNavigationReady` helper
- `app/sagas/deepLinking.js` — uses shared `waitForNavigationReady` instead of inline version
- Tests updated accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can now request stopping the VoIP foreground call service from the JS layer.

* **Bug Fixes**
  * Improved VoIP termination and cleanup to reduce stale native call remnants.
  * Call UI navigation now waits for readiness before transitioning for more reliable call flows.
  * Increased native-call stale timeout from 15s to 60s to reduce premature state clearing.
  * Centralized native call teardown to suppress platform/bridge errors.

* **Tests**
  * Updated mocks and integration tests to cover navigation readiness and VoIP flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->