### PR TITLE
fix(android): remove isRunning guard + add double-tap guard on Accept/Decline

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -3,6 +3,7 @@ package chat.rocket.reactnative.voip
 import android.app.Activity
 import chat.rocket.reactnative.BuildConfig
 import android.app.KeyguardManager
+import java.util.concurrent.atomic.AtomicBoolean
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -45,6 +46,7 @@ class IncomingCallActivity : Activity() {
     private var isCallStateReceiverRegistered = false
     private val timeoutHandler = Handler(Looper.getMainLooper())
     private var timeoutRunnable: Runnable? = null
+    private val acceptDeclineGuard = AtomicBoolean(false)
     private val callStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             val payload = VoipPayload.fromBundle(intent?.extras) ?: return
@@ -258,6 +260,7 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleAccept(payload: VoipPayload) {
+        if (acceptDeclineGuard.compareAndSet(false, true)) return
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Call accepted - callId: ${payload.callId}")
         }
@@ -268,6 +271,7 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleDecline(payload: VoipPayload) {
+        if (acceptDeclineGuard.compareAndSet(false, true)) return
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Call declined - callId: ${payload.callId}")
         }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -75,12 +75,8 @@ class VoipCallService : Service() {
                 if (BuildConfig.DEBUG) {
                     Log.d(TAG, "Starting VoipCallService for callId: $callId")
                 }
-                if (!isRunning) {
-                    isRunning = true
-                    startForegroundWithNotification(callId)
-                } else {
-                    Log.d(TAG, "Service already running, skipping duplicate start")
-                }
+                isRunning = true
+                startForegroundWithNotification(callId)
                 return START_NOT_STICKY
             }
             else -> {


### PR DESCRIPTION
## Summary
- C3: Remove isRunning boolean guard so startForegroundWithNotification() is called on every ACTION_START (Android 14+ foreground service compliance)
- C4: Add AtomicBoolean guard on handleAccept/handleDecline to prevent double-tap from triggering multiple service starts

## Test plan
- [ ] Kotlin syntax check passes
- [ ] Android build succeeds

Closes #6918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate execution of call accept/decline actions to improve reliability and avoid repeated side effects.
  * Ensured the VoIP service consistently marks itself running and presents the foreground notification on each start to improve notification and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->