### PR TITLE
fix(voip): deep equality check + propagate ICE servers to session

### DIFF
--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -11,6 +11,7 @@ import {
 import RNCallKeep from 'react-native-callkeep';
 import { registerGlobals } from 'react-native-webrtc';
 import { getUniqueIdSync } from 'react-native-device-info';
+import { dequal } from 'dequal';
 
 import { mediaSessionStore } from './MediaSessionStore';
 import { useCallStore } from './useCallStore';
@@ -225,7 +226,7 @@ class MediaSessionInstance {
 
 		this.storeIceServersUnsubscribe = store.subscribe(() => {
 			const currentIceServers = this.getIceServers();
-			if (JSON.stringify(currentIceServers) !== JSON.stringify(this.iceServers)) {
+			if (!dequal(currentIceServers, this.iceServers)) {
 				this.iceServers = currentIceServers;
 				this.instance?.setIceServers(this.iceServers);
 			}

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -225,8 +225,9 @@ class MediaSessionInstance {
 
 		this.storeIceServersUnsubscribe = store.subscribe(() => {
 			const currentIceServers = this.getIceServers();
-			if (currentIceServers !== this.iceServers) {
+			if (JSON.stringify(currentIceServers) !== JSON.stringify(this.iceServers)) {
 				this.iceServers = currentIceServers;
+				this.instance?.setIceServers(this.iceServers);
 			}
 		});
 	}


### PR DESCRIPTION
## Proposed changes
- Replace reference equality with deep equality check for ICE server config using `dequal`
- Call `setIceServers()` on the active `MediaSignalingSession` when servers change

## Issue(s)

## How to test or reproduce
- Change VoIP ICE server settings while a session is initialized and confirm the active session picks up the new servers

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of ICE server configuration changes and ensured updated server settings are propagated into active media sessions so ongoing VoIP calls apply the new configuration immediately, reducing mismatches between stored settings and live connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->