### PR TITLE
fix(ios): capture finishAcceptInvoked by reference in DispatchWorkItem closure

### DIFF
--- a/ios/Libraries/VoipService.swift
+++ b/ios/Libraries/VoipService.swift
@@ -457,10 +457,10 @@ public final class VoipService: NSObject {
 
         cancelIncomingCallTimeout(for: payload.callId)
 
-        var finishAcceptInvoked = false
+        var finishAcceptInvoked = [false]
         let finishAccept: (Bool) -> Void = { [weak payload] success in
-            guard !finishAcceptInvoked else { return }
-            finishAcceptInvoked = true
+            guard !finishAcceptInvoked[0] else { return }
+            finishAcceptInvoked[0] = true
             guard let payload else { return }
             stopDDPClientInternal(callId: payload.callId)
             if success {
@@ -498,7 +498,7 @@ public final class VoipService: NSObject {
         // 10-second timeout guard: if REST hasn't completed by then, call finishAccept(false).
         let timeoutWorkItem = DispatchWorkItem { [weak payload, finishAcceptInvoked] in
             guard let payload else { return }
-            guard !finishAcceptInvoked else { return }
+            guard !finishAcceptInvoked[0] else { return }
             // Check the callId is still tracked (not already cleaned up).
             nativeAcceptLock.lock()
             let isStillTracked = nativeAcceptHandledCallIds.contains(payload.callId)


### PR DESCRIPTION
## Summary
- Wrap finishAcceptInvoked in reference-capturable container so DispatchWorkItem closure sees mutations
- Prevents 10s timeout from firing finishAccept(false) after user already accepted call

## Test plan
- [ ] Swift syntax check passes
- [ ] iOS build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in VoIP call acceptance where the accept action could be triggered multiple times for the same incoming call, improving system reliability and preventing unintended duplicate acceptances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->