### PR TITLE
fix(ios): reject plaintext http:// in VoIP DDPClient URL builder

### DIFF
--- a/ios/Libraries/DDPClient.swift
+++ b/ios/Libraries/DDPClient.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+enum DDPClientError: Error, LocalizedError {
+    case plaintextHttpNotSupported
+
+    var errorDescription: String? {
+        switch self {
+        case .plaintextHttpNotSupported:
+            return "DDPClient does not support plaintext http:// servers — use https://"
+        }
+    }
+}
+
 /// Minimal DDP WebSocket client for listening to Rocket.Chat media-signal events from native iOS.
 /// Only implements the subset needed to detect call hangup: connect, login, subscribe, and ping/pong.
 final class DDPClient {
@@ -33,8 +44,17 @@ final class DDPClient {
     
     func connect(host: String, completion: @escaping (Bool) -> Void) {
         stateQueue.async {
-            let wsUrl = Self.buildWebSocketURL(host: host)
-            
+            let wsUrl: String
+            do {
+                wsUrl = try Self.buildWebSocketURL(host: host)
+            } catch {
+                #if DEBUG
+                print("[\(Self.TAG)] Failed to build WebSocket URL: \(error.localizedDescription)")
+                #endif
+                completion(false)
+                return
+            }
+
             guard let url = URL(string: wsUrl) else {
                 #if DEBUG
                 print("[\(Self.TAG)] Invalid WebSocket URL: \(wsUrl)")
@@ -401,27 +421,21 @@ final class DDPClient {
     }
     
     // MARK: - URL Helpers
-    
-    private static func buildWebSocketURL(host: String) -> String {
+
+    static func buildWebSocketURL(host: String) throws -> String {
         var cleaned = host
-        
+
         if cleaned.hasSuffix("/") {
             cleaned = String(cleaned.dropLast())
         }
-        
-        let useSsl: Bool
+
         if cleaned.hasPrefix("https://") {
-            useSsl = true
             cleaned = String(cleaned.dropFirst("https://".count))
         } else if cleaned.hasPrefix("http://") {
-            useSsl = false
-            cleaned = String(cleaned.dropFirst("http://".count))
-        } else {
-            useSsl = true
+            throw DDPClientError.plaintextHttpNotSupported
         }
-        
-        let scheme = useSsl ? "wss" : "ws"
-        return "\(scheme)://\(cleaned)/websocket"
+
+        return "wss://\(cleaned)/websocket"
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Make the iOS VoIP `DDPClient` WebSocket URL builder reject any host that starts with `http://`, instead of silently downgrading to `ws://`. The rejection surfaces as a fast connect-time failure (`completion(false)` with a DEBUG log) so a misconfigured server host fails loudly — matching the `IllegalStateException` thrown by the Android VoIP `DDPClient` for the same input.

Behavior for `https://`, bare hosts (no scheme), and trailing slashes is unchanged — they still produce `wss://…/websocket`.

### What changed

- `ios/Libraries/DDPClient.swift`:
  - New `DDPClientError.plaintextHttpNotSupported` with a message mirroring Android (`"DDPClient does not support plaintext http:// servers — use https://"`) for cross-platform grep-ability.
  - `buildWebSocketURL(host:)` is now `throws` and throws `.plaintextHttpNotSupported` on an `http://` prefix. The previous `http://` → `ws://` branch is removed.
  - `connect(host:completion:)` now catches the builder error, logs it (DEBUG), and calls `completion(false)` so the failure propagates to the existing connect-failure path in `VoipService.startListeningForCallEnd`.
  - Builder is promoted from `private static` to `internal static` (no access modifier) for future test visibility; otherwise unchanged.

### What did not change

- `https://` input → `wss://…/websocket` (unchanged)
- Bare host input (no scheme) → defaults to `wss://…/websocket` (unchanged)
- Trailing-slash normalization (unchanged)
- Android `DDPClient` (already rejects)
- JS layer (does not construct WebSocket URLs)
- `ios/Shared/RocketChat/API/API.swift` SSL pinning (H2, out of scope for this PR)

## Issue(s)

Plan: [voip-wednesday-reviews/prd-m1-ios-http-rejection.md](https://github.com/RocketChat/Rocket.Chat.ReactNative/compare/feat.voip-lib-new...voip/m1-ios-http-rejection) — M1 in the Wednesday VoIP review split.

## How to test or reproduce

1. Set a workspace server host to `http://<your-host>` in the iOS client (misconfigured).
2. Trigger the native VoIP DDP listener (incoming VoIP push during app cold start / background).
3. Before this PR: client silently connected over plaintext `ws://` and call-end detection worked over an unencrypted channel.
4. After this PR: `DDPClient.connect` fails immediately, DEBUG log shows `Failed to build WebSocket URL: DDPClient does not support plaintext http:// servers — use https://`, and the DDP listener stops (same code path as any other connect failure in `VoipService.startListeningForCallEnd`).
5. Reset the host to `https://<your-host>` — connection succeeds as before.

Positive cases preserved (manual or lldb-eval on `DDPClient.buildWebSocketURL`):
- `"https://example.com"` → `"wss://example.com/websocket"`
- `"https://example.com/"` → `"wss://example.com/websocket"`
- `"example.com"` → `"wss://example.com/websocket"`
- `"http://example.com"` → throws `DDPClientError.plaintextHttpNotSupported`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

> Note: Any iOS staging/test deployment currently relying on the tolerant `http://` behavior will start failing at connect time after this ships — that is the intent, and mirrors Android's existing behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — the iOS project has no XCTest target; adding one is out of scope for this fix. Android side already has the equivalent coverage.
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Merge Order

This PR targets `feat.voip-lib-new` as part of the Wednesday VoIP review split:

1. **This PR (M1)** — iOS VoIP `DDPClient` rejects plaintext `http://`. Independent; can merge standalone.
2. **H2 (future PR)** — REST `API.swift` SSL pinning. Naturally pairs with this PR as the combined "SSL-pinning split" but is a distinct change.

No hard dependency on other open PRs.

## Further comments

- Risk profile: low. Single function, one added branch, mirrored from Android.
- Error shape chosen (`throws` + `LocalizedError`) matches other Swift error-surface patterns already used in the iOS VoIP module and keeps the caller site explicit (`try` + `do/catch` at the one connect site).
- Error message string is kept verbatim-compatible with Android's `IllegalStateException` message so cross-platform log/error grep turns up both platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened connection URL validation by rejecting plaintext HTTP protocols and enforcing encrypted connections with descriptive error messaging.
  * Improved error handling in the connection establishment process to provide clearer feedback when invalid or unsupported parameters are encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->