### PR TITLE
fix: make reaction tab bar horizontally scrollable when emoji count overflows

### DIFF
--- a/app/containers/MessageComposer/__snapshots__/MessageComposer.test.tsx.snap
+++ b/app/containers/MessageComposer/__snapshots__/MessageComposer.test.tsx.snap
@@ -2482,7 +2482,7 @@ exports[`MessageComposer Toolbar Markdown tap bold 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={45}
+        handlerTag={46}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -3093,7 +3093,7 @@ exports[`MessageComposer Toolbar Markdown tap code 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={123}
+        handlerTag={124}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -3704,7 +3704,7 @@ exports[`MessageComposer Toolbar Markdown tap code-block 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={149}
+        handlerTag={150}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -4315,7 +4315,7 @@ exports[`MessageComposer Toolbar Markdown tap italic 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={71}
+        handlerTag={72}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -5537,7 +5537,7 @@ exports[`MessageComposer Toolbar Markdown tap strike 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={97}
+        handlerTag={98}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -6148,7 +6148,7 @@ exports[`MessageComposer Toolbar Markdown type test and tap bold 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={58}
+        handlerTag={59}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -6759,7 +6759,7 @@ exports[`MessageComposer Toolbar Markdown type test and tap code 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={136}
+        handlerTag={137}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -7370,7 +7370,7 @@ exports[`MessageComposer Toolbar Markdown type test and tap code-block 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={162}
+        handlerTag={163}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -7981,7 +7981,7 @@ exports[`MessageComposer Toolbar Markdown type test and tap italic 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={84}
+        handlerTag={85}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -8592,7 +8592,7 @@ exports[`MessageComposer Toolbar Markdown type test and tap strike 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={110}
+        handlerTag={111}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {
@@ -9616,951 +9616,962 @@ exports[`MessageComposer Toolbar tap emoji 1`] = `
         <View
           style={
             {
-              "flexDirection": "row",
               "width": "100%",
             }
           }
         >
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
+          <RCTScrollView
+            collapsable={false}
+            handlerTag={-1}
+            handlerType="NativeViewGestureHandler"
+            horizontal={true}
+            onGestureHandlerEvent={[Function]}
+            onGestureHandlerStateChange={[Function]}
+            showsHorizontalScrollIndicator={false}
           >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
+            <View>
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Recently used"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Recently used"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#156FF5",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-clock"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#156FF5",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#156FF5",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-clock"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#156FF5",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Smileys and people"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Smileys and people"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-emoji"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-emoji"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Animals and nature"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Animals and nature"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-leaf"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-leaf"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Food and drink"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Food and drink"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-burger"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-burger"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Activity"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Activity"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-basketball"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-basketball"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Travel and places"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Travel and places"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-airplane"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-airplane"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Objects"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Objects"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-lamp-bulb"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-lamp-bulb"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Symbols"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Symbols"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-percentage"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-percentage"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Flags"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Flags"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-flag"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-flag"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              {
-                "alignItems": "center",
-                "flex": 1,
-                "flexDirection": "column",
-              }
-            }
-          >
-            <RNGestureHandlerButton
-              collapsable={false}
-              delayLongPress={600}
-              enabled={true}
-              exclusive={true}
-              handlerTag={-1}
-              handlerType="NativeViewGestureHandler"
-              hitSlop={
-                {
-                  "bottom": 10,
-                  "left": 10,
-                  "right": 10,
-                  "top": 10,
-                }
-              }
-              innerRef={null}
-              onGestureHandlerEvent={[Function]}
-              onGestureHandlerStateChange={[Function]}
-              rippleColor="transparent"
-              style={
-                [
-                  undefined,
-                  {
-                    "cursor": undefined,
-                  },
-                ]
-              }
-              touchSoundDisabled={false}
-            >
               <View
-                accessible={true}
-                collapsable={false}
                 style={
                   {
-                    "opacity": 1,
+                    "alignItems": "center",
+                    "flexDirection": "column",
+                    "paddingHorizontal": 8,
                   }
                 }
               >
-                <Text
-                  accessibilityLabel="Custom"
-                  accessible={true}
-                  allowFontScaling={false}
-                  selectable={false}
+                <RNGestureHandlerButton
+                  collapsable={false}
+                  delayLongPress={600}
+                  enabled={true}
+                  exclusive={true}
+                  handlerTag={-1}
+                  handlerType="NativeViewGestureHandler"
+                  hitSlop={
+                    {
+                      "bottom": 10,
+                      "left": 10,
+                      "right": 10,
+                      "top": 10,
+                    }
+                  }
+                  innerRef={null}
+                  onGestureHandlerEvent={[Function]}
+                  onGestureHandlerStateChange={[Function]}
+                  rippleColor="transparent"
+                  style={
+                    [
+                      undefined,
+                      {
+                        "cursor": undefined,
+                      },
+                    ]
+                  }
+                  touchSoundDisabled={false}
+                >
+                  <View
+                    accessible={true}
+                    collapsable={false}
+                    style={
+                      {
+                        "opacity": 1,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityLabel="Custom"
+                      accessible={true}
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 24,
+                          },
+                          [
+                            {
+                              "lineHeight": 24,
+                            },
+                            {
+                              "paddingVertical": 4,
+                            },
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                      testID="emoji-picker-tab-rocket"
+                    >
+                      
+                    </Text>
+                  </View>
+                </RNGestureHandlerButton>
+                <View
                   style={
                     [
                       {
-                        "color": "#6C727A",
-                        "fontSize": 24,
+                        "height": 2,
+                        "width": "100%",
                       },
-                      [
-                        {
-                          "lineHeight": 24,
-                        },
-                        {
-                          "paddingVertical": 4,
-                        },
-                      ],
                       {
-                        "fontFamily": "custom",
-                        "fontStyle": "normal",
-                        "fontWeight": "normal",
+                        "backgroundColor": "#EBECEF",
                       },
-                      {},
                     ]
                   }
-                  testID="emoji-picker-tab-rocket"
-                >
-                  
-                </Text>
+                />
               </View>
-            </RNGestureHandlerButton>
-            <View
-              style={
-                [
-                  {
-                    "height": 2,
-                    "width": "100%",
-                  },
-                  {
-                    "backgroundColor": "#EBECEF",
-                  },
-                ]
-              }
-            />
-          </View>
+            </View>
+          </RCTScrollView>
         </View>
         <View
           collapsable={false}
@@ -11414,7 +11425,7 @@ exports[`MessageComposer Toolbar tap mention 1`] = `
         borderless={true}
         collapsable={false}
         delayLongPress={600}
-        handlerTag={175}
+        handlerTag={176}
         handlerType="NativeViewGestureHandler"
         hitSlop={
           {

--- a/app/containers/TabView/index.tsx
+++ b/app/containers/TabView/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { View } from 'react-native';
 import { TabView as ReanimatedTabView, type Route, type NavigationState } from 'reanimated-tab-view';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
 
 import styles from './styles';
 import { useTheme } from '../../theme';
@@ -26,19 +26,21 @@ export const TabView = ({ routes, renderTabItem, renderScene }: TabViewProps) =>
 	const renderTabBar = useCallback(
 		({ jumpTo, routeIndex }: { jumpTo: (key: string) => void; routeIndex: number }) => (
 			<View style={styles.tabsContainer}>
-				{routes.map((tab: Route, index: number) => (
-					<View key={tab.key} style={styles.tab}>
-						<TouchableOpacity onPress={() => jumpTo(tab.key)} hitSlop={10}>
-							{renderTabItem(tab, routeIndex === index ? colors.strokeHighlight : colors.fontSecondaryInfo)}
-						</TouchableOpacity>
-						<View
-							style={[
-								styles.tabLine,
-								{ backgroundColor: routeIndex === index ? colors.strokeHighlight : colors.strokeExtraLight }
-							]}
-						/>
-					</View>
-				))}
+				<ScrollView horizontal showsHorizontalScrollIndicator={false}>
+					{routes.map((tab: Route, index: number) => (
+						<View key={tab.key} style={styles.tab}>
+							<TouchableOpacity onPress={() => jumpTo(tab.key)} hitSlop={10}>
+								{renderTabItem(tab, routeIndex === index ? colors.strokeHighlight : colors.fontSecondaryInfo)}
+							</TouchableOpacity>
+							<View
+								style={[
+									styles.tabLine,
+									{ backgroundColor: routeIndex === index ? colors.strokeHighlight : colors.strokeExtraLight }
+								]}
+							/>
+						</View>
+					))}
+				</ScrollView>
 			</View>
 		),
 		[colors, renderTabItem, routes]

--- a/app/containers/TabView/styles.ts
+++ b/app/containers/TabView/styles.ts
@@ -2,13 +2,12 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
 	tabsContainer: {
-		flexDirection: 'row',
 		width: '100%'
 	},
 	tab: {
 		flexDirection: 'column',
-		flex: 1,
-		alignItems: 'center'
+		alignItems: 'center',
+		paddingHorizontal: 8
 	},
 	tabLine: {
 		width: '100%',


### PR DESCRIPTION
## Proposed changes
The reaction tab bar in the message reactions bottom sheet was not scrollable, causing emoji tabs to overflow and clip off-screen when a message had many distinct reactions. This PR fixes the layout by wrapping the tab items in a horizontal `ScrollView` inside the existing `View` container, ensuring all reaction tabs are accessible regardless of count.
 
## Issue(s)
 emoji tabs to overflow and clip off-screen when a message had many distinct reactions.

## How to test or reproduce
 
1. Open a message that has **many distinct emoji reactions** (enough to overflow the screen width)
2. Observe the reaction tab bar — tabs were previously clipped with no way to scroll
3. After this fix, the tab bar scrolls horizontally and all reaction tabs are reachable
4. Tap each tab and verify the reaction list filters correctly
5. Also verify that with **few reactions**, the layout looks normal with no blank space between the tab bar and the list

## Screenshots
 
| Before | After |
|--------|-------|
| <img width="447" height="531" alt="image" src="https://github.com/user-attachments/assets/fda0cc5b-322d-4a0d-9704-fb318f93d152" /> | <img width="444" height="528" alt="image" src="https://github.com/user-attachments/assets/1d961d40-8a52-4f11-b4e6-ac386ca92f0f" /> |
 
**With fewer reactions**
<img width="451" height="537" alt="image" src="https://github.com/user-attachments/assets/c6b05afb-616c-429e-9e31-64cc52b61d88" />


### Recording
https://github.com/user-attachments/assets/faa16f06-add1-45df-b812-4191ef87fdbf

> [!NOTE]
> the empty userlist for a reaction shown in video is a bug solved in #7204 and with server change https://github.com/RocketChat/Rocket.Chat/pull/40254

## Types of changes
 
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
 
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
 
The outer `View` wrapper is intentionally kept around the `ScrollView` — replacing the top-level element with a `ScrollView` affecting the layout by adding huge space at the bottom. Wrapping preserves layout while still enabling horizontal scroll. The `ScrollView` is imported from `react-native-gesture-handler` to ensure correct gesture handling on both iOS and Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tab navigation now supports horizontal scrolling, allowing access to more tabs without expanding the interface.

* **Improvements**
  * Enhanced tab spacing and layout for better visual presentation and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->