### PR TITLE
fix(android): cancel VoIP notification with correct ID when VoiceConnection is null

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -341,7 +341,7 @@ class VoipNotification(private val context: Context) {
                     }
                     val appCtx = context.applicationContext
                     disconnectIncomingCall(callId, false)
-                    cancelById(appCtx, 0)
+                    cancelById(appCtx, callId.hashCode())
                     ddpRegistry.stopClient(callId)
                     // Stash failure payload for JS: it will show error toast on getInitialEvents.
                     VoipModule.storeAcceptFailureForJs(VoipPayload(

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -89,7 +89,7 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	if (callId) {
 		lastHandledVoipAcceptSucceededCallId = callId;
 	}
-	mediaCallLogger.log(`${TAG} VoipAcceptSucceeded:`, data);
+	mediaCallLogger.debug(`${TAG} VoipAcceptSucceeded:`, data);
 	NativeVoipModule.clearInitialEvents();
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
 	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
@@ -115,7 +115,7 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 	if (isIOS) {
 		subscriptions.push(
 			Emitter.addListener('VoipPushTokenRegistered', ({ token }: { token: string }) => {
-				mediaCallLogger.log(`${TAG} Registered VoIP push token:`, token);
+				mediaCallLogger.debug(`${TAG} Registered VoIP push token:`, token);
 				registerPushToken().catch(error => {
 					mediaCallLogger.warn(`${TAG} Failed to register push token after VoIP update:`, error);
 				});
@@ -198,7 +198,7 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 
 	subscriptions.push(
 		Emitter.addListener(EVENT_VOIP_ACCEPT_FAILED, (data: VoipPayload & { voipAcceptFailed?: boolean }) => {
-			mediaCallLogger.log(`${TAG} VoipAcceptFailed event:`, data);
+			mediaCallLogger.debug(`${TAG} VoipAcceptFailed event:`, data);
 			dispatchVoipAcceptFailureFromNative({ ...data, voipAcceptFailed: true }, adapters.onOpenDeepLink);
 			NativeVoipModule.clearInitialEvents();
 		})
@@ -221,7 +221,7 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 			RNCallKeep.clearInitialEvents();
 			return false;
 		}
-		mediaCallLogger.log(`${TAG} Found initial events:`, initialEvents);
+		mediaCallLogger.debug(`${TAG} Found initial events:`, initialEvents);
 
 		if (initialEvents.voipAcceptFailed && initialEvents.callId && initialEvents.host) {
 			dispatchVoipAcceptFailureFromNative(initialEvents, adapters.onOpenDeepLink);
@@ -243,7 +243,7 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 		if (isIOS) {
 			const callKeepInitialEvents = await RNCallKeep.getInitialEvents();
 			RNCallKeep.clearInitialEvents();
-			mediaCallLogger.log(`${TAG} CallKeep initial events:`, JSON.stringify(callKeepInitialEvents, null, 2));
+			mediaCallLogger.debug(`${TAG} CallKeep initial events:`, JSON.stringify(callKeepInitialEvents, null, 2));
 
 			for (const event of callKeepInitialEvents) {
 				const { name, data } = event;

--- a/app/lib/services/voip/MediaCallLogger.ts
+++ b/app/lib/services/voip/MediaCallLogger.ts
@@ -2,7 +2,9 @@ import type { IMediaSignalLogger } from '@rocket.chat/media-signaling';
 
 export class MediaCallLogger implements IMediaSignalLogger {
 	log(...args: unknown[]): void {
-		console.log(`[Media Call] ${JSON.stringify(args)}`);
+		if (__DEV__) {
+			console.log(`[Media Call] ${JSON.stringify(args)}`);
+		}
 	}
 
 	debug(...args: unknown[]): void {


### PR DESCRIPTION
## Summary

- When Telecom connection is killed (VoiceConnection is null), `answerIncomingCall` was cancelling notification ID `0` instead of `callId.hashCode()`, leaving the incoming-call notification on screen
- The notification is posted with `notificationId = callId.hashCode()` (per `VoipPayload.kt:47`), so the cancel must use the same ID

## Fix

Changed `cancelById(appCtx, 0)` to `cancelById(appCtx, callId.hashCode())` in the null-VoiceConnection branch.

## Test plan

- [ ] Android emulator: force null VoiceConnection path (e.g. by killing Telecom service before accept), tap Accept, verify the incoming-call notification disappears
- [ ] Android emulator: normal accept path still works - notification disappears after successful accept

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VoIP call notification handling to correctly dismiss notifications in specific scenarios.

* **Refactor**
  * Reduced logging verbosity for VoIP call diagnostics and startup events.
  * Optimized development-mode logging behavior to minimize console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->