### PR TITLE
fix(VoIP): gate MediaCallLogger.log() and switch sensitive call sites to debug()

### DIFF
--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -246,10 +246,7 @@ describe('setupMediaCallEvents — VoipPushTokenRegistered (iOS)', () => {
 		const { __mockDebug, __mockLog } = jest.requireMock('./MediaCallLogger');
 
 		// debug() must be called (sensitive data goes through debug level)
-		expect(__mockDebug).toHaveBeenCalledWith(
-			expect.stringContaining('Registered VoIP push token:'),
-			'voip-token-sensitive'
-		);
+		expect(__mockDebug).toHaveBeenCalledWith(expect.stringContaining('Registered VoIP push token:'), 'voip-token-sensitive');
 		// log() must NOT be called (sensitive data must not reach ungated log())
 		expect(__mockLog).not.toHaveBeenCalled();
 	});

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -88,14 +88,23 @@ jest.mock('../restApi', () => ({
 	registerPushToken: jest.fn(() => Promise.resolve())
 }));
 
-jest.mock('./MediaCallLogger', () => ({
-	MediaCallLogger: class {
-		log = jest.fn();
-		debug = jest.fn();
-		error = jest.fn();
-		warn = jest.fn();
+jest.mock('./MediaCallLogger', () => {
+	const log = jest.fn();
+	const debug = jest.fn();
+	const error = jest.fn();
+	const warn = jest.fn();
+	class MockMediaCallLogger {
+		log = log;
+		debug = debug;
+		error = error;
+		warn = warn;
 	}
-}));
+	return {
+		MediaCallLogger: MockMediaCallLogger,
+		__mockLog: log,
+		__mockDebug: debug
+	};
+});
 
 const mockAddEventListener = jest.fn();
 
@@ -227,6 +236,22 @@ describe('setupMediaCallEvents — VoipPushTokenRegistered (iOS)', () => {
 		emitNativeVoipEvent('VoipPushTokenRegistered', { token: 'voip-token-xyz' });
 		await Promise.resolve();
 		expect(registerPushToken).toHaveBeenCalledWith();
+	});
+
+	it('calls debug() with the token but NOT log() when VoipPushTokenRegistered is fired', () => {
+		setupMediaCallEvents(makeTestAdapters());
+		emitNativeVoipEvent('VoipPushTokenRegistered', { token: 'voip-token-sensitive' });
+
+		// Access the mock functions that were passed to the MediaCallLogger class
+		const { __mockDebug, __mockLog } = jest.requireMock('./MediaCallLogger');
+
+		// debug() must be called (sensitive data goes through debug level)
+		expect(__mockDebug).toHaveBeenCalledWith(
+			expect.stringContaining('Registered VoIP push token:'),
+			'voip-token-sensitive'
+		);
+		// log() must NOT be called (sensitive data must not reach ungated log())
+		expect(__mockLog).not.toHaveBeenCalled();
 	});
 });
 

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -89,7 +89,7 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	if (callId) {
 		lastHandledVoipAcceptSucceededCallId = callId;
 	}
-	mediaCallLogger.log(`${TAG} VoipAcceptSucceeded:`, data);
+	mediaCallLogger.debug(`${TAG} VoipAcceptSucceeded:`, data);
 	NativeVoipModule.clearInitialEvents();
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
 	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
@@ -115,7 +115,7 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 	if (isIOS) {
 		subscriptions.push(
 			Emitter.addListener('VoipPushTokenRegistered', ({ token }: { token: string }) => {
-				mediaCallLogger.log(`${TAG} Registered VoIP push token:`, token);
+				mediaCallLogger.debug(`${TAG} Registered VoIP push token:`, token);
 				registerPushToken().catch(error => {
 					mediaCallLogger.warn(`${TAG} Failed to register push token after VoIP update:`, error);
 				});
@@ -198,7 +198,7 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 
 	subscriptions.push(
 		Emitter.addListener(EVENT_VOIP_ACCEPT_FAILED, (data: VoipPayload & { voipAcceptFailed?: boolean }) => {
-			mediaCallLogger.log(`${TAG} VoipAcceptFailed event:`, data);
+			mediaCallLogger.debug(`${TAG} VoipAcceptFailed event:`, data);
 			dispatchVoipAcceptFailureFromNative({ ...data, voipAcceptFailed: true }, adapters.onOpenDeepLink);
 			NativeVoipModule.clearInitialEvents();
 		})
@@ -221,7 +221,7 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 			RNCallKeep.clearInitialEvents();
 			return false;
 		}
-		mediaCallLogger.log(`${TAG} Found initial events:`, initialEvents);
+		mediaCallLogger.debug(`${TAG} Found initial events:`, initialEvents);
 
 		if (initialEvents.voipAcceptFailed && initialEvents.callId && initialEvents.host) {
 			dispatchVoipAcceptFailureFromNative(initialEvents, adapters.onOpenDeepLink);
@@ -243,7 +243,7 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 		if (isIOS) {
 			const callKeepInitialEvents = await RNCallKeep.getInitialEvents();
 			RNCallKeep.clearInitialEvents();
-			mediaCallLogger.log(`${TAG} CallKeep initial events:`, JSON.stringify(callKeepInitialEvents, null, 2));
+			mediaCallLogger.debug(`${TAG} CallKeep initial events:`, JSON.stringify(callKeepInitialEvents, null, 2));
 
 			for (const event of callKeepInitialEvents) {
 				const { name, data } = event;

--- a/app/lib/services/voip/MediaCallLogger.test.ts
+++ b/app/lib/services/voip/MediaCallLogger.test.ts
@@ -1,0 +1,107 @@
+import { MediaCallLogger } from './MediaCallLogger';
+
+describe('MediaCallLogger', () => {
+	describe('log()', () => {
+		it('writes to console.log when __DEV__ is true', () => {
+			const originalDev = __DEV__;
+			// @ts-expect-error __DEV__ is not writable but we need to test
+			global.__DEV__ = true;
+			const spy = jest.spyOn(console, 'log').mockImplementation();
+
+			const logger = new MediaCallLogger();
+			logger.log('test message');
+
+			expect(spy).toHaveBeenCalledWith('[Media Call] ["test message"]');
+
+			spy.mockRestore();
+			// @ts-expect-error restoring
+			global.__DEV__ = originalDev;
+		});
+
+		it('does NOT write to console.log when __DEV__ is false', () => {
+			const originalDev = __DEV__;
+			// @ts-expect-error __DEV__ is not writable but we need to test
+			global.__DEV__ = false;
+			const spy = jest.spyOn(console, 'log').mockImplementation();
+
+			const logger = new MediaCallLogger();
+			logger.log('sensitive data', { token: 'secret', callId: 'abc' });
+
+			expect(spy).not.toHaveBeenCalled();
+
+			spy.mockRestore();
+			// @ts-expect-error restoring
+			global.__DEV__ = originalDev;
+		});
+	});
+
+	describe('debug()', () => {
+		it('writes to console.log when __DEV__ is true', () => {
+			const originalDev = __DEV__;
+			// @ts-expect-error __DEV__ is not writable but we need to test
+			global.__DEV__ = true;
+			const spy = jest.spyOn(console, 'log').mockImplementation();
+
+			const logger = new MediaCallLogger();
+			logger.debug('debug message');
+
+			expect(spy).toHaveBeenCalledWith('[Media Call Debug] ["debug message"]');
+
+			spy.mockRestore();
+			// @ts-expect-error restoring
+			global.__DEV__ = originalDev;
+		});
+
+		it('does NOT write to console.log when __DEV__ is false', () => {
+			const originalDev = __DEV__;
+			// @ts-expect-error __DEV__ is not writable but we need to test
+			global.__DEV__ = false;
+			const spy = jest.spyOn(console, 'log').mockImplementation();
+
+			const logger = new MediaCallLogger();
+			logger.debug('debug message');
+
+			expect(spy).not.toHaveBeenCalled();
+
+			spy.mockRestore();
+			// @ts-expect-error restoring
+			global.__DEV__ = originalDev;
+		});
+	});
+
+	describe('error()', () => {
+		it('writes to console.error regardless of __DEV__', () => {
+			const originalDev = __DEV__;
+			// @ts-expect-error __DEV__ is not writable but we need to test
+			global.__DEV__ = false;
+			const spy = jest.spyOn(console, 'error').mockImplementation();
+
+			const logger = new MediaCallLogger();
+			logger.error('error message');
+
+			expect(spy).toHaveBeenCalledWith('[Media Call Error] ["error message"]');
+
+			spy.mockRestore();
+			// @ts-expect-error restoring
+			global.__DEV__ = originalDev;
+		});
+	});
+
+	describe('warn()', () => {
+		it('writes to console.warn regardless of __DEV__', () => {
+			const originalDev = __DEV__;
+			// @ts-expect-error __DEV__ is not writable but we need to test
+			global.__DEV__ = false;
+			const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+			const logger = new MediaCallLogger();
+			logger.warn('warn message');
+
+			expect(spy).toHaveBeenCalledWith('[Media Call Warning] ["warn message"]');
+
+			spy.mockRestore();
+			// @ts-expect-error restoring
+			global.__DEV__ = originalDev;
+		});
+	});
+});

--- a/app/lib/services/voip/MediaCallLogger.ts
+++ b/app/lib/services/voip/MediaCallLogger.ts
@@ -2,7 +2,9 @@ import type { IMediaSignalLogger } from '@rocket.chat/media-signaling';
 
 export class MediaCallLogger implements IMediaSignalLogger {
 	log(...args: unknown[]): void {
-		console.log(`[Media Call] ${JSON.stringify(args)}`);
+		if (__DEV__) {
+			console.log(`[Media Call] ${JSON.stringify(args)}`);
+		}
 	}
 
 	debug(...args: unknown[]): void {


### PR DESCRIPTION
## Summary

- Gate `MediaCallLogger.log()` behind `if (__DEV__)` so it no-ops in production builds, preventing accidental leakage of sensitive VoIP data (tokens, call IDs, usernames, hostnames)
- Switch 5 sensitive `log()` call sites in `MediaCallEvents.ts` to `debug()`:
  - `VoipPushTokenRegistered` event handler (token value)
  - `VoipAcceptSucceeded` event handler (full VoipPayload)
  - `VoipAcceptFailed` event handler (full VoipPayload)
  - `getInitialMediaCallEvents` initial events log (initialEvents)
  - `getInitialMediaCallEvents` CallKeep events log (JSON.stringify output)
- Keep `error()` and `warn()` ungated so operational signals remain visible in crash reporters
- Add unit test verifying `setupMediaCallEvents` uses `debug()` for the VoipPushTokenRegistered handler and NOT `log()`

## Test plan

- [x] `TZ=UTC yarn test -- --testPathPattern='app/lib/services/voip/MediaCallEvents.ios.test.ts'` — 11 tests pass
- [ ] Manual QA: release build — verify no `[Media Call]` lines with sensitive values in device log
- [ ] Manual QA: dev build — verify `[Media Call Debug]` lines appear with sensitive data for development debugging

## Related issue

Fixes sensitive data logging as described in PRD-voip-high-blockers.md (H3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying logging behavior across development/production modes and that debug/log/error/warn follow expected output rules.
  * Added an iOS VoIP test that verifies push-token event handling and logging expectations.

* **Bug Fixes**
  * Logging now respects development-mode flag: verbose logs emit only in development.
  * VoIP event messages use the appropriate logging level (debug vs log).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->