### PR TITLE
fix(android): cancel VoIP notification with correct ID when VoiceConnection is null

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -341,7 +341,7 @@ class VoipNotification(private val context: Context) {
                     }
                     val appCtx = context.applicationContext
                     disconnectIncomingCall(callId, false)
-                    cancelById(appCtx, 0)
+                    cancelById(appCtx, callId.hashCode())
                     ddpRegistry.stopClient(callId)
                     // Stash failure payload for JS: it will show error toast on getInitialEvents.
                     VoipModule.storeAcceptFailureForJs(VoipPayload(


### PR DESCRIPTION
## Summary

Fix for 7223 - only the VoipNotification.kt change. Replaces the original PR which included unrelated TS files.

When VoiceConnection is null, answerIncomingCall was cancelling notification ID 0 instead of callId.hashCode(). The notification is posted with notificationId = callId.hashCode(), so cancel must use same ID.

## Test plan

- [ ] VoIP notification is canceled correctly on Android
- [ ] Notification uses correct call ID when VoiceConnection is null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VoIP notification cancellation for failed incoming calls to ensure notifications are properly cleared using unique call identifiers instead of default values, preventing notification persistence issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->