### PR TITLE
fix(voip): add "hold" to native accept supportedFeatures (iOS + Android parity)

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -309,7 +309,7 @@ class VoipNotification(private val context: Context) {
                 callId = payload.callId,
                 contractId = deviceId,
                 answer = "accept",
-                supportedFeatures = listOf("audio")
+                supportedFeatures = listOf("audio", "hold")
             ) { success ->
                 finish(success)
             }

--- a/ios/Libraries/VoipService.swift
+++ b/ios/Libraries/VoipService.swift
@@ -521,7 +521,7 @@ public final class VoipService: NSObject {
             callId: payload.callId,
             contractId: DeviceUID.uid(),
             answer: "accept",
-            supportedFeatures: ["audio"]
+            supportedFeatures: ["audio", "hold"]
         )) { result in
             DispatchQueue.main.async {
                 switch result {


### PR DESCRIPTION
## Proposed changes

iOS (`VoipService.finishAccept`) and Android (`VoipNotification.handleAcceptAction`) both hardcoded `supportedFeatures = ["audio"]` on `POST /api/v1/media-calls.answer`. The TypeScript source of truth (`app/lib/services/voip/MediaSessionStore.ts`) declares the canonical feature set as `['audio', 'hold']`. Native accepts were missing `"hold"`, so the server received an inconsistent capability list depending on which side answered the call.

Both platforms now send `["audio", "hold"]` on accept. Reject path continues to send no features (`nil` / `null`), which matches existing behavior confirmed during the trace.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-88

## How to test or reproduce

1. Build on iOS and accept an incoming VoIP call from a different device/account.
2. Build on Android and accept an incoming VoIP call from a different device/account.
3. Capture the `POST /api/v1/media-calls.answer` request body on each platform (proxy or backend log) and confirm `supportedFeatures: ["audio", "hold"]`.
4. Decline a call on each platform and confirm `supportedFeatures` is omitted (unchanged).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Change is two lines total, one on each platform. No JS/TS code changed. Base branch is `feat.voip-lib-new` per the VoIP PR plan — all VoIP code currently lives on that feature branch and this PR lands there to be shipped together with the rest of the VoIP work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VoIP calls now advertise support for call hold functionality in addition to audio capabilities across both iOS and Android platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->