### PR TITLE
fix(VoIP): await onStreamData promise so voipPermissionListener.stop exists on logout

### DIFF
--- a/app/sagas/login.js
+++ b/app/sagas/login.js
@@ -283,7 +283,8 @@ const startVoipFork = function* startVoipFork() {
 	yield call(checkVoipPermission);
 
 	stopVoipPermissionListener();
-	voipPermissionListener = sdk.current.onStreamData('stream-notify-logged', async ddpMessage => {
+	// Logout between yield start and resolve leaks this listener; safe because the SDK tears down on logout.
+	voipPermissionListener = yield call([sdk.current, 'onStreamData'], 'stream-notify-logged', async ddpMessage => {
 		const { eventName } = ddpMessage.fields || {};
 		if (/permissions-changed/.test(eventName)) {
 			await checkVoipPermission();


### PR DESCRIPTION
## Proposed changes

`sdk.onStreamData` returns a `Promise` that resolves to `{ stop }`. `startVoipFork` was storing the Promise itself in `voipPermissionListener`, so on logout `stopVoipPermissionListener()` called `.stop()` on a Promise and threw:

```
[TypeError: voipPermissionListener.stop is not a function (it is undefined)]
  created by takeLatest(LOGOUT, handleLogout)
```

The thrown error also cancelled sibling root sagas (`LOGIN_REQUEST`, `USER_SET`, `DELETE_ACCOUNT`).

Fix: `yield call([sdk.current, 'onStreamData'], ...)` so the resolved `{ stop }` object is stored. Matches the `yield call(...)` style used elsewhere in this saga.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-101

## How to test or reproduce

1. Log in on a server with VoIP enabled.
2. Log out.
3. Without the fix: red-box `voipPermissionListener.stop is not a function` and sibling sagas cancelled.
4. With the fix: logout completes cleanly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

A theoretical race remains: if logout fires between the `yield call` suspending and the `onStreamData` Promise resolving, `stopVoipPermissionListener()` sees `null` and the listener is stored after logout. The SDK tears down on logout so the stray listener is collected — documented inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined internal VoIP event listener setup for improved system management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->