### PR TITLE
fix(android/voip): use phoneCall FGS type and fix inverted accept/decline guard

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -152,7 +152,7 @@
             android:name="chat.rocket.reactnative.voip.VoipCallService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="microphone" />
+            android:foregroundServiceType="phoneCall" />
 
         <!-- react-native-webrtc ships MediaProjectionService (foregroundServiceType=mediaProjection)
              for screen sharing. We don't use screen sharing, and Android 15+ forbids starting

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -260,7 +260,7 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleAccept(payload: VoipPayload) {
-        if (acceptDeclineGuard.compareAndSet(false, true)) return
+        if (!acceptDeclineGuard.compareAndSet(false, true)) return
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Call accepted - callId: ${payload.callId}")
         }
@@ -271,7 +271,7 @@ class IncomingCallActivity : Activity() {
     }
 
     private fun handleDecline(payload: VoipPayload) {
-        if (acceptDeclineGuard.compareAndSet(false, true)) return
+        if (!acceptDeclineGuard.compareAndSet(false, true)) return
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Call declined - callId: ${payload.callId}")
         }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -94,7 +94,7 @@ class VoipCallService : Service() {
             startForeground(
                 NOTIFICATION_ID,
                 notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
             )
         } else {
             startForeground(NOTIFICATION_ID, notification)


### PR DESCRIPTION
## Proposed changes

Two independent bugs surfaced in user reports on Android 16 (targetSdk=36) when a VoIP call arrives on a locked device:

**Bug 1 — `VoipCallService` microphone FGS eligibility violation (process crash).**
`VoipCallService.startForegroundWithNotification` was calling `startForeground(..., FOREGROUND_SERVICE_TYPE_MICROPHONE)` unconditionally on API 29+. On Android 14+ the microphone type is a "while-in-use" FGS and requires the process to be in a foreground-eligible state at `startForeground()` time. Our accept paths call `VoipCallService.startService` as the first statement of `VoipNotification.handleAcceptAction`, which runs from either `IncomingCallActivity` (FSI, above-lock separate-task Activity) or `MainActivity.onNewIntent` (HUN, not yet resumed) — neither context satisfies the eligibility check on targetSdk 36. The result is a `FATAL EXCEPTION: main` caused by `SecurityException: Starting FGS with type microphone ... requires permissions [FOREGROUND_SERVICE_MICROPHONE] and any of [RECORD_AUDIO, ...] and the app must be in the eligible state/exemptions`.

Switching to `FOREGROUND_SERVICE_TYPE_PHONE_CALL` resolves this: the `phoneCall` type's eligibility is satisfied by the self-managed Telecom call already registered via `telecomManager.addNewIncomingCall` in `VoipNotification.registerCallWithTelecomManager`. `FOREGROUND_SERVICE_PHONE_CALL` is already declared in the manifest.

**Bug 2 — Inverted `acceptDeclineGuard` in `IncomingCallActivity` (first-tap no-op on locked screen).**
`handleAccept` / `handleDecline` both had `if (acceptDeclineGuard.compareAndSet(false, true)) return`. `AtomicBoolean.compareAndSet(false, true)` returns `true` on the first call (CAS succeeds), so the guard was returning on the FIRST tap and only letting subsequent taps through — the opposite of a single-fire guard. This is only observable on the FSI/locked-screen path (the HUN path goes through `MainActivity`), which matches the "accepting while locked doesn't open the app" symptom.

Inverting to `if (!acceptDeclineGuard.compareAndSet(false, true)) return` restores the intended "first tap proceeds, subsequent taps dropped" semantics.

## Issue(s)

User-reported FATAL crash on Android 16 tapping incoming VoIP call notification; lock-screen Accept appearing to do nothing.

## How to test or reproduce

1. Build against targetSdk 36 and install on an Android 16 device.
2. Lock the device.
3. Trigger an incoming VoIP call.
4. On the full-screen incoming-call UI, tap **Accept** — the call should accept on the first tap (Bug 2) and the app should open without crashing (Bug 1).
5. Repeat with **Decline** on first tap to verify Bug 2 for the decline path too.
6. Repeat unlocked (HUN path) — Accept should still work; this path did not exhibit Bug 2 but relies on the same `VoipCallService`, so Bug 1's fix applies here as well.

## Screenshots

N/A — native Android behavior change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

CallKeep's own `VoiceConnectionService` already declares `microphone|phoneCall` in the manifest but is never actually promoted to FGS at runtime because `RNCallKeep.setup()` is not passed a `foregroundService` config from the JS side — so `VoipCallService` is the only FGS keeping the audio session alive. A cleaner future refactor would pass that config to CallKeep and remove `VoipCallService` entirely, relying on the Telecom-exempted FGS path. That is out of scope for this surgical fix.

Known separate observation (not addressed here): the `registerCallWithTelecomManager` catches at `VoipNotification.kt:794-798` silently swallow `SecurityException`/`Exception` at `Log.e` severity only. If `addNewIncomingCall` fails, the Telecom FGS exemption is never granted and `phoneCall` eligibility may still fail. Worth tracking in a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed handling of rapid accept/decline button taps on incoming calls to prevent unintended duplicate actions
  - Updated VoIP service configuration to properly support phone call operations on Android devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->