### PR TITLE
fix(voip): refine Dialpad layout and CallView button spacing

### DIFF
--- a/app/views/CallView/CallView.stories.tsx
+++ b/app/views/CallView/CallView.stories.tsx
@@ -8,6 +8,7 @@ import { CallButtons } from './components/CallButtons';
 import { styles as callViewStyles } from './styles';
 import { useTheme } from '../../theme';
 import { useCallStore } from '../../lib/services/voip/useCallStore';
+import { ActionSheetProvider } from '../../containers/ActionSheet';
 import {
 	BASE_ROW_HEIGHT,
 	BASE_ROW_HEIGHT_CONDENSED,
@@ -37,6 +38,7 @@ const setStoreState = (overrides: Partial<ReturnType<typeof useCallStore.getStat
 		setHeld: () => {},
 		hangup: () => {},
 		reject: () => {},
+		sendDTMF: () => {},
 		emitter: {
 			on: () => {},
 			off: () => {}
@@ -118,13 +120,22 @@ export const SpeakerOn = () => {
 	return <CallView />;
 };
 
+export const WithDialpad = () => {
+	setStoreState({ callState: 'active' });
+	return (
+		<ActionSheetProvider>
+			<CallView />
+		</ActionSheetProvider>
+	);
+};
+
 // Tablet / wide layout stories — force layoutMode='wide' via ResponsiveLayoutContext width
 const TabletCallView = () => {
 	const { colors } = useTheme();
 	const call = useCallStore(state => state.call);
 	if (!call) return null;
 	return (
-		<ResponsiveLayoutContext.Provider value={{ ...responsiveLayoutProviderLargeFontValue(1), width: 800 }}>
+		<ResponsiveLayoutContext.Provider value={{ ...responsiveLayoutProviderLargeFontValue(1), width: 700 }}>
 			<View style={[callViewStyles.contentContainer, { backgroundColor: colors.surfaceLight }]}>
 				<CallerInfo />
 				<CallButtons />
@@ -161,4 +172,13 @@ export const TabletMutedAndOnHold = () => {
 export const TabletSpeakerOn = () => {
 	setStoreState({ callState: 'active', isSpeakerOn: true });
 	return <TabletCallView />;
+};
+
+export const TabletWithDialpad = () => {
+	setStoreState({ callState: 'active' });
+	return (
+		<ActionSheetProvider>
+			<TabletCallView />
+		</ActionSheetProvider>
+	);
 };

--- a/app/views/CallView/__snapshots__/index.test.tsx.snap
+++ b/app/views/CallView/__snapshots__/index.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -219,7 +219,8 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -310,7 +311,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -325,7 +326,8 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -416,7 +418,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -431,7 +433,8 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -522,7 +525,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -538,7 +541,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -548,7 +551,8 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -639,7 +643,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -654,7 +658,8 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -745,7 +750,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -760,7 +765,8 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -851,7 +857,7 @@ exports[`Story Snapshots: ConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -1077,7 +1083,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -1087,7 +1093,8 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -1180,7 +1187,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -1195,7 +1202,8 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -1288,7 +1296,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -1303,7 +1311,8 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -1396,7 +1405,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -1412,7 +1421,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -1422,7 +1431,8 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -1513,7 +1523,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -1528,7 +1538,8 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -1619,7 +1630,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -1634,7 +1645,8 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -1727,7 +1739,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -1953,7 +1965,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -1963,7 +1975,8 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -2054,7 +2067,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -2069,7 +2082,8 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -2160,7 +2174,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -2175,7 +2189,8 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -2266,7 +2281,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -2282,7 +2297,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -2292,7 +2307,8 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -2383,7 +2399,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -2398,7 +2414,8 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -2489,7 +2506,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -2504,7 +2521,8 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -2595,7 +2613,7 @@ exports[`Story Snapshots: MutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -2821,7 +2839,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -2831,7 +2849,8 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -2922,7 +2941,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -2937,7 +2956,8 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -3028,7 +3048,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -3043,7 +3063,8 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -3134,7 +3155,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -3150,7 +3171,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -3160,7 +3181,8 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -3251,7 +3273,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -3266,7 +3288,8 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -3357,7 +3380,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -3372,7 +3395,8 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -3463,7 +3487,7 @@ exports[`Story Snapshots: MutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -3689,7 +3713,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -3699,7 +3723,8 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -3790,7 +3815,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -3805,7 +3830,8 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -3896,7 +3922,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -3911,7 +3937,8 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4002,7 +4029,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -4018,7 +4045,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -4028,7 +4055,8 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4119,7 +4147,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -4134,7 +4162,8 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4225,7 +4254,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -4240,7 +4269,8 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4331,7 +4361,7 @@ exports[`Story Snapshots: OnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -4557,7 +4587,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -4567,7 +4597,8 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4658,7 +4689,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -4673,7 +4704,8 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4764,7 +4796,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -4779,7 +4811,8 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4870,7 +4903,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -4886,7 +4919,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -4896,7 +4929,8 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -4987,7 +5021,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5002,7 +5036,8 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -5093,7 +5128,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5108,7 +5143,8 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -5199,7 +5235,7 @@ exports[`Story Snapshots: SpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5408,7 +5444,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -5418,7 +5454,8 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -5509,7 +5546,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5524,7 +5561,8 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -5615,7 +5653,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5630,7 +5668,8 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -5721,7 +5760,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5736,7 +5775,8 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -5827,7 +5867,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5842,7 +5882,8 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -5933,7 +5974,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -5948,7 +5989,8 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -6039,7 +6081,7 @@ exports[`Story Snapshots: TabletConnectedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -6248,7 +6290,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -6258,7 +6300,8 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -6351,7 +6394,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -6366,7 +6409,8 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -6459,7 +6503,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -6474,7 +6518,8 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -6567,7 +6612,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -6582,7 +6627,8 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -6673,7 +6719,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -6688,7 +6734,8 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -6779,7 +6826,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -6794,7 +6841,8 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -6887,7 +6935,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -7096,7 +7144,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -7106,7 +7154,8 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -7197,7 +7246,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -7212,7 +7261,8 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -7303,7 +7353,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -7318,7 +7368,8 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -7409,7 +7460,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -7424,7 +7475,8 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -7515,7 +7567,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -7530,7 +7582,8 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -7621,7 +7674,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -7636,7 +7689,8 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -7727,7 +7781,7 @@ exports[`Story Snapshots: TabletMutedAndOnHold should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -7936,7 +7990,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -7946,7 +8000,8 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8037,7 +8092,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8052,7 +8107,8 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8143,7 +8199,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8158,7 +8214,8 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8249,7 +8306,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8264,7 +8321,8 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8355,7 +8413,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8370,7 +8428,8 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8461,7 +8520,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8476,7 +8535,8 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8567,7 +8627,7 @@ exports[`Story Snapshots: TabletMutedCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8776,7 +8836,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -8786,7 +8846,8 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8877,7 +8938,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8892,7 +8953,8 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -8983,7 +9045,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -8998,7 +9060,8 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -9089,7 +9152,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -9104,7 +9167,8 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -9195,7 +9259,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -9210,7 +9274,8 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -9301,7 +9366,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -9316,7 +9381,8 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -9407,7 +9473,7 @@ exports[`Story Snapshots: TabletOnHoldCall should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -9616,7 +9682,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
         style={
           {
             "flexDirection": "row",
-            "gap": 24,
+            "gap": 48,
             "justifyContent": "center",
           }
         }
@@ -9626,7 +9692,8 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -9717,7 +9784,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -9732,7 +9799,8 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -9823,7 +9891,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -9838,7 +9906,8 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -9929,7 +9998,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -9944,7 +10013,8 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -10035,7 +10105,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -10050,7 +10120,8 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -10141,7 +10212,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -10156,7 +10227,8 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
+              "overflow": "hidden",
+              "width": 64,
             }
           }
         >
@@ -10247,7 +10319,7 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
                   "fontSize": 14,
                   "fontWeight": "400",
                   "lineHeight": 20,
-                  "textAlign": "center",
+                  "textAlign": "left",
                 },
                 {
                   "color": "#2F343D",
@@ -10261,5 +10333,1725 @@ exports[`Story Snapshots: TabletSpeakerOn should match snapshot 1`] = `
       </View>
     </View>
   </View>
+</View>
+`;
+
+exports[`Story Snapshots: TabletWithDialpad should match snapshot 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "flex": 1,
+          "justifyContent": "space-between",
+        },
+        {
+          "backgroundColor": "#FFFFFF",
+        },
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="Toggle call controls"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginBottom": 100,
+          "paddingHorizontal": 24,
+        }
+      }
+      testID="caller-info-toggle"
+    >
+      <View
+        style={
+          {
+            "marginBottom": 16,
+            "position": "relative",
+          }
+        }
+      >
+        <View
+          accessibilityLabel="bob.burnquist's avatar"
+          accessible={true}
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "height": 120,
+                "width": 120,
+              },
+              undefined,
+            ]
+          }
+          testID="avatar"
+        >
+          <ViewManagerAdapter_ExpoImage
+            borderRadius={2}
+            containerViewRef={{"current":"Object"}}
+            contentFit="cover"
+            contentPosition={
+              {
+                "left": "50%",
+                "top": "50%",
+              }
+            }
+            height={120}
+            nativeViewRef={{"current":"NativeComponent"}}
+            onError={[Function]}
+            onLoad={[Function]}
+            onLoadStart={[Function]}
+            onProgress={[Function]}
+            placeholder={[]}
+            priority="high"
+            source={
+              [
+                {
+                  "headers": {
+                    "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                  },
+                  "uri": "https://open.rocket.chat/avatar/bob.burnquist?format=png&size=240",
+                },
+              ]
+            }
+            style={
+              {
+                "borderRadius": 2,
+                "height": 120,
+                "width": 120,
+              }
+            }
+            transition={null}
+            width={120}
+          />
+        </View>
+      </View>
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            [Function],
+          ]
+        }
+      >
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "backgroundColor": "transparent",
+                "fontFamily": "Inter",
+                "fontSize": 24,
+                "fontWeight": "700",
+                "lineHeight": 32,
+                "marginBottom": 4,
+                "textAlign": "center",
+              },
+              {
+                "color": "#2F343D",
+              },
+            ]
+          }
+          testID="caller-info-name"
+        >
+          Bob Burnquist
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityElementsHidden={false}
+      importantForAccessibility="auto"
+      pointerEvents="auto"
+      style={
+        [
+          {
+            "borderTopWidth": 0.5,
+            "bottom": 0,
+            "gap": 24,
+            "left": 0,
+            "padding": 24,
+            "paddingBottom": 48,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "backgroundColor": "#FFFFFF",
+            "borderTopColor": "#EBECEF",
+          },
+          [Function],
+        ]
+      }
+      testID="call-buttons"
+    >
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "gap": 48,
+            "justifyContent": "center",
+          }
+        }
+        testID="call-buttons-row-0"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Speaker"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-speaker"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Speaker
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Hold"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-hold"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Hold
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Mute"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-mute"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Mute
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Message"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-message"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Message
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="End"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#EC0D2A",
+                },
+              ]
+            }
+            testID="call-view-end"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            End
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Dialpad"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-dialpad"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Dialpad
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`Story Snapshots: WithDialpad should match snapshot 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaView
+    edges={
+      {
+        "bottom": "off",
+        "left": "additive",
+        "right": "additive",
+        "top": "off",
+      }
+    }
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        {
+          "backgroundColor": "#F2F3F5",
+        },
+        [
+          {
+            "flex": 1,
+            "justifyContent": "space-between",
+          },
+          {
+            "backgroundColor": "#FFFFFF",
+          },
+        ],
+      ]
+    }
+    testID="call-view-container"
+  >
+    <View
+      accessibilityLabel="Toggle call controls"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginBottom": 100,
+          "paddingHorizontal": 24,
+        }
+      }
+      testID="caller-info-toggle"
+    >
+      <View
+        style={
+          {
+            "marginBottom": 16,
+            "position": "relative",
+          }
+        }
+      >
+        <View
+          accessibilityLabel="bob.burnquist's avatar"
+          accessible={true}
+          style={
+            [
+              {
+                "borderRadius": 2,
+                "height": 120,
+                "width": 120,
+              },
+              undefined,
+            ]
+          }
+          testID="avatar"
+        >
+          <ViewManagerAdapter_ExpoImage
+            borderRadius={2}
+            containerViewRef={{"current":"Object"}}
+            contentFit="cover"
+            contentPosition={
+              {
+                "left": "50%",
+                "top": "50%",
+              }
+            }
+            height={120}
+            nativeViewRef={{"current":"NativeComponent"}}
+            onError={[Function]}
+            onLoad={[Function]}
+            onLoadStart={[Function]}
+            onProgress={[Function]}
+            placeholder={[]}
+            priority="high"
+            source={
+              [
+                {
+                  "headers": {
+                    "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                  },
+                  "uri": "https://open.rocket.chat/avatar/bob.burnquist?format=png&size=240",
+                },
+              ]
+            }
+            style={
+              {
+                "borderRadius": 2,
+                "height": 120,
+                "width": 120,
+              }
+            }
+            transition={null}
+            width={120}
+          />
+        </View>
+      </View>
+      <View
+        style={
+          [
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            [Function],
+          ]
+        }
+      >
+        <Text
+          numberOfLines={1}
+          style={
+            [
+              {
+                "backgroundColor": "transparent",
+                "fontFamily": "Inter",
+                "fontSize": 24,
+                "fontWeight": "700",
+                "lineHeight": 32,
+                "marginBottom": 4,
+                "textAlign": "center",
+              },
+              {
+                "color": "#2F343D",
+              },
+            ]
+          }
+          testID="caller-info-name"
+        >
+          Bob Burnquist
+        </Text>
+      </View>
+    </View>
+    <View
+      accessibilityElementsHidden={false}
+      importantForAccessibility="auto"
+      pointerEvents="auto"
+      style={
+        [
+          {
+            "borderTopWidth": 0.5,
+            "bottom": 0,
+            "gap": 24,
+            "left": 0,
+            "padding": 24,
+            "paddingBottom": 48,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "backgroundColor": "#FFFFFF",
+            "borderTopColor": "#EBECEF",
+          },
+          [Function],
+        ]
+      }
+      testID="call-buttons"
+    >
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "gap": 48,
+            "justifyContent": "center",
+          }
+        }
+        testID="call-buttons-row-0"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Speaker"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-speaker"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Speaker
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Hold"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-hold"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Hold
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Mute"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-mute"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Mute
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          {
+            "flexDirection": "row",
+            "gap": 48,
+            "justifyContent": "center",
+          }
+        }
+        testID="call-buttons-row-1"
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Message"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-message"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Message
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="End"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#EC0D2A",
+                },
+              ]
+            }
+            testID="call-view-end"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#FFFFFF",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            End
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "overflow": "hidden",
+              "width": 64,
+            }
+          }
+        >
+          <View
+            accessibilityLabel="Dialpad"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "borderRadius": 8,
+                  "height": 64,
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                  "width": 64,
+                },
+                false,
+                {
+                  "backgroundColor": "#E4E7EA",
+                },
+              ]
+            }
+            testID="call-view-dialpad"
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#1F2329",
+                    "fontSize": 32,
+                  },
+                  [
+                    {
+                      "lineHeight": 32,
+                    },
+                    undefined,
+                  ],
+                  {
+                    "fontFamily": "custom",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+            >
+              
+            </Text>
+          </View>
+          <Text
+            numberOfLines={1}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "400",
+                  "lineHeight": 20,
+                  "textAlign": "left",
+                },
+                {
+                  "color": "#2F343D",
+                },
+              ]
+            }
+          >
+            Dialpad
+          </Text>
+        </View>
+      </View>
+    </View>
+  </RNCSafeAreaView>
 </View>
 `;

--- a/app/views/CallView/components/Dialpad/DialpadButton.tsx
+++ b/app/views/CallView/components/Dialpad/DialpadButton.tsx
@@ -22,6 +22,8 @@ const DialpadButton = ({ digit, letters }: IDialpadButton): React.ReactElement =
 		Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 	};
 
+	const isLargeDigit = ['*', '#'].includes(digit);
+
 	return (
 		<Pressable
 			onPress={handleDigitPress}
@@ -32,8 +34,8 @@ const DialpadButton = ({ digit, letters }: IDialpadButton): React.ReactElement =
 				{ backgroundColor: pressed ? colors.buttonBackgroundSecondaryPress : colors.buttonBackgroundSecondaryDefault }
 			]}>
 			<View style={styles.digitContainer}>
-				<Text style={[styles.digit, { color: colors.fontDefault }]}>{digit}</Text>
-				<Text style={[styles.letters, { color: colors.fontSecondaryInfo }]}>{letters || ''}</Text>
+				<Text style={[styles.digit, isLargeDigit && styles.digitLarge, { color: colors.fontDefault }]}>{digit}</Text>
+				{!isLargeDigit ? <Text style={[styles.letters, { color: colors.fontSecondaryInfo }]}>{letters || ''}</Text> : null}
 			</View>
 		</Pressable>
 	);

--- a/app/views/CallView/components/Dialpad/__snapshots__/Dialpad.test.tsx.snap
+++ b/app/views/CallView/components/Dialpad/__snapshots__/Dialpad.test.tsx.snap
@@ -13,8 +13,11 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
     style={
       [
         {
+          "alignSelf": "center",
+          "maxWidth": 400,
           "padding": 32,
           "paddingBottom": 32,
+          "width": "100%",
         },
         {
           "backgroundColor": "#FFFFFF",
@@ -117,7 +120,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -159,6 +162,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -186,6 +190,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -252,6 +257,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -279,6 +285,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -347,6 +354,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -374,6 +382,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -410,7 +419,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -452,6 +461,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -479,6 +489,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -547,6 +558,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -574,6 +586,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -642,6 +655,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -669,6 +683,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -705,7 +720,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -747,6 +762,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -774,6 +790,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -842,6 +859,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -869,6 +887,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -937,6 +956,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -964,6 +984,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -1000,7 +1021,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -1042,6 +1063,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -1070,6 +1092,12 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "textAlign": "center",
                   },
                   {
+                    "fontSize": 38,
+                    "lineHeight": 40,
+                    "textAlign": "center",
+                    "textAlignVertical": "center",
+                  },
+                  {
                     "color": "#2F343D",
                   },
                 ]
@@ -1077,24 +1105,6 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
             >
               *
             </Text>
-            <Text
-              style={
-                [
-                  {
-                    "backgroundColor": "transparent",
-                    "fontFamily": "Inter",
-                    "fontSize": 12,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 18,
-                    "textAlign": "center",
-                  },
-                  {
-                    "color": "#6C727A",
-                  },
-                ]
-              }
-            />
           </View>
         </View>
         <View
@@ -1135,6 +1145,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -1162,6 +1173,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -1230,6 +1242,7 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -1258,6 +1271,12 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
                     "textAlign": "center",
                   },
                   {
+                    "fontSize": 38,
+                    "lineHeight": 40,
+                    "textAlign": "center",
+                    "textAlignVertical": "center",
+                  },
+                  {
                     "color": "#2F343D",
                   },
                 ]
@@ -1265,24 +1284,6 @@ exports[`Story Snapshots: Default should match snapshot 1`] = `
             >
               #
             </Text>
-            <Text
-              style={
-                [
-                  {
-                    "backgroundColor": "transparent",
-                    "fontFamily": "Inter",
-                    "fontSize": 12,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 18,
-                    "textAlign": "center",
-                  },
-                  {
-                    "color": "#6C727A",
-                  },
-                ]
-              }
-            />
           </View>
         </View>
       </View>
@@ -1311,8 +1312,11 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
       style={
         [
           {
+            "alignSelf": "center",
+            "maxWidth": 400,
             "padding": 32,
             "paddingBottom": 32,
+            "width": "100%",
           },
           {
             "backgroundColor": "#FFFFFF",
@@ -1415,7 +1419,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -1457,6 +1461,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -1484,6 +1489,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -1550,6 +1556,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -1577,6 +1584,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -1645,6 +1653,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -1672,6 +1681,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -1708,7 +1718,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -1750,6 +1760,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -1777,6 +1788,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -1845,6 +1857,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -1872,6 +1885,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -1940,6 +1954,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -1967,6 +1982,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -2003,7 +2019,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -2045,6 +2061,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2072,6 +2089,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -2140,6 +2158,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2167,6 +2186,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -2235,6 +2255,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2262,6 +2283,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -2298,7 +2320,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -2340,6 +2362,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2368,6 +2391,12 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "textAlign": "center",
                     },
                     {
+                      "fontSize": 38,
+                      "lineHeight": 40,
+                      "textAlign": "center",
+                      "textAlignVertical": "center",
+                    },
+                    {
                       "color": "#2F343D",
                     },
                   ]
@@ -2375,24 +2404,6 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
               >
                 *
               </Text>
-              <Text
-                style={
-                  [
-                    {
-                      "backgroundColor": "transparent",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 18,
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#6C727A",
-                    },
-                  ]
-                }
-              />
             </View>
           </View>
           <View
@@ -2433,6 +2444,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2460,6 +2472,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -2528,6 +2541,7 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2556,6 +2570,12 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
                       "textAlign": "center",
                     },
                     {
+                      "fontSize": 38,
+                      "lineHeight": 40,
+                      "textAlign": "center",
+                      "textAlignVertical": "center",
+                    },
+                    {
                       "color": "#2F343D",
                     },
                   ]
@@ -2563,24 +2583,6 @@ exports[`Story Snapshots: TabletLandscape should match snapshot 1`] = `
               >
                 #
               </Text>
-              <Text
-                style={
-                  [
-                    {
-                      "backgroundColor": "transparent",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 18,
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#6C727A",
-                    },
-                  ]
-                }
-              />
             </View>
           </View>
         </View>
@@ -2610,8 +2612,11 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
       style={
         [
           {
+            "alignSelf": "center",
+            "maxWidth": 400,
             "padding": 32,
             "paddingBottom": 32,
+            "width": "100%",
           },
           {
             "backgroundColor": "#FFFFFF",
@@ -2714,7 +2719,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -2756,6 +2761,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2783,6 +2789,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -2849,6 +2856,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2876,6 +2884,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -2944,6 +2953,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -2971,6 +2981,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3007,7 +3018,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -3049,6 +3060,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3076,6 +3088,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3144,6 +3157,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3171,6 +3185,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3239,6 +3254,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3266,6 +3282,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3302,7 +3319,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -3344,6 +3361,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3371,6 +3389,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3439,6 +3458,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3466,6 +3486,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3534,6 +3555,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3561,6 +3583,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3597,7 +3620,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
             {
               "flexDirection": "row",
               "gap": 40,
-              "justifyContent": "space-between",
+              "justifyContent": "center",
             }
           }
         >
@@ -3639,6 +3662,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3667,6 +3691,12 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "textAlign": "center",
                     },
                     {
+                      "fontSize": 38,
+                      "lineHeight": 40,
+                      "textAlign": "center",
+                      "textAlignVertical": "center",
+                    },
+                    {
                       "color": "#2F343D",
                     },
                   ]
@@ -3674,24 +3704,6 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
               >
                 *
               </Text>
-              <Text
-                style={
-                  [
-                    {
-                      "backgroundColor": "transparent",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 18,
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#6C727A",
-                    },
-                  ]
-                }
-              />
             </View>
           </View>
           <View
@@ -3732,6 +3744,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3759,6 +3772,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "lineHeight": 36,
                       "textAlign": "center",
                     },
+                    false,
                     {
                       "color": "#2F343D",
                     },
@@ -3827,6 +3841,7 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                   "aspectRatio": 1,
                   "borderRadius": 8,
                   "flex": 1,
+                  "maxWidth": 68,
                 },
                 {
                   "backgroundColor": "#E4E7EA",
@@ -3855,6 +3870,12 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
                       "textAlign": "center",
                     },
                     {
+                      "fontSize": 38,
+                      "lineHeight": 40,
+                      "textAlign": "center",
+                      "textAlignVertical": "center",
+                    },
+                    {
                       "color": "#2F343D",
                     },
                   ]
@@ -3862,24 +3883,6 @@ exports[`Story Snapshots: TabletLandscapeWithValue should match snapshot 1`] = `
               >
                 #
               </Text>
-              <Text
-                style={
-                  [
-                    {
-                      "backgroundColor": "transparent",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "400",
-                      "letterSpacing": 0,
-                      "lineHeight": 18,
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#6C727A",
-                    },
-                  ]
-                }
-              />
             </View>
           </View>
         </View>
@@ -3902,8 +3905,11 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
     style={
       [
         {
+          "alignSelf": "center",
+          "maxWidth": 400,
           "padding": 32,
           "paddingBottom": 32,
+          "width": "100%",
         },
         {
           "backgroundColor": "#FFFFFF",
@@ -4006,7 +4012,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -4048,6 +4054,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4075,6 +4082,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4141,6 +4149,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4168,6 +4177,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4236,6 +4246,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4263,6 +4274,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4299,7 +4311,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -4341,6 +4353,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4368,6 +4381,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4436,6 +4450,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4463,6 +4478,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4531,6 +4547,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4558,6 +4575,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4594,7 +4612,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -4636,6 +4654,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4663,6 +4682,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4731,6 +4751,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4758,6 +4779,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4826,6 +4848,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4853,6 +4876,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -4889,7 +4913,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
           {
             "flexDirection": "row",
             "gap": 40,
-            "justifyContent": "space-between",
+            "justifyContent": "center",
           }
         }
       >
@@ -4931,6 +4955,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -4959,6 +4984,12 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "textAlign": "center",
                   },
                   {
+                    "fontSize": 38,
+                    "lineHeight": 40,
+                    "textAlign": "center",
+                    "textAlignVertical": "center",
+                  },
+                  {
                     "color": "#2F343D",
                   },
                 ]
@@ -4966,24 +4997,6 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
             >
               *
             </Text>
-            <Text
-              style={
-                [
-                  {
-                    "backgroundColor": "transparent",
-                    "fontFamily": "Inter",
-                    "fontSize": 12,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 18,
-                    "textAlign": "center",
-                  },
-                  {
-                    "color": "#6C727A",
-                  },
-                ]
-              }
-            />
           </View>
         </View>
         <View
@@ -5024,6 +5037,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -5051,6 +5065,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "lineHeight": 36,
                     "textAlign": "center",
                   },
+                  false,
                   {
                     "color": "#2F343D",
                   },
@@ -5119,6 +5134,7 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                 "aspectRatio": 1,
                 "borderRadius": 8,
                 "flex": 1,
+                "maxWidth": 68,
               },
               {
                 "backgroundColor": "#E4E7EA",
@@ -5147,6 +5163,12 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
                     "textAlign": "center",
                   },
                   {
+                    "fontSize": 38,
+                    "lineHeight": 40,
+                    "textAlign": "center",
+                    "textAlignVertical": "center",
+                  },
+                  {
                     "color": "#2F343D",
                   },
                 ]
@@ -5154,24 +5176,6 @@ exports[`Story Snapshots: WithValue should match snapshot 1`] = `
             >
               #
             </Text>
-            <Text
-              style={
-                [
-                  {
-                    "backgroundColor": "transparent",
-                    "fontFamily": "Inter",
-                    "fontSize": 12,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 18,
-                    "textAlign": "center",
-                  },
-                  {
-                    "color": "#6C727A",
-                  },
-                ]
-              }
-            />
           </View>
         </View>
       </View>

--- a/app/views/CallView/components/Dialpad/styles.ts
+++ b/app/views/CallView/components/Dialpad/styles.ts
@@ -5,7 +5,10 @@ import sharedStyles from '../../../Styles';
 export const styles = StyleSheet.create({
 	container: {
 		padding: 32,
-		paddingBottom: 32
+		paddingBottom: 32,
+		maxWidth: 400,
+		alignSelf: 'center',
+		width: '100%'
 	},
 	inputContainer: {
 		marginBottom: 24
@@ -16,11 +19,12 @@ export const styles = StyleSheet.create({
 	},
 	row: {
 		flexDirection: 'row',
-		justifyContent: 'space-between',
+		justifyContent: 'center',
 		gap: 40
 	},
 	button: {
 		flex: 1,
+		maxWidth: 68,
 		aspectRatio: 1,
 		borderRadius: 8
 	},
@@ -34,6 +38,12 @@ export const styles = StyleSheet.create({
 		fontSize: 32,
 		lineHeight: 36,
 		textAlign: 'center'
+	},
+	digitLarge: {
+		fontSize: 38,
+		lineHeight: 40,
+		textAlign: 'center',
+		textAlignVertical: 'center'
 	},
 	letters: {
 		...sharedStyles.textRegular,

--- a/app/views/CallView/components/__snapshots__/CallActionButton.test.tsx.snap
+++ b/app/views/CallView/components/__snapshots__/CallActionButton.test.tsx.snap
@@ -21,7 +21,8 @@ exports[`Story Snapshots: ActiveButton should match snapshot 1`] = `
       style={
         {
           "alignItems": "center",
-          "flex": 1,
+          "overflow": "hidden",
+          "width": 64,
         }
       }
     >
@@ -112,7 +113,7 @@ exports[`Story Snapshots: ActiveButton should match snapshot 1`] = `
               "fontSize": 14,
               "fontWeight": "400",
               "lineHeight": 20,
-              "textAlign": "center",
+              "textAlign": "left",
             },
             {
               "color": "#2F343D",
@@ -156,7 +157,8 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -247,7 +249,7 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -262,7 +264,8 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -353,7 +356,7 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -368,7 +371,8 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -459,7 +463,7 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -488,7 +492,8 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -579,7 +584,7 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -594,7 +599,8 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -685,7 +691,7 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -700,7 +706,8 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -791,7 +798,7 @@ exports[`Story Snapshots: AllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -828,7 +835,8 @@ exports[`Story Snapshots: DangerButton should match snapshot 1`] = `
       style={
         {
           "alignItems": "center",
-          "flex": 1,
+          "overflow": "hidden",
+          "width": 64,
         }
       }
     >
@@ -919,7 +927,7 @@ exports[`Story Snapshots: DangerButton should match snapshot 1`] = `
               "fontSize": 14,
               "fontWeight": "400",
               "lineHeight": 20,
-              "textAlign": "center",
+              "textAlign": "left",
             },
             {
               "color": "#2F343D",
@@ -955,7 +963,8 @@ exports[`Story Snapshots: DefaultButton should match snapshot 1`] = `
       style={
         {
           "alignItems": "center",
-          "flex": 1,
+          "overflow": "hidden",
+          "width": 64,
         }
       }
     >
@@ -1046,7 +1055,7 @@ exports[`Story Snapshots: DefaultButton should match snapshot 1`] = `
               "fontSize": 14,
               "fontWeight": "400",
               "lineHeight": 20,
-              "textAlign": "center",
+              "textAlign": "left",
             },
             {
               "color": "#2F343D",
@@ -1082,7 +1091,8 @@ exports[`Story Snapshots: DisabledButton should match snapshot 1`] = `
       style={
         {
           "alignItems": "center",
-          "flex": 1,
+          "overflow": "hidden",
+          "width": 64,
         }
       }
     >
@@ -1175,7 +1185,7 @@ exports[`Story Snapshots: DisabledButton should match snapshot 1`] = `
               "fontSize": 14,
               "fontWeight": "400",
               "lineHeight": 20,
-              "textAlign": "center",
+              "textAlign": "left",
             },
             {
               "color": "#2F343D",
@@ -1220,7 +1230,8 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -1311,7 +1322,7 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -1326,7 +1337,8 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -1417,7 +1429,7 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -1432,7 +1444,8 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -1523,7 +1536,7 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -1538,7 +1551,8 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -1629,7 +1643,7 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -1644,7 +1658,8 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -1735,7 +1750,7 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",
@@ -1750,7 +1765,8 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "flex": 1,
+            "overflow": "hidden",
+            "width": 64,
           }
         }
       >
@@ -1841,7 +1857,7 @@ exports[`Story Snapshots: TabletAllVariants should match snapshot 1`] = `
                 "fontSize": 14,
                 "fontWeight": "400",
                 "lineHeight": 20,
-                "textAlign": "center",
+                "textAlign": "left",
               },
               {
                 "color": "#2F343D",

--- a/app/views/CallView/index.test.tsx
+++ b/app/views/CallView/index.test.tsx
@@ -55,7 +55,8 @@ jest.mock('../../lib/hooks/useResponsiveLayout/useResponsiveLayout', () => {
 const mockShowActionSheetRef = jest.fn();
 jest.mock('../../containers/ActionSheet', () => ({
 	showActionSheetRef: (options: any) => mockShowActionSheetRef(options),
-	hideActionSheetRef: jest.fn()
+	hideActionSheetRef: jest.fn(),
+	ActionSheetProvider: ({ children }: { children: React.ReactNode }) => children
 }));
 
 // Helper to create a mock call

--- a/app/views/CallView/styles.ts
+++ b/app/views/CallView/styles.ts
@@ -61,10 +61,11 @@ export const styles = StyleSheet.create({
 	buttonsRow: {
 		flexDirection: 'row',
 		justifyContent: 'center',
-		gap: 24
+		gap: 48
 	},
 	actionButtonCell: {
-		flex: 1,
+		width: 64,
+		overflow: 'hidden',
 		alignItems: 'center'
 	},
 	actionButton: {
@@ -78,7 +79,6 @@ export const styles = StyleSheet.create({
 	actionButtonLabel: {
 		...sharedStyles.textRegular,
 		fontSize: 14,
-		lineHeight: 20,
-		textAlign: 'center'
+		lineHeight: 20
 	}
 });


### PR DESCRIPTION
## Proposed changes

Tighten CallView/Dialpad visuals and add Storybook coverage for the dialpad action sheet:

- Dialpad: enlarge `*` and `#` digits, hide the letters row for those two keys, cap container width and center it, pin button max size.
- CallView buttons: widen the row gap (24 → 48) and switch `actionButtonCell` from `flex: 1` to a fixed 64px width with overflow hidden so labels don't shove buttons off-center.
- Stories: add `WithDialpad` and `TabletWithDialpad` stories wrapping `CallView` / `TabletCallView` in `ActionSheetProvider`, and drop the tablet story width from 800 → 700 to match the new breakpoint.
- Tests: the CallView test mocks `../../containers/ActionSheet`, and the new stories import `ActionSheetProvider` from that module — stub it as a pass-through so story composition doesn't render `undefined`.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-96
https://rocketchat.atlassian.net/browse/VMUX-97


## How to test or reproduce

- `TZ=UTC yarn test` — all suites pass, 2 snapshots updated for the new stories.
- Storybook: open CallView → `WithDialpad` / `TabletWithDialpad` to verify the dialpad bottom sheet renders.
- On device: start a call, tap the dialpad button, confirm digit sizing and centered layout.

## Screenshots

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

## Further comments