### PR TITLE
fix(android): restore Google Play device support for non-phone Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,8 +22,9 @@
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
-    <uses-feature android:name="android.hardware.audio.output" />
+    <uses-feature android:name="android.hardware.audio.output" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
     <!-- android 13 notifications -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />


### PR DESCRIPTION
## Proposed changes

Fixes the Google Play warning observed when uploading builds from #6918 to production: *"This release no longer supports 3,838 devices that were supported in your previous release."*

### Root cause

#6918 adds `<uses-permission android:name="android.permission.READ_PHONE_STATE" />` to `AndroidManifest.xml`. Per Google Play's implicit feature rules, declaring `READ_PHONE_STATE` implicitly requires `android.hardware.telephony` with `required="true"`. Google Play then filters Wi-Fi-only tablets, Chromebooks, Android TVs, Android Auto units and other non-phone devices from the supported list.

#6918 also declares `<uses-feature android:name="android.hardware.audio.output" />` without `android:required="false"`, which defaults to required and excludes devices without audio output.

VoIP (WebRTC peer-to-peer over the server signaling channel) does not need a cellular radio or a mandatory audio-output feature at install time — runtime permission checks are enough.

### Change

In `android/app/src/main/AndroidManifest.xml`:

- Add explicit `<uses-feature android:name="android.hardware.telephony" android:required="false" />` to override the implicit `required="true"` introduced by `READ_PHONE_STATE`.
- Set `android:required="false"` on the existing `android.hardware.audio.output` declaration.

No code changes, no runtime behavior change.

## Issue(s)

Google Play production upload warning on #6918 builds.

## How to test or reproduce

1. Build AAB: `cd android && ./gradlew :app:bundleRelease`.
2. Upload to Google Play Console (internal / closed track is enough).
3. Open **Release → Production (or the track used) → Supported devices** and compare the total supported device count vs. the previous release. Count should return to the pre-#6918 baseline (3,838 devices restored).
4. Optional local check: `./gradlew :app:processReleaseManifest` and grep the merged manifest under `android/app/build/intermediates/merged_manifests/release/` for `uses-feature` — confirm `android.hardware.telephony` and `android.hardware.audio.output` both appear with `android:required="false"`.
5. Smoke-test a VoIP call on a phone device (telephony present) to confirm nothing regressed at runtime.

## Screenshots

N/A (manifest-only change).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Targets the `feat.voip-lib-new` branch so the fix lands inside #6918 before it merges to `develop`. If additional native libs pulled in by #6918 (`react-native-webrtc`, `react-native-callkeep`, `react-native-incall-manager`) turn out to contribute their own implicit feature requirements, those can be overridden with the same `required="false"` pattern in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded device compatibility by making audio output and telephony features optional, allowing the app to be installed on a broader range of devices that may lack these capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->