### PR TITLE
fix(voip): pending-accept test mocks

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipModule.kt
@@ -19,6 +19,7 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
         private const val TAG = "RocketChat.VoipModule"
         private const val EVENT_VOIP_ACCEPT_SUCCEEDED = "VoipAcceptSucceeded"
         private const val EVENT_VOIP_ACCEPT_FAILED = "VoipAcceptFailed"
+        private const val EVENT_VOIP_PENDING_ACCEPT = "VoipPendingAccept"
 
         private var reactContextRef: WeakReference<ReactApplicationContext>? = null
 
@@ -81,6 +82,21 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to emit VoipAcceptFailed", e)
+            }
+        }
+
+        @JvmStatic
+        fun emitPendingAcceptEvent(voipPayload: VoipPayload) {
+            try {
+                reactContextRef?.get()?.let { context ->
+                    if (context.hasActiveReactInstance()) {
+                        context
+                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                            .emit(EVENT_VOIP_PENDING_ACCEPT, mapOf("callId" to voipPayload.callId, "payload" to voipPayload.toWritableMap()))
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to emit VoipPendingAccept", e)
             }
         }
 
@@ -156,6 +172,14 @@ class VoipModule(reactContext: ReactApplicationContext) : NativeVoipSpec(reactCo
         } catch (e: Exception) {
             Log.e(TAG, "stopVoipCallService: failed to stop service", e)
         }
+    }
+
+    /**
+     * Continues a native-accepted VoIP call that was queued in the pending-accept window.
+     * Android: No-op (Android handles accept natively via Telecom).
+     */
+    override fun proceedAccept(callId: String) {
+        Log.d(TAG, "proceedAccept called on Android (no-op)")
     }
 
     /**

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipPayload.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipPayload.kt
@@ -20,19 +20,19 @@ enum class VoipPushType(val value: String) {
 data class VoipPayload(
     @SerializedName("callId")
     val callId: String,
-    
+
     @SerializedName("caller")
     val caller: String,
 
     @SerializedName("username")
     val username: String,
-    
+
     @SerializedName("host")
     val host: String,
-    
+
     @SerializedName("type")
     val type: String,
-    
+
     @SerializedName("hostName")
     val hostName: String,
 
@@ -43,6 +43,7 @@ data class VoipPayload(
     val createdAt: String?,
 
     val voipAcceptFailed: Boolean = false,
+    val pendingAccept: Boolean = false,
 ) {
     val notificationId: Int = callId.hashCode()
     val pushType: VoipPushType?
@@ -73,6 +74,7 @@ data class VoipPayload(
             putString("createdAt", createdAt)
             putInt("notificationId", notificationId)
             putBoolean("voipAcceptFailed", voipAcceptFailed)
+            putBoolean("pendingAccept", pendingAccept)
             // Useful flag for MainActivity to know it's handling a VoIP action
             putBoolean("voipAction", true)
         }
@@ -91,6 +93,9 @@ data class VoipPayload(
             putInt("notificationId", notificationId)
             if (voipAcceptFailed) {
                 putBoolean("voipAcceptFailed", true)
+            }
+            if (pendingAccept) {
+                putBoolean("pendingAccept", true)
             }
         }
     }
@@ -196,7 +201,8 @@ data class VoipPayload(
             }
 
             val voipAcceptFailed = bundle.getBoolean("voipAcceptFailed", false)
-            return VoipPayload(callId, caller, username, host, type, hostName, avatarUrl, createdAt, voipAcceptFailed)
+            val pendingAccept = bundle.getBoolean("pendingAccept", false)
+            return VoipPayload(callId, caller, username, host, type, hostName, avatarUrl, createdAt, voipAcceptFailed, pendingAccept)
         }
 
         private fun parseRemotePayload(data: Map<String, String>): RemoteVoipPayload? {

--- a/app/definitions/Voip.ts
+++ b/app/definitions/Voip.ts
@@ -15,4 +15,5 @@ export interface VoipPayload {
 	readonly createdAt?: string | null;
 	readonly notificationId: number;
 	readonly voipAcceptFailed?: boolean;
+	readonly pendingAccept?: boolean;
 }

--- a/app/lib/native/NativeVoip.ts
+++ b/app/lib/native/NativeVoip.ts
@@ -43,6 +43,13 @@ export interface Spec extends TurboModule {
 	stopVoipCallService(): void;
 
 	/**
+	 * Continues a native-accepted VoIP call that was queued in the pending-accept window.
+	 * iOS: Calls `proceedAccept` on VoipService.
+	 * Android: No-op (Android handles accept natively).
+	 */
+	proceedAccept(callId: string): void;
+
+	/**
 	 * Required for NativeEventEmitter in TurboModules.
 	 * Called when JS starts listening to events.
 	 * @platform android
@@ -66,6 +73,7 @@ const NativeVoipModule =
 		getLastVoipToken: () => '',
 		stopNativeDDPClient: () => undefined,
 		stopVoipCallService: () => undefined,
+		proceedAccept: () => undefined,
 		addListener: () => undefined,
 		removeListeners: () => undefined
 	} as Spec);

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -17,9 +17,73 @@ const mockAddEventListener = jest.fn();
 const mockRNCallKeepClearInitialEvents = jest.fn();
 const mockSetCurrentCallActive = jest.fn();
 
+/**
+ * Shared event bus: lets tests synchronously trigger listeners registered via NativeEventEmitter.
+ * Stored on global so the mock factory can access the same map.
+ */
+(global as any).__nativeEventBus__ = new Map<string, Set<(data: any) => void>>();
+
+/**
+ * Complete react-native mock using __nativeEventBus__.
+ * Both NativeEventEmitter (used by MediaCallEvents to create Emitter) and DeviceEventEmitter
+ * (used by tests to emit events) share the same bus, so listeners registered via
+ * NativeEventEmitter.addListener are triggered by DeviceEventEmitter.emit.
+ */
+jest.mock('react-native', () => {
+	class MockNativeEventEmitter {
+		private nativeModule: any;
+		constructor(nativeModule?: any) {
+			this.nativeModule = nativeModule;
+		}
+		addListener(event: string, handler: (...args: any[]) => void) {
+			this.nativeModule?.addListener(event);
+			const bus = (global as any).__nativeEventBus__;
+			if (!bus.has(event)) bus.set(event, new Set());
+			bus.get(event)!.add(handler);
+			return { remove: () => bus.get(event)?.delete(handler) };
+		}
+		removeAllListeners(_event: string) {
+			this.nativeModule?.removeListeners(1);
+		}
+		emit(event: string, ...args: any[]) {
+			const bus = (global as any).__nativeEventBus__;
+			bus.get(event)?.forEach((h: (...args: any[]) => void) => {
+				if (typeof h === 'function') h(...args);
+			});
+		}
+		listenerCount(event: string) {
+			return (global as any).__nativeEventBus__.get(event)?.size ?? 0;
+		}
+	}
+
+	const DeviceEventEmitter = {
+		emit(event: string, ...args: any[]) {
+			const bus = (global as any).__nativeEventBus__;
+			bus.get(event)?.forEach((h: (...args: any[]) => void) => {
+				if (typeof h === 'function') {
+					h(...args);
+				}
+			});
+		},
+		addListener(event: string, handler: (...args: any[]) => void) {
+			const bus = (global as any).__nativeEventBus__;
+			if (!bus.has(event)) bus.set(event, new Set());
+			bus.get(event)!.add(handler);
+			return { remove: () => bus.get(event)?.delete(handler) };
+		},
+		removeListeners(_count: number) {}
+	};
+
+	return {
+		NativeEventEmitter: MockNativeEventEmitter,
+		DeviceEventEmitter,
+		Platform: { OS: 'ios', select: (obj: any) => obj.ios }
+	};
+});
+
 jest.mock('../../methods/helpers', () => ({
-	...jest.requireActual('../../methods/helpers'),
-	isIOS: false
+	isIOS: true,
+	normalizeDeepLinkingServerHost: (host: string) => host
 }));
 
 const mockServerSelector = jest.fn(() => 'https://workspace-a.example.com');
@@ -33,15 +97,31 @@ function makeTestAdapters(): MediaCallEventsAdapters {
 
 jest.mock('./useCallStore', () => ({
 	useCallStore: {
-		getState: jest.fn()
+		getState: jest.fn(),
+		setState: jest.fn()
 	}
 }));
 
 jest.mock('../../native/NativeVoip', () => ({
 	__esModule: true,
 	default: {
+		addListener: jest.fn((event: string, handler: (data: any) => void) => {
+			const bus = (global as any).__nativeEventBus__;
+			if (!bus.has(event)) bus.set(event, new Set());
+			bus.get(event)!.add(handler);
+			return { remove: () => bus.get(event)?.delete(handler) };
+		}),
+		removeListeners: jest.fn(),
 		clearInitialEvents: jest.fn(),
-		getInitialEvents: jest.fn(() => null)
+		getInitialEvents: jest.fn(() => null),
+		proceedAccept: jest.fn(),
+		resetFromLogout: jest.fn(),
+		emit: (event: string, data: any) => {
+			const bus = (global as any).__nativeEventBus__;
+			bus.get(event)?.forEach((handler: (data: any) => void) => {
+				if (typeof handler === 'function') handler(data);
+			});
+		}
 	}
 }));
 
@@ -58,8 +138,18 @@ jest.mock('react-native-callkeep', () => ({
 jest.mock('./MediaSessionInstance', () => ({
 	mediaSessionInstance: {
 		endCall: jest.fn(),
-		applyRestStateSignals: jest.fn(() => Promise.resolve())
+		applyRestStateSignals: jest.fn(() => Promise.resolve()),
+		registerOnInitComplete: jest.fn()
 	}
+}));
+
+jest.mock('./clearPendingCallView', () => ({
+	clearPendingCallView: jest.fn()
+}));
+
+jest.mock('../../navigation/appNavigation', () => ({
+    __esModule: true,
+    default: { navigate: jest.fn(), back: jest.fn() }
 }));
 
 jest.mock('../restApi', () => ({
@@ -464,5 +554,195 @@ describe('setupMediaCallEvents — didToggleHoldCallAction', () => {
 		const cleanup = setupMediaCallEvents(makeTestAdapters());
 		cleanup();
 		expect(remove).toHaveBeenCalled();
+	});
+});
+
+describe('Pending-accept fast-path acceptance tests', () => {
+	const getState = useCallStore.getState as jest.Mock;
+	const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
+	const { clearPendingCallView } = jest.requireMock('./clearPendingCallView');
+	const { default: Navigation } = jest.requireMock('../../navigation/appNavigation');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		(global as any).__nativeEventBus__.clear();
+		resetMediaCallEventsStateForTesting();
+		mockAddEventListener.mockImplementation(() => ({ remove: jest.fn() }));
+		mediaSessionInstance.registerOnInitComplete.mockClear();
+		mediaSessionInstance.registerOnInitComplete.mockImplementation((cb: () => void) => {
+			// Simulate MediaSessionInstance already initialized: invoke cb immediately
+			cb();
+		});
+		getState.mockReturnValue({
+			setNativeAcceptedCallId: mockSetNativeAcceptedCallId,
+			setContact: jest.fn()
+		});
+	});
+
+	describe('AC1: VoipPendingAccept queues callId and navigates to CallView', () => {
+		it('emits VoipPendingAccept → queuedCallIds has callId + calls setNativeAcceptedCallId + setContact + navigates to CallView', () => {
+			const teardown = setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({
+				callId: 'pending-call-1',
+				caller: 'Bob Burnquist',
+				username: 'bob.burnquist'
+			});
+
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'pending-call-1', payload });
+
+			expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith('pending-call-1');
+			expect(getState().setContact).toHaveBeenCalledWith({
+				displayName: 'Bob Burnquist',
+				username: 'bob.burnquist'
+			});
+			expect(Navigation.navigate).toHaveBeenCalledWith('CallView');
+			teardown();
+		});
+
+		it('second VoipPendingAccept with same callId is ignored (dedup)', () => {
+			const teardown = setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({ callId: 'dup-accept', caller: 'Alice', username: 'alice' });
+
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'dup-accept', payload });
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'dup-accept', payload });
+
+			expect(mockSetNativeAcceptedCallId).toHaveBeenCalledTimes(1);
+			expect(getState().setContact).toHaveBeenCalledTimes(1);
+			expect(Navigation.navigate).toHaveBeenCalledTimes(1);
+			teardown();
+		});
+	});
+
+	describe('AC2: VoipAcceptSucceeded with queued callId removes from queue and proceeds', () => {
+		it('VoipAcceptSucceeded for a queued callId clears it from queuedCallIds', () => {
+			const teardown = setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({ callId: 'queue-succeeded', host: 'https://workspace-b.example.com' });
+
+			// Queue the call
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'queue-succeeded', payload });
+			expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith('queue-succeeded');
+
+			// Accept succeeds — queuedCallIds entry should be gone
+			DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+
+			// The callId should not be in queuedCallIds anymore
+			const { isCallIdQueued } = jest.requireActual('./MediaCallEvents');
+			expect(isCallIdQueued('queue-succeeded')).toBe(false);
+			teardown();
+		});
+	});
+
+	describe('AC3: VoipAcceptFailed for queued callId clears queue and shows error', () => {
+		it('VoipAcceptFailed for a queued callId removes it from queuedCallIds and calls clearPendingCallView', () => {
+			const teardown = setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({
+				callId: 'queue-failed',
+				host: 'https://workspace-b.example.com',
+				username: 'bob'
+			});
+
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'queue-failed', payload });
+			expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith('queue-failed');
+
+			DeviceEventEmitter.emit('VoipAcceptFailed', {
+				...payload,
+				voipAcceptFailed: true
+			});
+
+			const { isCallIdQueued } = jest.requireActual('./MediaCallEvents');
+			expect(isCallIdQueued('queue-failed')).toBe(false);
+			expect(clearPendingCallView).toHaveBeenCalledTimes(1);
+			expect(mockOnOpenDeepLink).toHaveBeenCalledWith({
+				host: 'https://workspace-b.example.com',
+				callId: 'queue-failed',
+				username: 'bob',
+				voipAcceptFailed: true
+			});
+			teardown();
+		});
+	});
+
+	describe('AC4: isCallIdQueued guards notification/accepted DDP handling', () => {
+		it('notification/accepted handler should skip processing for a queued callId', () => {
+			setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({
+				callId: 'guard-test',
+				host: 'https://workspace-b.example.com'
+			});
+
+			// Queue the call
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'guard-test', payload });
+
+			// Simulate DDP notification/accepted arriving — it should be ignored because callId is queued
+			const { isCallIdQueued } = jest.requireActual('./MediaCallEvents');
+			expect(isCallIdQueued('guard-test')).toBe(true);
+		});
+	});
+
+	describe('AC5: registerOnInitComplete queues proceedAccept until init', () => {
+		it('proceedAccept is registered as an onInitComplete callback', () => {
+			const teardown = setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({ callId: 'init-callback-test' });
+
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'init-callback-test', payload });
+
+			expect(mediaSessionInstance.registerOnInitComplete).toHaveBeenCalledTimes(1);
+			// Callback was invoked immediately since init was complete in the mock
+			teardown();
+		});
+	});
+
+	describe('AC6: TTL expiry removes from queue and calls clearPendingCallView', () => {
+		it('VoipAcceptFailed with a TTL-expiry callId clears queue and triggers error view', () => {
+			const teardown = setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({
+				callId: 'ttl-expired',
+				host: 'https://workspace-b.example.com',
+				username: 'bob'
+			});
+
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'ttl-expired', payload });
+			expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith('ttl-expired');
+
+			// Simulate TTL expiry by emitting VoipAcceptFailed
+			DeviceEventEmitter.emit('VoipAcceptFailed', {
+				...payload,
+				voipAcceptFailed: true
+			});
+
+			const { isCallIdQueued } = jest.requireActual('./MediaCallEvents');
+			expect(isCallIdQueued('ttl-expired')).toBe(false);
+			expect(clearPendingCallView).toHaveBeenCalledTimes(1);
+			expect(mockOnOpenDeepLink).toHaveBeenCalledWith({
+				host: 'https://workspace-b.example.com',
+				callId: 'ttl-expired',
+				username: 'bob',
+				voipAcceptFailed: true
+			});
+			teardown();
+		});
+	});
+
+	describe('AC7: resetMediaCallEventsStateForTesting clears all sentinels', () => {
+		it('after resetMediaCallEventsStateForTesting, previously queued callIds can be re-processed', () => {
+			setupMediaCallEvents(makeTestAdapters());
+			const payload = buildIncomingPayload({
+				callId: 'reset-sentinel',
+				host: 'https://workspace-b.example.com'
+			});
+
+			// Queue a callId
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'reset-sentinel', payload });
+			let { isCallIdQueued } = jest.requireActual('./MediaCallEvents');
+			expect(isCallIdQueued('reset-sentinel')).toBe(true);
+
+			// Reset all sentinels
+			resetMediaCallEventsStateForTesting();
+
+			// Same callId can now be queued again
+			DeviceEventEmitter.emit('VoipPendingAccept', { callId: 'reset-sentinel', payload });
+			({ isCallIdQueued } = jest.requireActual('./MediaCallEvents'));
+			expect(isCallIdQueued('reset-sentinel')).toBe(true);
+		});
 	});
 });

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -126,13 +126,16 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	});
 }
 
-function handleVoipPendingAccept({ callId }: { callId: string; payload: VoipPayload }) {
-	// payload is kept in the param type for documentation; callId is the only field needed
+function handleVoipPendingAccept({ callId, payload }: { callId: string; payload: VoipPayload }) {
 	if (queuedCallIds.has(callId)) {
 		return;
 	}
 	queuedCallIds.add(callId);
 	useCallStore.getState().setNativeAcceptedCallId(callId);
+	useCallStore.getState().setContact({
+		displayName: payload.caller,
+		username: payload.username
+	});
 	Navigation.navigate('CallView');
 	mediaCallLogger.debug(`${TAG} VoIP FAST ACCEPT QUEUED`, { callId });
 	mediaSessionInstance.registerOnInitComplete(() => NativeVoipModule.proceedAccept(callId));

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -8,6 +8,8 @@ import type { VoipPayload } from '../../../definitions/Voip';
 import NativeVoipModule from '../../native/NativeVoip';
 import { registerPushToken } from '../restApi';
 import { MediaCallLogger } from './MediaCallLogger';
+import { clearPendingCallView } from './clearPendingCallView';
+import Navigation from '../../navigation/appNavigation';
 
 const Emitter = isIOS ? new NativeEventEmitter(NativeVoipModule) : DeviceEventEmitter;
 const platform = isIOS ? 'iOS' : 'Android';
@@ -16,6 +18,7 @@ const mediaCallLogger = new MediaCallLogger();
 
 const EVENT_VOIP_ACCEPT_FAILED = 'VoipAcceptFailed';
 const EVENT_VOIP_ACCEPT_SUCCEEDED = 'VoipAcceptSucceeded';
+const EVENT_VOIP_PENDING_ACCEPT = 'VoipPendingAccept';
 
 // Populated by handleVoipPendingAccept in Phase 2
 const queuedCallIds = new Set<string>();
@@ -103,6 +106,13 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	}
 	mediaCallLogger.debug(`${TAG} VoipAcceptSucceeded:`, data);
 	NativeVoipModule.clearInitialEvents();
+
+	// If this callId was queued, remove from set and log completion
+	if (callId && queuedCallIds.has(callId)) {
+		queuedCallIds.delete(callId);
+		mediaCallLogger.debug(`${TAG} VoIP FAST ACCEPT COMPLETED`, { callId });
+	}
+
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
 	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
 		mediaSessionInstance.applyRestStateSignals().catch(error => {
@@ -114,6 +124,18 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 		callId: data.callId,
 		host: data.host
 	});
+}
+
+function handleVoipPendingAccept({ callId }: { callId: string; payload: VoipPayload }) {
+	// payload is kept in the param type for documentation; callId is the only field needed
+	if (queuedCallIds.has(callId)) {
+		return;
+	}
+	queuedCallIds.add(callId);
+	useCallStore.getState().setNativeAcceptedCallId(callId);
+	Navigation.navigate('CallView');
+	mediaCallLogger.debug(`${TAG} VoIP FAST ACCEPT QUEUED`, { callId });
+	mediaSessionInstance.registerOnInitComplete(() => NativeVoipModule.proceedAccept(callId));
 }
 
 /**
@@ -211,8 +233,26 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 	subscriptions.push(
 		Emitter.addListener(EVENT_VOIP_ACCEPT_FAILED, (data: VoipPayload & { voipAcceptFailed?: boolean }) => {
 			mediaCallLogger.debug(`${TAG} VoipAcceptFailed event:`, data);
+
+			// If this callId was queued, remove from set and treat as TTL expiry
+			if (data.callId && queuedCallIds.has(data.callId)) {
+				queuedCallIds.delete(data.callId);
+				mediaCallLogger.debug(`${TAG} VoIP FAST ACCEPT TTL_EXPIRED`, { callId: data.callId });
+				clearPendingCallView();
+			}
+
 			dispatchVoipAcceptFailureFromNative({ ...data, voipAcceptFailed: true }, adapters.onOpenDeepLink);
 			NativeVoipModule.clearInitialEvents();
+		})
+	);
+
+	subscriptions.push(
+		Emitter.addListener(EVENT_VOIP_PENDING_ACCEPT, (data: { callId: string; payload: VoipPayload }) => {
+			try {
+				handleVoipPendingAccept(data);
+			} catch (error) {
+				mediaCallLogger.error(`${TAG} Error handling VoipPendingAccept:`, error);
+			}
 		})
 	);
 
@@ -240,6 +280,13 @@ export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapter
 			RNCallKeep.clearInitialEvents();
 			NativeVoipModule.clearInitialEvents();
 			// Avoid racing `appInit()` with the deep-linking saga that handles the failure
+			return true;
+		}
+
+		if (initialEvents.pendingAccept && initialEvents.callId) {
+			mediaCallLogger.debug(`${TAG} Cold start: pendingAccept fast path`, { callId: initialEvents.callId });
+			handleVoipPendingAccept({ callId: initialEvents.callId, payload: initialEvents as VoipPayload });
+			RNCallKeep.clearInitialEvents();
 			return true;
 		}
 

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -17,6 +17,18 @@ const mediaCallLogger = new MediaCallLogger();
 const EVENT_VOIP_ACCEPT_FAILED = 'VoipAcceptFailed';
 const EVENT_VOIP_ACCEPT_SUCCEEDED = 'VoipAcceptSucceeded';
 
+// Populated by handleVoipPendingAccept in Phase 2
+const queuedCallIds = new Set<string>();
+
+/**
+ * Returns true when the given callId is currently in the native fast-accept pending-accept
+ * window. Consumers must short-circuit any live-DDP `notification/accepted` handling for
+ * queued callIds — `proceedAccept` is the sole `answerCall` trigger during that window.
+ */
+export function isCallIdQueued(callId: string): boolean {
+	return queuedCallIds.has(callId);
+}
+
 /** Params forwarded into the app deep-linking pipeline for VoIP-driven navigation. */
 export type VoipDeepLinkParams = {
 	host?: string;

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -83,17 +83,25 @@ jest.mock('react-native-callkeep', () => ({
 	}
 }));
 
+jest.mock('../../methods/helpers', () => ({
+	isIOS: false,
+	normalizeDeepLinkingServerHost: (host: string) => host
+}));
+
 jest.mock('react-native-device-info', () => ({
+	__esModule: true,
 	default: {
 		getUniqueId: jest.fn(() => 'test-device-id'),
 		getUniqueIdSync: jest.fn(() => 'test-device-id'),
 		hasNotch: jest.fn(() => false),
-		getReadableVersion: jest.fn(() => '1.0.0')
+		getReadableVersion: jest.fn(() => '1.0.0'),
+		getBundleId: jest.fn(() => 'com.rocket.chat.test')
 	},
 	getUniqueId: jest.fn(() => 'test-device-id'),
 	getUniqueIdSync: jest.fn(() => 'test-device-id'),
 	hasNotch: jest.fn(() => false),
-	getReadableVersion: jest.fn(() => '1.0.0')
+	getReadableVersion: jest.fn(() => '1.0.0'),
+	getBundleId: jest.fn(() => 'com.rocket.chat.test')
 }));
 
 jest.mock('../../native/NativeVoip', () => ({

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -16,6 +16,7 @@ import { dequal } from 'dequal';
 import { mediaSessionStore } from './MediaSessionStore';
 import { terminateNativeCall } from './terminateNativeCall';
 import { useCallStore } from './useCallStore';
+import { isCallIdQueued } from './MediaCallEvents';
 import { store } from '../../store/auxStore';
 import sdk from '../sdk';
 import { mediaCallsStateSignals } from '../restApi';
@@ -28,6 +29,16 @@ import { getDMSubscriptionByUsername } from '../../database/services/Subscriptio
 import { getUidDirectMessage } from '../../methods/helpers/helpers';
 import { requestPhoneStatePermission } from '../../methods/voipPhoneStatePermission';
 
+/**
+ * Invariant: `proceedAccept` is the only path that fires `answerCall` for callIds in
+ * the pending-accept queue. During the pending-accept window `mainCall` is still null,
+ * so if we let the live `notification/accepted` DDP signal drive `answerCall`, it falls
+ * through the `mainCall == null` branch and terminates the native call via
+ * `terminateNativeCall` / `RNCallKeep.endCall`. Instead, `handleVoipPendingAccept`
+ * registers an init-complete callback that invokes `NativeVoipModule.proceedAccept`,
+ * which is the authoritative trigger. Do not reintroduce the direct-answer path for
+ * queued callIds or the cold-start fast-accept race will regress.
+ */
 class MediaSessionInstance {
 	private iceServers: IceServer[] = [];
 	private iceGatheringTimeout: number = 5000;
@@ -36,8 +47,17 @@ class MediaSessionInstance {
 	private mediaSessionStoreChangeUnsubscribe: (() => void) | null = null;
 	private storeTimeoutUnsubscribe: (() => void) | null = null;
 	private storeIceServersUnsubscribe: (() => void) | null = null;
+	private pendingInitCallbacks: Array<() => void> = [];
 
 	private tryAnswerIfNativeAcceptedNotification(signal: ServerMediaSignal): void {
+		// Live-DDP race guard: during pending-accept window, `proceedAccept` is the sole
+		// trigger for `answerCall`. Covers both call sites (`applyRestStateSignals` and the
+		// stream-notify-user listener). See class-level Invariant comment.
+		// TypeScript doesn't narrow ServerMediaSignal union via `type === 'notification'` alone,
+		// so we cast to access callId on the notification variant.
+		if (isCallIdQueued((signal as any).callId)) {
+			return;
+		}
 		const { call, nativeAcceptedCallId } = useCallStore.getState();
 		if (
 			signal.type === 'notification' &&
@@ -50,6 +70,24 @@ class MediaSessionInstance {
 				console.error('[VoIP] Error answering call on notification/accepted:', error);
 			});
 		}
+	}
+
+	/**
+	 * Registers a callback to fire once `init()` finishes populating `this.instance` and
+	 * replaying REST state signals. If `init` has already completed, invokes the callback
+	 * synchronously. FIFO drain order; `reset()` clears any queued callbacks.
+	 */
+	public registerOnInitComplete(cb: () => void): void {
+		if (this.instance) {
+			cb();
+			return;
+		}
+		this.pendingInitCallbacks.push(cb);
+	}
+
+	/** No-op stub; wired to `NativeVoipModule.resetFromLogout` in Phase 6. */
+	private notifyNativeReset(): void {
+		// TODO: wired in Phase 6
 	}
 
 	/** Replays `media-calls.stateSignals`. Used on init and when native accept raced ahead of `nativeAcceptedCallId`. Caller must ensure SDK/session host matches the call (see MediaCallEvents host gate). `tryAnswerIfNativeAcceptedNotification` may also fire from the stream-notify-user path; `answerCall` is idempotent. */
@@ -134,6 +172,18 @@ class MediaSessionInstance {
 				});
 			}
 		});
+
+		// FIFO drain of callbacks registered before init completed. Swap-then-clear so
+		// callbacks that re-register (or that queue new ones) are not re-drained here.
+		const callbacks = this.pendingInitCallbacks;
+		this.pendingInitCallbacks = [];
+		for (const cb of callbacks) {
+			try {
+				cb();
+			} catch (error) {
+				console.error('[VoIP] pending init callback threw:', error);
+			}
+		}
 	}
 
 	public answerCall = async (callId: string) => {
@@ -236,6 +286,7 @@ class MediaSessionInstance {
 	}
 
 	public reset() {
+		this.notifyNativeReset();
 		if (this.mediaSessionStoreChangeUnsubscribe) {
 			this.mediaSessionStoreChangeUnsubscribe();
 			this.mediaSessionStoreChangeUnsubscribe = null;
@@ -252,6 +303,7 @@ class MediaSessionInstance {
 			this.storeIceServersUnsubscribe();
 			this.storeIceServersUnsubscribe = null;
 		}
+		this.pendingInitCallbacks = [];
 		mediaSessionStore.dispose();
 		this.instance = null;
 		useCallStore.getState().reset();

--- a/app/lib/services/voip/clearPendingCallView.ts
+++ b/app/lib/services/voip/clearPendingCallView.ts
@@ -1,0 +1,8 @@
+import { useCallStore } from './useCallStore';
+import Navigation from '../../navigation/appNavigation';
+
+export function clearPendingCallView(): void {
+	useCallStore.getState().resetNativeCallId();
+	// If we're on CallView, navigate back
+	Navigation.back();
+}

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -10,6 +10,12 @@ import { useIsScreenReaderEnabled } from '../../hooks/useIsScreenReaderEnabled';
 
 const STALE_NATIVE_MS = 60_000;
 
+/**
+ * Source of truth for the JS-readiness deadline for native fast-accept handshake;
+ * native sides (iOS `VoipService.swift`, Android `VoipNotification.kt`) must match this value.
+ */
+export const PENDING_ACCEPT_TTL_MS = 15_000;
+
 let callListenersCleanup: (() => void) | null = null;
 let staleNativeTimer: ReturnType<typeof setTimeout> | null = null;
 /** Call id this timer is for; only `nativeAcceptedCallId` is cleared when it fires, not `callId`. */

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -102,6 +102,7 @@ interface CallStoreActions {
 	reset: () => void;
 	setDialpadValue: (value: string) => void;
 	setRoomId: (roomId: string | null) => void;
+	setContact: (contact: CallContact) => void;
 }
 
 export type CallStore = CallStoreState & CallStoreActions;
@@ -277,6 +278,10 @@ export const useCallStore = create<CallStore>((set, get) => ({
 
 	setRoomId: (roomId: string | null) => {
 		set({ roomId });
+	},
+
+	setContact: (contact: CallContact) => {
+		set({ contact });
 	},
 
 	endCall: () => {

--- a/app/views/CallView/CallView.stories.tsx
+++ b/app/views/CallView/CallView.stories.tsx
@@ -96,7 +96,13 @@ export const ConnectedCall = () => {
 };
 
 export const ConnectingCall = () => {
-	setStoreState({ callState: 'accepted', callStartTime: null });
+	setStoreState({
+		call: null,
+		nativeAcceptedCallId: 'pending-call-id',
+		callState: 'none',
+		callStartTime: null,
+		contact: { displayName: 'Bob Burnquist', username: 'bob.burnquist' }
+	});
 	return <CallView />;
 };
 
@@ -150,7 +156,13 @@ export const TabletConnectedCall = () => {
 };
 
 export const TabletConnectingCall = () => {
-	setStoreState({ callState: 'accepted', callStartTime: null });
+	setStoreState({
+		call: null,
+		nativeAcceptedCallId: 'pending-call-id',
+		callState: 'none',
+		callStartTime: null,
+		contact: { displayName: 'Bob Burnquist', username: 'bob.burnquist' }
+	});
 	return <TabletCallView />;
 };
 

--- a/app/views/CallView/components/CallerInfo.tsx
+++ b/app/views/CallView/components/CallerInfo.tsx
@@ -9,7 +9,11 @@ import { useIsScreenReaderEnabled } from '../../../lib/hooks/useIsScreenReaderEn
 import { CONTROLS_ANIMATION_DURATION, styles } from '../styles';
 import { useTheme } from '../../../theme';
 
-const CallerInfo = (): React.ReactElement => {
+interface CallerInfoProps {
+	isConnecting?: boolean;
+}
+
+const CallerInfo = ({ isConnecting = false }: CallerInfoProps): React.ReactElement => {
 	const { colors } = useTheme();
 	const contact = useCallContact();
 	const toggleControlsVisible = useCallStore(state => state.toggleControlsVisible);
@@ -38,6 +42,11 @@ const CallerInfo = (): React.ReactElement => {
 				<Text style={[styles.caller, { color: colors.fontDefault }]} numberOfLines={1} testID='caller-info-name'>
 					{name}
 				</Text>
+				{isConnecting && (
+					<Text style={[styles.statusText, { color: colors.fontHint }]} testID='caller-info-status'>
+						{I18n.t('Connecting')}
+					</Text>
+				)}
 			</Animated.View>
 		</Pressable>
 	);

--- a/app/views/CallView/index.tsx
+++ b/app/views/CallView/index.tsx
@@ -12,15 +12,17 @@ const CallView = (): React.ReactElement | null => {
 
 	const { colors } = useTheme();
 	const call = useCallStore(state => state.call);
+	const nativeAcceptedCallId = useCallStore(state => state.nativeAcceptedCallId);
+	const isConnecting = !call && !!nativeAcceptedCallId;
 
-	if (!call) {
+	if (!call && !isConnecting) {
 		return null;
 	}
 
 	return (
 		<SafeAreaView testID='call-view-container' style={[styles.contentContainer, { backgroundColor: colors.surfaceLight }]}>
-			<CallerInfo />
-			<CallButtons />
+			<CallerInfo isConnecting={isConnecting} />
+			{isConnecting ? null : <CallButtons />}
 		</SafeAreaView>
 	);
 };

--- a/ios/Libraries/VoipModule.mm
+++ b/ios/Libraries/VoipModule.mm
@@ -35,7 +35,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"VoipPushTokenRegistered", @"VoipAcceptFailed", @"VoipAcceptSucceeded"];
+    return @[@"VoipPushTokenRegistered", @"VoipAcceptFailed", @"VoipAcceptSucceeded", @"VoipPendingAccept"];
 }
 
 - (void)startObserving {
@@ -115,6 +115,12 @@ RCT_EXPORT_MODULE()
 
 - (void)stopNativeDDPClient {
     [VoipService stopDDPClient];
+}
+
+- (void)proceedAccept:(NSString *)callId {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [VoipService proceedAccept:callId];
+    });
 }
 
 // TurboModule codegen calls these on VoipModule directly. Empty implementations replaced

--- a/ios/Libraries/VoipPayload.swift
+++ b/ios/Libraries/VoipPayload.swift
@@ -89,6 +89,7 @@ public class VoipPayload: NSObject {
     @objc public let avatarUrl: String?
     @objc public let createdAt: String?
     @objc public let voipAcceptFailed: Bool
+    @objc public let pendingAccept: Bool
 
     private var createdAtDate: Date? {
         return Self.parseCreatedAt(createdAt)
@@ -136,7 +137,8 @@ public class VoipPayload: NSObject {
         hostName: String,
         avatarUrl: String?,
         createdAt: String?,
-        voipAcceptFailed: Bool = false
+        voipAcceptFailed: Bool = false,
+        pendingAccept: Bool = false
     ) {
         self.callId = callId
         self.callUUID = callUUID
@@ -148,6 +150,7 @@ public class VoipPayload: NSObject {
         self.avatarUrl = avatarUrl
         self.createdAt = createdAt
         self.voipAcceptFailed = voipAcceptFailed
+        self.pendingAccept = pendingAccept
         super.init()
     }
 
@@ -171,6 +174,9 @@ public class VoipPayload: NSObject {
         ]
         if voipAcceptFailed {
             dict["voipAcceptFailed"] = true
+        }
+        if pendingAccept {
+            dict["pendingAccept"] = true
         }
         return dict
     }

--- a/ios/Libraries/VoipService.swift
+++ b/ios/Libraries/VoipService.swift
@@ -55,6 +55,9 @@ public final class VoipService: NSObject {
     private static let incomingCallObserver = IncomingCallObserver()
     private static var isCallObserverConfigured = false
     private static var observedIncomingCalls: [UUID: ObservedIncomingCall] = [:]
+    /// Stores payloads for calls that were native-accepted during the pending-accept window
+    /// (JS hadn't booted yet). Cleared when JS calls `proceedAccept` or when the call ends.
+    private static var pendingAcceptPayloads: [String: VoipPayload] = [:]
     /// Deduplication guard: `CXCallObserver` can call `callChanged` with `hasConnected = true`
     /// multiple times for the same call (e.g. observer re-registration, system race). This set
     /// ensures `handleNativeAccept` sends the DDP accept signal exactly once per `callId` (not a
@@ -225,6 +228,45 @@ public final class VoipService: NSObject {
         #if DEBUG
         print("[\(TAG)] Cleared initial events")
         #endif
+    }
+
+    // MARK: - Pending Accept (Fast Accept Handoff)
+
+    /// Stores a payload for a call that was native-accepted before JS was ready.
+    /// Called from `handleNativeAccept` when a fast-accept occurs.
+    @objc
+    public static func storePendingAccept(_ payload: VoipPayload) {
+        bridgeStateQueue.sync {
+            pendingAcceptPayloads[payload.callId] = payload
+            #if DEBUG
+            print("[\(TAG)] Stored pending accept payload: \(payload.callId)")
+            #endif
+        }
+    }
+
+    /// Called from JS after `init` completes to continue a native-accepted call.
+    /// Retrieves the stored payload and sends the REST accept (or is a no-op if already accepted).
+    @objc
+    public static func proceedAccept(_ callId: String) {
+        guard let payload = bridgeStateQueue.sync({ pendingAcceptPayloads[callId] }) else {
+            #if DEBUG
+            print("[\(TAG)] proceedAccept: no stored payload for \(callId)")
+            #endif
+            return
+        }
+
+        #if DEBUG
+        print("[\(TAG)] proceedAccept: resuming accept for \(callId)")
+        #endif
+
+        // Remove from pending so we don't process again
+        bridgeStateQueue.sync {
+            pendingAcceptPayloads.removeValue(forKey: callId)
+        }
+
+        // Re-run handleNativeAccept with the stored payload.
+        // Deduplication (nativeAcceptHandledCallIds) ensures this is a no-op if already accepted.
+        handleNativeAccept(payload: payload)
     }
 
     // MARK: - VoIP Token
@@ -457,6 +499,9 @@ public final class VoipService: NSObject {
 
         cancelIncomingCallTimeout(for: payload.callId)
 
+        // Store payload in case JS needs to call proceedAccept after init completes
+        storePendingAccept(payload)
+
         var finishAcceptInvoked = [false]
         let finishAccept: (Bool) -> Void = { [weak payload] success in
             guard !finishAcceptInvoked[0] else { return }
@@ -464,6 +509,10 @@ public final class VoipService: NSObject {
             guard let payload else { return }
             stopDDPClientInternal(callId: payload.callId)
             if success {
+                // Remove from pending since we're completing now
+                bridgeStateQueue.sync {
+                    pendingAcceptPayloads.removeValue(forKey: payload.callId)
+                }
                 storeInitialEvents(payload)
                 clearNativeAcceptDedupe(for: payload.callId)
                 NotificationCenter.default.post(


### PR DESCRIPTION
## Summary

Fixes 3 failing VoIP acceptance tests (AC1, AC5, AC7) that verify the pending-accept fast-path behavior in `MediaCallEvents.test.ts`.

### Root Cause

The tests used `DeviceEventEmitter.emit()` to trigger `VoipPendingAccept` events, but handlers registered via `NativeEventEmitter.addListener()` store handlers in the native `RCTDeviceEventEmitter`, not in any JavaScript-accessible location. So the emitted events never reached the listeners.

### Fix

Mock `react-native` completely with a shared `__nativeEventBus__` Map on `global` that both `NativeEventEmitter.addListener` (which stores handlers) and `DeviceEventEmitter.emit` (which invokes them) use. This allows tests to synchronously trigger events that the module under test listens for.

Additional fixes:
- Added `__esModule: true` to the `appNavigation` mock so its default export is recognized
- Added `proceedAccept` and `resetFromLogout` to the `NativeVoip` mock (missing from the original mock)
- Removed debug `console.error` from the VoipPendingAccept handler in `MediaCallEvents.ts`

## Test Plan

- [x] `yarn test -- --testPathPattern='MediaCallEvents.test.ts' --testNamePattern="AC1.*navigates"` — passes
- [x] `yarn test -- --testPathPattern='MediaCallEvents.test.ts' --testNamePattern="AC5"` — passes  
- [x] `yarn test -- --testPathPattern='MediaCallEvents.test.ts' --testNamePattern="AC7"` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added pending accept mechanism for VoIP calls with automatic 15-second timeout for better handling during initialization
  * New "Connecting" status indicator displays during the call acceptance phase
  * Improved call state management when accepting and initializing calls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->