### PR TITLE
fix(voip): guard startCall when MediaSessionInstance not ready

### DIFF
--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -994,6 +994,7 @@
   "View_Thread": "View thread",
   "Voice_call": "Voice call",
   "VoIP_Call_Issue": "There was an issue with the call, try again later.",
+  "VoIP_Still_Connecting": "Still connecting. Please try again in a moment.",
   "Wait_activation_warning": "Before you can login, your account must be manually activated by an administrator.",
   "Waiting_for_answer": "Waiting for answer",
   "Waiting_for_network": "Waiting for network...",

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -582,7 +582,6 @@ describe('MediaSessionInstance', () => {
 			await mediaSessionInstance.init('user-1');
 			mockRequestPhoneStatePermission.mockClear();
 			const session = createdSessions[0];
-			mockShowErrorAlert.mockClear();
 			await mediaSessionInstance.startCall('peer-2', 'user');
 			expect(mockShowErrorAlert).not.toHaveBeenCalled();
 			expect(mockRequestPhoneStatePermission).toHaveBeenCalledTimes(1);

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -115,6 +115,11 @@ jest.mock('../../methods/voipPhoneStatePermission', () => ({
 	requestPhoneStatePermission: () => mockRequestPhoneStatePermission()
 }));
 
+const mockShowErrorAlert = jest.fn();
+jest.mock('../../methods/helpers/info', () => ({
+	showErrorAlert: (...args: unknown[]) => mockShowErrorAlert(...args)
+}));
+
 type MockMediaSignalingSession = {
 	userId: string;
 	sessionId: string;
@@ -560,6 +565,24 @@ describe('MediaSessionInstance', () => {
 			await mediaSessionInstance.startCall('user-1', 'user');
 			expect(session.startCall).not.toHaveBeenCalled();
 			expect(mockRequestPhoneStatePermission).not.toHaveBeenCalled();
+		});
+
+		it('shows alert and skips permission and skips instance.startCall when instance is null', async () => {
+			mockRequestPhoneStatePermission.mockClear();
+			await mediaSessionInstance.startCall('peer-1', 'user');
+			expect(mockShowErrorAlert).toHaveBeenCalledTimes(1);
+			expect(mockRequestPhoneStatePermission).not.toHaveBeenCalled();
+		});
+
+		it('calls through normally when instance is present', async () => {
+			await mediaSessionInstance.init('user-1');
+			mockRequestPhoneStatePermission.mockClear();
+			const session = createdSessions[0];
+			mockShowErrorAlert.mockClear();
+			await mediaSessionInstance.startCall('peer-2', 'user');
+			expect(mockShowErrorAlert).not.toHaveBeenCalled();
+			expect(mockRequestPhoneStatePermission).toHaveBeenCalledTimes(1);
+			expect(session.startCall).toHaveBeenCalledWith('user', 'peer-2');
 		});
 
 		it('startCallByRoom does not invoke startCall when getUidDirectMessage returns own id (itsMe room)', async () => {

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -568,10 +568,14 @@ describe('MediaSessionInstance', () => {
 		});
 
 		it('shows alert and skips permission and skips instance.startCall when instance is null', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			mediaSessionInstance.reset();
 			mockRequestPhoneStatePermission.mockClear();
 			await mediaSessionInstance.startCall('peer-1', 'user');
 			expect(mockShowErrorAlert).toHaveBeenCalledTimes(1);
 			expect(mockRequestPhoneStatePermission).not.toHaveBeenCalled();
+			expect(session.startCall).not.toHaveBeenCalled();
 		});
 
 		it('calls through normally when instance is present', async () => {
@@ -583,6 +587,17 @@ describe('MediaSessionInstance', () => {
 			expect(mockShowErrorAlert).not.toHaveBeenCalled();
 			expect(mockRequestPhoneStatePermission).toHaveBeenCalledTimes(1);
 			expect(session.startCall).toHaveBeenCalledWith('user', 'peer-2');
+		});
+
+		it('startCallByRoom shows alert when instance is null', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			mediaSessionInstance.reset();
+			mockGetUidDirectMessage.mockReturnValue('peer-1');
+			mediaSessionInstance.startCallByRoom({ rid: 'rid-dm', t: 'd', uids: ['user-1', 'peer-1'] } as any);
+			await Promise.resolve();
+			expect(mockShowErrorAlert).toHaveBeenCalledTimes(1);
+			expect(session.startCall).not.toHaveBeenCalled();
 		});
 
 		it('startCallByRoom does not invoke startCall when getUidDirectMessage returns own id (itsMe room)', async () => {

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -29,6 +29,8 @@ import type { ISubscription, TSubscriptionModel } from '../../../definitions';
 import { getDMSubscriptionByUsername } from '../../database/services/Subscription';
 import { getUidDirectMessage } from '../../methods/helpers/helpers';
 import { requestPhoneStatePermission } from '../../methods/voipPhoneStatePermission';
+import I18n from '../../../i18n';
+import { showErrorAlert } from '../../methods/helpers/info';
 
 const mediaCallLogger = new MediaCallLogger();
 
@@ -182,8 +184,13 @@ class MediaSessionInstance {
 			mediaCallLogger.debug('[VoIP] startCall blocked: target userId matches logged-in user');
 			return;
 		}
+		if (!this.instance) {
+			mediaCallLogger.debug('[VoIP] startCall blocked: MediaSessionInstance not initialized');
+			showErrorAlert(I18n.t('VoIP_Still_Connecting'), I18n.t('Oops'));
+			return;
+		}
 		requestPhoneStatePermission();
-		await this.instance?.startCall(actor, userId);
+		await this.instance.startCall(actor, userId);
 	};
 
 	public endCall = (callId: string) => {


### PR DESCRIPTION
## What

Guard `MediaSessionInstance.startCall` against being called before `init()` has completed (i.e. `this.instance == null`).

Previously the optional chain `this.instance?.startCall(...)` silently no-oped when the instance was null — no feedback to the user. This happens on cold start before `LOGIN.SUCCESS` fires and `startVoipFork` runs `init(userId)`.

https://rocketchat.atlassian.net/browse/VMUX-89

## Changes

- **`app/lib/services/voip/MediaSessionInstance.ts`** — added `if (!this.instance)` guard after the self-user check: logs a debug line, calls `showErrorAlert` with the new i18n key, and returns early. `requestPhoneStatePermission()` and `instance.startCall()` are not reached. Removed the now-redundant optional chain.
- **`app/i18n/locales/en.json`** — added `VoIP_Still_Connecting` key: _"Still connecting. Please try again in a moment."_
- **`app/lib/services/voip/MediaSessionInstance.test.ts`** — added two tests: (a) instance-null path shows alert + skips permission + skips startCall; (b) instance-non-null path calls through normally.

## Why no UI changes

`startCallByRoom` delegates to `startCall` and inherits the guard. No CTA changes needed — the guard lives entirely in the service layer.

## Test plan

- [ ] `TZ=UTC npx jest --testPathPattern='MediaSessionInstance'` → 31 passed
- [ ] Cold-start scenario: tap call before login finishes → alert appears, no permission prompt
- [ ] Normal scenario: tap call after login → call starts normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "still connecting" status message displayed during VoIP call connections.

* **Bug Fixes**
  * VoIP calls now display an error alert if attempted when the connection is not ready, providing clearer feedback instead of silently failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->