### PR TITLE
feat: add copy button to code blocks

### DIFF
--- a/app/containers/markdown/components/code/Code.tsx
+++ b/app/containers/markdown/components/code/Code.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { type Code as CodeProps } from '@rocket.chat/message-parser';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 import styles from '../../styles';
 import { useTheme } from '../../../../theme';
+import { CustomIcon } from '../../../CustomIcon';
+import EventEmitter from '../../../../lib/methods/helpers/events';
+import { LISTENER } from '../../../Toast';
+import I18n from '../../../../i18n';
 import CodeLine from './CodeLine';
 
 interface ICodeProps {
@@ -12,6 +17,15 @@ interface ICodeProps {
 
 const Code = ({ value }: ICodeProps): React.ReactElement => {
 	const { colors } = useTheme();
+
+	const handleCopy = () => {
+		const text = value
+			.filter(block => block.type === 'CODE_LINE')
+			.map(block => (block.value.type === 'PLAIN_TEXT' ? block.value.value : ''))
+			.join('\n');
+		Clipboard.setString(text);
+		EventEmitter.emit(LISTENER, { message: I18n.t('Copied_to_clipboard') });
+	};
 
 	return (
 		<View
@@ -22,6 +36,9 @@ const Code = ({ value }: ICodeProps): React.ReactElement => {
 					borderColor: colors.strokeLight
 				}
 			]}>
+			<Pressable style={styles.codeBlockCopyButton} onPress={handleCopy} hitSlop={8}>
+				<CustomIcon name='copy' size={18} color={colors.fontSecondaryInfo} />
+			</Pressable>
 			{value.map(block => {
 				switch (block.type) {
 					case 'CODE_LINE':

--- a/app/containers/markdown/styles.ts
+++ b/app/containers/markdown/styles.ts
@@ -80,7 +80,14 @@ export default StyleSheet.create({
 	codeBlock: {
 		borderWidth: 1,
 		borderRadius: 4,
-		padding: 4
+		padding: 4,
+		position: 'relative' as const
+	},
+	codeBlockCopyButton: {
+		position: 'absolute' as const,
+		top: 4,
+		right: 4,
+		zIndex: 1
 	},
 	codeBlockText: {
 		fontSize: 16,


### PR DESCRIPTION
Code blocks in messages don't have a way to copy just the code. You have to long-press the whole message and use "Copy", which grabs everything including the backtick markers. This adds a small copy icon to the top-right corner of each code block — tap it, and the code content goes to the clipboard without any markdown syntax. A toast confirms the copy.

## Issue(s)

Closes #5499

## How to test or reproduce

1. Send a message containing a code block (triple backticks)
2. Look for the copy icon in the top-right corner of the rendered code block
3. Tap it
4. Paste somewhere — should contain only the code, no backtick markers
5. A "Copied to clipboard!" toast should appear


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Two files changed. Code.tsx gets a Pressable with a copy icon that extracts CODE_LINE text, joins it with newlines, and sends it to the clipboard. Uses the same Clipboard + toast pattern as Link.tsx. The styles.ts file gets position: relative on the code block and position: absolute on the button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy-to-clipboard button to code blocks positioned in the top-right corner. Users can copy code snippets with a single click, with a confirmation message displayed upon successful copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->