### PR TITLE
fix(voip): enable speaker toggle during ringing and accepted

### DIFF
--- a/app/views/CallView/__snapshots__/index.test.tsx.snap
+++ b/app/views/CallView/__snapshots__/index.test.tsx.snap
@@ -1105,7 +1105,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -1140,9 +1140,7 @@ exports[`Story Snapshots: ConnectingCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },
@@ -6312,7 +6310,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
               {
                 "busy": undefined,
                 "checked": undefined,
-                "disabled": true,
+                "disabled": false,
                 "expanded": undefined,
                 "selected": undefined,
               }
@@ -6347,9 +6345,7 @@ exports[`Story Snapshots: TabletConnectingCall should match snapshot 1`] = `
                   "marginBottom": 8,
                   "width": 64,
                 },
-                {
-                  "opacity": 0.5,
-                },
+                false,
                 {
                   "backgroundColor": "#E4E7EA",
                 },

--- a/app/views/CallView/components/CallButtons.test.tsx
+++ b/app/views/CallView/components/CallButtons.test.tsx
@@ -131,14 +131,14 @@ describe('CallButtons', () => {
 		expect(getByText('Dialpad')).toBeTruthy();
 	});
 
-	it('disabled states when ringing', () => {
+	it('speaker enabled but hold/mute/dialpad disabled when ringing', () => {
 		setStoreState({ callState: 'ringing' });
 		const { getByTestId } = render(
 			<Wrapper>
 				<CallButtons />
 			</Wrapper>
 		);
-		expect(getByTestId('call-view-speaker').props.accessibilityState?.disabled).toBe(true);
+		expect(getByTestId('call-view-speaker').props.accessibilityState?.disabled).toBeFalsy();
 		expect(getByTestId('call-view-hold').props.accessibilityState?.disabled).toBe(true);
 		expect(getByTestId('call-view-mute').props.accessibilityState?.disabled).toBe(true);
 		expect(getByTestId('call-view-dialpad').props.accessibilityState?.disabled).toBe(true);

--- a/app/views/CallView/components/CallButtons.tsx
+++ b/app/views/CallView/components/CallButtons.tsx
@@ -53,6 +53,7 @@ export const CallButtons = () => {
 	}));
 
 	const isConnecting = callState === 'none' || callState === 'ringing' || callState === 'accepted';
+	const speakerDisabled = callState === 'none';
 	const messageDisabled = roomId == null;
 
 	const handleMessage = () => {
@@ -74,7 +75,7 @@ export const CallButtons = () => {
 			label: I18n.t('Speaker'),
 			onPress: toggleSpeaker,
 			variant: isSpeakerOn ? 'active' : 'default',
-			disabled: isConnecting
+			disabled: speakerDisabled
 		},
 		{
 			testID: 'call-view-hold',

--- a/app/views/CallView/index.test.tsx
+++ b/app/views/CallView/index.test.tsx
@@ -505,7 +505,7 @@ describe('CallView (tablet/wide layout)', () => {
 		expect(queryByTestId('call-buttons-row-0')).toBeNull();
 	});
 
-	it('disables action buttons while connecting on wide layout', () => {
+	it('disables hold/mute/dialpad while connecting; speaker stays enabled on wide layout', () => {
 		const toggleHold = jest.fn();
 		const toggleMute = jest.fn();
 		const toggleSpeaker = jest.fn();
@@ -520,10 +520,11 @@ describe('CallView (tablet/wide layout)', () => {
 
 		fireEvent.press(getByTestId('call-view-hold'));
 		fireEvent.press(getByTestId('call-view-mute'));
+		fireEvent.press(getByTestId('call-view-dialpad'));
 		fireEvent.press(getByTestId('call-view-speaker'));
 		expect(toggleHold).not.toHaveBeenCalled();
 		expect(toggleMute).not.toHaveBeenCalled();
-		expect(toggleSpeaker).not.toHaveBeenCalled();
+		expect(toggleSpeaker).toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Proposed changes

Enable the speaker toggle button while a VoIP call is in `'ringing'` or `'accepted'` state. Previously the speaker was disabled alongside hold / mute / dialpad via the shared `isConnecting` predicate, which prevented users from pre-selecting speakerphone before the remote answers (a common pattern: place the phone on a table while the call rings).

Only the speaker button changes. Hold, mute, end-label, and dialpad continue to use `isConnecting`. `toggleSpeaker` and `setCall` in `useCallStore` are unchanged — when `callState !== 'none'`, `call` is non-null and `InCallManager.start({ media: 'audio' })` has already run, so `setForceSpeakerphoneOn` is valid.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-91

## How to test or reproduce

Manual verification recommended on iOS + Android before merge:

1. Place an outgoing VoIP call — speaker button is enabled while ringing.
2. Tap speaker during ringing — icon flips, audio routes to loudspeaker once the call connects.
3. Accept an incoming call — speaker button remains enabled during the `accepted` state.
4. Hold, mute, and dialpad remain disabled during ringing / accepted.
5. With no call in progress (`callState === 'none'`), the speaker button stays disabled.

## Screenshots

N/A — no visual changes; only the enabled state of the existing speaker button.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Verification: \`yarn lint\`, \`TZ=UTC yarn test -- --testPathPattern='CallButtons'\` (8 tests), the wide-layout \`CallView\` test, and the regenerated \`ConnectingCall\` / \`TabletConnectingCall\` storybook snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Speaker button is enabled during the ringing state, letting users adjust audio while calls ring before acceptance.
* **Tests**
  * Updated tests to reflect the new speaker behavior and to include dialpad interaction during connecting/ringing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->