### PR TITLE
fix: check start discussion permission in action button

### DIFF
--- a/app/containers/MessageComposer/components/Buttons/ActionsButton.test.tsx
+++ b/app/containers/MessageComposer/components/Buttons/ActionsButton.test.tsx
@@ -85,13 +85,7 @@ const messageInnerContext: IMessageInnerContext = {
 	setMarkdownToolbar: jest.fn()
 };
 
-const Render = ({
-	context,
-	permissions
-}: {
-	context?: Partial<IRoomContext>;
-	permissions?: IPermissionsState;
-}) => {
+const Render = ({ context, permissions }: { context?: Partial<IRoomContext>; permissions?: IPermissionsState }) => {
 	if (permissions) {
 		mockedStore.dispatch(setPermissions(permissions));
 	}

--- a/app/containers/MessageComposer/components/Buttons/ActionsButton.test.tsx
+++ b/app/containers/MessageComposer/components/Buttons/ActionsButton.test.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+
+import { ActionsButton } from './ActionsButton';
+import { setPermissions } from '../../../../actions/permissions';
+import { selectServerRequest } from '../../../../actions/server';
+import { setUser } from '../../../../actions/login';
+import { mockedStore } from '../../../../reducers/mockedStore';
+import { type IPermissionsState } from '../../../../reducers/permissions';
+import { RoomContext, type IRoomContext } from '../../../../views/RoomView/context';
+import { MessageInnerContext, type IMessageInnerContext } from '../../context';
+import { initStore } from '../../../../lib/store/auxStore';
+
+jest.mock('../../../ActionSheet', () => ({
+	useActionSheet: () => ({
+		showActionSheet: jest.fn(),
+		hideActionSheet: jest.fn()
+	})
+}));
+
+let mockCanUploadFile = false;
+jest.mock('../../hooks/useCanUploadFile', () => ({
+	useCanUploadFile: () => mockCanUploadFile
+}));
+
+jest.mock('../../hooks/useChooseMedia', () => ({
+	useChooseMedia: () => ({
+		takePhoto: jest.fn(),
+		takeVideo: jest.fn(),
+		chooseFromLibrary: jest.fn(),
+		chooseFile: jest.fn()
+	})
+}));
+
+const initialStoreState = () => {
+	const baseUrl = 'https://open.rocket.chat';
+	mockedStore.dispatch(selectServerRequest(baseUrl, '6.4.0'));
+	mockedStore.dispatch(
+		setUser({
+			id: 'abc',
+			username: 'rocket.cat',
+			name: 'Rocket Cat',
+			roles: ['user'],
+			settings: {
+				preferences: {
+					convertAsciiEmoji: true
+				}
+			}
+		})
+	);
+	initStore(mockedStore);
+};
+
+const roomContext: IRoomContext = {
+	rid: 'rid',
+	tmid: undefined,
+	room: {
+		rid: 'rid',
+		t: 'c',
+		tmid: undefined,
+		name: 'general',
+		fname: 'general',
+		usernames: undefined,
+		prid: undefined,
+		federated: false
+	},
+	sharing: false,
+	action: null,
+	selectedMessages: [],
+	editCancel: jest.fn(),
+	editRequest: jest.fn(),
+	onSendMessage: jest.fn(),
+	onRemoveQuoteMessage: jest.fn()
+};
+
+const messageInnerContext: IMessageInnerContext = {
+	closeEmojiKeyboardAndAction: jest.fn(),
+	openEmojiKeyboard: jest.fn(),
+	closeEmojiKeyboard: jest.fn(),
+	mentions: [],
+	channels: [],
+	mentionsLoading: false,
+	channelMentionsLoading: false,
+	setMarkdownToolbar: jest.fn()
+};
+
+const Render = ({
+	context,
+	permissions
+}: {
+	context?: Partial<IRoomContext>;
+	permissions?: IPermissionsState;
+}) => {
+	if (permissions) {
+		mockedStore.dispatch(setPermissions(permissions));
+	}
+	return (
+		<Provider store={mockedStore}>
+			<RoomContext.Provider value={{ ...roomContext, ...context }}>
+				<MessageInnerContext.Provider value={messageInnerContext}>
+					<ActionsButton />
+				</MessageInnerContext.Provider>
+			</RoomContext.Provider>
+		</Provider>
+	);
+};
+
+describe('ActionsButton', () => {
+	beforeEach(() => {
+		mockedStore.dispatch(setPermissions({}));
+		mockCanUploadFile = false;
+	});
+
+	describe('given user has start-discussion permission', () => {
+		test('then Actions button is visible', () => {
+			initialStoreState();
+			render(
+				<Render
+					permissions={{
+						'start-discussion': ['user']
+					}}
+				/>
+			);
+			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+		});
+	});
+
+	describe('given user lacks start-discussion permission', () => {
+		describe('and is not in livechat room', () => {
+			test('then Actions button is not visible', () => {
+				initialStoreState();
+				render(
+					<Render
+						permissions={{
+							'start-discussion': []
+						}}
+					/>
+				);
+				expect(screen.queryByTestId('message-composer-actions')).not.toBeOnTheScreen();
+			});
+		});
+	});
+
+	describe('given user has view-canned-responses permission', () => {
+		test('and is in livechat room then Actions button is visible', () => {
+			initialStoreState();
+			render(
+				<Render
+					context={{
+						t: 'l',
+						room: {
+							...roomContext.room,
+							t: 'l'
+						}
+					}}
+					permissions={{
+						'view-canned-responses': ['user']
+					}}
+				/>
+			);
+			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+		});
+	});
+
+	describe('permission combinations', () => {
+		test('given only start-discussion permission, button is visible', () => {
+			initialStoreState();
+			render(
+				<Render
+					permissions={{
+						'start-discussion': ['user'],
+						'mobile-upload-file': [],
+						'view-canned-responses': []
+					}}
+				/>
+			);
+			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+		});
+
+		test('given only upload permission, button is visible', () => {
+			initialStoreState();
+			mockCanUploadFile = true;
+			render(<Render permissions={{}} />);
+			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+		});
+
+		test('given no permissions, button is not visible', () => {
+			initialStoreState();
+			render(
+				<Render
+					permissions={{
+						'start-discussion': [],
+						'view-canned-responses': []
+					}}
+				/>
+			);
+			expect(screen.queryByTestId('message-composer-actions')).not.toBeOnTheScreen();
+		});
+	});
+});

--- a/app/containers/MessageComposer/components/Buttons/ActionsButton.test.tsx
+++ b/app/containers/MessageComposer/components/Buttons/ActionsButton.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 
 import { ActionsButton } from './ActionsButton';
@@ -7,16 +7,16 @@ import { setPermissions } from '../../../../actions/permissions';
 import { selectServerRequest } from '../../../../actions/server';
 import { setUser } from '../../../../actions/login';
 import { mockedStore } from '../../../../reducers/mockedStore';
-import { type IPermissionsState } from '../../../../reducers/permissions';
 import { RoomContext, type IRoomContext } from '../../../../views/RoomView/context';
-import { MessageInnerContext, type IMessageInnerContext } from '../../context';
+import { MessageInnerContext, type TMessageInnerContext } from '../../context';
 import { initStore } from '../../../../lib/store/auxStore';
 
+const mockActionSheet = {
+	showActionSheet: jest.fn(),
+	hideActionSheet: jest.fn()
+};
 jest.mock('../../../ActionSheet', () => ({
-	useActionSheet: () => ({
-		showActionSheet: jest.fn(),
-		hideActionSheet: jest.fn()
-	})
+	useActionSheet: () => mockActionSheet
 }));
 
 let mockCanUploadFile = false;
@@ -74,28 +74,15 @@ const roomContext: IRoomContext = {
 	onRemoveQuoteMessage: jest.fn()
 };
 
-const messageInnerContext: IMessageInnerContext = {
-	closeEmojiKeyboardAndAction: jest.fn(),
-	openEmojiKeyboard: jest.fn(),
-	closeEmojiKeyboard: jest.fn(),
-	mentions: [],
-	channels: [],
-	mentionsLoading: false,
-	channelMentionsLoading: false,
-	setMarkdownToolbar: jest.fn()
+const messageInnerContext: TMessageInnerContext = {
+	sendMessage: jest.fn(),
+	onEmojiSelected: jest.fn(),
+	closeEmojiKeyboardAndAction: (action?: Function, params?: any) => action?.(params),
+	focus: jest.fn()
 };
 
-const Render = ({
-	context,
-	permissions
-}: {
-	context?: Partial<IRoomContext>;
-	permissions?: IPermissionsState;
-}) => {
-	if (permissions) {
-		mockedStore.dispatch(setPermissions(permissions));
-	}
-	return (
+const renderActionsButton = ({ context }: { context?: Partial<IRoomContext> }) =>
+	render(
 		<Provider store={mockedStore}>
 			<RoomContext.Provider value={{ ...roomContext, ...context }}>
 				<MessageInnerContext.Provider value={messageInnerContext}>
@@ -104,40 +91,46 @@ const Render = ({
 			</RoomContext.Provider>
 		</Provider>
 	);
-};
 
 describe('ActionsButton', () => {
 	beforeEach(() => {
 		mockedStore.dispatch(setPermissions({}));
 		mockCanUploadFile = false;
+		mockActionSheet.showActionSheet.mockReset();
 	});
 
 	describe('given user has start-discussion permission', () => {
-		test('then Actions button is visible', () => {
+		test('then Actions button is visible and Create discussion option is present', () => {
 			initialStoreState();
-			render(
-				<Render
-					permissions={{
-						'start-discussion': ['user']
-					}}
-				/>
-			);
+			mockedStore.dispatch(setPermissions({ 'start-discussion': ['user'] }));
+			renderActionsButton({});
 			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+			fireEvent.press(screen.getByTestId('message-composer-actions'));
+			expect(mockActionSheet.showActionSheet).toHaveBeenCalled();
+			const { options } = mockActionSheet.showActionSheet.mock.calls.at(-1)[0];
+			expect(options.some((o: { title: string }) => o.title === 'Create discussion')).toBe(true);
 		});
 	});
 
 	describe('given user lacks start-discussion permission', () => {
-		describe('and is not in livechat room', () => {
+		describe('and has no other permissions', () => {
 			test('then Actions button is not visible', () => {
 				initialStoreState();
-				render(
-					<Render
-						permissions={{
-							'start-discussion': []
-						}}
-					/>
-				);
+				mockedStore.dispatch(setPermissions({ 'start-discussion': [] }));
+				renderActionsButton({});
 				expect(screen.queryByTestId('message-composer-actions')).not.toBeOnTheScreen();
+			});
+		});
+		describe('but has upload permission', () => {
+			test('then Actions button is visible but Create discussion option is absent', () => {
+				initialStoreState();
+				mockCanUploadFile = true;
+				mockedStore.dispatch(setPermissions({ 'start-discussion': [] }));
+				renderActionsButton({});
+				expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+				fireEvent.press(screen.getByTestId('message-composer-actions'));
+				const { options } = mockActionSheet.showActionSheet.mock.calls.at(-1)[0];
+				expect(options.some((o: { title: string }) => o.title === 'Create discussion')).toBe(false);
 			});
 		});
 	});
@@ -145,56 +138,57 @@ describe('ActionsButton', () => {
 	describe('given user has view-canned-responses permission', () => {
 		test('and is in livechat room then Actions button is visible', () => {
 			initialStoreState();
-			render(
-				<Render
-					context={{
-						t: 'l',
-						room: {
-							...roomContext.room,
-							t: 'l'
-						}
-					}}
-					permissions={{
-						'view-canned-responses': ['user']
-					}}
-				/>
-			);
+			mockedStore.dispatch(setPermissions({ 'view-canned-responses': ['user'] }));
+			renderActionsButton({
+				context: {
+					t: 'l',
+					room: {
+						...roomContext.room,
+						t: 'l'
+					}
+				}
+			});
 			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
 		});
 	});
 
 	describe('permission combinations', () => {
-		test('given only start-discussion permission, button is visible', () => {
+		test('given only start-discussion permission, button is visible and option is present', () => {
 			initialStoreState();
-			render(
-				<Render
-					permissions={{
-						'start-discussion': ['user'],
-						'mobile-upload-file': [],
-						'view-canned-responses': []
-					}}
-				/>
+			mockedStore.dispatch(
+				setPermissions({
+					'start-discussion': ['user'],
+					'mobile-upload-file': [],
+					'view-canned-responses': []
+				})
 			);
+			renderActionsButton({});
 			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+			fireEvent.press(screen.getByTestId('message-composer-actions'));
+			const { options } = mockActionSheet.showActionSheet.mock.calls.at(-1)[0];
+			expect(options.some((o: { title: string }) => o.title === 'Create discussion')).toBe(true);
 		});
 
-		test('given only upload permission, button is visible', () => {
+		test('given only upload permission, button is visible but Create discussion is absent', () => {
 			initialStoreState();
 			mockCanUploadFile = true;
-			render(<Render permissions={{}} />);
+			mockedStore.dispatch(setPermissions({}));
+			renderActionsButton({});
 			expect(screen.getByTestId('message-composer-actions')).toBeOnTheScreen();
+			fireEvent.press(screen.getByTestId('message-composer-actions'));
+			const { options } = mockActionSheet.showActionSheet.mock.calls.at(-1)[0];
+			expect(options.some((o: { title: string }) => o.title === 'Create discussion')).toBe(false);
 		});
 
 		test('given no permissions, button is not visible', () => {
 			initialStoreState();
-			render(
-				<Render
-					permissions={{
-						'start-discussion': [],
-						'view-canned-responses': []
-					}}
-				/>
+			mockedStore.dispatch(
+				setPermissions({
+					'start-discussion': [],
+					'view-canned-responses': []
+				})
 			);
+			renderActionsButton({});
 			expect(screen.queryByTestId('message-composer-actions')).not.toBeOnTheScreen();
 		});
 	});

--- a/app/containers/MessageComposer/components/Buttons/ActionsButton.tsx
+++ b/app/containers/MessageComposer/components/Buttons/ActionsButton.tsx
@@ -17,7 +17,11 @@ export const ActionsButton = () => {
 	const { rid, tmid, t } = useRoomContext();
 	const { closeEmojiKeyboardAndAction } = useContext(MessageInnerContext);
 	const permissionToUpload = useCanUploadFile(rid);
-	const [permissionToViewCannedResponses] = usePermissions(['view-canned-responses'], rid);
+	const [permissionToViewCannedResponses] = usePermissions(
+		['view-canned-responses'],
+		rid
+	);
+	const [permissionToStartDiscussion] = usePermissions(['start-discussion']);
 	const { takePhoto, takeVideo, chooseFromLibrary, chooseFile } = useChooseMedia({
 		rid,
 		tmid,
@@ -89,14 +93,23 @@ export const ActionsButton = () => {
 			);
 		}
 
-		options.push({
-			title: I18n.t('Create_Discussion'),
-			icon: 'discussions',
-			onPress: () => createDiscussion()
-		});
+		if (permissionToStartDiscussion) {
+			options.push({
+				title: I18n.t('Create_Discussion'),
+				icon: 'discussions',
+				onPress: () => createDiscussion()
+			});
+		}
 
 		closeEmojiKeyboardAndAction(showActionSheet, { options });
 	};
+
+	const hasOptions =
+		(t === 'l' && permissionToViewCannedResponses) || permissionToUpload || permissionToStartDiscussion;
+
+	if (!hasOptions) {
+		return null;
+	}
 
 	return <BaseButton onPress={onPress} testID='message-composer-actions' accessibilityLabel='Actions' icon='add' />;
 };

--- a/app/containers/MessageComposer/components/Buttons/ActionsButton.tsx
+++ b/app/containers/MessageComposer/components/Buttons/ActionsButton.tsx
@@ -41,7 +41,7 @@ export const ActionsButton = () => {
 		}
 	};
 
-	const onPress = () => {
+	const getActionOptions = (): TActionSheetOptionsItem[] => {
 		const options: TActionSheetOptionsItem[] = [];
 		if (t === 'l' && permissionToViewCannedResponses) {
 			options.push({
@@ -92,7 +92,6 @@ export const ActionsButton = () => {
 				}
 			);
 		}
-
 		if (permissionToStartDiscussion) {
 			options.push({
 				title: I18n.t('Create_Discussion'),
@@ -100,12 +99,15 @@ export const ActionsButton = () => {
 				onPress: () => createDiscussion()
 			});
 		}
+		return options;
+	};
 
+	const onPress = () => {
+		const options = getActionOptions();
 		closeEmojiKeyboardAndAction(showActionSheet, { options });
 	};
 
-	const hasOptions =
-		(t === 'l' && permissionToViewCannedResponses) || permissionToUpload || permissionToStartDiscussion;
+	const hasOptions = getActionOptions().length > 0;
 
 	if (!hasOptions) {
 		return null;

--- a/app/containers/MessageComposer/components/Buttons/ActionsButton.tsx
+++ b/app/containers/MessageComposer/components/Buttons/ActionsButton.tsx
@@ -17,10 +17,7 @@ export const ActionsButton = () => {
 	const { rid, tmid, t } = useRoomContext();
 	const { closeEmojiKeyboardAndAction } = useContext(MessageInnerContext);
 	const permissionToUpload = useCanUploadFile(rid);
-	const [permissionToViewCannedResponses] = usePermissions(
-		['view-canned-responses'],
-		rid
-	);
+	const [permissionToViewCannedResponses] = usePermissions(['view-canned-responses'], rid);
 	const [permissionToStartDiscussion] = usePermissions(['start-discussion']);
 	const { takePhoto, takeVideo, chooseFromLibrary, chooseFile } = useChooseMedia({
 		rid,
@@ -104,8 +101,7 @@ export const ActionsButton = () => {
 		closeEmojiKeyboardAndAction(showActionSheet, { options });
 	};
 
-	const hasOptions =
-		(t === 'l' && permissionToViewCannedResponses) || permissionToUpload || permissionToStartDiscussion;
+	const hasOptions = (t === 'l' && permissionToViewCannedResponses) || permissionToUpload || permissionToStartDiscussion;
 
 	if (!hasOptions) {
 		return null;

--- a/app/containers/MessageComposer/context.tsx
+++ b/app/containers/MessageComposer/context.tsx
@@ -29,7 +29,7 @@ export const useRecordingAudio = (): State['recordingAudio'] => useContext(Recor
 export const useAutocompleteParams = (): State['autocompleteParams'] => useContext(AutocompleteParamsContext);
 
 // TODO: rename
-type TMessageInnerContext = {
+export type TMessageInnerContext = {
 	sendMessage(): void;
 	onEmojiSelected(emoji: IEmoji): void;
 	// TODO: action should be required


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
This PR updates the action button behavior to improve UX and enforce permission checks. The “Start Discussion” option is now hidden for users who do not have the required permissions. Additionally, the action button itself is not displayed when no actionable options are available, preventing empty or redundant UI elements.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/CORE-1281

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The "Create Discussion" action in the message composer is now properly gated based on user permissions and will only appear when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->