### PR TITLE
fix(android/voip): don't require READ_PHONE_STATE for outgoing calls

### DIFF
--- a/app/lib/methods/voipCallPermissions.test.ts
+++ b/app/lib/methods/voipCallPermissions.test.ts
@@ -58,7 +58,7 @@ describe('requestVoipCallPermissions', () => {
 		expect(granted).toBe(false);
 	});
 
-	it('returns false when READ_PHONE_STATE is denied (never_ask_again)', async () => {
+	it('returns true when READ_PHONE_STATE is denied but RECORD_AUDIO is granted', async () => {
 		jest.resetModules();
 		jest.doMock('./helpers', () => ({
 			...jest.requireActual('./helpers'),
@@ -72,6 +72,6 @@ describe('requestVoipCallPermissions', () => {
 
 		const granted = await requestVoipCallPermissions();
 
-		expect(granted).toBe(false);
+		expect(granted).toBe(true);
 	});
 });

--- a/app/lib/methods/voipCallPermissions.ts
+++ b/app/lib/methods/voipCallPermissions.ts
@@ -10,8 +10,6 @@ export const requestVoipCallPermissions = async (): Promise<boolean> => {
 		PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE,
 		PermissionsAndroid.PERMISSIONS.RECORD_AUDIO
 	]);
-	return (
-		results[PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE] === PermissionsAndroid.RESULTS.GRANTED &&
-		results[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO] === PermissionsAndroid.RESULTS.GRANTED
-	);
+	// READ_PHONE_STATE only enhances Telecom integration; native falls back without it.
+	return results[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO] === PermissionsAndroid.RESULTS.GRANTED;
 };


### PR DESCRIPTION
## Proposed changes

`requestVoipCallPermissions` previously required both `READ_PHONE_STATE` and `RECORD_AUDIO` to be granted before allowing an outgoing VoIP call. `READ_PHONE_STATE` is only used to enrich Telecom integration on the native side (`VoipNotification.kt`), which already falls back gracefully when the permission is missing. The JS guard now blocks only on `RECORD_AUDIO`.

This unblocks calls on devices where the OS silently denies `READ_PHONE_STATE` — reproduced on a fresh install on Samsung S10e (Android 12), where `PermissionsAndroid.requestMultiple` returned `never_ask_again` for `READ_PHONE_STATE` without showing a dialog, even with the mic permission granted. The user saw the "Microphone access needed" alert despite both permissions being toggled on in Settings.

## Issue(s)

n/a — reported manually during VoIP testing.

## How to test or reproduce

1. Fresh install on a Samsung Android 12 device (or any OEM that auto-denies `READ_PHONE_STATE`).
2. Log in and start a VoIP call.
3. Grant the microphone permission when prompted.
4. **Before:** "Microphone access needed to record audio" alert; call doesn't start.
5. **After:** Call proceeds. (The user may still grant `READ_PHONE_STATE` in Settings to enable Telecom in-call detection on the native side.)

The unit test at \`app/lib/methods/voipCallPermissions.test.ts\` flips its previous assertion to verify the new behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VoIP call permission handling by simplifying authentication requirements. The system now requires only audio recording permission for calls to succeed, removing the previous mandatory requirement for additional phone state permissions. This reduces permission prompts and user friction while preserving all core functionality and system integration features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->