### PR TITLE
chore(ci): drop duplicate bundle install in Android jobs

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -49,12 +49,7 @@ runs:
       with:
         ruby-version: 2.7.7
         bundler-cache: true
-
-    - name: Install Fastlane
-      working-directory: android
-      run: |
-        bundle install --path gems
-      shell: bash
+        working-directory: android
 
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v4

--- a/.github/actions/upload-android/action.yml
+++ b/.github/actions/upload-android/action.yml
@@ -40,12 +40,7 @@ runs:
       with:
         ruby-version: 2.7.7
         bundler-cache: true
-
-    - name: Install Fastlane
-      working-directory: android
-      run: |
-        bundle install --path gems
-      shell: bash
+        working-directory: android
 
     - name: Store the Google service account key
       working-directory: android

--- a/.github/actions/upload-internal-android/action.yml
+++ b/.github/actions/upload-internal-android/action.yml
@@ -40,12 +40,7 @@ runs:
       with:
         ruby-version: 2.7.7
         bundler-cache: true
-
-    - name: Install Fastlane
-      working-directory: android
-      run: |
-        bundle install --path gems
-      shell: bash
+        working-directory: android
 
     - name: Store the Google service account key
       working-directory: android


### PR DESCRIPTION
## Proposed changes

Every Android build/upload job in CI ran `bundle install` twice. The first install was triggered implicitly by `ruby/setup-ruby@v1` with `bundler-cache: true` and resolved against the **root** `Gemfile` — which carries iOS-only deps (`cocoapods`, `xcodeproj`, ~125 gems). Android jobs threw all of that away and then ran a second explicit `bundle install --path gems` against `android/Gemfile`.

Pointing `setup-ruby` at `android/` via `working-directory: android` makes `bundler-cache: true` target the correct Gemfile from the start, so the explicit "Install Fastlane" step becomes redundant. The deprecated `--path` flag goes away as a bonus.

Affects:
- `.github/actions/build-android/action.yml`
- `.github/actions/upload-android/action.yml`
- `.github/actions/upload-internal-android/action.yml`

Saves roughly ~40s per Android build/upload job (and enables proper cache hits, which the previous setup also missed because the cache key was rooted at the wrong lockfile).

## Issue(s)

https://rocketchat.atlassian.net/browse/CORE-2139

## How to test or reproduce

Trigger any Android build job (this PR's own checks are sufficient). In the `Set up Ruby and Bundler` step, confirm:
- only one `bundle install` runs (against `android/Gemfile.lock`, ~88 gems)
- no `[DEPRECATED] The --path flag is deprecated` warning
- no separate "Install Fastlane" step in the job timeline

Subsequent runs on the same branch should hit the bundler cache.

## Screenshots

N/A — CI-only change.

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — N/A, CI-only
- [ ] I have added necessary documentation (if applicable) — N/A
- [ ] Any dependent changes have been merged and published in downstream modules — N/A

## Further comments

`bundler-cache: true` already runs `bundle install` automatically; the prior setup was effectively running it twice with two different lockfiles. Verified against [run 25008420199](https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/25008420199/job/73239391404), where both installs were visible back-to-back (~68s combined).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined GitHub Actions build workflows by simplifying dependency installation configuration across Android build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->