### PR TITLE
fix(VoIP): NewMediaCall sheet hugs content on Android

### DIFF
--- a/app/containers/ActionSheet/styles.ts
+++ b/app/containers/ActionSheet/styles.ts
@@ -68,7 +68,6 @@ export default StyleSheet.create({
 	},
 	fullContainer: {
 		width: '100%',
-		height: '100%',
 		flex: 0
 	}
 });

--- a/app/containers/NewMediaCall/NewMediaCall.tsx
+++ b/app/containers/NewMediaCall/NewMediaCall.tsx
@@ -27,7 +27,6 @@ export const NewMediaCall = (): React.ReactElement => {
 
 const styles = StyleSheet.create({
 	screen: {
-		flex: 1,
 		paddingHorizontal: 16,
 		paddingTop: 16
 	}


### PR DESCRIPTION
## Proposed changes

Two layout fixes for the NewMediaCall action sheet on Android, which was rendering with ~250-300px of empty space below the green "Ligar" button.

**Fix 1 — `app/containers/ActionSheet/styles.ts`**: drop `height: '100%'` from the shared `fullContainer` style.

`useActionSheetDetents` has two detent paths: snap-driven and contentHeight-driven. When `fullContainer: true` propagated `height: '100%'` to the inner wrapping View, callers in the contentHeight path got a detent locked at the max fraction (0.75) because `onLayout` reported the View's forced 100% of TrueSheet's max area instead of actual content height. NewMediaCall is the only `fullContainer: true` caller that doesn't pass snaps, so it was the only one stuck. iOS bypasses the affected branch (`fullContainer: false`).

**Fix 2 — `app/containers/NewMediaCall/NewMediaCall.tsx`**: drop `flex: 1` from the `screen` style.

After fix 1, the parent wrapper became `flex: 0` with no fixed height. The inner `screen` View's `flex: 1` then collapsed to padding-only (~84px on a 2400px-tall emulator), clipping the "New call" title and "Enter username or number" helper — only the search input, selected-peer pill, and Call button rendered. Dropping `flex: 1` lets the screen size to its children's intrinsic heights so the full UI renders and the detent reflects actual content height.

The naive alternative — dropping `fullContainer: isAndroid` from the NewMediaCall caller — was tried earlier and breaks Android rendering: title and helper disappear because the detent collapses too small. The flag wasn't wrong; the underlying styles were.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-103

## How to test or reproduce

Android:
1. Open a DM and tap the phone icon in the room header.
2. NewMediaCall sheet hugs content: handle, "New call" title, search input, "Enter username or number" helper, selected-peer pill, green "Ligar" button — no large empty area below the button.
3. Tap the search input → keyboard up; sheet height holds.
4. Type a few characters → peer-list autocomplete renders.
5. Drag the handle down → sheet dismisses.

Audit of all 5 `fullContainer: true` callsites:

| Callsite | Snaps | Visual after fix |
|---|---|---|
| `useNewMediaCall.tsx` | none | hugs content, title + input + helper + pill + Call all render ✓ |
| `useVideoConf/index.tsx` | 60% / 90% | not visually verified — snap-driven detent path; insulated by construction |
| `RoomView/index.tsx` (ReactionPicker) | 50% | renders at 50%, no regression ✓ |
| `RoomView/index.tsx` (ReactionsList) | 50% | renders at 50%, no regression ✓ |
| `NewMessageView/Item.tsx` | 60% / 90% | not visually verified — snap-driven detent path; insulated by construction |

iOS: unchanged (bypasses both paths via `fullContainer: false` for NewMediaCall).

## Screenshots

Visual diff vs Figma reference: pass (`visual-verdict` score 93/100 on the post-fix state; remaining differences are theme/i18n/content variations).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally (`yarn lint` clean; `TZ=UTC yarn test --testPathPattern='NewMediaCall|ActionSheet|useActionSheetDetents'` — 8 suites / 65 tests / 10 snapshots green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Action Sheet layout and sizing so it no longer forces full-height behavior.
  * Adjusted Main Media Call screen spacing to rely on padding for layout, improving rendering and consistent sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->