### PR TITLE
fix(e2e): restore testID='sidebar-view' on SidebarView

### DIFF
--- a/app/views/SidebarView/index.tsx
+++ b/app/views/SidebarView/index.tsx
@@ -25,7 +25,7 @@ const SidebarView = ({ navigation }: { navigation: DrawerNavigationProp<DrawerPa
 	}, [navigation]);
 
 	return (
-		<ScrollView style={styles.container} {...scrollPersistTaps}>
+		<ScrollView testID='sidebar-view' style={styles.container} {...scrollPersistTaps}>
 			<Profile navigation={navigation} />
 			<SupportedVersionsWarnItem />
 			<CustomStatus />


### PR DESCRIPTION
## Summary
- Restore `testID='sidebar-view'` to `<ScrollView>` in `app/views/SidebarView/index.tsx`. Re-enables Maestro drawer flows that were timing out.

## Root cause
Commit `e7185612e "Add voice call item on sidebar"` removed the `<SafeAreaView testID='sidebar-view'>` wrapper without re-attaching the testID. 5 of 13 Android E2E shards were failing every drawer-opening flow with `Assertion is false: id: sidebar-view is visible`.

Reference failing run: https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/25008420199/job/73243273302

## Test plan
- [x] Verified locally on emulator-5554: `maestro test .maestro/tests/assorted/change-avatar.yaml` passes the `sidebar-view` visibility step.
- [ ] CI: E2E Android shards 5/6/8/9 should now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced automated testing infrastructure for the sidebar component to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->