### PR TITLE
fix(ios): resolve bridging-header imports after Libraries/ move

### DIFF
--- a/ios/RocketChatRN-Bridging-Header.h
+++ b/ios/RocketChatRN-Bridging-Header.h
@@ -3,8 +3,8 @@
 //
 
 #import <RNCallKeep/RNCallKeep.h>
-#import "SecureStorage.h"
-#import "MMKVKeyManager.h"
+#import "Libraries/SecureStorage.h"
+#import "Libraries/MMKVKeyManager.h"
 #import "Shared/RocketChat/MMKVBridge.h"
 #import <RNBootSplash.h>
 #import <RNDeviceInfo/DeviceUID.h>
@@ -12,4 +12,4 @@
 #import <MobileCrypto/AESCrypto.h>
 #import <MobileCrypto/RandomUtils.h>
 #import <MobileCrypto/CryptoUtils.h>
-#import "SSLPinning.h"
+#import "Libraries/SSLPinning.h"

--- a/ios/RocketChatRN.xcodeproj/project.pbxproj
+++ b/ios/RocketChatRN.xcodeproj/project.pbxproj
@@ -289,8 +289,6 @@
 		66C2701B2EBBCB570062725F /* MMKVKeyManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 66C2701A2EBBCB570062725F /* MMKVKeyManager.mm */; };
 		66C2701C2EBBCB570062725F /* MMKVKeyManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 66C2701A2EBBCB570062725F /* MMKVKeyManager.mm */; };
 		66C2701D2EBBCB570062725F /* MMKVKeyManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 66C2701A2EBBCB570062725F /* MMKVKeyManager.mm */; };
-		66C270202EBBCB780062725F /* SecureStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 66C2701F2EBBCB780062725F /* SecureStorage.m */; };
-		66C270212EBBCB780062725F /* SecureStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 66C2701F2EBBCB780062725F /* SecureStorage.m */; };
 		6FA7E2382F28A9D300A1D45E /* ExternalInputModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7E2372F28A9D300A1D45E /* ExternalInputModule.m */; };
 		6FA7E2392F28A9D300A1D45E /* ExternalInputModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FA7E2372F28A9D300A1D45E /* ExternalInputModule.m */; };
 		782E0520ED599FF8DDC2318F /* Pods_defaults_Rocket_Chat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88ED4E003393D3A9256F4EB3 /* Pods_defaults_Rocket_Chat.framework */; };
@@ -648,8 +646,6 @@
 		65B9A7192AFC24190088956F /* ringtone.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = ringtone.mp3; sourceTree = "<group>"; };
 		66C270192EBBCB570062725F /* MMKVKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MMKVKeyManager.h; sourceTree = "<group>"; };
 		66C2701A2EBBCB570062725F /* MMKVKeyManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MMKVKeyManager.mm; sourceTree = "<group>"; };
-		66C2701E2EBBCB780062725F /* SecureStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SecureStorage.h; sourceTree = "<group>"; };
-		66C2701F2EBBCB780062725F /* SecureStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SecureStorage.m; sourceTree = "<group>"; };
 		6CE8C7A54627937DB698E839 /* Pods-defaults-NotificationService.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-defaults-NotificationService.debug.xcconfig"; path = "Target Support Files/Pods-defaults-NotificationService/Pods-defaults-NotificationService.debug.xcconfig"; sourceTree = "<group>"; };
 		6FA7E2362F28A9D300A1D45E /* ExternalInputModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExternalInputModule.h; sourceTree = "<group>"; };
 		6FA7E2372F28A9D300A1D45E /* ExternalInputModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExternalInputModule.m; sourceTree = "<group>"; };
@@ -769,8 +765,6 @@
 		13B07FAE1A68108700A75B9A /* RocketChatRN */ = {
 			isa = PBXGroup;
 			children = (
-				66C2701E2EBBCB780062725F /* SecureStorage.h */,
-				66C2701F2EBBCB780062725F /* SecureStorage.m */,
 				6FA7E2362F28A9D300A1D45E /* ExternalInputModule.h */,
 				6FA7E2372F28A9D300A1D45E /* ExternalInputModule.m */,
 				7ACFE7D82DDE48760090D9BC /* AppDelegate.swift */,
@@ -2174,7 +2168,6 @@
 				7AC0A1E02C000010001CAA11 /* Challenge.mm in Sources */,
 				1E76CBCF25152C310067298C /* NotificationType.swift in Sources */,
 				1E76CBDA25152C8E0067298C /* SendMessage.swift in Sources */,
-				66C270212EBBCB780062725F /* SecureStorage.m in Sources */,
 				6FA7E2382F28A9D300A1D45E /* ExternalInputModule.m in Sources */,
 				4C4C8603EF082F0A33A95522 /* ExpoModulesProvider.swift in Sources */,
 				A2C6E2DD38F8BEE19BFB2E1D /* SecureStorage.m in Sources */,
@@ -2462,7 +2455,6 @@
 				7AC0A1E02C000011001CAA11 /* Challenge.mm in Sources */,
 				7AAB3E30257E6A6E00707CF6 /* NotificationType.swift in Sources */,
 				7AAB3E31257E6A6E00707CF6 /* SendMessage.swift in Sources */,
-				66C270202EBBCB780062725F /* SecureStorage.m in Sources */,
 				6FA7E2392F28A9D300A1D45E /* ExternalInputModule.m in Sources */,
 				BC404914E86821389EEB543D /* ExpoModulesProvider.swift in Sources */,
 				79D8C97F8CE2EC1B6882826B /* SecureStorage.m in Sources */,


### PR DESCRIPTION
## Proposed changes

Fixes the iOS CI failure on PR #6918 where the build aborts with:

\`\`\`
RocketChatRN-Bridging-Header.h:6:9: fatal error: 'SecureStorage.h' file not found
\`\`\`

### Root cause

\`SecureStorage.{h,m}\`, \`MMKVKeyManager.{h,mm}\` and \`SSLPinning.{h,mm}\` were moved from \`ios/\` into \`ios/Libraries/\` (commit \`b6766f3\`), but the Swift bridging header still imported them with bare names. \`HEADER_SEARCH_PATHS\` does not include \`ios/Libraries\`, so the preprocessor scan that runs before Swift compilation fails to resolve the imports.

The build wasn't failing locally only because uncommitted/stale copies of the headers existed at \`ios/\` on developer machines, masking the issue.

### What this PR does

1. Update the three bare-name imports in \`ios/RocketChatRN-Bridging-Header.h\` to use the \`Libraries/\` prefix — matching the existing \`Shared/RocketChat/MMKVBridge.h\` convention. This is the minimal change that fixes CI and avoids encouraging an inconsistent bare-name import style.
2. Drop two stale \`PBXFileReference\` entries (\`66C2701E…\` for \`SecureStorage.h\`, \`66C2701F…\` for \`SecureStorage.m\`) that still pointed at the pre-move path \`ios/SecureStorage.{h,m}\`, plus the two \`PBXBuildFile\` entries and Compile Sources references that used them. Only the \`Libraries\`-group references (\`B179038F…\`, \`9B215A42…\`) remain.

\`HEADER_SEARCH_PATHS\` was intentionally left untouched: with explicit \`Libraries/\` paths in the bridging header, no extra search path is required.

## Issue(s)

Targets PR #6918 (\`feat.voip-lib-new\`). CI run that exposed this: https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/25024563893/job/73293514149

## How to test or reproduce

- Re-run iOS CI on \`feat.voip-lib-new\` after merging this; the previously failing \"Bridging header dependency scan failure\" should be gone for all four iOS targets (\`RocketChatRN\`, \`Rocket.Chat\`, \`NotificationService\`, \`Rocket.Chat.Watch\` / \`RocketChatRN Watch\`).
- Local: \`yarn pod-install && yarn ios\` should build cleanly without an \`ios/SecureStorage.h\` shim present.

## Screenshots

n/a — build-config fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build system configuration and project structure for improved library reference management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->