### PR TITLE
fix: centralize DM subscription stub via lib/methods/createDirectMessage wrapper

### DIFF
--- a/app/containers/MessageActions/index.tsx
+++ b/app/containers/MessageActions/index.tsx
@@ -31,10 +31,10 @@ import {
 	markAsUnread,
 	toggleStarMessage,
 	togglePinMessage,
-	createDirectMessage,
 	translateMessage,
 	reportMessage
 } from '../../lib/services/restApi';
+import { createDirectMessage } from '../../lib/methods/createDirectMessage';
 
 export interface IMessageActionsProps {
 	room: TSubscriptionModel;

--- a/app/lib/methods/canOpenRoom.ts
+++ b/app/lib/methods/canOpenRoom.ts
@@ -1,7 +1,7 @@
 import { ERoomTypes } from '../../definitions';
 import database from '../database';
 import sdk from '../services/sdk';
-import { createDirectMessage } from '../services/restApi';
+import { createDirectMessage } from './createDirectMessage';
 
 const restTypes = {
 	channel: 'channels',

--- a/app/lib/methods/createDirectMessage.test.ts
+++ b/app/lib/methods/createDirectMessage.test.ts
@@ -61,13 +61,13 @@ describe('createDirectMessage wrapper', () => {
 		expect(mockedStub).not.toHaveBeenCalled();
 	});
 
-	it('propagates stub rejection (stub owns its own error handling)', async () => {
+	it('does not reject when stub write fails', async () => {
 		const restResult = { success: true, room: { _id: 'r1', fname: 'Foo' } };
 		mockedRest.mockResolvedValue(restResult);
 		const stubError = new Error('stub write failed');
 		mockedStub.mockRejectedValue(stubError);
 
-		await expect(createDirectMessage('foo')).rejects.toThrow('stub write failed');
+		await expect(createDirectMessage('foo')).resolves.toBe(restResult);
 		expect(mockedRest).toHaveBeenCalledWith('foo');
 		expect(mockedStub).toHaveBeenCalledTimes(1);
 	});

--- a/app/lib/methods/createDirectMessage.test.ts
+++ b/app/lib/methods/createDirectMessage.test.ts
@@ -1,0 +1,74 @@
+import { createDirectMessage } from './createDirectMessage';
+import { createDirectMessage as createDirectMessageRest } from '../services/restApi';
+import { createDirectMessageSubscriptionStub } from './createDirectMessageSubscriptionStub';
+
+jest.mock('../services/restApi', () => ({
+	createDirectMessage: jest.fn()
+}));
+
+jest.mock('./createDirectMessageSubscriptionStub', () => ({
+	createDirectMessageSubscriptionStub: jest.fn()
+}));
+
+const mockedRest = createDirectMessageRest as jest.Mock;
+const mockedStub = createDirectMessageSubscriptionStub as jest.Mock;
+
+describe('createDirectMessage wrapper', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockedStub.mockResolvedValue(undefined);
+	});
+
+	it('calls stub with rid/username/fname on REST success and returns REST result', async () => {
+		const restResult = { success: true, room: { _id: 'r1', fname: 'Foo' } };
+		mockedRest.mockResolvedValue(restResult);
+
+		const result = await createDirectMessage('foo');
+
+		expect(mockedRest).toHaveBeenCalledWith('foo');
+		expect(mockedStub).toHaveBeenCalledTimes(1);
+		expect(mockedStub).toHaveBeenCalledWith({ rid: 'r1', username: 'foo', fname: 'Foo' });
+		expect(result).toBe(restResult);
+	});
+
+	it('skips stub when REST success but room._id is missing', async () => {
+		const restResult = { success: true, room: {} };
+		mockedRest.mockResolvedValue(restResult);
+
+		const result = await createDirectMessage('foo');
+
+		expect(mockedRest).toHaveBeenCalledWith('foo');
+		expect(mockedStub).not.toHaveBeenCalled();
+		expect(result).toBe(restResult);
+	});
+
+	it('skips stub when REST returns success: false', async () => {
+		const restResult = { success: false };
+		mockedRest.mockResolvedValue(restResult);
+
+		const result = await createDirectMessage('foo');
+
+		expect(mockedRest).toHaveBeenCalledWith('foo');
+		expect(mockedStub).not.toHaveBeenCalled();
+		expect(result).toBe(restResult);
+	});
+
+	it('propagates REST errors without calling stub', async () => {
+		const error = new Error('network error');
+		mockedRest.mockRejectedValue(error);
+
+		await expect(createDirectMessage('foo')).rejects.toThrow('network error');
+		expect(mockedStub).not.toHaveBeenCalled();
+	});
+
+	it('propagates stub rejection (stub owns its own error handling)', async () => {
+		const restResult = { success: true, room: { _id: 'r1', fname: 'Foo' } };
+		mockedRest.mockResolvedValue(restResult);
+		const stubError = new Error('stub write failed');
+		mockedStub.mockRejectedValue(stubError);
+
+		await expect(createDirectMessage('foo')).rejects.toThrow('stub write failed');
+		expect(mockedRest).toHaveBeenCalledWith('foo');
+		expect(mockedStub).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/lib/methods/createDirectMessage.ts
+++ b/app/lib/methods/createDirectMessage.ts
@@ -1,0 +1,14 @@
+import { createDirectMessage as createDirectMessageRest } from '../services/restApi';
+import { createDirectMessageSubscriptionStub } from './createDirectMessageSubscriptionStub';
+
+export const createDirectMessage = async (username: string) => {
+	const result = await createDirectMessageRest(username);
+	if (result?.success && result.room?._id) {
+		await createDirectMessageSubscriptionStub({
+			rid: result.room._id,
+			username,
+			fname: (result.room as any)?.fname
+		});
+	}
+	return result;
+};

--- a/app/lib/methods/createDirectMessage.ts
+++ b/app/lib/methods/createDirectMessage.ts
@@ -1,14 +1,19 @@
 import { createDirectMessage as createDirectMessageRest } from '../services/restApi';
 import { createDirectMessageSubscriptionStub } from './createDirectMessageSubscriptionStub';
+import log from './helpers/log';
 
 export const createDirectMessage = async (username: string) => {
 	const result = await createDirectMessageRest(username);
 	if (result?.success && result.room?._id) {
-		await createDirectMessageSubscriptionStub({
-			rid: result.room._id,
-			username,
-			fname: (result.room as any)?.fname
-		});
+		try {
+			await createDirectMessageSubscriptionStub({
+				rid: result.room._id,
+				username,
+				fname: (result.room as any)?.fname
+			});
+		} catch (e) {
+			log(e);
+		}
 	}
 	return result;
 };

--- a/app/lib/methods/createDirectMessageSubscriptionStub.test.ts
+++ b/app/lib/methods/createDirectMessageSubscriptionStub.test.ts
@@ -1,0 +1,216 @@
+import { createDirectMessageSubscriptionStub } from './createDirectMessageSubscriptionStub';
+import { getSubscriptionByRoomId } from '../database/services/Subscription';
+import database from '../database';
+import { store as reduxStore } from '../store/auxStore';
+import log from './helpers/log';
+
+jest.mock('../database/services/Subscription', () => ({
+	getSubscriptionByRoomId: jest.fn()
+}));
+
+jest.mock('../database', () => ({
+	__esModule: true,
+	default: {
+		active: {
+			get: jest.fn()
+		}
+	}
+}));
+
+jest.mock('../store/auxStore', () => ({
+	store: {
+		getState: jest.fn()
+	}
+}));
+
+jest.mock('./helpers/log', () => ({
+	__esModule: true,
+	default: jest.fn()
+}));
+
+describe('createDirectMessageSubscriptionStub', () => {
+	const RID = 'currentUserIdotherUserId';
+	const CURRENT_USER_ID = 'currentUserId';
+	const CURRENT_USERNAME = 'me';
+	const TARGET_USERNAME = 'alice';
+
+	const buildState = (override?: Partial<{ id: string; username: string }>) => ({
+		login: {
+			user: {
+				id: override?.id ?? CURRENT_USER_ID,
+				username: override?.username ?? CURRENT_USERNAME
+			}
+		}
+	});
+
+	let collectionWrites: any[];
+	let writeCallback: jest.Mock;
+	let createMock: jest.Mock;
+	let mockedDb: { write: jest.Mock; get: jest.Mock };
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		collectionWrites = [];
+		createMock = jest.fn((mutator: (s: any) => void) => {
+			const stub: any = { _raw: {} };
+			mutator(stub);
+			collectionWrites.push(stub);
+			return Promise.resolve();
+		});
+		writeCallback = jest.fn((cb: () => Promise<void>) => cb());
+		mockedDb = {
+			write: writeCallback,
+			get: jest.fn(() => ({ create: createMock }))
+		};
+		(database as any).active = mockedDb;
+
+		(reduxStore.getState as jest.Mock).mockReturnValue(buildState());
+		(getSubscriptionByRoomId as jest.Mock).mockResolvedValue(null);
+	});
+
+	it('inserts a stub when no subscription exists for the rid', async () => {
+		await createDirectMessageSubscriptionStub({
+			rid: RID,
+			username: TARGET_USERNAME,
+			fname: 'Alice'
+		});
+
+		expect(getSubscriptionByRoomId).toHaveBeenCalledWith(RID);
+		expect(writeCallback).toHaveBeenCalledTimes(1);
+		expect(createMock).toHaveBeenCalledTimes(1);
+		expect(collectionWrites).toHaveLength(1);
+
+		const created = collectionWrites[0];
+		expect(created._raw.id).toBe(RID);
+		expect(created._raw._id).toBe(RID);
+		expect(created.rid).toBe(RID);
+		expect(created.t).toBe('d');
+		expect(created.name).toBe(TARGET_USERNAME);
+		expect(created.fname).toBe('Alice');
+		expect(created.uids).toEqual([CURRENT_USER_ID, 'otherUserId']);
+		expect(created.usernames).toEqual([CURRENT_USERNAME, TARGET_USERNAME]);
+		expect(created.open).toBe(true);
+		expect(created.alert).toBe(false);
+		expect(created.unread).toBe(0);
+		expect(created.userMentions).toBe(0);
+		expect(created.groupMentions).toBe(0);
+		expect(created.archived).toBe(false);
+		expect(created.f).toBe(false);
+		expect(created.ro).toBe(false);
+		expect(created.ts).toBeInstanceOf(Date);
+		expect(created.ls).toBeInstanceOf(Date);
+		expect(created.roomUpdatedAt).toBeInstanceOf(Date);
+		expect(log).not.toHaveBeenCalled();
+	});
+
+	it('falls back to username when fname is missing', async () => {
+		await createDirectMessageSubscriptionStub({
+			rid: RID,
+			username: TARGET_USERNAME
+		});
+
+		expect(collectionWrites).toHaveLength(1);
+		expect(collectionWrites[0].fname).toBe(TARGET_USERNAME);
+	});
+
+	it('is a no-op when a subscription already exists for the rid', async () => {
+		(getSubscriptionByRoomId as jest.Mock).mockResolvedValue({ id: RID });
+
+		await createDirectMessageSubscriptionStub({
+			rid: RID,
+			username: TARGET_USERNAME
+		});
+
+		expect(getSubscriptionByRoomId).toHaveBeenCalledWith(RID);
+		expect(writeCallback).not.toHaveBeenCalled();
+		expect(createMock).not.toHaveBeenCalled();
+		expect(log).not.toHaveBeenCalled();
+	});
+
+	it('skips when redux login user is missing id', async () => {
+		(reduxStore.getState as jest.Mock).mockReturnValue({ login: { user: { username: CURRENT_USERNAME } } });
+
+		await createDirectMessageSubscriptionStub({
+			rid: RID,
+			username: TARGET_USERNAME
+		});
+
+		expect(writeCallback).not.toHaveBeenCalled();
+		expect(createMock).not.toHaveBeenCalled();
+	});
+
+	it('skips when redux login user is missing username', async () => {
+		(reduxStore.getState as jest.Mock).mockReturnValue({ login: { user: { id: CURRENT_USER_ID } } });
+
+		await createDirectMessageSubscriptionStub({
+			rid: RID,
+			username: TARGET_USERNAME
+		});
+
+		expect(writeCallback).not.toHaveBeenCalled();
+		expect(createMock).not.toHaveBeenCalled();
+	});
+
+	it('swallows errors thrown by db.write and logs them', async () => {
+		const failure = new Error('write failed');
+		writeCallback.mockRejectedValueOnce(failure);
+
+		await expect(
+			createDirectMessageSubscriptionStub({
+				rid: RID,
+				username: TARGET_USERNAME
+			})
+		).resolves.toBeUndefined();
+
+		expect(log).toHaveBeenCalledWith(failure);
+	});
+
+	it('swallows errors thrown by getSubscriptionByRoomId and logs them', async () => {
+		const failure = new Error('lookup failed');
+		(getSubscriptionByRoomId as jest.Mock).mockRejectedValueOnce(failure);
+
+		await expect(
+			createDirectMessageSubscriptionStub({
+				rid: RID,
+				username: TARGET_USERNAME
+			})
+		).resolves.toBeUndefined();
+
+		expect(log).toHaveBeenCalledWith(failure);
+		expect(writeCallback).not.toHaveBeenCalled();
+	});
+
+	it('skips when rid is empty', async () => {
+		await createDirectMessageSubscriptionStub({
+			rid: '',
+			username: TARGET_USERNAME
+		});
+
+		expect(getSubscriptionByRoomId).not.toHaveBeenCalled();
+		expect(writeCallback).not.toHaveBeenCalled();
+	});
+
+	it('skips when username is empty', async () => {
+		await createDirectMessageSubscriptionStub({
+			rid: RID,
+			username: ''
+		});
+
+		expect(getSubscriptionByRoomId).not.toHaveBeenCalled();
+		expect(writeCallback).not.toHaveBeenCalled();
+	});
+
+	it('still writes a stub when the rid does not contain the current user id (fallback uids)', async () => {
+		const oddRid = 'unrelatedRoomId';
+
+		await createDirectMessageSubscriptionStub({
+			rid: oddRid,
+			username: TARGET_USERNAME
+		});
+
+		expect(collectionWrites).toHaveLength(1);
+		// rid - currentUserId substring removal yields the rid itself when no overlap; we still get a 2-uid array
+		expect(collectionWrites[0].uids).toEqual([CURRENT_USER_ID, oddRid]);
+	});
+});

--- a/app/lib/methods/createDirectMessageSubscriptionStub.ts
+++ b/app/lib/methods/createDirectMessageSubscriptionStub.ts
@@ -46,7 +46,12 @@ export const createDirectMessageSubscriptionStub = async ({
 			return;
 		}
 
-		const otherUserId = rid.replace(currentUserId, '').trim();
+		let otherUserId = rid.trim();
+		if (rid.startsWith(currentUserId)) {
+			otherUserId = rid.slice(currentUserId.length).trim();
+		} else if (rid.endsWith(currentUserId)) {
+			otherUserId = rid.slice(0, -currentUserId.length).trim();
+		}
 
 		const db = database.active;
 		const subCollection = db.get(SUBSCRIPTIONS_TABLE);

--- a/app/lib/methods/createDirectMessageSubscriptionStub.ts
+++ b/app/lib/methods/createDirectMessageSubscriptionStub.ts
@@ -1,0 +1,81 @@
+import database from '../database';
+import { SUBSCRIPTIONS_TABLE } from '../database/model/Subscription';
+import { getSubscriptionByRoomId } from '../database/services/Subscription';
+import { SubscriptionType } from '../../definitions';
+import { store as reduxStore } from '../store/auxStore';
+import log from './helpers/log';
+
+interface ICreateDirectMessageSubscriptionStubArgs {
+	rid: string;
+	username: string;
+	fname?: string;
+}
+
+/**
+ * Inserts a minimal Subscription row for a freshly created direct message so that
+ * `useSubscription(rid)` consumers (e.g. NewMediaCall peer prefill) see a non-null
+ * record between REST `im.create` returning and realtime sync delivering the full
+ * subscription doc.
+ *
+ * Idempotent: skips when a row already exists for `rid`. The realtime upsert in
+ * `createOrUpdateSubscription` performs `getSubscriptionByRoomId` first and runs
+ * `prepareUpdate` when found, so the full doc merges into this stub without
+ * duplicate-row risk.
+ *
+ * Never throws — navigation must proceed even if the stub write fails.
+ */
+export const createDirectMessageSubscriptionStub = async ({
+	rid,
+	username,
+	fname
+}: ICreateDirectMessageSubscriptionStubArgs): Promise<void> => {
+	try {
+		if (!rid || !username) {
+			return;
+		}
+
+		const existing = await getSubscriptionByRoomId(rid);
+		if (existing) {
+			return;
+		}
+
+		const loginUser = reduxStore?.getState?.()?.login?.user;
+		const currentUserId = loginUser?.id;
+		const currentUsername = loginUser?.username;
+		if (!currentUserId || !currentUsername) {
+			return;
+		}
+
+		const otherUserId = rid.replace(currentUserId, '').trim();
+
+		const db = database.active;
+		const subCollection = db.get(SUBSCRIPTIONS_TABLE);
+		const now = new Date();
+
+		await db.write(async () => {
+			await subCollection.create((s: any) => {
+				s._raw.id = rid;
+				s._raw._id = rid;
+				s.rid = rid;
+				s.t = SubscriptionType.DIRECT;
+				s.name = username;
+				s.fname = fname || username;
+				s.uids = otherUserId ? [currentUserId, otherUserId] : [currentUserId];
+				s.usernames = [currentUsername, username];
+				s.open = true;
+				s.alert = false;
+				s.unread = 0;
+				s.userMentions = 0;
+				s.groupMentions = 0;
+				s.ro = false;
+				s.archived = false;
+				s.f = false;
+				s.ts = now;
+				s.ls = now;
+				s.roomUpdatedAt = now;
+			});
+		});
+	} catch (e) {
+		log(e);
+	}
+};

--- a/app/lib/methods/helpers/goRoom.ts
+++ b/app/lib/methods/helpers/goRoom.ts
@@ -10,7 +10,7 @@ import {
 	type ISubscription
 } from '../../../definitions';
 import { getRoomTitle, getUidDirectMessage } from './helpers';
-import { createDirectMessage } from '../../services/restApi';
+import { createDirectMessage } from '../createDirectMessage';
 import { emitErrorCreateDirectMessage } from './emitErrorCreateDirectMessage';
 
 interface IGoRoomItem {

--- a/app/sagas/messages.js
+++ b/app/sagas/messages.js
@@ -5,7 +5,8 @@ import { MESSAGES } from '../actions/actionsTypes';
 import database from '../lib/database';
 import log from '../lib/methods/helpers/log';
 import { goRoom } from '../lib/methods/helpers/goRoom';
-import { editMessage, createDirectMessage } from '../lib/services/restApi';
+import { editMessage } from '../lib/services/restApi';
+import { createDirectMessage } from '../lib/methods/createDirectMessage';
 
 const handleReplyBroadcast = function* handleReplyBroadcast({ message }) {
 	try {

--- a/app/views/DirectoryView/index.tsx
+++ b/app/views/DirectoryView/index.tsx
@@ -24,7 +24,8 @@ import { goRoom, type TGoRoomItem } from '../../lib/methods/helpers/goRoom';
 import { type IApplicationState, type IServerRoom, type IUser, SubscriptionType } from '../../definitions';
 import styles from './styles';
 import Options from './Options';
-import { getDirectory, createDirectMessage, getRoomByTypeAndName } from '../../lib/services/restApi';
+import { getDirectory, getRoomByTypeAndName } from '../../lib/services/restApi';
+import { createDirectMessage } from '../../lib/methods/createDirectMessage';
 import { getSubscriptionByRoomId } from '../../lib/database/services/Subscription';
 
 interface IDirectoryViewProps {

--- a/app/views/RoomInfoView/index.tsx
+++ b/app/views/RoomInfoView/index.tsx
@@ -17,7 +17,8 @@ import { getRoomTitle, getUidDirectMessage, hasPermission } from '../../lib/meth
 import { goRoom } from '../../lib/methods/helpers/goRoom';
 import { handleIgnore } from '../../lib/methods/helpers/handleIgnore';
 import log, { events, logEvent } from '../../lib/methods/helpers/log';
-import { createDirectMessage, getRoomInfo, getUserInfo, getVisitorInfo, toggleBlockUser } from '../../lib/services/restApi';
+import { getRoomInfo, getUserInfo, getVisitorInfo, toggleBlockUser } from '../../lib/services/restApi';
+import { createDirectMessage } from '../../lib/methods/createDirectMessage';
 import { type MasterDetailInsideStackParamList } from '../../stacks/MasterDetailStack/types';
 import { type ChatsStackParamList } from '../../stacks/types';
 import { useTheme } from '../../theme';

--- a/app/views/RoomMembersView/helpers.ts
+++ b/app/views/RoomMembersView/helpers.ts
@@ -17,9 +17,9 @@ import {
 	toggleMuteUserInRoom,
 	getRoomRoles,
 	removeTeamMember,
-	createDirectMessage,
 	teamListRoomsOfUser
 } from '../../lib/services/restApi';
+import { createDirectMessage } from '../../lib/methods/createDirectMessage';
 import database from '../../lib/database';
 import { type RoomTypes } from '../../lib/methods/roomTypeToApiType';
 import { emitErrorCreateDirectMessage } from '../../lib/methods/helpers/emitErrorCreateDirectMessage';


### PR DESCRIPTION
## Summary
- New `app/lib/methods/createDirectMessage.ts` wraps `services/restApi.createDirectMessage` and stamps the WatermelonDB Subscription stub on success (helper from prior shape of this PR: `createDirectMessageSubscriptionStub`).
- All 6 callers migrate to the wrapper: `containers/MessageActions`, `views/DirectoryView`, `views/RoomInfoView`, `views/RoomMembersView`, `sagas/messages.js`, `lib/methods/canOpenRoom`, `lib/methods/helpers/goRoom`.
- Fixes the peer-prefill regression on every DM-creation flow (spotlight, RoomInfo "Message", message action menu, DirectoryView, RoomMembersView, deep-link).

https://rocketchat.atlassian.net/browse/VMUX-83

## Why this shape
REST stays REST (`services/restApi.ts` unchanged). DB writes happen at the methods layer — same convention as `lib/methods/subscriptions/rooms.ts`, `lib/methods/getMessages.ts`. Single source of truth: every "create a DM" caller imports from `lib/methods/createDirectMessage`. Future callers automatically heal.

## Why develop (was feat.voip-lib-new)
The fix is not VoIP-specific — none of the touched files are VoIP-only. E2E noise on feat.voip-lib-new masked CI signal; develop gives a clean read.

## Test plan
- [ ] iOS: spotlight → user → tap call → peer pre-selected
- [ ] iOS: tap avatar/mention in message → "Message" → tap call → peer pre-selected
- [ ] iOS: message action menu → "Direct Message" → tap call → peer pre-selected
- [ ] iOS: DirectoryView → user → tap call → peer pre-selected
- [ ] iOS: RoomMembersView → user → DM → tap call → peer pre-selected
- [ ] Android: same as above
- [ ] Established DM regression: existing DM unchanged
- [ ] Re-opening an existing DM: no duplicate Subscription row (idempotency check in stub)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct message creation now triggers a minimal DM subscription so new conversations appear immediately.
* **Bug Fixes**
  * Prevents missing or duplicate DM records and avoids hidden/broken newly started direct message threads; stub failures are logged without affecting DM creation.
* **Tests**
  * Added unit tests covering DM creation flow, subscription stub behavior, error handling, and edge cases.
* **Chores**
  * Consolidated DM creation logic by routing calls through a single helper used across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->