### PR TITLE
feat(voip): double-tap call header to start DM call instantly

### DIFF
--- a/app/lib/hooks/useNewMediaCall/useNewMediaCall.test.tsx
+++ b/app/lib/hooks/useNewMediaCall/useNewMediaCall.test.tsx
@@ -10,6 +10,9 @@ const mockShowActionSheetRef = jest.fn();
 const mockGetUidDirectMessage = jest.fn();
 const mockSetSelectedPeer = jest.fn();
 const mockUseIsInActiveVoipCall = jest.fn(() => false);
+const mockStartCall = jest.fn();
+const mockIsSelfUserId = jest.fn((_userId: unknown) => false);
+const mockShowErrorAlert = jest.fn();
 const mockGetState = jest.fn(() => ({
 	setSelectedPeer: mockSetSelectedPeer
 }));
@@ -48,10 +51,34 @@ jest.mock('../../methods/helpers/deviceInfo', () => ({
 	isAndroid: false
 }));
 
+jest.mock('../../services/voip/MediaSessionInstance', () => ({
+	mediaSessionInstance: {
+		startCall: (...args: unknown[]) => mockStartCall(...args)
+	}
+}));
+
+jest.mock('../../services/voip/isSelfUserId', () => ({
+	isSelfUserId: (userId: unknown) => mockIsSelfUserId(userId)
+}));
+
+jest.mock('../../methods/helpers/info', () => ({
+	showErrorAlert: (...args: unknown[]) => mockShowErrorAlert(...args)
+}));
+
+jest.mock('../../../i18n', () => ({
+	__esModule: true,
+	default: {
+		t: (key: string) => key
+	}
+}));
+
 describe('useNewMediaCall', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockUseIsInActiveVoipCall.mockReturnValue(false);
+		mockIsSelfUserId.mockReturnValue(false);
+		mockStartCall.mockReset();
+		mockStartCall.mockResolvedValue(undefined);
 	});
 
 	const expectNewMediaCallActionSheet = (expectedFullContainer = false) => {
@@ -140,6 +167,109 @@ describe('useNewMediaCall', () => {
 
 		expect(mockShowActionSheetRef).not.toHaveBeenCalled();
 		expect(mockSetSelectedPeer).not.toHaveBeenCalled();
+	});
+
+	describe('startCallImmediate', () => {
+		it('starts the call directly when room has a direct message peer', async () => {
+			const room = { name: 'Alice' };
+			mockUseSubscription.mockReturnValue(room);
+			mockUseMediaCallPermission.mockReturnValue(true);
+			mockGetUidDirectMessage.mockReturnValue('user-id');
+
+			const { result } = renderHook(() => useNewMediaCall('room-id'));
+
+			await act(async () => {
+				await result.current.startCallImmediate();
+			});
+
+			expect(mockStartCall).toHaveBeenCalledWith('user-id', 'user');
+			expect(mockShowActionSheetRef).not.toHaveBeenCalled();
+			expect(mockShowErrorAlert).not.toHaveBeenCalled();
+		});
+
+		it('falls back to action sheet when room has no direct message peer', async () => {
+			const room = { name: 'Group' };
+			mockUseSubscription.mockReturnValue(room);
+			mockUseMediaCallPermission.mockReturnValue(true);
+			mockGetUidDirectMessage.mockReturnValue(undefined);
+
+			const { result } = renderHook(() => useNewMediaCall('room-id'));
+
+			await act(async () => {
+				await result.current.startCallImmediate();
+			});
+
+			expect(mockStartCall).not.toHaveBeenCalled();
+			expectNewMediaCallActionSheet();
+		});
+
+		it('falls back to action sheet when peer is the logged-in user (note-to-self)', async () => {
+			const room = { name: 'Me' };
+			mockUseSubscription.mockReturnValue(room);
+			mockUseMediaCallPermission.mockReturnValue(true);
+			mockGetUidDirectMessage.mockReturnValue('self-id');
+			mockIsSelfUserId.mockReturnValue(true);
+
+			const { result } = renderHook(() => useNewMediaCall('room-id'));
+
+			await act(async () => {
+				await result.current.startCallImmediate();
+			});
+
+			expect(mockStartCall).not.toHaveBeenCalled();
+			expectNewMediaCallActionSheet();
+		});
+
+		it('shows error alert when startCall throws', async () => {
+			const room = { name: 'Alice' };
+			mockUseSubscription.mockReturnValue(room);
+			mockUseMediaCallPermission.mockReturnValue(true);
+			mockGetUidDirectMessage.mockReturnValue('user-id');
+			mockStartCall.mockRejectedValueOnce(new Error('boom'));
+
+			const { result } = renderHook(() => useNewMediaCall('room-id'));
+
+			await act(async () => {
+				await result.current.startCallImmediate();
+			});
+
+			expect(mockStartCall).toHaveBeenCalledWith('user-id', 'user');
+			expect(mockShowErrorAlert).toHaveBeenCalledWith('boom', 'Oops');
+		});
+
+		it('falls back to default i18n message when error has no message', async () => {
+			const room = { name: 'Alice' };
+			mockUseSubscription.mockReturnValue(room);
+			mockUseMediaCallPermission.mockReturnValue(true);
+			mockGetUidDirectMessage.mockReturnValue('user-id');
+			mockStartCall.mockRejectedValueOnce(new Error(''));
+
+			const { result } = renderHook(() => useNewMediaCall('room-id'));
+
+			await act(async () => {
+				await result.current.startCallImmediate();
+			});
+
+			expect(mockShowErrorAlert).toHaveBeenCalledWith('VoIP_Call_Issue', 'Oops');
+		});
+
+		it('no-ops when isInActiveCall is true', async () => {
+			const room = { name: 'Alice' };
+			mockUseSubscription.mockReturnValue(room);
+			mockUseMediaCallPermission.mockReturnValue(true);
+			mockGetUidDirectMessage.mockReturnValue('user-id');
+			mockUseIsInActiveVoipCall.mockReturnValue(true);
+
+			const { result } = renderHook(() => useNewMediaCall('room-id'));
+
+			await act(async () => {
+				await result.current.startCallImmediate();
+			});
+
+			expect(mockStartCall).not.toHaveBeenCalled();
+			expect(mockShowActionSheetRef).not.toHaveBeenCalled();
+			expect(mockShowErrorAlert).not.toHaveBeenCalled();
+		});
 	});
 
 	it('should pass fullContainer to the action sheet when isAndroid is true', () => {

--- a/app/lib/hooks/useNewMediaCall/useNewMediaCall.tsx
+++ b/app/lib/hooks/useNewMediaCall/useNewMediaCall.tsx
@@ -5,6 +5,10 @@ import { showActionSheetRef } from '../../../containers/ActionSheet';
 import { getUidDirectMessage } from '../../methods/helpers/helpers';
 import { usePeerAutocompleteStore } from '../../services/voip/usePeerAutocompleteStore';
 import { useIsInActiveVoipCall } from '../../services/voip/isInActiveVoipCall';
+import { mediaSessionInstance } from '../../services/voip/MediaSessionInstance';
+import { isSelfUserId } from '../../services/voip/isSelfUserId';
+import { showErrorAlert } from '../../methods/helpers/info';
+import I18n from '../../../i18n';
 import { useSubscription } from '../useSubscription';
 import { useMediaCallPermission } from '../useMediaCallPermission';
 import { isAndroid } from '../../methods/helpers/deviceInfo';
@@ -28,5 +32,20 @@ export const useNewMediaCall = (rid?: string) => {
 		});
 	};
 
-	return { openNewMediaCall, hasMediaCallPermission, isInActiveCall };
+	const startCallImmediate = async () => {
+		if (isInActiveCall) return;
+		const otherUserId = room ? getUidDirectMessage(room) : undefined;
+		if (!otherUserId || isSelfUserId(otherUserId)) {
+			openNewMediaCall();
+			return;
+		}
+		try {
+			await mediaSessionInstance.startCall(otherUserId, 'user');
+		} catch (e) {
+			const message = e instanceof Error && e.message ? e.message : I18n.t('VoIP_Call_Issue');
+			showErrorAlert(message, I18n.t('Oops'));
+		}
+	};
+
+	return { openNewMediaCall, startCallImmediate, hasMediaCallPermission, isInActiveCall };
 };

--- a/app/views/RoomView/components/HeaderCallButton.tsx
+++ b/app/views/RoomView/components/HeaderCallButton.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import * as HeaderButton from '../../../containers/Header/components/HeaderButton';
 import { useVideoConf } from '../../../lib/hooks/useVideoConf';
 import { useNewMediaCall } from '../../../lib/hooks/useNewMediaCall';
 import { useIsInActiveVoipCall } from '../../../lib/services/voip/isInActiveVoipCall';
+
+const DOUBLE_TAP_WINDOW_MS = 300;
 
 export const HeaderCallButton = ({
 	rid,
@@ -17,8 +19,37 @@ export const HeaderCallButton = ({
 	'use memo';
 
 	const { showInitCallActionSheet, callEnabled, disabledTooltip } = useVideoConf(rid);
-	const { openNewMediaCall, hasMediaCallPermission, isInActiveCall } = useNewMediaCall(rid);
+	const { openNewMediaCall, startCallImmediate, hasMediaCallPermission, isInActiveCall } = useNewMediaCall(rid);
 	const isInActiveVoipCall = useIsInActiveVoipCall();
+
+	const lastTapRef = useRef(0);
+	const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(
+		() => () => {
+			if (pendingTimerRef.current) {
+				clearTimeout(pendingTimerRef.current);
+				pendingTimerRef.current = null;
+			}
+		},
+		[]
+	);
+
+	const handleVoipPress = () => {
+		const now = Date.now();
+		if (pendingTimerRef.current && now - lastTapRef.current < DOUBLE_TAP_WINDOW_MS) {
+			clearTimeout(pendingTimerRef.current);
+			pendingTimerRef.current = null;
+			lastTapRef.current = 0;
+			startCallImmediate();
+			return;
+		}
+		lastTapRef.current = now;
+		pendingTimerRef.current = setTimeout(() => {
+			pendingTimerRef.current = null;
+			openNewMediaCall();
+		}, DOUBLE_TAP_WINDOW_MS);
+	};
 
 	if (hasMediaCallPermission) {
 		return (
@@ -26,7 +57,7 @@ export const HeaderCallButton = ({
 				accessibilityLabel={accessibilityLabel}
 				disabled={disabled || isInActiveCall}
 				iconName='phone'
-				onPress={openNewMediaCall}
+				onPress={handleVoipPress}
 				testID='room-view-header-call'
 			/>
 		);


### PR DESCRIPTION
## Proposed changes

Adds a quick-call shortcut to the room header phone button on the VoIP code path: a double-tap (within 300ms) on a DM skips the new media call action sheet and starts the call to the other user directly. Single tap is unchanged — it opens the action sheet as before.

The shortcut is intentionally scoped to the VoIP branch (`hasMediaCallPermission`); the legacy VideoConf (`callEnabled`) branch is untouched.

### Behavior

- Single tap → `openNewMediaCall()` (action sheet, as today). Single tap is deferred 300ms so the double-tap window can be observed.
- Double tap (DM, peer present, not in active call) → `mediaSessionInstance.startCall(otherUserId, 'user')` with the same error handling as `CreateCall` (`showErrorAlert(I18n.t('VoIP_Call_Issue'), I18n.t('Oops'))`).
- Double tap with no peer / note-to-self DM → falls back to opening the action sheet.
- Already in an active call → no-op (button is already disabled, but guard kept for safety).

### Implementation notes

- `useNewMediaCall` exposes a new `startCallImmediate()` that owns the DM peer lookup, guards, and error handling. The hook now returns `{ openNewMediaCall, startCallImmediate, hasMediaCallPermission, isInActiveCall }`.
- `HeaderCallButton` holds the gesture timing only: a `useRef` last-tap timestamp + pending `setTimeout`, cleared on unmount.
- We picked timestamp-based detection over `Gesture.Tap().numberOfTaps(2)` because `HeaderButton.Item` is built around `BorderlessButton` (RNGH), and composing a `GestureDetector` around it would have meant locally re-implementing the styled button and losing `BorderlessButton`'s native Android touch feedback.
- 300ms window is hardcoded (matches iOS HIG default; iOS exposes no public API for the user-configured double-tap interval, and Android's `ViewConfiguration.getDoubleTapTimeout()` also defaults to 300ms).
- Screen-reader users still get the action sheet path: VoiceOver/TalkBack reroute their own activation gesture, so the double-tap shortcut is not reachable via assistive tech — the existing accessible flow is preserved.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-13

## How to test or reproduce

1. Open a 1:1 DM where you have media call permission.
2. Single tap the phone icon in the header → action sheet opens (as before), with the peer pre-selected.
3. Double tap (within 300ms) the phone icon → no sheet; the call to the other user starts immediately.
4. In a group / channel, double tap → falls back to the action sheet.
5. While in an active call, the button is disabled (no-op for both single and double tap).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Single tap incurs a 300ms delay so the double-tap window can be observed. We considered firing single-tap immediately and dismissing the sheet on second tap, but that produces a visible flicker. The 300ms delay is below typical perceived-lag thresholds for this action and matches platform double-tap conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immediate call initiation capability for streamlined call establishment
  * Implemented double-tap gesture on the header call button: single tap displays call options menu, double tap directly initiates an immediate call
  * Improved error handling with localized alert messages to provide clear feedback when call initiation fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->