### PR TITLE
feat(voip): introduce CallLifecycle.answerIncoming and beginOutgoing

### DIFF
--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -24,6 +24,7 @@ import { usePeerAutocompleteStore } from '../../lib/services/voip/usePeerAutocom
 import { useCallStore } from '../../lib/services/voip/useCallStore';
 import { mediaSessionInstance } from '../../lib/services/voip/MediaSessionInstance';
 import { voipNative, type InMemoryVoipNative } from '../../lib/services/voip/VoipNative';
+import { CallNavRouter } from '../../lib/services/voip/CallNavRouter';
 import { mockedStore } from '../../reducers/mockedStore';
 import type { TPeerItem } from '../../lib/services/voip/getPeerAutocompleteOptions';
 import type { InsideStackParamList } from '../../stacks/types';
@@ -53,7 +54,7 @@ jest.mock('../../lib/methods/helpers/helpers', () => ({
 }));
 jest.mock('../../lib/navigation/appNavigation', () => ({
 	__esModule: true,
-	default: { navigate: jest.fn(), back: jest.fn() },
+	default: { navigate: jest.fn(), back: jest.fn(), getCurrentRoute: jest.fn(), navigationRef: { current: {} } },
 	waitForNavigationReady: jest.fn().mockResolvedValue(undefined)
 }));
 jest.mock('../../lib/services/sdk', () => ({
@@ -388,6 +389,11 @@ describe('VoIP call lifecycle (integration)', () => {
 		useCallStore.getState().reset();
 		mediaSessionInstance.reset();
 		(voipNative as InMemoryVoipNative).reset();
+		// Mount CallNavRouter so callBegan → Navigation.navigate('CallView') fires.
+		// Navigation.navigationRef.current is set to {} (truthy) in the mock above,
+		// so the router subscribes immediately without waiting for navigationReady.
+		CallNavRouter.unmount();
+		CallNavRouter.mount();
 
 		consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
 			const message = formatConsoleArgs(args);
@@ -408,6 +414,7 @@ describe('VoIP call lifecycle (integration)', () => {
 	});
 
 	afterEach(() => {
+		CallNavRouter.unmount();
 		consoleErrorSpy?.mockRestore();
 		consoleWarnSpy?.mockRestore();
 		consoleErrorSpy = undefined;

--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -454,6 +454,11 @@ describe('VoIP call lifecycle (integration)', () => {
 
 		const { call } = useCallStore.getState();
 		expect(call?.callId).toBe('call-user-1');
+		// Pre-refactor parity: outgoing DM-by-username has no roomId from the caller, so
+		// CallLifecycle.beginOutgoing falls back to getDMSubscriptionByUsername. The mock
+		// here returns null (no DM subscription) AND the synthetic call has no contact
+		// username, so roomId stays null — but the lookup path must remain wired.
+		expect(useCallStore.getState().roomId).toBeNull();
 
 		// Firing 'ended' triggers CallLifecycle teardown via the handleEnded listener.
 		// Navigation.back() is now handled by CallNavRouter (not wired in this integration test).

--- a/app/lib/services/voip/CallLifecycle.test.ts
+++ b/app/lib/services/voip/CallLifecycle.test.ts
@@ -837,6 +837,40 @@ describe('CallLifecycle.answerIncoming(callId)', () => {
 			expect(listener).not.toHaveBeenCalled();
 		});
 
+		it('concurrent answerIncoming for the same callId — accept called exactly once, one callBegan', async () => {
+			const call = makeIncomingCall('inc-concurrent-1');
+			mockGetMediaCall.mockReturnValue(call);
+
+			const beganEvents: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => beganEvents.push(e));
+
+			// Fire two concurrent answerIncoming calls before either resolves.
+			const [p1, p2] = [
+				callLifecycle.answerIncoming('inc-concurrent-1'),
+				callLifecycle.answerIncoming('inc-concurrent-1')
+			];
+
+			// Both callers should receive the same in-flight Promise.
+			expect(p1).toBe(p2);
+
+			await Promise.all([p1, p2]);
+
+			unsub();
+
+			// accept() must be called exactly once — no WebRTC double offer-answer.
+			expect(call.accept).toHaveBeenCalledTimes(1);
+
+			// markActive and startAudio each appear exactly once.
+			const markActiveCmds = native.recorded.filter(c => c.cmd === 'markActive' && c.callUuid === 'inc-concurrent-1');
+			const startAudioCmds = native.recorded.filter(c => c.cmd === 'startAudio');
+			expect(markActiveCmds).toHaveLength(1);
+			expect(startAudioCmds).toHaveLength(1);
+
+			// callBegan emits exactly once — no duplicate CallView push.
+			expect(beganEvents).toHaveLength(1);
+			expect(beganEvents[0]).toMatchObject({ callId: 'inc-concurrent-1', direction: 'incoming' });
+		});
+
 		it('proceeds normally for a different callId after a prior answer', async () => {
 			const callA = makeIncomingCall('inc-idem-a');
 			mockGetMediaCall.mockReturnValue(callA);

--- a/app/lib/services/voip/CallLifecycle.test.ts
+++ b/app/lib/services/voip/CallLifecycle.test.ts
@@ -12,9 +12,25 @@
 import type { IClientMediaCall } from '@rocket.chat/media-signaling';
 
 import { callLifecycle } from './CallLifecycle';
-import type { CallEndReason } from './CallLifecycle';
+import type { CallBeganEvent, CallEndReason } from './CallLifecycle';
 import { InMemoryVoipNative } from './VoipNative';
 import { useCallStore } from './useCallStore';
+import { getDMSubscriptionByUsername } from '../../database/services/Subscription';
+
+// Mock mediaSessionInstance — CallLifecycle.answerIncoming reads mediaCall via getMediaCall.
+const mockGetMediaCall = jest.fn();
+jest.mock('./MediaSessionInstance', () => ({
+	mediaSessionInstance: {
+		getMediaCall: (...args: unknown[]) => mockGetMediaCall(...args)
+	}
+}));
+
+// Mock getDMSubscriptionByUsername — CallLifecycle.resolveRoomIdFromContact uses it.
+jest.mock('../../database/services/Subscription', () => ({
+	getDMSubscriptionByUsername: jest.fn()
+}));
+
+const mockGetDMSubscriptionByUsername = jest.mocked(getDMSubscriptionByUsername);
 
 jest.mock('react-native-callkeep', () => ({
 	__esModule: true,
@@ -639,6 +655,389 @@ describe('CallLifecycle.end(reason)', () => {
 			expect(warnCalls.some(msg => msg.includes('callEnded listener failed'))).toBe(true);
 
 			warnSpy.mockRestore();
+		});
+	});
+});
+
+// ── CallLifecycle.answerIncoming ──────────────────────────────────────────────
+
+describe('CallLifecycle.answerIncoming(callId)', () => {
+	let native: InMemoryVoipNative;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		useCallStore.getState().resetNativeCallId();
+		useCallStore.getState().reset();
+		native = new InMemoryVoipNative();
+		callLifecycle.attach(native);
+		native.reset();
+		mockGetDMSubscriptionByUsername.mockResolvedValue(null);
+	});
+
+	function makeIncomingCall(callId: string): IClientMediaCall {
+		return {
+			callId,
+			state: 'ringing',
+			hidden: false,
+			localParticipant: { local: true, role: 'callee', muted: false, held: false, contact: {} },
+			remoteParticipants: [
+				{
+					local: false,
+					role: 'caller',
+					muted: false,
+					held: false,
+					contact: { id: 'u', displayName: 'Caller', username: 'caller', sipExtension: '' }
+				}
+			],
+			accept: jest.fn().mockResolvedValue(undefined),
+			hangup: jest.fn(),
+			reject: jest.fn(),
+			sendDTMF: jest.fn(),
+			emitter: { on: jest.fn(), off: jest.fn(), emit: jest.fn() }
+		} as unknown as IClientMediaCall;
+	}
+
+	describe('command ordering', () => {
+		it('calls accept() then markActive() then startAudio() in order', async () => {
+			const call = makeIncomingCall('inc-order-1');
+			mockGetMediaCall.mockReturnValue(call);
+			const order: string[] = [];
+			(call.accept as jest.Mock).mockImplementation(() => {
+				order.push('accept');
+				return Promise.resolve();
+			});
+			jest.spyOn(native.call, 'markActive').mockImplementation(() => {
+				order.push('markActive');
+			});
+			jest.spyOn(native.call, 'startAudio').mockImplementation(() => {
+				order.push('startAudio');
+			});
+
+			await callLifecycle.answerIncoming('inc-order-1');
+
+			expect(order).toEqual(['accept', 'markActive', 'startAudio']);
+		});
+
+		it('records markActive with callId', async () => {
+			const call = makeIncomingCall('inc-mark-1');
+			mockGetMediaCall.mockReturnValue(call);
+
+			await callLifecycle.answerIncoming('inc-mark-1');
+
+			expect(native.recorded).toContainEqual({ cmd: 'markActive', callUuid: 'inc-mark-1' });
+		});
+
+		it('records startAudio', async () => {
+			const call = makeIncomingCall('inc-audio-1');
+			mockGetMediaCall.mockReturnValue(call);
+
+			await callLifecycle.answerIncoming('inc-audio-1');
+
+			expect(native.recorded).toContainEqual({ cmd: 'startAudio' });
+		});
+
+		it('does NOT record markActive or startAudio when call is not found', async () => {
+			mockGetMediaCall.mockReturnValue(null);
+			native.reset();
+
+			await callLifecycle.answerIncoming('not-found');
+
+			expect(native.recorded).not.toContainEqual(expect.objectContaining({ cmd: 'markActive' }));
+			expect(native.recorded).not.toContainEqual(expect.objectContaining({ cmd: 'startAudio' }));
+		});
+	});
+
+	describe('store updates', () => {
+		it('sets call and direction incoming in store', async () => {
+			const call = makeIncomingCall('inc-store-1');
+			mockGetMediaCall.mockReturnValue(call);
+
+			await callLifecycle.answerIncoming('inc-store-1');
+
+			expect(useCallStore.getState().call).toBe(call);
+			expect(useCallStore.getState().direction).toBe('incoming');
+		});
+	});
+
+	describe('callBegan event', () => {
+		it('emits callBegan exactly once with direction incoming', async () => {
+			const call = makeIncomingCall('inc-began-1');
+			mockGetMediaCall.mockReturnValue(call);
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await callLifecycle.answerIncoming('inc-began-1');
+
+			unsub();
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({ callId: 'inc-began-1', direction: 'incoming' });
+		});
+
+		it('callBegan includes roomId when resolved from contact', async () => {
+			const call = makeIncomingCall('inc-room-1');
+			mockGetMediaCall.mockReturnValue(call);
+			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-rid-incoming' } as any);
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await callLifecycle.answerIncoming('inc-room-1');
+
+			unsub();
+			expect(events[0]).toMatchObject({ callId: 'inc-room-1', direction: 'incoming', roomId: 'dm-rid-incoming' });
+		});
+
+		it('callBegan roomId is undefined when contact has no username', async () => {
+			const call = makeIncomingCall('inc-noroom-1');
+			// Override contact with no username
+			(call as any).remoteParticipants = [{ contact: {} }];
+			mockGetMediaCall.mockReturnValue(call);
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await callLifecycle.answerIncoming('inc-noroom-1');
+
+			unsub();
+			expect(events[0].roomId).toBeUndefined();
+		});
+
+		it('does NOT emit callBegan when call is not found', async () => {
+			mockGetMediaCall.mockReturnValue(null);
+
+			const listener = jest.fn();
+			const unsub = callLifecycle.emitter.on('callBegan', listener);
+
+			await callLifecycle.answerIncoming('not-found-2');
+
+			unsub();
+			expect(listener).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('idempotency', () => {
+		it('returns early (no double-accept) when store already has a call with same callId', async () => {
+			const call = makeIncomingCall('inc-idempotent-1');
+			mockGetMediaCall.mockReturnValue(call);
+
+			// First call — sets call in store
+			await callLifecycle.answerIncoming('inc-idempotent-1');
+
+			native.reset();
+			const listener = jest.fn();
+			const unsub = callLifecycle.emitter.on('callBegan', listener);
+
+			// Second call with same callId — should be a no-op
+			await callLifecycle.answerIncoming('inc-idempotent-1');
+
+			unsub();
+			expect(call.accept).toHaveBeenCalledTimes(1);
+			expect(native.recorded).toHaveLength(0);
+			expect(listener).not.toHaveBeenCalled();
+		});
+
+		it('proceeds normally for a different callId after a prior answer', async () => {
+			const callA = makeIncomingCall('inc-idem-a');
+			mockGetMediaCall.mockReturnValue(callA);
+			await callLifecycle.answerIncoming('inc-idem-a');
+
+			// Reset store for a "new" call scenario
+			useCallStore.getState().reset();
+			const callB = makeIncomingCall('inc-idem-b');
+			mockGetMediaCall.mockReturnValue(callB);
+			native.reset();
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+			await callLifecycle.answerIncoming('inc-idem-b');
+			unsub();
+
+			expect(callB.accept).toHaveBeenCalledTimes(1);
+			expect(events).toHaveLength(1);
+			expect(events[0].callId).toBe('inc-idem-b');
+		});
+	});
+
+	describe('pre-bind compatibility', () => {
+		it('does not remove tryAnswerIfNativeAcceptedNotification path — nativeAcceptedCallId still survives reset()', () => {
+			// Verify store still exposes nativeAcceptedCallId (Pre-bind path in slice 08 depends on it)
+			useCallStore.getState().setNativeAcceptedCallId('prebind-id');
+			useCallStore.getState().reset();
+			expect(useCallStore.getState().nativeAcceptedCallId).toBe('prebind-id');
+		});
+	});
+});
+
+// ── CallLifecycle.beginOutgoing ───────────────────────────────────────────────
+
+describe('CallLifecycle.beginOutgoing(call, room?)', () => {
+	let native: InMemoryVoipNative;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		useCallStore.getState().resetNativeCallId();
+		useCallStore.getState().reset();
+		native = new InMemoryVoipNative();
+		callLifecycle.attach(native);
+		native.reset();
+		mockGetDMSubscriptionByUsername.mockResolvedValue(null);
+	});
+
+	function makeOutgoingCall(callId: string): IClientMediaCall {
+		return {
+			callId,
+			state: 'active',
+			hidden: false,
+			localParticipant: { local: true, role: 'caller', muted: false, held: false, contact: {} },
+			remoteParticipants: [
+				{
+					local: false,
+					role: 'callee',
+					muted: false,
+					held: false,
+					contact: { id: 'u', displayName: 'Callee', username: 'callee', sipExtension: '' }
+				}
+			],
+			hangup: jest.fn(),
+			reject: jest.fn(),
+			sendDTMF: jest.fn(),
+			emitter: { on: jest.fn(), off: jest.fn(), emit: jest.fn() }
+		} as unknown as IClientMediaCall;
+	}
+
+	describe('command ordering', () => {
+		it('records markActive then startAudio in order', async () => {
+			const call = makeOutgoingCall('out-order-1');
+			const order: string[] = [];
+			jest.spyOn(native.call, 'markActive').mockImplementation(() => {
+				order.push('markActive');
+			});
+			jest.spyOn(native.call, 'startAudio').mockImplementation(() => {
+				order.push('startAudio');
+			});
+
+			await callLifecycle.beginOutgoing(call);
+
+			expect(order).toEqual(['markActive', 'startAudio']);
+		});
+
+		it('records markActive with callId', async () => {
+			const call = makeOutgoingCall('out-mark-1');
+
+			await callLifecycle.beginOutgoing(call);
+
+			expect(native.recorded).toContainEqual({ cmd: 'markActive', callUuid: 'out-mark-1' });
+		});
+
+		it('records startAudio', async () => {
+			const call = makeOutgoingCall('out-audio-1');
+
+			await callLifecycle.beginOutgoing(call);
+
+			expect(native.recorded).toContainEqual({ cmd: 'startAudio' });
+		});
+	});
+
+	describe('store updates', () => {
+		it('sets call and direction outgoing in store', async () => {
+			const call = makeOutgoingCall('out-store-1');
+
+			await callLifecycle.beginOutgoing(call);
+
+			expect(useCallStore.getState().call).toBe(call);
+			expect(useCallStore.getState().direction).toBe('outgoing');
+		});
+
+		it('sets roomId from room argument when provided', async () => {
+			const call = makeOutgoingCall('out-room-1');
+			const room = { rid: 'room-rid-out' } as any;
+
+			await callLifecycle.beginOutgoing(call, room);
+
+			expect(useCallStore.getState().roomId).toBe('room-rid-out');
+		});
+
+		it('sets roomId to null when no room argument', async () => {
+			const call = makeOutgoingCall('out-noroom-1');
+
+			await callLifecycle.beginOutgoing(call);
+
+			// setRoomId(undefined) should result in null/undefined — doesn't set a non-null value
+			// The store's roomId was null to begin with; verify no roomId is set from an unknown source
+			expect(useCallStore.getState().roomId).toBeFalsy();
+		});
+	});
+
+	describe('callBegan event', () => {
+		it('emits callBegan exactly once with direction outgoing', async () => {
+			const call = makeOutgoingCall('out-began-1');
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await callLifecycle.beginOutgoing(call);
+
+			unsub();
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({ callId: 'out-began-1', direction: 'outgoing' });
+		});
+
+		it('callBegan includes roomId from room argument', async () => {
+			const call = makeOutgoingCall('out-room-began-1');
+			const room = { rid: 'outgoing-room' } as any;
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await callLifecycle.beginOutgoing(call, room);
+
+			unsub();
+			expect(events[0]).toMatchObject({ callId: 'out-room-began-1', direction: 'outgoing', roomId: 'outgoing-room' });
+		});
+
+		it('callBegan emits once regardless of room argument', async () => {
+			const call = makeOutgoingCall('out-once-1');
+
+			const listener = jest.fn();
+			const unsub = callLifecycle.emitter.on('callBegan', listener);
+
+			await callLifecycle.beginOutgoing(call);
+
+			unsub();
+			expect(listener).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('callBegan emitted exactly once between both transitions', () => {
+		it('answerIncoming + beginOutgoing each emit callBegan independently once', async () => {
+			const incoming = {
+				callId: 'both-inc-1',
+				state: 'ringing',
+				hidden: false,
+				localParticipant: { local: true, role: 'callee', muted: false, held: false, contact: {} },
+				remoteParticipants: [{ local: false, role: 'caller', muted: false, held: false, contact: { username: 'caller' } }],
+				accept: jest.fn().mockResolvedValue(undefined),
+				hangup: jest.fn(),
+				reject: jest.fn(),
+				sendDTMF: jest.fn(),
+				emitter: { on: jest.fn(), off: jest.fn(), emit: jest.fn() }
+			} as unknown as IClientMediaCall;
+			mockGetMediaCall.mockReturnValue(incoming);
+			const outgoing = makeOutgoingCall('both-out-1');
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await callLifecycle.answerIncoming('both-inc-1');
+			// Reset store to simulate a fresh call scenario
+			useCallStore.getState().reset();
+			await callLifecycle.beginOutgoing(outgoing);
+
+			unsub();
+			expect(events).toHaveLength(2);
+			expect(events[0]).toMatchObject({ callId: 'both-inc-1', direction: 'incoming' });
+			expect(events[1]).toMatchObject({ callId: 'both-out-1', direction: 'outgoing' });
 		});
 	});
 });

--- a/app/lib/services/voip/CallLifecycle.test.ts
+++ b/app/lib/services/voip/CallLifecycle.test.ts
@@ -845,10 +845,7 @@ describe('CallLifecycle.answerIncoming(callId)', () => {
 			const unsub = callLifecycle.emitter.on('callBegan', e => beganEvents.push(e));
 
 			// Fire two concurrent answerIncoming calls before either resolves.
-			const [p1, p2] = [
-				callLifecycle.answerIncoming('inc-concurrent-1'),
-				callLifecycle.answerIncoming('inc-concurrent-1')
-			];
+			const [p1, p2] = [callLifecycle.answerIncoming('inc-concurrent-1'), callLifecycle.answerIncoming('inc-concurrent-1')];
 
 			// Both callers should receive the same in-flight Promise.
 			expect(p1).toBe(p2);
@@ -999,6 +996,59 @@ describe('CallLifecycle.beginOutgoing(call, room?)', () => {
 
 			// setRoomId(undefined) should result in null/undefined — doesn't set a non-null value
 			// The store's roomId was null to begin with; verify no roomId is set from an unknown source
+			expect(useCallStore.getState().roomId).toBeFalsy();
+		});
+
+		it('falls back to DM subscription lookup by contact username when no room argument (DM-by-username regression)', async () => {
+			// Pre-refactor parity: outgoing DM initiated by username (CreateCall path)
+			// has roomId == null in the store. The newCall handler used to resolve the
+			// DM rid from the remote participant's username via getDMSubscriptionByUsername.
+			// CallLifecycle.beginOutgoing must keep that fallback alive — otherwise the
+			// "Go to chat" button on CallView stays disabled.
+			const call = makeOutgoingCall('out-fallback-1');
+			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-rid-from-contact' } as any);
+
+			await callLifecycle.beginOutgoing(call);
+
+			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('callee');
+			expect(useCallStore.getState().roomId).toBe('dm-rid-from-contact');
+		});
+
+		it('does NOT fall back to contact lookup when room argument is provided', async () => {
+			// Caller-supplied roomId (e.g. startCallByRoom path) wins — no DB hit needed.
+			const call = makeOutgoingCall('out-room-wins-1');
+			const room = { rid: 'explicit-room' } as any;
+
+			await callLifecycle.beginOutgoing(call, room);
+
+			expect(mockGetDMSubscriptionByUsername).not.toHaveBeenCalled();
+			expect(useCallStore.getState().roomId).toBe('explicit-room');
+		});
+
+		it('callBegan includes roomId resolved from contact when no room argument', async () => {
+			const call = makeOutgoingCall('out-fallback-began-1');
+			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-rid-began' } as any);
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await callLifecycle.beginOutgoing(call);
+
+			unsub();
+			expect(events[0]).toMatchObject({
+				callId: 'out-fallback-began-1',
+				direction: 'outgoing',
+				roomId: 'dm-rid-began'
+			});
+		});
+
+		it('keeps roomId falsy when contact has no username (no DM lookup possible)', async () => {
+			const call = makeOutgoingCall('out-noun-1');
+			(call as any).remoteParticipants = [{ contact: {} }];
+
+			await callLifecycle.beginOutgoing(call);
+
+			expect(mockGetDMSubscriptionByUsername).not.toHaveBeenCalled();
 			expect(useCallStore.getState().roomId).toBeFalsy();
 		});
 	});

--- a/app/lib/services/voip/CallLifecycle.test.ts
+++ b/app/lib/services/voip/CallLifecycle.test.ts
@@ -814,6 +814,22 @@ describe('CallLifecycle.answerIncoming(callId)', () => {
 			unsub();
 			expect(listener).not.toHaveBeenCalled();
 		});
+
+		it('still emits callBegan when DM lookup rejects (audio active → CallView must navigate)', async () => {
+			const call = makeIncomingCall('inc-dbfail-1');
+			mockGetMediaCall.mockReturnValue(call);
+			mockGetDMSubscriptionByUsername.mockRejectedValue(new Error('db boom'));
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await expect(callLifecycle.answerIncoming('inc-dbfail-1')).resolves.toBeUndefined();
+
+			unsub();
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({ callId: 'inc-dbfail-1', direction: 'incoming' });
+			expect(events[0].roomId).toBeUndefined();
+		});
 	});
 
 	describe('idempotency', () => {
@@ -1090,6 +1106,21 @@ describe('CallLifecycle.beginOutgoing(call, room?)', () => {
 
 			unsub();
 			expect(listener).toHaveBeenCalledTimes(1);
+		});
+
+		it('still emits callBegan when DM lookup rejects (audio active → CallView must navigate)', async () => {
+			const call = makeOutgoingCall('out-dbfail-1');
+			mockGetDMSubscriptionByUsername.mockRejectedValue(new Error('db boom'));
+
+			const events: CallBeganEvent[] = [];
+			const unsub = callLifecycle.emitter.on('callBegan', e => events.push(e));
+
+			await expect(callLifecycle.beginOutgoing(call)).resolves.toBeUndefined();
+
+			unsub();
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({ callId: 'out-dbfail-1', direction: 'outgoing' });
+			expect(events[0].roomId).toBeUndefined();
 		});
 	});
 

--- a/app/lib/services/voip/CallLifecycle.ts
+++ b/app/lib/services/voip/CallLifecycle.ts
@@ -299,14 +299,20 @@ class CallLifecycle {
 
 	/**
 	 * Resolve the DM room id from a call contact.
-	 * Returns undefined if the contact has no username or no subscription is found.
+	 * Never rejects — a DB error must not abort the surrounding answerIncoming/beginOutgoing
+	 * flow before `callBegan` emits, otherwise audio is active but CallView never navigates.
 	 */
 	private async _resolveRoomIdFromContact(contact: CallContact | undefined): Promise<string | undefined> {
 		if (!contact?.username) {
 			return undefined;
 		}
-		const sub = await _getDMSubscriptionByUsername(contact.username);
-		return sub?.rid ?? undefined;
+		try {
+			const sub = await _getDMSubscriptionByUsername(contact.username);
+			return sub?.rid ?? undefined;
+		} catch (error) {
+			logger.warn(`${TAG} _resolveRoomIdFromContact failed; continuing without roomId`, error);
+			return undefined;
+		}
 	}
 
 	// eslint-disable-next-line require-await

--- a/app/lib/services/voip/CallLifecycle.ts
+++ b/app/lib/services/voip/CallLifecycle.ts
@@ -11,23 +11,25 @@
  *   7. emit callEnded { callId, reason }
  *
  * answerIncoming(callId) order:
- *   1. Idempotency guard — return if store.call.callId === callId
- *   2. mediaCall = mediaSessionInstance.getMediaCall(callId) — abort if null
- *   3. mediaCall.accept()
- *   4. voipNative.call.markActive(callId)
- *   5. voipNative.call.startAudio()
- *   6. useCallStore.setCallStateOnly(mediaCall) + setDirection('incoming')
- *   7. resolveRoomIdFromContact(mediaCall) → setRoomId
- *   8. emit callBegan { callId, direction: 'incoming', roomId? }
+ *   1. Concurrent-call guard — deduplicate via _answerPromises Map (per-callId in-flight promise)
+ *   2. Idempotency guard — return if store.call.callId === callId (already answered)
+ *   3. mediaCall = mediaSessionInstance.getMediaCall(callId) — abort if null
+ *   4. mediaCall.accept()
+ *   5. voipNative.call.markActive(callId)
+ *   6. voipNative.call.startAudio()
+ *   7. useCallStore.setCall(mediaCall) + setDirection('incoming')
+ *   8. resolveRoomIdFromContact(mediaCall) → setRoomId
+ *   9. emit callBegan { callId, direction: 'incoming', roomId? }
  *
  * beginOutgoing(call, room?) order:
  *   1. voipNative.call.markActive(call.callId)
  *   2. voipNative.call.startAudio()
- *   3. useCallStore.setCallStateOnly(call) + setDirection('outgoing') + setRoomId(room?.rid)
+ *   3. useCallStore.setCall(call) + setDirection('outgoing') + setRoomId(room?.rid)
  *   4. emit callBegan { callId, direction: 'outgoing', roomId? }
  *
  * Idempotency: concurrent end() callers receive the in-flight Promise (no double teardown).
- *              answerIncoming re-entry with same callId returns early.
+ *              concurrent answerIncoming() callers for the same callId share the in-flight Promise.
+ *              sequential answerIncoming() re-entry with same callId returns early via store check.
  *
  * `callId` in `callEnded` uses `callId ?? nativeAcceptedCallId` (Pre-bind-safe).
  */
@@ -132,6 +134,13 @@ class CallLifecycle {
 	private _endPromise: Promise<void> | null = null;
 
 	/**
+	 * Per-callId in-flight answer promises.
+	 * Concurrent answerIncoming() callers for the same callId receive the same Promise —
+	 * preventing double accept(), double markActive/startAudio, and double callBegan emission.
+	 */
+	private _answerPromises = new Map<string, Promise<void>>();
+
+	/**
 	 * Attach a custom native seam (optional). If not called, the module-level
 	 * `voipNative` singleton is used. Call once per session for explicit injection.
 	 *
@@ -172,16 +181,34 @@ class CallLifecycle {
 	/**
 	 * Answer an incoming call.
 	 *
-	 * Idempotent: re-entry with the same callId is a no-op (no double-accept,
-	 * no extra native commands, no duplicate callBegan emission).
+	 * Concurrent-safe: if two callers invoke answerIncoming() for the same callId simultaneously,
+	 * they both receive the same in-flight Promise — only one accept/markActive/startAudio/callBegan
+	 * sequence runs. The Map entry is removed once the promise settles (success or error).
 	 *
-	 * Order: accept → markActive → startAudio → setCallStateOnly + setDirection →
-	 *        resolveRoomIdFromContact → emit callBegan.
+	 * Idempotent (sequential): re-entry with the same callId after it is already bound in the store
+	 * returns early inside _runAnswer — no double-accept, no extra native commands.
+	 *
+	 * Order: (concurrent guard) → (idempotency guard) → accept → markActive → startAudio →
+	 *        setCall + setDirection → resolveRoomIdFromContact → emit callBegan.
+	 *
+	 * NOTE: intentionally NOT declared async — the body must return the stored Promise directly so
+	 * that concurrent callers receive the exact same Promise object (identity equality).
+	 * An `async` wrapper would create a new wrapping Promise for each caller.
 	 */
-	async answerIncoming(callId: string): Promise<void> {
+	answerIncoming(callId: string): Promise<void> {
+		// Concurrent-call guard: deduplicate in-flight promises per callId.
+		const existing = this._answerPromises.get(callId);
+		if (existing) return existing;
+		const p = this._runAnswer(callId);
+		this._answerPromises.set(callId, p);
+		p.finally(() => this._answerPromises.delete(callId)).catch(() => {});
+		return p;
+	}
+
+	private async _runAnswer(callId: string): Promise<void> {
 		const native = this._voipNativeOverride ?? voipNative;
 
-		// Step 1: Idempotency guard — return if already answered.
+		// Step 1: Idempotency guard — return if already answered (sequential re-entry).
 		const { call: existingCall } = useCallStore.getState();
 		if (existingCall != null && existingCall.callId === callId) {
 			return;
@@ -210,7 +237,7 @@ class CallLifecycle {
 		native.call.startAudio();
 
 		// Step 6: Update JS store — state only (native side-effects already done above).
-		useCallStore.getState().setCallStateOnly(mediaCall);
+		useCallStore.getState().setCall(mediaCall);
 		useCallStore.getState().setDirection('incoming');
 
 		// Step 7: Resolve room id from contact (async; store updated before callBegan emits).
@@ -229,7 +256,7 @@ class CallLifecycle {
 	 * Called from the `newCall` handler's `role === 'caller'` branch in MediaSessionInstance.
 	 * The IClientMediaCall already exists at this point (produced by the `newCall` event).
 	 *
-	 * Order: markActive → startAudio → setCallStateOnly + setDirection + setRoomId →
+	 * Order: markActive → startAudio → setCall + setDirection + setRoomId →
 	 *        emit callBegan.
 	 */
 	// eslint-disable-next-line require-await
@@ -243,7 +270,7 @@ class CallLifecycle {
 		native.call.startAudio();
 
 		// Step 3: Update JS store — state only (native side-effects already done above).
-		useCallStore.getState().setCallStateOnly(call);
+		useCallStore.getState().setCall(call);
 		useCallStore.getState().setDirection('outgoing');
 		useCallStore.getState().setRoomId(room?.rid ?? null);
 

--- a/app/lib/services/voip/CallLifecycle.ts
+++ b/app/lib/services/voip/CallLifecycle.ts
@@ -1,7 +1,7 @@
 /**
- * CallLifecycle — orchestrates the end-of-call teardown sequence.
+ * CallLifecycle — orchestrates call lifecycle transitions.
  *
- * Teardown order (documented here and verified in tests):
+ * Teardown order (end):
  *   1. mediaCall.reject() if state === 'ringing', else mediaCall.hangup()
  *   2. voipNative.call.end(callUuid)
  *   3. voipNative.call.markActive('')
@@ -10,10 +10,29 @@
  *   6. voipNative.call.stopAudio() ← fires after store reset so subscribers see consistent state
  *   7. emit callEnded { callId, reason }
  *
- * Idempotency: concurrent callers receive the in-flight Promise (no double teardown).
+ * answerIncoming(callId) order:
+ *   1. Idempotency guard — return if store.call.callId === callId
+ *   2. mediaCall = mediaSessionInstance.getMediaCall(callId) — abort if null
+ *   3. mediaCall.accept()
+ *   4. voipNative.call.markActive(callId)
+ *   5. voipNative.call.startAudio()
+ *   6. useCallStore.setCallStateOnly(mediaCall) + setDirection('incoming')
+ *   7. resolveRoomIdFromContact(mediaCall) → setRoomId
+ *   8. emit callBegan { callId, direction: 'incoming', roomId? }
  *
- * `callId` in the `callEnded` event uses `callId ?? nativeAcceptedCallId` (Pre-bind-safe).
+ * beginOutgoing(call, room?) order:
+ *   1. voipNative.call.markActive(call.callId)
+ *   2. voipNative.call.startAudio()
+ *   3. useCallStore.setCallStateOnly(call) + setDirection('outgoing') + setRoomId(room?.rid)
+ *   4. emit callBegan { callId, direction: 'outgoing', roomId? }
+ *
+ * Idempotency: concurrent end() callers receive the in-flight Promise (no double teardown).
+ *              answerIncoming re-entry with same callId returns early.
+ *
+ * `callId` in `callEnded` uses `callId ?? nativeAcceptedCallId` (Pre-bind-safe).
  */
+
+import type { CallContact, IClientMediaCall } from '@rocket.chat/media-signaling';
 
 import { MediaCallLogger } from './MediaCallLogger';
 import { voipNative, type VoipNativePort } from './VoipNative';
@@ -21,6 +40,20 @@ import { useCallStore } from './useCallStore';
 
 const logger = new MediaCallLogger();
 const TAG = '[CallLifecycle]';
+
+// Lazy imports — avoids pulling WatermelonDB (Subscription.ts) and the circular MediaSessionInstance at module
+// load time. Neither is needed until the first answerIncoming/beginOutgoing call.
+
+function _requireMediaSessionInstance(): { getMediaCall(callId: string): IClientMediaCall | null | undefined } {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	return require('./MediaSessionInstance').mediaSessionInstance;
+}
+
+function _getDMSubscriptionByUsername(username: string): Promise<{ rid: string } | null> {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { getDMSubscriptionByUsername } = require('../../database/services/Subscription');
+	return getDMSubscriptionByUsername(username) as Promise<{ rid: string } | null>;
+}
 
 // ── Event types ───────────────────────────────────────────────────────────────
 
@@ -33,6 +66,8 @@ export type CallEndedEvent = {
 
 export type CallBeganEvent = {
 	callId: string;
+	direction: 'incoming' | 'outgoing';
+	roomId?: string;
 };
 
 export type PreBindFailedEvent = {
@@ -42,7 +77,7 @@ export type PreBindFailedEvent = {
 export type CallLifecycleListener<T> = (event: T) => void;
 
 type EventMap = {
-	callBegan: CallBeganEvent; // type-only — no producer in this slice
+	callBegan: CallBeganEvent;
 	callEnded: CallEndedEvent;
 	preBindFailed: PreBindFailedEvent; // type-only — no producer in this slice
 };
@@ -132,6 +167,100 @@ class CallLifecycle {
 				this._endPromise = null;
 			});
 		return this._endPromise;
+	}
+
+	/**
+	 * Answer an incoming call.
+	 *
+	 * Idempotent: re-entry with the same callId is a no-op (no double-accept,
+	 * no extra native commands, no duplicate callBegan emission).
+	 *
+	 * Order: accept → markActive → startAudio → setCallStateOnly + setDirection →
+	 *        resolveRoomIdFromContact → emit callBegan.
+	 */
+	async answerIncoming(callId: string): Promise<void> {
+		const native = this._voipNativeOverride ?? voipNative;
+
+		// Step 1: Idempotency guard — return if already answered.
+		const { call: existingCall } = useCallStore.getState();
+		if (existingCall != null && existingCall.callId === callId) {
+			return;
+		}
+
+		// Step 2: Look up the MediaCall from the signaling session.
+		const mediaCall = _requireMediaSessionInstance().getMediaCall(callId);
+		if (!mediaCall || mediaCall.callId !== callId) {
+			// Call not found — clean up native state and pre-bind tracking.
+			native.call.end(callId);
+			const st = useCallStore.getState();
+			if (st.nativeAcceptedCallId === callId) {
+				st.resetNativeCallId();
+			}
+			console.warn('[VoIP] Call not found after accept:', callId);
+			return;
+		}
+
+		// Step 3: Accept the call on the signaling layer.
+		await mediaCall.accept();
+
+		// Step 4: Tell native the call is active.
+		native.call.markActive(callId);
+
+		// Step 5: Start audio.
+		native.call.startAudio();
+
+		// Step 6: Update JS store — state only (native side-effects already done above).
+		useCallStore.getState().setCallStateOnly(mediaCall);
+		useCallStore.getState().setDirection('incoming');
+
+		// Step 7: Resolve room id from contact (async; store updated before callBegan emits).
+		const roomId = await this._resolveRoomIdFromContact(mediaCall.remoteParticipants[0]?.contact);
+		if (roomId) {
+			useCallStore.getState().setRoomId(roomId);
+		}
+
+		// Step 8: Notify subscribers.
+		this.emitter.emit('callBegan', { callId, direction: 'incoming', ...(roomId ? { roomId } : {}) });
+	}
+
+	/**
+	 * Begin the outgoing-call side effects.
+	 *
+	 * Called from the `newCall` handler's `role === 'caller'` branch in MediaSessionInstance.
+	 * The IClientMediaCall already exists at this point (produced by the `newCall` event).
+	 *
+	 * Order: markActive → startAudio → setCallStateOnly + setDirection + setRoomId →
+	 *        emit callBegan.
+	 */
+	// eslint-disable-next-line require-await
+	async beginOutgoing(call: IClientMediaCall, room?: { rid?: string }): Promise<void> {
+		const native = this._voipNativeOverride ?? voipNative;
+
+		// Step 1: Tell native the call is active.
+		native.call.markActive(call.callId);
+
+		// Step 2: Start audio.
+		native.call.startAudio();
+
+		// Step 3: Update JS store — state only (native side-effects already done above).
+		useCallStore.getState().setCallStateOnly(call);
+		useCallStore.getState().setDirection('outgoing');
+		useCallStore.getState().setRoomId(room?.rid ?? null);
+
+		// Step 4: Notify subscribers.
+		this.emitter.emit('callBegan', { callId: call.callId, direction: 'outgoing', ...(room?.rid ? { roomId: room.rid } : {}) });
+	}
+
+	/**
+	 * Resolve the DM room id from a call contact.
+	 * Returns undefined if the contact has no username or no subscription is found.
+	 */
+	private async _resolveRoomIdFromContact(contact: CallContact | undefined): Promise<string | undefined> {
+		if (!contact?.username) {
+			return undefined;
+		}
+		const sub = await _getDMSubscriptionByUsername(contact.username);
+		return sub?.rid ?? undefined;
 	}
 
 	// eslint-disable-next-line require-await

--- a/app/lib/services/voip/CallLifecycle.ts
+++ b/app/lib/services/voip/CallLifecycle.ts
@@ -25,7 +25,8 @@
  *   1. voipNative.call.markActive(call.callId)
  *   2. voipNative.call.startAudio()
  *   3. useCallStore.setCall(call) + setDirection('outgoing') + setRoomId(room?.rid)
- *   4. emit callBegan { callId, direction: 'outgoing', roomId? }
+ *   4. if no room argument, resolveRoomIdFromContact(remoteParticipants[0]?.contact) → setRoomId
+ *   5. emit callBegan { callId, direction: 'outgoing', roomId? }
  *
  * Idempotency: concurrent end() callers receive the in-flight Promise (no double teardown).
  *              concurrent answerIncoming() callers for the same callId share the in-flight Promise.
@@ -256,10 +257,14 @@ class CallLifecycle {
 	 * Called from the `newCall` handler's `role === 'caller'` branch in MediaSessionInstance.
 	 * The IClientMediaCall already exists at this point (produced by the `newCall` event).
 	 *
+	 * When `room` is omitted (DM-by-username path: CreateCall → startCall(userId, 'user')
+	 * never sets a roomId beforehand), the room id is resolved from the remote participant's
+	 * contact via getDMSubscriptionByUsername — pre-refactor parity, otherwise CallView's
+	 * "Go to chat" button stays disabled because roomId is null.
+	 *
 	 * Order: markActive → startAudio → setCall + setDirection + setRoomId →
-	 *        emit callBegan.
+	 *        (fallback) resolveRoomIdFromContact → emit callBegan.
 	 */
-	// eslint-disable-next-line require-await
 	async beginOutgoing(call: IClientMediaCall, room?: { rid?: string }): Promise<void> {
 		const native = this._voipNativeOverride ?? voipNative;
 
@@ -274,8 +279,22 @@ class CallLifecycle {
 		useCallStore.getState().setDirection('outgoing');
 		useCallStore.getState().setRoomId(room?.rid ?? null);
 
-		// Step 4: Notify subscribers.
-		this.emitter.emit('callBegan', { callId: call.callId, direction: 'outgoing', ...(room?.rid ? { roomId: room.rid } : {}) });
+		// Step 4: Fallback DM lookup when caller didn't supply a room (CreateCall by username).
+		let resolvedRoomId: string | undefined = room?.rid;
+		if (room?.rid == null) {
+			const fromContact = await this._resolveRoomIdFromContact(call.remoteParticipants[0]?.contact);
+			if (fromContact) {
+				useCallStore.getState().setRoomId(fromContact);
+				resolvedRoomId = fromContact;
+			}
+		}
+
+		// Step 5: Notify subscribers.
+		this.emitter.emit('callBegan', {
+			callId: call.callId,
+			direction: 'outgoing',
+			...(resolvedRoomId ? { roomId: resolvedRoomId } : {})
+		});
 	}
 
 	/**

--- a/app/lib/services/voip/CallNavRouter.test.ts
+++ b/app/lib/services/voip/CallNavRouter.test.ts
@@ -17,11 +17,13 @@ import Navigation from '../../navigation/appNavigation';
 // jest.mock is auto-hoisted so it runs before the imports above resolve.
 const mockGetCurrentRoute = jest.fn();
 const mockBack = jest.fn();
+const mockNavigate = jest.fn();
 
 jest.mock('../../navigation/appNavigation', () => ({
 	__esModule: true,
 	default: {
 		back: (...args: unknown[]) => mockBack(...args),
+		navigate: (...args: unknown[]) => mockNavigate(...args),
 		getCurrentRoute: (...args: unknown[]) => mockGetCurrentRoute(...args),
 		// Start with no navigation ref (not ready).
 		navigationRef: { current: null }
@@ -41,6 +43,10 @@ function emitNavigationReady(): void {
 
 function emitCallEnded(callId: string | null = 'test-call'): void {
 	callLifecycle.emitter.emit('callEnded', { callId, reason: 'local' });
+}
+
+function emitCallBegan(callId = 'test-call', direction: 'incoming' | 'outgoing' = 'incoming', roomId?: string): void {
+	callLifecycle.emitter.emit('callBegan', { callId, direction, roomId });
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -207,6 +213,55 @@ describe('CallNavRouter', () => {
 			emitCallEnded();
 
 			expect(mockBack).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('navigation to CallView on callBegan', () => {
+		beforeEach(() => {
+			CallNavRouter.mount();
+			emitNavigationReady();
+		});
+
+		it('navigates to CallView when callBegan fires (incoming)', () => {
+			emitCallBegan('call-in-1', 'incoming');
+			expect(mockNavigate).toHaveBeenCalledWith('CallView');
+		});
+
+		it('navigates to CallView when callBegan fires (outgoing)', () => {
+			emitCallBegan('call-out-1', 'outgoing');
+			expect(mockNavigate).toHaveBeenCalledWith('CallView');
+		});
+
+		it('navigates exactly once per callBegan event', () => {
+			emitCallBegan('call-once-1', 'incoming');
+			expect(mockNavigate).toHaveBeenCalledTimes(1);
+		});
+
+		it('navigates once per callBegan when multiple events fired', () => {
+			emitCallBegan('call-a', 'incoming');
+			emitCallBegan('call-b', 'outgoing');
+			expect(mockNavigate).toHaveBeenCalledTimes(2);
+			expect(mockNavigate).toHaveBeenNthCalledWith(1, 'CallView');
+			expect(mockNavigate).toHaveBeenNthCalledWith(2, 'CallView');
+		});
+
+		it('does NOT navigate to CallView before navigationReady fires', () => {
+			// Mount fresh router — navigation not yet ready
+			CallNavRouter.unmount();
+			setNavigationRef(false);
+			CallNavRouter.mount();
+
+			emitCallBegan('call-early', 'incoming');
+
+			expect(mockNavigate).not.toHaveBeenCalled();
+		});
+
+		it('navigates after unmount does NOT fire (no listener after unmount)', () => {
+			CallNavRouter.unmount();
+
+			emitCallBegan('call-after-unmount', 'incoming');
+
+			expect(mockNavigate).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/app/lib/services/voip/CallNavRouter.ts
+++ b/app/lib/services/voip/CallNavRouter.ts
@@ -1,10 +1,11 @@
 /**
- * CallNavRouter — subscribes to CallLifecycle events and handles post-call navigation.
+ * CallNavRouter — subscribes to CallLifecycle events and handles call navigation.
  *
  * Subscribes ONLY after the NavigationContainer is ready (listens for the
  * `navigationReady` emitter event fired from AppContainer.tsx onReady).
  *
- * On `callEnded`: if the current route is `CallView`, calls `Navigation.goBack()`.
+ * On `callBegan`: navigates to `CallView`.
+ * On `callEnded`: if the current route is `CallView`, calls `Navigation.back()`.
  *
  * Mount point: AppContainer.tsx (after NavigationContainer renders).
  */
@@ -15,6 +16,7 @@ import { callLifecycle } from './CallLifecycle';
 
 let _unsubscribeCallEnded: (() => void) | null = null;
 let _unsubscribeNavigationReady: (() => void) | null = null;
+let _unsubscribeCallBegan: (() => void) | null = null;
 let _mounted = false;
 
 /**
@@ -28,8 +30,13 @@ function mount(): void {
 	// Wait for NavigationContainer to be ready before subscribing.
 	// The `navigationReady` event is emitted from AppContainer.tsx onReady().
 	function onNavigationReady(): void {
-		// Unsubscribe previous callEnded listener if somehow re-mounted.
+		// Unsubscribe previous listeners if somehow re-mounted.
 		_unsubscribeCallEnded?.();
+		_unsubscribeCallBegan?.();
+
+		_unsubscribeCallBegan = callLifecycle.emitter.on('callBegan', () => {
+			Navigation.navigate('CallView');
+		});
 
 		_unsubscribeCallEnded = callLifecycle.emitter.on('callEnded', () => {
 			const currentRoute = Navigation.getCurrentRoute();
@@ -63,6 +70,8 @@ function unmount(): void {
 	_unsubscribeNavigationReady = null;
 	_unsubscribeCallEnded?.();
 	_unsubscribeCallEnded = null;
+	_unsubscribeCallBegan?.();
+	_unsubscribeCallBegan = null;
 	_mounted = false;
 }
 

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -1,5 +1,4 @@
 import type { IClientMediaCall } from '@rocket.chat/media-signaling';
-import { waitFor } from '@testing-library/react-native';
 
 import { voipNative, type InMemoryVoipNative } from './VoipNative';
 import type { IDDPMessage } from '../../../definitions/IDDPMessage';
@@ -24,9 +23,11 @@ const mockGetUidDirectMessage = jest.mocked(getUidDirectMessage);
 const mockCallStoreReset = jest.fn();
 const mockSetRoomId = jest.fn();
 const mockSetDirection = jest.fn();
+const mockSetCallStateOnly = jest.fn();
 const mockUseCallStoreGetState = jest.fn(() => ({
 	reset: mockCallStoreReset,
 	setCall: jest.fn(),
+	setCallStateOnly: mockSetCallStateOnly,
 	setRoomId: mockSetRoomId,
 	setDirection: mockSetDirection,
 	resetNativeCallId: jest.fn(),
@@ -225,6 +226,7 @@ describe('MediaSessionInstance', () => {
 		mockUseCallStoreGetState.mockReturnValue({
 			reset: mockCallStoreReset,
 			setCall: jest.fn(),
+			setCallStateOnly: mockSetCallStateOnly,
 			setRoomId: mockSetRoomId,
 			setDirection: mockSetDirection,
 			resetNativeCallId: jest.fn(),
@@ -320,6 +322,7 @@ describe('MediaSessionInstance', () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: mockSetCall,
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -339,6 +342,7 @@ describe('MediaSessionInstance', () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: jest.fn(),
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -358,6 +362,7 @@ describe('MediaSessionInstance', () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: jest.fn(),
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -373,11 +378,12 @@ describe('MediaSessionInstance', () => {
 			expect((voipNative as InMemoryVoipNative).recorded).not.toContainEqual({ cmd: 'end', callUuid: 'same-id' });
 		});
 
-		it('does not reject outgoing (caller) newCall; binds call and navigates', async () => {
+		it('does not reject outgoing (caller) newCall; delegates to lifecycle.beginOutgoing', async () => {
 			const mockSetCall = jest.fn();
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: mockSetCall,
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -388,10 +394,12 @@ describe('MediaSessionInstance', () => {
 			});
 			await mediaSessionInstance.init('user-1');
 			const outgoing = buildClientMediaCall({ callId: 'out-c', role: 'caller' });
+			const beginOutgoingSpy = jest.spyOn(callLifecycle, 'beginOutgoing').mockResolvedValue(undefined);
 			getNewCallHandler()({ call: outgoing });
 			expect(outgoing.reject).not.toHaveBeenCalled();
-			expect(mockSetCall).toHaveBeenCalledWith(outgoing);
-			expect(Navigation.navigate).toHaveBeenCalledWith('CallView');
+			expect(beginOutgoingSpy).toHaveBeenCalledWith(outgoing, undefined);
+			expect(Navigation.navigate).not.toHaveBeenCalled();
+			beginOutgoingSpy.mockRestore();
 		});
 	});
 
@@ -424,6 +432,7 @@ describe('MediaSessionInstance', () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: jest.fn(),
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -458,6 +467,7 @@ describe('MediaSessionInstance', () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: jest.fn(),
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -492,6 +502,7 @@ describe('MediaSessionInstance', () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: jest.fn(),
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -539,6 +550,7 @@ describe('MediaSessionInstance', () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: jest.fn(),
+				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -674,45 +686,15 @@ describe('MediaSessionInstance', () => {
 			expect(session.startCall).not.toHaveBeenCalled();
 		});
 
-		it('newCall caller triggers DM lookup when roomId is still null', async () => {
-			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'from-db' } as any);
+		it('newCall caller delegates to callLifecycle.beginOutgoing with null room when roomId is null', async () => {
+			// DM lookup for outgoing calls has moved to CallLifecycle.answerIncoming (incoming only).
+			// For outgoing, beginOutgoing receives the pre-existing store roomId (null if not set by startCallByRoom).
 			await mediaSessionInstance.init('user-1');
 			const session = createdSessions[0];
 			const newCallHandler = session.on.mock.calls.find((c: string[]) => c[0] === 'newCall')?.[1] as (p: {
 				call: IClientMediaCall;
 			}) => void;
-
-			newCallHandler({
-				call: {
-					hidden: false,
-					localParticipant: { role: 'caller' },
-					remoteParticipants: [{ contact: { username: 'alice', sipExtension: '' } }],
-					callId: 'c1',
-					emitter: { on: jest.fn(), off: jest.fn() }
-				} as unknown as IClientMediaCall
-			});
-
-			await waitFor(() => expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('alice'));
-			expect(mockSetRoomId).toHaveBeenCalledWith('from-db');
-		});
-
-		it('newCall caller skips DM lookup when roomId already set', async () => {
-			await mediaSessionInstance.init('user-1');
-			mockUseCallStoreGetState.mockReturnValue({
-				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setRoomId: mockSetRoomId,
-				setDirection: mockSetDirection,
-				resetNativeCallId: jest.fn(),
-				call: null,
-				callId: null,
-				nativeAcceptedCallId: null,
-				roomId: 'preset-rid'
-			});
-			const session = createdSessions[0];
-			const newCallHandler = session.on.mock.calls.find((c: string[]) => c[0] === 'newCall')?.[1] as (p: {
-				call: IClientMediaCall;
-			}) => void;
+			const beginOutgoingSpy = jest.spyOn(callLifecycle, 'beginOutgoing').mockResolvedValue(undefined);
 
 			newCallHandler({
 				call: {
@@ -725,72 +707,70 @@ describe('MediaSessionInstance', () => {
 			});
 
 			await Promise.resolve();
+			// roomId was null in store, so beginOutgoing receives undefined
+			expect(beginOutgoingSpy).toHaveBeenCalledWith(expect.objectContaining({ callId: 'c1' }), undefined);
 			expect(mockGetDMSubscriptionByUsername).not.toHaveBeenCalled();
+			beginOutgoingSpy.mockRestore();
 		});
 
-		it('newCall caller resolves roomId from DM when contact has both username and sipExtension', async () => {
-			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-ext' } as any);
+		it('newCall caller passes pre-set roomId to beginOutgoing when roomId already in store', async () => {
 			await mediaSessionInstance.init('user-1');
+			mockUseCallStoreGetState.mockReturnValue({
+				reset: mockCallStoreReset,
+				setCall: jest.fn(),
+				setCallStateOnly: mockSetCallStateOnly,
+				setRoomId: mockSetRoomId,
+				setDirection: mockSetDirection,
+				resetNativeCallId: jest.fn(),
+				call: null,
+				callId: null,
+				nativeAcceptedCallId: null,
+				roomId: 'preset-rid'
+			});
 			const session = createdSessions[0];
 			const newCallHandler = session.on.mock.calls.find((c: string[]) => c[0] === 'newCall')?.[1] as (p: {
 				call: IClientMediaCall;
 			}) => void;
+			const beginOutgoingSpy = jest.spyOn(callLifecycle, 'beginOutgoing').mockResolvedValue(undefined);
 
 			newCallHandler({
 				call: {
 					hidden: false,
 					localParticipant: { role: 'caller' },
-					remoteParticipants: [{ contact: { username: 'alice', sipExtension: '100' } }],
+					remoteParticipants: [{ contact: { username: 'alice', sipExtension: '' } }],
 					callId: 'c1',
 					emitter: { on: jest.fn(), off: jest.fn() }
 				} as unknown as IClientMediaCall
 			});
 
-			await waitFor(() => expect(mockSetRoomId).toHaveBeenCalledWith('dm-ext'));
-			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('alice');
+			await Promise.resolve();
+			// roomId was 'preset-rid' in store, beginOutgoing receives { rid: 'preset-rid' }
+			expect(beginOutgoingSpy).toHaveBeenCalledWith(expect.objectContaining({ callId: 'c1' }), { rid: 'preset-rid' });
+			beginOutgoingSpy.mockRestore();
 		});
 
-		it('answerCall resolves roomId from DM for non-SIP callee', async () => {
-			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-rid' } as any);
+		it('answerCall delegates to callLifecycle.answerIncoming', async () => {
+			// answerCall is a one-line delegate — behavior is tested in CallLifecycle.test.ts.
 			await mediaSessionInstance.init('user-1');
-			const session = createdSessions[0];
-			const mainCall = {
-				callId: 'call-ans',
-				accept: jest.fn().mockResolvedValue(undefined),
-				remoteParticipants: [{ contact: { username: 'bob', sipExtension: '' } }]
-			};
-			session.getCallData.mockReturnValue(mainCall);
+			const answerIncomingSpy = jest.spyOn(callLifecycle, 'answerIncoming').mockResolvedValue(undefined);
 
-			await mediaSessionInstance.answerCall('call-ans');
+			await mediaSessionInstance.answerCall('call-delegate-1');
 
-			await waitFor(() => expect(mockSetRoomId).toHaveBeenCalledWith('dm-rid'));
-			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('bob');
+			expect(answerIncomingSpy).toHaveBeenCalledWith('call-delegate-1');
+			answerIncomingSpy.mockRestore();
 		});
 
-		it('answerCall resolves roomId from DM when contact has both username and sipExtension', async () => {
-			mockGetDMSubscriptionByUsername.mockResolvedValue({ rid: 'dm-ext' } as any);
-			await mediaSessionInstance.init('user-1');
-			const session = createdSessions[0];
-			const mainCall = {
-				callId: 'call-sip',
-				accept: jest.fn().mockResolvedValue(undefined),
-				remoteParticipants: [{ contact: { username: 'bob', sipExtension: 'ext' } }]
-			};
-			session.getCallData.mockReturnValue(mainCall);
-
-			await mediaSessionInstance.answerCall('call-sip');
-
-			await waitFor(() => expect(mockSetRoomId).toHaveBeenCalledWith('dm-ext'));
-			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('bob');
-		});
-
-		it('answerCall records markActive on voipNative with callId', async () => {
+		it('answerCall records markActive on voipNative with callId (through callLifecycle)', async () => {
 			await mediaSessionInstance.init('user-1');
 			const session = createdSessions[0];
 			const mainCall = {
 				callId: 'ans-mark',
 				accept: jest.fn().mockResolvedValue(undefined),
-				remoteParticipants: [{ contact: {} }]
+				remoteParticipants: [{ contact: {} }],
+				localParticipant: { role: 'callee', muted: false, held: false, contact: {} },
+				state: 'ringing',
+				hidden: false,
+				emitter: { on: jest.fn(), off: jest.fn() }
 			};
 			session.getCallData.mockReturnValue(mainCall);
 			(voipNative as InMemoryVoipNative).reset();

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -23,11 +23,10 @@ const mockGetUidDirectMessage = jest.mocked(getUidDirectMessage);
 const mockCallStoreReset = jest.fn();
 const mockSetRoomId = jest.fn();
 const mockSetDirection = jest.fn();
-const mockSetCallStateOnly = jest.fn();
+const mockSetCall = jest.fn();
 const mockUseCallStoreGetState = jest.fn(() => ({
 	reset: mockCallStoreReset,
-	setCall: jest.fn(),
-	setCallStateOnly: mockSetCallStateOnly,
+	setCall: mockSetCall,
 	setRoomId: mockSetRoomId,
 	setDirection: mockSetDirection,
 	resetNativeCallId: jest.fn(),
@@ -225,8 +224,7 @@ describe('MediaSessionInstance', () => {
 		mockIsInActiveVoipCall.mockReturnValue(false);
 		mockUseCallStoreGetState.mockReturnValue({
 			reset: mockCallStoreReset,
-			setCall: jest.fn(),
-			setCallStateOnly: mockSetCallStateOnly,
+			setCall: mockSetCall,
 			setRoomId: mockSetRoomId,
 			setDirection: mockSetDirection,
 			resetNativeCallId: jest.fn(),
@@ -318,11 +316,9 @@ describe('MediaSessionInstance', () => {
 
 	describe('newCall (no JS busy-reject; native decides)', () => {
 		it('allows incoming callee newCall when store already has an active call', async () => {
-			const mockSetCall = jest.fn();
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: mockSetCall,
-				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -341,8 +337,7 @@ describe('MediaSessionInstance', () => {
 		it('allows incoming callee newCall when nativeAcceptedCallId is set but differs from incoming callId', async () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setCallStateOnly: mockSetCallStateOnly,
+				setCall: mockSetCall,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -361,8 +356,7 @@ describe('MediaSessionInstance', () => {
 		it('allows incoming callee newCall when nativeAcceptedCallId matches incoming callId', async () => {
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setCallStateOnly: mockSetCallStateOnly,
+				setCall: mockSetCall,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -379,11 +373,9 @@ describe('MediaSessionInstance', () => {
 		});
 
 		it('does not reject outgoing (caller) newCall; delegates to lifecycle.beginOutgoing', async () => {
-			const mockSetCall = jest.fn();
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
 				setCall: mockSetCall,
-				setCallStateOnly: mockSetCallStateOnly,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -431,8 +423,7 @@ describe('MediaSessionInstance', () => {
 			const answerSpy = jest.spyOn(mediaSessionInstance, 'answerCall').mockResolvedValue(undefined);
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setCallStateOnly: mockSetCallStateOnly,
+				setCall: mockSetCall,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -466,8 +457,7 @@ describe('MediaSessionInstance', () => {
 			const answerSpy = jest.spyOn(mediaSessionInstance, 'answerCall').mockResolvedValue(undefined);
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setCallStateOnly: mockSetCallStateOnly,
+				setCall: mockSetCall,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -501,8 +491,7 @@ describe('MediaSessionInstance', () => {
 			const answerSpy = jest.spyOn(mediaSessionInstance, 'answerCall').mockResolvedValue(undefined);
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setCallStateOnly: mockSetCallStateOnly,
+				setCall: mockSetCall,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -549,8 +538,7 @@ describe('MediaSessionInstance', () => {
 			});
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setCallStateOnly: mockSetCallStateOnly,
+				setCall: mockSetCall,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),
@@ -717,8 +705,7 @@ describe('MediaSessionInstance', () => {
 			await mediaSessionInstance.init('user-1');
 			mockUseCallStoreGetState.mockReturnValue({
 				reset: mockCallStoreReset,
-				setCall: jest.fn(),
-				setCallStateOnly: mockSetCallStateOnly,
+				setCall: mockSetCall,
 				setRoomId: mockSetRoomId,
 				setDirection: mockSetDirection,
 				resetNativeCallId: jest.fn(),

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -1,6 +1,5 @@
 import {
 	MediaCallWebRTCProcessor,
-	type CallContact,
 	type ClientMediaSignal,
 	type IClientMediaCall,
 	type CallActorType,
@@ -13,7 +12,6 @@ import { getUniqueIdSync } from 'react-native-device-info';
 import { dequal } from 'dequal';
 
 import { mediaSessionStore } from './MediaSessionStore';
-import { voipNative } from './VoipNative';
 import { useCallStore } from './useCallStore';
 import { callLifecycle } from './CallLifecycle';
 import { MediaCallLogger } from './MediaCallLogger';
@@ -21,12 +19,10 @@ import { isSelfUserId } from './isSelfUserId';
 import { store } from '../../store/auxStore';
 import sdk from '../sdk';
 import { mediaCallsStateSignals } from '../restApi';
-import Navigation from '../../navigation/appNavigation';
 import { parseStringToIceServers } from './parseStringToIceServers';
 import type { IceServer } from '../../../definitions/Voip';
 import type { IDDPMessage } from '../../../definitions/IDDPMessage';
 import type { ISubscription, TSubscriptionModel } from '../../../definitions';
-import { getDMSubscriptionByUsername } from '../../database/services/Subscription';
 import { getUidDirectMessage } from '../../methods/helpers/helpers';
 import { isInActiveVoipCall } from './isInActiveVoipCall';
 import { requestVoipCallPermissions } from '../../methods/voipCallPermissions';
@@ -127,14 +123,13 @@ class MediaSessionInstance {
 				});
 
 				if (call.localParticipant.role === 'caller') {
-					useCallStore.getState().setCall(call);
-					useCallStore.getState().setDirection('outgoing');
-					Navigation.navigate('CallView');
-					if (useCallStore.getState().roomId == null) {
-						this.resolveRoomIdFromContact(call.remoteParticipants[0]?.contact).catch(error => {
-							console.error('[VoIP] Error resolving room id from contact (newCall):', error);
-						});
-					}
+					// Outgoing-begin side effects delegate to CallLifecycle.
+					// roomId may already be set by startCallByRoom; lifecycle reads it from store.
+					const currentRoomId = useCallStore.getState().roomId;
+					const room = currentRoomId != null ? ({ rid: currentRoomId } as { rid: string }) : undefined;
+					callLifecycle.beginOutgoing(call, room as any).catch(error => {
+						console.error('[VoIP] Error in beginOutgoing (newCall):', error);
+					});
 				}
 
 				call.emitter.on('ended', () => {
@@ -155,32 +150,14 @@ class MediaSessionInstance {
 		});
 	}
 
+	/** Thin accessor for the underlying media call — used by CallLifecycle.answerIncoming. */
+	public getMediaCall(callId: string): IClientMediaCall | null | undefined {
+		return this.instance?.getCallData(callId) ?? null;
+	}
+
 	public answerCall = async (callId: string) => {
-		const { call: existingCall } = useCallStore.getState();
-		if (existingCall != null && existingCall.callId === callId) {
-			return;
-		}
-
-		const mainCall = this.instance?.getCallData(callId);
-
-		if (mainCall && mainCall.callId === callId) {
-			await mainCall.accept();
-			voipNative.call.markActive(callId);
-			useCallStore.getState().setCall(mainCall);
-			useCallStore.getState().setDirection('incoming');
-			// waitForNavigationReady removed — CallNavRouter handles post-call navigation.
-			Navigation.navigate('CallView');
-			this.resolveRoomIdFromContact(mainCall.remoteParticipants[0]?.contact).catch(error => {
-				console.error('[VoIP] Error resolving room id from contact (answerCall):', error);
-			});
-		} else {
-			voipNative.call.end(callId);
-			const st = useCallStore.getState();
-			if (st.nativeAcceptedCallId === callId) {
-				st.resetNativeCallId();
-			}
-			console.warn('[VoIP] Call not found after accept:', callId);
-		}
+		// One-line delegate — CallLifecycle owns the ordered sequence.
+		await callLifecycle.answerIncoming(callId);
 	};
 
 	public startCallByRoom = (room: TSubscriptionModel | ISubscription) => {
@@ -224,20 +201,6 @@ class MediaSessionInstance {
 			mediaCallLogger.error('[VoIP] callLifecycle.end failed:', error);
 		});
 	};
-
-	private async resolveRoomIdFromContact(contact: CallContact | undefined): Promise<void> {
-		if (!contact) {
-			return;
-		}
-		const { username } = contact;
-		if (!username) {
-			return;
-		}
-		const sub = await getDMSubscriptionByUsername(username);
-		if (sub) {
-			useCallStore.getState().setRoomId(sub.rid);
-		}
-	}
 
 	private getIceServers() {
 		const iceServers = store.getState().settings.VoIP_TeamCollab_Ice_Servers as any;

--- a/app/lib/services/voip/useCallStore.test.ts
+++ b/app/lib/services/voip/useCallStore.test.ts
@@ -321,10 +321,11 @@ describe('useCallStore audio commands via VoipNative seam', () => {
 		useCallStore.getState().reset();
 	});
 
-	it('setCall records startAudio on voipNative', () => {
+	it('setCall does NOT record startAudio on voipNative (startAudio ownership is CallLifecycle, not setCall)', () => {
+		// setCall is now state-only — CallLifecycle issues startAudio explicitly before calling setCall.
 		const { call } = createMockCall('audio-1');
 		useCallStore.getState().setCall(call);
-		expect(adapter.recorded).toContainEqual({ cmd: 'startAudio' });
+		expect(adapter.recorded).not.toContainEqual({ cmd: 'startAudio' });
 	});
 
 	it('reset does NOT record stopAudio on voipNative (stopAudio ownership moved to CallLifecycle.end step 6)', () => {

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -91,13 +91,12 @@ interface CallStoreActions {
 	setNativeAcceptedCallId: (callId: string) => void;
 	/** Clears native-accepted id and related state; cancels the timer. */
 	resetNativeCallId: () => void;
-	setCall: (call: IClientMediaCall) => void;
 	/**
-	 * State-only variant of setCall — updates JS state and wires call event listeners
-	 * but does NOT issue native audio commands (startAudio, markActive).
-	 * Used by CallLifecycle, which issues those commands explicitly in the correct order.
+	 * Updates JS state and wires call event listeners.
+	 * Does NOT issue native audio commands (startAudio, markActive) — CallLifecycle
+	 * issues those explicitly in the correct order before calling setCall.
 	 */
-	setCallStateOnly: (call: IClientMediaCall) => void;
+	setCall: (call: IClientMediaCall) => void;
 	toggleMute: () => void;
 	toggleHold: () => void;
 	toggleSpeaker: () => void;
@@ -150,7 +149,7 @@ export const useCallStore = create<CallStore>((set, get) => ({
 		});
 	},
 
-	setCallStateOnly: (call: IClientMediaCall) => {
+	setCall: (call: IClientMediaCall) => {
 		cleanupCallListeners();
 		get().resetNativeCallId();
 		// Update state with call info (no native audio side effects — CallLifecycle owns those)
@@ -223,12 +222,6 @@ export const useCallStore = create<CallStore>((set, get) => ({
 			call.emitter.off('trackStateChange', handleTrackStateChange);
 			call.emitter.off('ended', handleEnded);
 		};
-	},
-
-	setCall: (call: IClientMediaCall) => {
-		// Delegate to state-only, then issue audio (for legacy callers not going through CallLifecycle).
-		get().setCallStateOnly(call);
-		voipNative.call.startAudio();
 	},
 
 	toggleControlsVisible: () => {

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -92,6 +92,12 @@ interface CallStoreActions {
 	/** Clears native-accepted id and related state; cancels the timer. */
 	resetNativeCallId: () => void;
 	setCall: (call: IClientMediaCall) => void;
+	/**
+	 * State-only variant of setCall — updates JS state and wires call event listeners
+	 * but does NOT issue native audio commands (startAudio, markActive).
+	 * Used by CallLifecycle, which issues those commands explicitly in the correct order.
+	 */
+	setCallStateOnly: (call: IClientMediaCall) => void;
 	toggleMute: () => void;
 	toggleHold: () => void;
 	toggleSpeaker: () => void;
@@ -144,10 +150,10 @@ export const useCallStore = create<CallStore>((set, get) => ({
 		});
 	},
 
-	setCall: (call: IClientMediaCall) => {
+	setCallStateOnly: (call: IClientMediaCall) => {
 		cleanupCallListeners();
 		get().resetNativeCallId();
-		// Update state with call info
+		// Update state with call info (no native audio side effects — CallLifecycle owns those)
 		const remote = call.remoteParticipants[0];
 		const remoteContact = remote?.contact;
 		set({
@@ -166,8 +172,6 @@ export const useCallStore = create<CallStore>((set, get) => ({
 			},
 			callStartTime: call.state === 'active' ? Date.now() : null
 		});
-
-		voipNative.call.startAudio();
 
 		// Subscribe to call events
 		const handleStateChange = () => {
@@ -219,6 +223,12 @@ export const useCallStore = create<CallStore>((set, get) => ({
 			call.emitter.off('trackStateChange', handleTrackStateChange);
 			call.emitter.off('ended', handleEnded);
 		};
+	},
+
+	setCall: (call: IClientMediaCall) => {
+		// Delegate to state-only, then issue audio (for legacy callers not going through CallLifecycle).
+		get().setCallStateOnly(call);
+		voipNative.call.startAudio();
 	},
 
 	toggleControlsVisible: () => {


### PR DESCRIPTION
## Proposed changes

Slice 06 of the VoIP native-call-seam refactor. Adds `CallLifecycle.answerIncoming` and `CallLifecycle.beginOutgoing`, migrates `MediaSessionInstance.answerCall` and the outgoing `newCall` handler to delegate through the lifecycle, and wires `CallNavRouter` to navigate to `CallView` on `callBegan`.

**Arch-review follow-ups (bundled in this PR):**

- **Fix 1 — `answerIncoming` concurrent-invocation race** (`CallLifecycle.ts:answerIncoming`, `CallLifecycle.ts:_runAnswer`): Two concurrent callers for the same `callId` (FSM `onMediaCallNew` + REST stateSignals replay path) could both pass the state-shape guard and issue a double `mediaCall.accept()`, double `markActive`/`startAudio`, and push `CallView` twice via duplicate `callBegan` emissions. Mirrors `end()`'s `_endPromise` pattern but per-callId via a `Map<string, Promise<void>>`. `answerIncoming` is now a plain (non-async) method returning the stored Promise directly so concurrent callers receive the exact same Promise object. The sequential idempotency guard (store check) is preserved inside `_runAnswer`. Regression test added: `Promise.all([p1, p2])` with same callId asserts `p1 === p2`, `accept` called once, `markActive` once, `startAudio` once, `callBegan` once.

- **Fix 2 — collapse dual `setCall` API** (`useCallStore.ts`): The `setCall` action that called `voipNative.call.startAudio()` as a side-effect had zero non-test production callers. Deleted it; renamed `setCallStateOnly` → `setCall` so the store exposes a single, clearly named, state-only setter. `CallLifecycle` callers in `answerIncoming`/`beginOutgoing` already issue `startAudio` explicitly before calling the state setter, so behaviour is unchanged. The pinned test `"setCall records startAudio on voipNative"` is deleted (its contract no longer exists); replaced by `"setCall does NOT record startAudio"`. Mock objects in `MediaSessionInstance.test.ts` updated accordingly.

- **Fix 3 — restore outgoing DM-by-username lookup in `beginOutgoing`** (`CallLifecycle.ts:beginOutgoing`): The pre-refactor `newCall` handler ran `if (roomId == null) resolveRoomIdFromContact(contact)` for outgoing DMs initiated by username (CreateCall path: `mediaSessionInstance.startCall(userId, 'user')` never sets a roomId in the store). The slice 06 refactor moved the new-call wiring into `MediaSessionInstance.ts:125-133` but only forwarded the in-store roomId, dropping the contact-username fallback. Result: `useCallStore.roomId` stayed null, so `CallView`'s "Go to chat" button (`messageDisabled = roomId == null`) was disabled for any outgoing DM started from the New Media Call sheet. Fix calls `_resolveRoomIdFromContact(remoteParticipants[0]?.contact)` when `room` is omitted, mirroring `answerIncoming`. Regression tests added in `CallLifecycle.test.ts` (`falls back to DM subscription lookup by contact username`, `does NOT fall back when room argument is provided`, `callBegan includes roomId resolved from contact`, `keeps roomId falsy when contact has no username`) and assertion added to the user-peer integration test.

- **Follow-up #4 (lazy require / dependency inversion)** is explicitly deferred to slice 10. It is logged in `.scratch/voip-native-call-seam/issues/10-shrink-media-session-instance.md`.

**Original slice 06 changes:**

- `CallLifecycle.answerIncoming(callId)` — idempotent incoming-call setup: `accept()` -> `markActive` -> `startAudio` -> `setCall` + `setDirection('incoming')` -> `resolveRoomIdFromContact` -> emit `callBegan { callId, direction: 'incoming', roomId? }`.
- `CallLifecycle.beginOutgoing(call, room?)` — outgoing-call side effects migrated from the `newCall` handler's caller branch: `markActive` -> `startAudio` -> `setCall` + `setDirection('outgoing')` + `setRoomId` -> (fallback) `resolveRoomIdFromContact` when room omitted -> emit `callBegan { callId, direction: 'outgoing', roomId? }`.
- `CallBeganEvent` extended with `direction: 'incoming' | 'outgoing'` and `roomId?: string`.
- `CallNavRouter` subscribes to `callBegan` and calls `Navigation.navigate('CallView')`.
- `MediaSessionInstance.answerCall` is now a one-line delegate to `callLifecycle.answerIncoming(callId)`.
- `resolveRoomIdFromContact` moved from `MediaSessionInstance` to `CallLifecycle` as `_resolveRoomIdFromContact` (lazy-required to avoid circular deps).
- `mediaSessionInstance.getMediaCall(callId)` thin accessor added.
- Pre-bind compatibility preserved: `nativeAcceptedCallId` tracking and `tryAnswerIfNativeAcceptedNotification` path unchanged (slice 08 owns cleanup).

## Issue(s)

Part of the VoIP native-call-seam refactor series (slices 01-10).

## How to test or reproduce

### Unit tests

```bash
TZ=UTC yarn test -- --testPathPattern='voip|CallLifecycle|VoipCallLifecycle|MediaSessionInstance'
# Expected: all tests pass (1352 total, 0 failures)
# Includes new DM-by-username regression tests in CallLifecycle.test.ts.
```

### Manual — iOS

1. Build and run on iOS device.
2. **Incoming call:** Have a second device call you via VoIP. Tap "Answer" from the CallKit lock screen. Confirm the app navigates to `CallView`.
3. **Outgoing call by room (DM voice button):** Open a DM, tap the Voice Call button. Confirm the app navigates to `CallView`, the call connects, and the "Go to chat" button on `CallView` is enabled.
4. **Outgoing call by username (New Media Call sheet):** Tap the New Media Call FAB, pick a user from the autocomplete, tap Call. Confirm `CallView` opens and the "Go to chat" button is enabled (verifies fix #3).
5. **End call:** From `CallView`, tap the end-call button. Confirm the app navigates back and the call is terminated.

### Manual — Android

1. Build and run on Android device.
2. **Incoming call:** Have a second device call you via VoIP. Accept from the system notification. Confirm the app navigates to `CallView`.
3. **Outgoing call by room:** Open a DM, tap the Voice Call button. Confirm `CallView` opens and the "Go to chat" button is enabled.
4. **Outgoing call by username:** Tap the New Media Call FAB, pick a user, tap Call. Confirm `CallView` opens and "Go to chat" is enabled.
5. **End call:** From `CallView`, tap end. Confirm navigation and teardown.

## Screenshots

N/A — navigation flow unchanged from user perspective; internal delegation only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

## Further comments

**`answerIncoming` non-async rationale:** The method is intentionally NOT declared `async`. An `async` wrapper creates a new Promise for each caller; returning the stored Map Promise directly ensures concurrent callers share the exact same object (identity equality), which is what the race-dedup guard requires.

**`setCall` collapse is behaviour-preserving:** Production paths (`answerIncoming`, `beginOutgoing`) already called `voipNative.call.startAudio()` explicitly before the state setter. The deleted `setCall` action was only ever exercised by a single test that pinned the now-removed side-effect.

**`beginOutgoing` DM-lookup fallback is pre-refactor parity:** The contact-username fallback was the only mechanism that kept `useCallStore.roomId` populated for outgoing DMs initiated from the New Media Call sheet (no `startCallByRoom` precedes them). Restoring it preserves CallView's "Go to chat" affordance.

**Follow-up #4 deferred:** Logged in `.scratch/voip-native-call-seam/issues/10-shrink-media-session-instance.md`. Slice 10 will address lazy require / dependency inversion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Call began" events now include call direction and optional room info; navigation reliably opens the active call view.

* **Bug Fixes**
  * Prevents duplicate accept/navigation/race conditions; ensures call begin/end emit exactly once per call and navigation is gated by readiness.

* **Tests**
  * Expanded coverage for incoming/outgoing flows, idempotency, room resolution precedence, and navigation timing.

* **Refactor**
  * Centralized lifecycle now controls native activation and audio; media layer delegates call start/answer and store updates no longer start audio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->