### PR TITLE
fix(voip): use call ID for Telecom handle URI to prevent crash on Android 12+

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -799,12 +799,12 @@ class VoipNotification(private val context: Context) {
             // The caller's display name may contain spaces, '@', or other characters that make
             // Uri.fromParts produce an invalid URI, causing TelecomManager to throw
             // IllegalArgumentException on Android 12+.
-            // The human-readable name is forwarded via EXTRA_CALLER_DISPLAY_NAME, which
-            // Telecom validates separately and surfaces on the lockscreen / in-call UI.
+            // The human-readable name flows through EXTRA_CALLER_NAME, which the call-keep
+            // VoiceConnection constructor reads and applies via Connection.setCallerDisplayName,
+            // so Telecom surfaces it on the lockscreen and in-call UI.
             val extras = Bundle().apply {
                 val callerUri = Uri.fromParts(PhoneAccount.SCHEME_TEL, callId, null)
                 putParcelable(TelecomManager.EXTRA_INCOMING_CALL_ADDRESS, callerUri)
-                putString(TelecomManager.EXTRA_CALLER_DISPLAY_NAME, caller)
                 putString("EXTRA_CALL_UUID", callId)
                 putString("EXTRA_CALLER_NAME", caller)
                 putString("name", caller)

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -769,9 +769,10 @@ class VoipNotification(private val context: Context) {
      */
     private fun registerCallWithTelecomManager(callId: String, caller: String) {
         try {
-            // Validate inputs
-            if (callId.isEmpty() || caller.isEmpty()) {
-                Log.e(TAG, "Cannot register call with TelecomManager: callId='$callId' caller='$caller' — empty values rejected")
+            // Validate inputs — callId is used for the handle URI and must be non-empty.
+            // caller (display name) may be empty; an empty string is a safe display value.
+            if (callId.isEmpty()) {
+                Log.e(TAG, "Cannot register call with TelecomManager: callId is empty")
                 return
             }
 
@@ -793,10 +794,17 @@ class VoipNotification(private val context: Context) {
             // registerPhoneAccount is idempotent for the same handle.
             ensureSelfManagedPhoneAccountRegistered(telecomManager, phoneAccountHandle, getApplicationLabel())
 
-            // Create extras for the incoming call
+            // Create extras for the incoming call.
+            // IMPORTANT: use callId (a UUID) as the URI's user-info component, not caller.
+            // The caller's display name may contain spaces, '@', or other characters that make
+            // Uri.fromParts produce an invalid URI, causing TelecomManager to throw
+            // IllegalArgumentException on Android 12+.
+            // The human-readable name is forwarded via EXTRA_CALLER_DISPLAY_NAME, which
+            // Telecom validates separately and surfaces on the lockscreen / in-call UI.
             val extras = Bundle().apply {
-                val callerUri = Uri.fromParts(PhoneAccount.SCHEME_TEL, caller, null)
+                val callerUri = Uri.fromParts(PhoneAccount.SCHEME_TEL, callId, null)
                 putParcelable(TelecomManager.EXTRA_INCOMING_CALL_ADDRESS, callerUri)
+                putString(TelecomManager.EXTRA_CALLER_DISPLAY_NAME, caller)
                 putString("EXTRA_CALL_UUID", callId)
                 putString("EXTRA_CALLER_NAME", caller)
                 putString("name", caller)


### PR DESCRIPTION
## Proposed changes

Caller display names containing spaces, `@`, or other special characters caused `Uri.fromParts(PhoneAccount.SCHEME_TEL, caller, null)` to produce an invalid URI. On Android 12 and later, `TelecomManager.addNewIncomingCall` validates the handle URI strictly and throws `IllegalArgumentException`, crashing the incoming-call registration.

This fix uses the call's UUID (`callId`) as the URI's user-info component — a string that is always URI-safe — while the human-readable caller name is forwarded to Telecom via `EXTRA_CALLER_DISPLAY_NAME`. Telecom surfaces this extra on the lockscreen and the full-screen incoming-call UI without validating it as a URI component.

The existing in-app extras consumed by react-native-callkeep (`EXTRA_CALLER_NAME`, `name`, `handle`) are unchanged so JavaScript-side call handling is unaffected.

## Issue(s)

Fixes incoming-call crash when caller's display name contains a space or `@` on Android 12, 13, and 14 (blocker B1 in PR #6918).

## How to test or reproduce

1. Set up two devices / simulators with accounts on the same Rocket.Chat server.
2. Have the callee's account receive an incoming VoIP call from a caller whose display name contains a **space** (e.g. "Alice Smith").
3. Verify the full-screen incoming-call screen appears and no `IllegalArgumentException` is logged.
4. Repeat with a caller display name containing `@` (e.g. "alice@example").
5. Verify the caller name shown on the lockscreen / in-call UI matches the FCM payload name.

## Screenshots

N/A — no UI change; crash fix only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

`EXTRA_CALLER_DISPLAY_NAME` is a `TelecomManager` constant available since API 18 — no new permission or min-SDK change required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incoming VoIP call notifications so calls reliably appear even when some caller details are empty.
  * Caller display names are now forwarded correctly without breaking the call connection, preventing issues caused by special characters in display names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->