### PR TITLE
fix(voip): recover answer-call and start-call failure paths

### DIFF
--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -996,6 +996,7 @@
   "View_Thread": "View thread",
   "Voice_call": "Voice call",
   "VoIP_Already_In_Call": "You are already in a call.",
+  "VoIP_Answer_Failed": "Could not answer call.",
   "VoIP_Call_Issue": "There was an issue with the call, try again later.",
   "VoIP_Still_Connecting": "Still connecting. Please try again in a moment.",
   "Wait_activation_warning": "Before you can login, your account must be manually activated by an administrator.",

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -882,5 +882,23 @@ describe('MediaSessionInstance', () => {
 
 			expect(session.startCall).toHaveBeenCalledWith('user', 'peer-1');
 		});
+
+		it('startCallByRoom clears optimistic roomId when post-permission guard rejects', async () => {
+			await mediaSessionInstance.init('user-1');
+			// pre-permission guard inside startCallByRoom passes (false),
+			// pre-permission check inside startCall passes (false),
+			// post-permission re-evaluation flips to true and triggers throw.
+			mockIsInActiveVoipCall.mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+			mediaSessionInstance.startCallByRoom({ rid: 'rid-dm', t: 'd', uids: ['a', 'b'] } as any);
+
+			// Flush microtasks: setRoomId(rid-dm) -> startCall -> permission await -> throw -> .catch -> setRoomId(null).
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(mockSetRoomId).toHaveBeenNthCalledWith(1, 'rid-dm');
+			expect(mockSetRoomId).toHaveBeenLastCalledWith(null);
+		});
 	});
 });

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -9,6 +9,11 @@ import { getUidDirectMessage } from '../../methods/helpers/helpers';
 import { mediaSessionStore } from './MediaSessionStore';
 import { mediaSessionInstance } from './MediaSessionInstance';
 
+const mockTerminateNativeCall = jest.fn();
+jest.mock('./terminateNativeCall', () => ({
+	terminateNativeCall: (...args: unknown[]) => mockTerminateNativeCall(...args)
+}));
+
 jest.mock('../../database/services/Subscription', () => ({
 	getDMSubscriptionByUsername: jest.fn()
 }));
@@ -789,6 +794,93 @@ describe('MediaSessionInstance', () => {
 
 			await waitFor(() => expect(mockSetRoomId).toHaveBeenCalledWith('dm-ext'));
 			expect(mockGetDMSubscriptionByUsername).toHaveBeenCalledWith('bob');
+		});
+	});
+
+	describe('answerCall error recovery (B5)', () => {
+		it('terminates native call and resets nativeAcceptedCallId when accept() rejects', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			const mockResetNativeCallId = jest.fn();
+			mockUseCallStoreGetState.mockReturnValue({
+				reset: mockCallStoreReset,
+				setCall: jest.fn(),
+				setRoomId: mockSetRoomId,
+				setDirection: mockSetDirection,
+				resetNativeCallId: mockResetNativeCallId,
+				call: null,
+				callId: null,
+				nativeAcceptedCallId: 'call-fail',
+				roomId: null
+			});
+			const mainCall = {
+				callId: 'call-fail',
+				accept: jest.fn().mockRejectedValue(new Error('ICE failure')),
+				remoteParticipants: [{ contact: { username: 'bob' } }]
+			};
+			session.getCallData.mockReturnValue(mainCall);
+
+			await mediaSessionInstance.answerCall('call-fail');
+
+			expect(mockTerminateNativeCall).toHaveBeenCalledWith('call-fail');
+			expect(mockResetNativeCallId).toHaveBeenCalledTimes(1);
+			expect(mockShowErrorAlert).toHaveBeenCalledTimes(1);
+			// Navigation.navigate should NOT be called on the failure path
+			expect(Navigation.navigate).not.toHaveBeenCalled();
+		});
+
+		it('does not navigate or set call when accept() rejects', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			const mockSetCall = jest.fn();
+			mockUseCallStoreGetState.mockReturnValue({
+				reset: mockCallStoreReset,
+				setCall: mockSetCall,
+				setRoomId: mockSetRoomId,
+				setDirection: mockSetDirection,
+				resetNativeCallId: jest.fn(),
+				call: null,
+				callId: null,
+				nativeAcceptedCallId: 'call-err',
+				roomId: null
+			});
+			const mainCall = {
+				callId: 'call-err',
+				accept: jest.fn().mockRejectedValue(new Error('timeout')),
+				remoteParticipants: [{ contact: { username: 'carol' } }]
+			};
+			session.getCallData.mockReturnValue(mainCall);
+
+			await mediaSessionInstance.answerCall('call-err');
+
+			expect(mockSetCall).not.toHaveBeenCalled();
+			expect(Navigation.navigate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('startCall post-permission guard (B6)', () => {
+		it('throws VoIP_Already_In_Call when active call arrives during permission prompt', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			// isInActiveVoipCall returns false initially, then true after permission resolves
+			mockIsInActiveVoipCall
+				.mockReturnValueOnce(false) // pre-permission synchronous check passes
+				.mockReturnValueOnce(true); // post-permission re-evaluation detects new call
+
+			await expect(mediaSessionInstance.startCall('peer-1', 'user')).rejects.toThrow('VoIP_Already_In_Call');
+			expect(mockRequestVoipCallPermissions).toHaveBeenCalledTimes(1);
+			expect(session.startCall).not.toHaveBeenCalled();
+		});
+
+		it('proceeds to start call when no active call during or after permission prompt', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			// isInActiveVoipCall stays false throughout
+			mockIsInActiveVoipCall.mockReturnValue(false);
+
+			await mediaSessionInstance.startCall('peer-1', 'user');
+
+			expect(session.startCall).toHaveBeenCalledWith('user', 'peer-1');
 		});
 	});
 });

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -189,6 +189,8 @@ class MediaSessionInstance {
 		const otherUserId = getUidDirectMessage(room);
 		if (otherUserId) {
 			this.startCall(otherUserId, 'user').catch(error => {
+				// Clear the optimistic roomId so a concurrent incoming call can resolve its own DM context.
+				useCallStore.getState().setRoomId(null);
 				console.error('[VoIP] Error starting call from room:', error);
 			});
 		}

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -153,7 +153,18 @@ class MediaSessionInstance {
 		const mainCall = this.instance?.getCallData(callId);
 
 		if (mainCall && mainCall.callId === callId) {
-			await mainCall.accept();
+			try {
+				await mainCall.accept();
+			} catch (error) {
+				console.error('[VoIP] accept() rejected:', error);
+				terminateNativeCall(callId);
+				const st = useCallStore.getState();
+				if (st.nativeAcceptedCallId === callId) {
+					st.resetNativeCallId();
+				}
+				showErrorAlert(I18n.t('VoIP_Answer_Failed'), I18n.t('Oops'));
+				return;
+			}
 			RNCallKeep.setCurrentCallActive(callId);
 			useCallStore.getState().setCall(mainCall);
 			useCallStore.getState().setDirection('incoming');
@@ -203,6 +214,10 @@ class MediaSessionInstance {
 				I18n.t('Microphone_access_needed_to_record_audio')
 			);
 			return;
+		}
+		// Re-evaluate: an incoming call may have been accepted during the permission prompt.
+		if (isInActiveVoipCall()) {
+			throw new Error(I18n.t('VoIP_Already_In_Call'));
 		}
 		await this.instance.startCall(actor, userId);
 	};


### PR DESCRIPTION
## Proposed changes

Two coupled fixes to the JS media-session lifecycle that prevent stuck call states.

**Answer-call error recovery (B5):** The `accept()` await in `answerCall` is now wrapped in a try/catch. When it rejects (signalling timeout, server reject, ICE failure, peer abort), the native call is terminated via `terminateNativeCall`, `nativeAcceptedCallId` is reset so the active-call guard releases immediately, and the user sees a localised "Could not answer call." alert. Previously a rejection left CallKit/Telecom stuck in "answering" state for the full 60-second timeout and blocked any new call attempt.

**Start-call post-permission guard (B6):** `startCall` re-evaluates `isInActiveVoipCall()` after awaiting `requestVoipCallPermissions`. On Android the microphone permission prompt can take several seconds; if the user accepts an incoming call from the heads-up notification while it is on screen, the guard transitions from `false` to `true` during that window. The re-evaluation throws the same `VoIP_Already_In_Call` error used in the original synchronous check, preventing a second concurrent call session from starting.

**Optimistic roomId cleanup:** `startCallByRoom` sets `roomId` optimistically before calling `startCall`. When the new B6 guard rejects after the permission await, the catch in `startCallByRoom` now resets `roomId` to `null` so a concurrent incoming call can resolve its own DM context instead of being suppressed by the stale value.

## Issue(s)

Part of PR #6918 fix series.

## How to test or reproduce

**B5:** With a real device, simulate a signalling failure (kill WebSocket while tapping Accept). Within ~1 second an alert "Could not answer call." appears; the call guard releases and a new outgoing call can be placed immediately.

**B6:** On Android, start an outgoing call; while the microphone permission prompt is on screen, accept an incoming call from the system notification. After granting (or denying) the permission, no second call session is started, and the incoming call's DM context resolves correctly (no stale `roomId` from the aborted outgoing attempt).

## Screenshots

N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

New i18n key `VoIP_Answer_Failed` added to `en.json`; other locales follow the standard translation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-facing error message for failed VoIP call answering.

* **Bug Fixes**
  * Ensured failed call answers clean up call state and show the new error message.
  * Prevented call-start conflicts when permissions are requested while an incoming call arrives.
  * Cleared temporary room selection if initiating a call by room fails, avoiding incorrect call bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->