### PR TITLE
fix(ios): update privacy metadata to disclose VoIP microphone and data usage

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -2,6 +2,51 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- TODO: Follow-up — Audit privacy manifest against full App Store Connect App Privacy disclosure for pre-existing data types (messages, email, name, photos) and add any additional NSPrivacyCollectedDataTypes entries required. -->
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<!-- Audio data: microphone input used for VoIP voice calls -->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeAudioData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<!-- Other user contact info: caller display name received via VoIP push notification -->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherUserContactInfo</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<!-- User ID: VoIP push token linked to the logged-in user on the server -->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/ios/RocketChatRN/Info.plist
+++ b/ios/RocketChatRN/Info.plist
@@ -72,7 +72,7 @@
 	<key>NSFaceIDUsageDescription</key>
 	<string>Unlock the app with FaceID</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Use your microphone to record audio messages</string>
+	<string>$(PRODUCT_NAME) uses your microphone to make voice calls and record audio messages</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Give $(PRODUCT_NAME) permission to save photos</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
## Proposed changes

Updates two iOS-only static metadata files required for App Store submission acceptance. No runtime behavior change.

**B9 — Microphone purpose string**: `NSMicrophoneUsageDescription` in `ios/RocketChatRN/Info.plist` is updated to disclose voice-call use in addition to audio-message use, satisfying Apple App Review Guideline 5.1.1. The string uses the `$(PRODUCT_NAME)` macro, matching the pattern of adjacent purpose strings.

**B11 — Privacy manifest**: `ios/PrivacyInfo.xcprivacy` is amended with:
- `NSPrivacyTracking: false` — explicit declaration that the app does not engage in cross-app tracking.
- `NSPrivacyCollectedDataTypes` array with three entries for the new VoIP feature: audio data (microphone), other-user contact info (caller display name via push), and user ID (VoIP push token). Each entry is marked linked-to-user, not used for tracking, App Functionality purpose.

A TODO comment in `PrivacyInfo.xcprivacy` tracks a follow-up audit of the manifest against the full App Privacy disclosure for pre-existing data types (messages, email, name, photos). That audit is out of scope for this slice.

## Issue(s)

Part of VoIP PR #6918 fixes — module 5, blockers B9 and B11.

## How to test or reproduce

1. Submit a build to App Store Connect (TestFlight).
2. Verify the automated privacy-manifest check passes without "Missing NSPrivacyTracking" or "Missing data type" warnings.
3. Review the microphone permission prompt on a real device — it should mention both voice calls and audio messages.

## Screenshots

N/A — static metadata changes only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

A follow-up audit of `PrivacyInfo.xcprivacy` against the full App Store Connect App Privacy disclosure (messages, email, name, photos) is needed and tracked via a TODO comment in the manifest file. Human reviewer should ensure this is scheduled before the next App Store submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated microphone permission message to clarify voice call usage alongside audio message recording.

* **Chores**
  * Added privacy manifest declarations for app data collection practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->