### PR TITLE
fix(voip): auto-decline second incoming call as busy

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -329,6 +329,13 @@ class IncomingCallActivity : Activity() {
         }
 
         // Same caller retrying (or first call hasn't been set yet) — refresh the activity.
+        if (acceptDeclineGuard.get()) {
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "onNewIntent: action already in progress, skipping refresh")
+            }
+            return
+        }
+
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "onNewIntent: refreshing UI for call ${newPayload.callId}")
         }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/IncomingCallActivity.kt
@@ -291,6 +291,53 @@ class IncomingCallActivity : Activity() {
         }
     }
 
+    /**
+     * Called when the OS delivers a new incoming-call Intent to this already-running
+     * singleInstance Activity (i.e. a second caller rings while we are showing the first).
+     *
+     * Two cases:
+     * 1. **Different call ID** — the user is already seeing call A. Silently decline call B
+     *    with a busy reason via [VoipNotification.rejectBusyCall] and leave the UI unchanged.
+     * 2. **Same call ID (or no call displayed yet)** — treat it as a refresh: re-parse the
+     *    payload, update the displayed caller info, and reschedule the ring timeout so a rapid
+     *    retry by the same caller does not leave a stale timer.
+     *
+     * [setIntent] is called first so [getIntent] always returns the latest intent, matching
+     * the Android convention for singleInstance activities.
+     */
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+
+        val newPayload = VoipPayload.fromBundle(intent?.extras)
+        if (newPayload == null || !newPayload.isVoipIncomingCall()) {
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "onNewIntent: invalid or non-VoIP payload — ignoring")
+            }
+            return
+        }
+
+        val currentCallId = voipPayload?.callId
+        if (currentCallId != null && currentCallId != newPayload.callId) {
+            // A second, distinct caller arrived while we are already handling another call.
+            // Decline it as busy without touching the on-screen UI.
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "onNewIntent: second call ${newPayload.callId} arrived while showing $currentCallId — declining as busy")
+            }
+            VoipNotification.rejectBusyCall(this, newPayload)
+            return
+        }
+
+        // Same caller retrying (or first call hasn't been set yet) — refresh the activity.
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "onNewIntent: refreshing UI for call ${newPayload.callId}")
+        }
+        voipPayload = newPayload
+        updateUI(newPayload)
+        setupButtons(newPayload)
+        scheduleTimeout(newPayload)
+    }
+
     override fun onBackPressed() {
         voipPayload?.let { handleDecline(it) } ?: finish()
     }


### PR DESCRIPTION
## Proposed changes

When a second incoming-call FCM push arrives while `IncomingCallActivity` is already showing the first caller, Android delivers the new `Intent` to the existing `singleInstance` Activity via `onNewIntent`. Without an override the activity's intent pointer silently shifts to the new call, so if the user taps Accept they answer the wrong caller.

This fix overrides `onNewIntent` to handle the two cases correctly:
- **Different call ID**: silently declines the new call with a busy reason via `VoipNotification.rejectBusyCall`, leaving the on-screen UI untouched.
- **Same call ID** (rapid retry by the same caller): refreshes caller info, rebinds buttons, and reschedules the ring timeout.

## Issue(s)

Related to PR #6918 — blocker B4 (busy-decline on second incoming call).

## How to test or reproduce

1. Have two devices (A and B) call the same callee simultaneously, a few seconds apart.
2. Callee sees device A's full-screen incoming-call UI throughout the second ring.
3. Device B receives a busy response from the server; the callee's UI never switches.
4. A single caller rapidly retrying refreshes the UI correctly without leaking timeout handlers.

## Screenshots

N/A — no visual change; the on-screen UI remains unchanged for the primary caller.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incoming-call handling improved when the call screen is already displayed: new incoming calls for a different call are rejected as busy to avoid conflicts.
  * Repeated incoming-call attempts for the same call now refresh the on-screen UI, reattach controls, and reschedule ring timeouts so retry storms don’t leave stale timers or broken buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->