### PR TITLE
fix(voip): gate MediaCallHeader to authenticated inside root only

### DIFF
--- a/app/AppContainer.test.tsx
+++ b/app/AppContainer.test.tsx
@@ -1,0 +1,113 @@
+import { render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { applyMiddleware, compose, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import reducers from './reducers';
+import AppContainer from './AppContainer';
+import { appStart } from './actions/app';
+import { RootEnum } from './definitions';
+
+// Mock Firebase analytics — the default __mocks__ file uses old API shape
+jest.mock('@react-native-firebase/analytics', () => ({
+	getAnalytics: () => ({
+		logEvent: jest.fn(),
+		logScreenView: jest.fn(),
+		setAnalyticsCollectionEnabled: jest.fn()
+	})
+}));
+
+// Mock navigation deps so we don't need a full native navigator
+jest.mock('@react-navigation/native', () => {
+	const React = require('react');
+	const actualNav = jest.requireActual('@react-navigation/native');
+	return {
+		...actualNav,
+		// eslint-disable-next-line react/display-name
+		NavigationContainer: ({ children }: { children: any }) => React.createElement(React.Fragment, null, children),
+		useFocusEffect: jest.fn(),
+		useIsFocused: () => true,
+		useRoute: () => ({}),
+		useNavigation: () => ({ navigate: jest.fn(), addListener: () => jest.fn() }),
+		createNavigationContainerRef: jest.fn(() => ({ current: null }))
+	};
+});
+
+jest.mock('@react-navigation/native-stack', () => {
+	const React = require('react');
+	return {
+		createNativeStackNavigator: () => ({
+			// eslint-disable-next-line react/display-name
+			Navigator: ({ children }: { children: any }) => React.createElement(React.Fragment, null, children),
+			Screen: () => null
+		})
+	};
+});
+
+// Stub heavy screen components — we only care about MediaCallHeader rendering
+jest.mock('./views/AuthLoadingView', () => 'AuthLoadingView');
+jest.mock('./views/SetUsernameView', () => 'SetUsernameView');
+jest.mock('./stacks/OutsideStack', () => 'OutsideStack');
+jest.mock('./stacks/InsideStack', () => 'InsideStack');
+jest.mock('./stacks/MasterDetailStack', () => 'MasterDetailStack');
+jest.mock('./stacks/ShareExtensionStack', () => 'ShareExtensionStack');
+
+// Mock MediaCallHeader with a testable placeholder
+jest.mock('./containers/MediaCallHeader/MediaCallHeader', () => {
+	const React = require('react');
+	const { View } = require('react-native');
+	// eslint-disable-next-line react/display-name
+	return () => React.createElement(View, { testID: 'media-call-header-root' });
+});
+
+const makeStore = () => {
+	const sagaMiddleware = createSagaMiddleware();
+	return createStore(reducers, compose(applyMiddleware(sagaMiddleware)));
+};
+
+const renderWithRoot = (root: RootEnum, isMasterDetail = false) => {
+	const React = require('react');
+	const store = makeStore();
+	store.dispatch(appStart({ root }));
+	if (isMasterDetail) {
+		store.dispatch({ type: 'APP/SET_MASTER_DETAIL', isMasterDetail: true });
+	}
+	return render(React.createElement(Provider, { store }, React.createElement(AppContainer)));
+};
+
+describe('AppContainer — MediaCallHeader gating', () => {
+	it('renders MediaCallHeader when root is ROOT_INSIDE', () => {
+		const { queryByTestId } = renderWithRoot(RootEnum.ROOT_INSIDE);
+		expect(queryByTestId('media-call-header-root')).not.toBeNull();
+	});
+
+	it('renders MediaCallHeader when root is ROOT_INSIDE with master-detail layout', () => {
+		const { queryByTestId } = renderWithRoot(RootEnum.ROOT_INSIDE, true);
+		expect(queryByTestId('media-call-header-root')).not.toBeNull();
+	});
+
+	it('does not render MediaCallHeader when root is ROOT_OUTSIDE', () => {
+		const { queryByTestId } = renderWithRoot(RootEnum.ROOT_OUTSIDE);
+		expect(queryByTestId('media-call-header-root')).toBeNull();
+	});
+
+	it('does not render MediaCallHeader when root is ROOT_LOADING', () => {
+		const { queryByTestId } = renderWithRoot(RootEnum.ROOT_LOADING);
+		expect(queryByTestId('media-call-header-root')).toBeNull();
+	});
+
+	it('does not render MediaCallHeader when root is ROOT_SET_USERNAME', () => {
+		const { queryByTestId } = renderWithRoot(RootEnum.ROOT_SET_USERNAME);
+		expect(queryByTestId('media-call-header-root')).toBeNull();
+	});
+
+	it('does not render MediaCallHeader when root is ROOT_SHARE_EXTENSION', () => {
+		const { queryByTestId } = renderWithRoot(RootEnum.ROOT_SHARE_EXTENSION);
+		expect(queryByTestId('media-call-header-root')).toBeNull();
+	});
+
+	it('does not render MediaCallHeader when root is ROOT_LOADING_SHARE_EXTENSION', () => {
+		const { queryByTestId } = renderWithRoot(RootEnum.ROOT_LOADING_SHARE_EXTENSION);
+		expect(queryByTestId('media-call-header-root')).toBeNull();
+	});
+});

--- a/app/AppContainer.tsx
+++ b/app/AppContainer.tsx
@@ -53,7 +53,7 @@ const App = memo(({ root, isMasterDetail }: { root: string; isMasterDetail: bool
 
 	return (
 		<>
-			<MediaCallHeader />
+			{root === RootEnum.ROOT_INSIDE ? <MediaCallHeader /> : null}
 			<NavigationContainer
 				theme={navTheme}
 				ref={Navigation.navigationRef}

--- a/app/containers/Header/components/HeaderContainer/index.tsx
+++ b/app/containers/Header/components/HeaderContainer/index.tsx
@@ -5,7 +5,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../../../theme';
 
 interface IHeaderContainer extends ViewProps {
-	addExtraNotchPadding?: boolean;
 	isMasterDetail?: boolean;
 	customLeftIcon?: boolean;
 	customRightIcon?: boolean;

--- a/app/containers/Header/index.tsx
+++ b/app/containers/Header/index.tsx
@@ -22,15 +22,6 @@ const Header = ({ options, navigation, route }: IHeader) => {
 	// 32.5 is the value I found that makes it work correctly on both platforms.
 	const size = 32.5 * fontScale;
 
-	const isRoomViewMasterDetail =
-		!isMasterDetail ||
-		route.name === 'RoomView' ||
-		route.name === 'RoomsListView' ||
-		route.name === 'ShareListView' ||
-		route.name === 'ShareView' ||
-		route.name === 'AttachmentView' ||
-		route.name === 'DrawerNavigator';
-
 	const handleOnLayout = ({
 		nativeEvent: {
 			layout: { width }
@@ -54,11 +45,7 @@ const Header = ({ options, navigation, route }: IHeader) => {
 	};
 
 	return (
-		<HeaderContainer
-			customRightIcon={!!headerRight}
-			customLeftIcon={!!headerLeft}
-			addExtraNotchPadding={isRoomViewMasterDetail}
-			isMasterDetail={isMasterDetail}>
+		<HeaderContainer customRightIcon={!!headerRight} customLeftIcon={!!headerLeft} isMasterDetail={isMasterDetail}>
 			{headerLeft ? (
 				headerLeft({ canGoBack: false })
 			) : (

--- a/app/containers/MediaCallHeader/MediaCallHeader.test.tsx
+++ b/app/containers/MediaCallHeader/MediaCallHeader.test.tsx
@@ -79,30 +79,28 @@ describe('MediaCallHeader', () => {
 		jest.clearAllMocks();
 	});
 
-	it('should render empty placeholder when there is no call', () => {
+	it('should render nothing when there is no call', () => {
 		useCallStore.setState({ call: null });
-		const { getByTestId, queryByTestId } = render(
+		const { queryByTestId } = render(
 			<Wrapper>
 				<MediaCallHeader />
 			</Wrapper>
 		);
 
-		expect(getByTestId('media-call-header-empty')).toBeTruthy();
 		expect(queryByTestId('media-call-header')).toBeNull();
 		expect(queryByTestId('media-call-header-collapse')).toBeNull();
 		expect(queryByTestId('media-call-header-content')).toBeNull();
 		expect(queryByTestId('media-call-header-end')).toBeNull();
 	});
 
-	it('should render empty placeholder when native accepted but call not bound yet (before answerCall completes)', () => {
+	it('should render nothing when native accepted but call not bound yet (before answerCall completes)', () => {
 		useCallStore.getState().setNativeAcceptedCallId('e3246c4d-d23a-412f-8a8b-37ec9f29ef1a');
-		const { getByTestId, queryByTestId } = render(
+		const { queryByTestId } = render(
 			<Wrapper>
 				<MediaCallHeader />
 			</Wrapper>
 		);
 
-		expect(getByTestId('media-call-header-empty')).toBeTruthy();
 		expect(queryByTestId('media-call-header')).toBeNull();
 	});
 

--- a/app/containers/MediaCallHeader/MediaCallHeader.tsx
+++ b/app/containers/MediaCallHeader/MediaCallHeader.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useShallow } from 'zustand/react/shallow';
@@ -51,7 +51,7 @@ const MediaCallHeader = () => {
 	};
 
 	if (!call) {
-		return <View style={defaultHeaderStyle} testID='media-call-header-empty' />;
+		return null;
 	}
 
 	return (

--- a/app/containers/MediaCallHeader/__snapshots__/MediaCallHeader.test.tsx.snap
+++ b/app/containers/MediaCallHeader/__snapshots__/MediaCallHeader.test.tsx.snap
@@ -1336,17 +1336,7 @@ exports[`Story Snapshots: NoCall should match snapshot 1`] = `
       "flex": 1,
     }
   }
->
-  <View
-    style={
-      {
-        "backgroundColor": "#E4E7EA",
-        "paddingTop": 0,
-      }
-    }
-    testID="media-call-header-empty"
-  />
-</View>
+/>
 `;
 
 exports[`Story Snapshots: WithRemoteHeld should match snapshot 1`] = `


### PR DESCRIPTION
## Proposed changes

`MediaCallHeader` was mounted unconditionally at the application root, alongside the `NavigationContainer`. Because its no-active-call branch returned a styled empty `View` (height equal to the safe-area top inset, coloured `surfaceNeutral`) instead of `null`, the header occupied vertical space on every screen — including the login screen, share extension, and loading splash — producing a visible coloured strip above each of those screens' content.

## Issue(s)

Part of the PR #6918 fix set — module 4, blocker B8.

## How to test or reproduce

1. Launch the app to the login screen — no coloured strip above the login form.
2. Open the share extension — no coloured strip above the share-target picker.
3. Sign in — InsideStack screens render with their normal status-bar appearance (no regression).
4. Place a VoIP call — the call header appears above the room view.
5. Hang up — the header disappears.

## Screenshots

N/A — visual regression fix; before/after comparison via manual testing on device.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Three changes in this slice:

1. **Root gating** (`app/AppContainer.tsx`): `<MediaCallHeader />` is now wrapped in `{root === RootEnum.ROOT_INSIDE ? <MediaCallHeader /> : null}` so it only mounts for the authenticated inside root.
2. **No-call branch returns null** (`app/containers/MediaCallHeader/MediaCallHeader.tsx`): The empty `<View>` placeholder is replaced with `null`. The `View` import is also removed.
3. **Dead prop removed** (`app/containers/Header/index.tsx`, `app/containers/Header/components/HeaderContainer/index.tsx`): `addExtraNotchPadding` was declared in the `IHeaderContainer` interface but never consumed in the component body; it is now removed from both the interface and the call site.

A new `app/AppContainer.test.tsx` asserts that `MediaCallHeader` is present in the inside tree and absent for all other roots (loading, outside, set-username, share extension, loading-share-extension).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Media Call Header now conditionally renders based on current application state rather than always displaying
  * Media Call Header no longer shows placeholder content when inactive
  * Removed unnecessary layout padding in specific application states

* **Tests**
  * Added comprehensive test coverage for Media Call Header rendering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->