### PR TITLE
fix(voip): strip restricted Android permissions from merged APK

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <!-- maxSdkVersion=29: on Android 11+ non-dialer apps cannot obtain this grant; native AudioManager fallback covers the detection path on API 30+. -->
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" android:maxSdkVersion="29" />
+    <!-- Strip restricted permissions inherited from react-native-callkeep. The app uses self-managed Telecom (MANAGE_OWN_CALLS) and does not need dialer or phone-number access. -->
+    <uses-permission android:name="android.permission.CALL_PHONE" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" tools:node="remove" />
     <uses-permission android:name="android.permission.BIND_TELECOM_CONNECTION_SERVICE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />

--- a/app/lib/methods/voipCallPermissions.test.ts
+++ b/app/lib/methods/voipCallPermissions.test.ts
@@ -11,7 +11,7 @@ describe('requestVoipCallPermissions', () => {
 			...jest.requireActual('./helpers'),
 			isAndroid: false
 		}));
-		const spy = jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValue({} as never);
+		const spy = jest.spyOn(PermissionsAndroid, 'request').mockResolvedValue(PermissionsAndroid.RESULTS.GRANTED);
 		const { requestVoipCallPermissions } = require('./voipCallPermissions');
 
 		const granted = await requestVoipCallPermissions();
@@ -20,25 +20,19 @@ describe('requestVoipCallPermissions', () => {
 		expect(spy).not.toHaveBeenCalled();
 	});
 
-	it('requests both READ_PHONE_STATE and RECORD_AUDIO on Android', async () => {
+	it('requests only RECORD_AUDIO on Android', async () => {
 		jest.resetModules();
 		jest.doMock('./helpers', () => ({
 			...jest.requireActual('./helpers'),
 			isAndroid: true
 		}));
-		const spy = jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValue({
-			[PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE]: PermissionsAndroid.RESULTS.GRANTED,
-			[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO]: PermissionsAndroid.RESULTS.GRANTED
-		} as never);
+		const spy = jest.spyOn(PermissionsAndroid, 'request').mockResolvedValue(PermissionsAndroid.RESULTS.GRANTED);
 		const { requestVoipCallPermissions } = require('./voipCallPermissions');
 
 		const granted = await requestVoipCallPermissions();
 
 		expect(granted).toBe(true);
-		expect(spy).toHaveBeenCalledWith([
-			PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE,
-			PermissionsAndroid.PERMISSIONS.RECORD_AUDIO
-		]);
+		expect(spy).toHaveBeenCalledWith(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO);
 	});
 
 	it('returns false when RECORD_AUDIO is denied', async () => {
@@ -47,10 +41,7 @@ describe('requestVoipCallPermissions', () => {
 			...jest.requireActual('./helpers'),
 			isAndroid: true
 		}));
-		jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValue({
-			[PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE]: PermissionsAndroid.RESULTS.GRANTED,
-			[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO]: PermissionsAndroid.RESULTS.DENIED
-		} as never);
+		jest.spyOn(PermissionsAndroid, 'request').mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
 		const { requestVoipCallPermissions } = require('./voipCallPermissions');
 
 		const granted = await requestVoipCallPermissions();
@@ -58,20 +49,17 @@ describe('requestVoipCallPermissions', () => {
 		expect(granted).toBe(false);
 	});
 
-	it('returns true when READ_PHONE_STATE is denied but RECORD_AUDIO is granted', async () => {
+	it('returns false when RECORD_AUDIO is set to never ask again', async () => {
 		jest.resetModules();
 		jest.doMock('./helpers', () => ({
 			...jest.requireActual('./helpers'),
 			isAndroid: true
 		}));
-		jest.spyOn(PermissionsAndroid, 'requestMultiple').mockResolvedValue({
-			[PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE]: PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN,
-			[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO]: PermissionsAndroid.RESULTS.GRANTED
-		} as never);
+		jest.spyOn(PermissionsAndroid, 'request').mockResolvedValue(PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN);
 		const { requestVoipCallPermissions } = require('./voipCallPermissions');
 
 		const granted = await requestVoipCallPermissions();
 
-		expect(granted).toBe(true);
+		expect(granted).toBe(false);
 	});
 });

--- a/app/lib/methods/voipCallPermissions.ts
+++ b/app/lib/methods/voipCallPermissions.ts
@@ -6,10 +6,6 @@ export const requestVoipCallPermissions = async (): Promise<boolean> => {
 	if (!isAndroid) {
 		return true;
 	}
-	const results = await PermissionsAndroid.requestMultiple([
-		PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE,
-		PermissionsAndroid.PERMISSIONS.RECORD_AUDIO
-	]);
-	// READ_PHONE_STATE only enhances Telecom integration; native falls back without it.
-	return results[PermissionsAndroid.PERMISSIONS.RECORD_AUDIO] === PermissionsAndroid.RESULTS.GRANTED;
+	const result = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.RECORD_AUDIO);
+	return result === PermissionsAndroid.RESULTS.GRANTED;
 };


### PR DESCRIPTION
## Proposed changes

Removes three restricted/dangerous Android permissions that were being included in the merged APK without Play Store justification, triggering policy review warnings.

- **B12 — `READ_PHONE_STATE`**: Added `android:maxSdkVersion="29"` so the declaration disappears on Android 11+ (where the grant is ungrantable to non-dialer apps anyway). The native `AudioManager`-based fallback in `VoipNotification.kt` already handles the detection path on API 30+.
- **B12 — runtime request**: `requestVoipCallPermissions` now calls `PermissionsAndroid.request(RECORD_AUDIO)` (single permission) instead of `requestMultiple([READ_PHONE_STATE, RECORD_AUDIO])`. Removed the obsolete comment that described `READ_PHONE_STATE` as "enhancing Telecom integration."
- **B13 — `CALL_PHONE` / `READ_PHONE_NUMBERS`**: Added `tools:node="remove"` overrides in the app manifest to strip these transitive permissions inherited from `react-native-callkeep`. The app uses self-managed Telecom (`MANAGE_OWN_CALLS`) and needs neither.

## Issue(s)

Part of PR #6918 fixes — blockers B12 and B13.

## How to test or reproduce

1. Build a release APK/AAB and inspect the merged manifest at `app/build/outputs/apk/release/.../AndroidManifest.xml`.
2. Verify `CALL_PHONE` and `READ_PHONE_NUMBERS` are absent.
3. Verify `READ_PHONE_STATE` appears only with `maxSdkVersion="29"` (not on Android 11+ devices).
4. On Android 11+: place an outgoing VoIP call — only the microphone permission prompt appears.
5. Incoming calls continue to function (Telecom registration succeeds).

> **Note (AC5)**: Merged-manifest build verification is deferred to CI. The worktree does not have Android build tooling available; the manifest XML changes are correct by inspection.

## Screenshots

N/A — manifest and permission hygiene only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined VoIP calling permissions to request only microphone access, eliminating unnecessary phone-related permission requests that cluttered the permission dialog
  * Improved permission handling by removing overly broad inherited permissions and constraining legacy permission requests to older Android versions
  * Enhanced user experience by streamlining the permission request flow during VoIP call setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->