### PR TITLE
fix(voip): heal stale SDK socket on warm lock-screen accept

### DIFF
--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -91,6 +91,11 @@ class MediaSessionInstance {
 		);
 		// TESTING: DDP signal transport — offer/answer/ICE stay on DDP
 		mediaSessionStore.setSendSignalFn((signal: ClientMediaSignal) => {
+			// Heal a stale socket on warm lock-screen accepts: when the device stays locked the
+			// foreground saga never fires, so nothing else nudges the SDK to reopen. checkAndReopen
+			// is a no-op when alive; otherwise it triggers reconnect → relogin → resubscribe so
+			// answer SDP and ICE candidates can flow over a fresh DDP session.
+			sdk.current?.checkAndReopen?.();
 			sdk.methodCall('stream-notify-user', `${userId}/media-calls`, JSON.stringify(signal));
 		});
 		this.instance = mediaSessionStore.getInstance(userId);


### PR DESCRIPTION
## Proposed changes

When an iOS user has the app warm in the background, locks the device, then accepts an incoming call from the lock screen, the local UI shows the call as connected but the remote peer keeps trying to connect for ~10s and then fails. Killed-app accept (cold start via PushKit) works.

Root cause: the SDK's DDP websocket can go stale during background suspension. On warm lock-screen accept, **nothing nudges it back to life**:

- `appHasComeBackToForeground` only runs on `AppState='active'`. The device stays locked through CallKit accept, so the saga never fires.
- The SDK's own `reopen()` only kicks in on an explicit `onClose` event; iOS suspended sockets often go zombie without firing `close`.
- Inside the dead-socket window, `mediaCall.accept()` resolves locally (CallKit shows "connected") but the answer SDP and ICE candidates queued in `setSendSignalFn → sdk.methodCall('stream-notify-user', …)` block forever in `ddp.send()` waiting on the `'open'` event.

Fix: call `sdk.current?.checkAndReopen?.()` before each signal send. It is a no-op when the socket is alive; otherwise it triggers the existing reconnect → relogin (`connectedListener` in `connect.ts:112`) → resubscribe (`subscribeAll` inside `ddp.login`) chain so signaling can flow over a fresh DDP session.

## Issue(s)

VoIP warm lock-screen accept regression discovered while testing #7283 / #7281 follow-up scenarios.

## How to test or reproduce

1. Install a Release build (debug masks the bug — debugger keeps WS alive).
2. Sign in, wait for the app to fully connect to the workspace.
3. Lock the device with the app in the background.
4. Have another user place a VoIP call to you.
5. Accept from the lock screen.

**Before:** local CallKit shows connected; remote stays on "calling…" for ~10s and drops.
**After:** call connects on both ends; audio flows.

Cold-start path (kill app → call → accept from lock screen) should remain unaffected (regression check).

## Screenshots

_n/a_

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

A regression test for this exact scenario is hard without an integration harness that simulates iOS suspension + CallKit accept; the bug only manifests on a real device with a Release build (debug attaches the JS debugger which keeps the socket alive). Suggested follow-up: add a unit assertion that `setSendSignalFn` calls `checkAndReopen` before `methodCall`, plus a manual QA item on the lock-screen accept flow.

Stronger alternative considered: full `mediaSessionInstance.reset()` + `init()` on `VoipAcceptSucceeded`. Rejected for blast radius — the minimal fix is co-located with the actual send site so any background-resume signaling path benefits, not just the iOS warm-locked accept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of accepting calls on the lock screen by ensuring VoIP signaling connections remain stable during call initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->