### PR TITLE
chore(voip): delete dead method-call queue and extract deviceId() helper

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -17,12 +17,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class DDPClient {
-    private data class QueuedMethodCall(
-        val method: String,
-        val params: JSONArray,
-        val callback: (Boolean) -> Unit
-    )
-
     companion object {
         private const val TAG = "RocketChat.DDPClient"
         private val sharedClient: OkHttpClient by lazy {
@@ -42,7 +36,6 @@ class DDPClient {
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val pendingCallbacks = mutableMapOf<String, (JSONObject) -> Unit>()
-    private val queuedMethodCalls = mutableListOf<QueuedMethodCall>()
 
     @Volatile
     private var connectedCallback: ((Boolean) -> Unit)? = null
@@ -176,7 +169,6 @@ class DDPClient {
         isConnected = false
         cancelConnectTimeout()
         synchronized(pendingCallbacks) { pendingCallbacks.clear() }
-        clearQueuedMethodCalls()
         connectedCallback = null
         onCollectionMessage = null
         webSocket?.close(1000, null)
@@ -218,37 +210,6 @@ class DDPClient {
         if (!send(msg)) {
             synchronized(pendingCallbacks) { pendingCallbacks.remove(msgId) }
             mainHandler.post { callback(false) }
-        }
-    }
-
-    fun queueMethodCall(method: String, params: JSONArray, callback: (Boolean) -> Unit = {}) {
-        synchronized(queuedMethodCalls) {
-            queuedMethodCalls.add(
-                QueuedMethodCall(
-                    method = method,
-                    params = params,
-                    callback = callback
-                )
-            )
-        }
-    }
-
-    fun hasQueuedMethodCalls(): Boolean =
-        synchronized(queuedMethodCalls) { queuedMethodCalls.isNotEmpty() }
-
-    fun flushQueuedMethodCalls() {
-        val queuedCalls = synchronized(queuedMethodCalls) {
-            queuedMethodCalls.toList().also { queuedMethodCalls.clear() }
-        }
-
-        queuedCalls.forEach { queuedCall ->
-            callMethod(queuedCall.method, queuedCall.params, queuedCall.callback)
-        }
-    }
-
-    fun clearQueuedMethodCalls() {
-        synchronized(queuedMethodCalls) {
-            queuedMethodCalls.clear()
         }
     }
 

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -76,12 +76,15 @@ class VoipNotification(private val context: Context) {
         private val timeoutHandler = Handler(Looper.getMainLooper())
         private val timeoutCallbacks = mutableMapOf<String, Runnable>()
         private val ddpRegistry = VoipPerCallDdpRegistry<DDPClient> { client ->
-            client.clearQueuedMethodCalls()
             client.disconnect()
         }
 
         /** False when [callId] was reassigned or torn down (stale DDP callback). */
         private fun isLiveClient(callId: String, client: DDPClient) = ddpRegistry.clientFor(callId) === client
+
+        /** Returns the stable Android device ID used as `contractId` in media-calls.answer requests. */
+        private fun deviceId(context: Context): String =
+            Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 
         /**
          * Cancels a VoIP notification by ID.
@@ -163,12 +166,11 @@ class VoipNotification(private val context: Context) {
             }
             cancelTimeout(payload.callId)
             ddpRegistry.stopClient(payload.callId)
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
                 context = context,
                 host = payload.host,
                 callId = payload.callId,
-                contractId = deviceId,
+                contractId = deviceId(context),
                 answer = "reject",
                 supportedFeatures = null
             ) { _ -> }
@@ -311,12 +313,11 @@ class VoipNotification(private val context: Context) {
             timeoutRunnable = postedTimeout
             timeoutHandler.postDelayed(postedTimeout, 10_000L)
 
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
                 context = context,
                 host = payload.host,
                 callId = payload.callId,
-                contractId = deviceId,
+                contractId = deviceId(context),
                 answer = "accept",
                 supportedFeatures = listOf("audio", "hold")
             ) { success ->
@@ -331,7 +332,7 @@ class VoipNotification(private val context: Context) {
                         context = appCtx,
                         host = payload.host,
                         callId = payload.callId,
-                        contractId = deviceId,
+                        contractId = deviceId(appCtx),
                         answer = "reject",
                         supportedFeatures = null
                     ) { rejectSucceeded ->
@@ -483,16 +484,6 @@ class VoipNotification(private val context: Context) {
             return false
         }
 
-        private fun flushPendingQueuedSignalsIfNeeded(callId: String): Boolean {
-            val client = ddpRegistry.clientFor(callId) ?: return false
-            if (!client.hasQueuedMethodCalls()) {
-                return false
-            }
-
-            client.flushQueuedMethodCalls()
-            return true
-        }
-
         /**
          * Rejects an incoming call because the user is already on another call.
          *
@@ -508,12 +499,11 @@ class VoipNotification(private val context: Context) {
                 Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
             }
             cancelTimeout(payload.callId)
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
                 context = context,
                 host = payload.host,
                 callId = payload.callId,
-                contractId = deviceId,
+                contractId = deviceId(context),
                 answer = "reject",
                 supportedFeatures = null
             ) { _ -> }
@@ -535,7 +525,6 @@ class VoipNotification(private val context: Context) {
                 return
             }
 
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             val callId = payload.callId
             val client = DDPClient()
             ddpRegistry.putClient(callId, client)
@@ -567,7 +556,7 @@ class VoipNotification(private val context: Context) {
                                 if (signalType == "notification" &&
                                     (
                                         // accepted from other device
-                                        (!signedContractId.isNullOrEmpty() && signedContractId != deviceId) ||
+                                        (!signedContractId.isNullOrEmpty() && signedContractId != deviceId(context)) ||
                                         // hung up by other device
                                         (signalNotification == "hangup")
                                     )) {
@@ -619,9 +608,6 @@ class VoipNotification(private val context: Context) {
                     }
 
                     ddpRegistry.markLoggedIn(callId)
-                    if (flushPendingQueuedSignalsIfNeeded(callId)) {
-                        return@login
-                    }
 
                     val params = JSONArray().apply {
                         put("$userId/media-signal")


### PR DESCRIPTION
## Proposed changes

Removes the permanently-empty method-call queue infrastructure from `DDPClient.kt` and collapses four identical `Settings.Secure.getString(...ANDROID_ID)` duplications in `VoipNotification.kt` into a single `deviceId(context)` helper.

## Issue(s)

Part of PR #6918 review cleanup — slice 05.

## How to test or reproduce

Existing flow: trigger an incoming VoIP call on Android. Verify accept and reject both reach the server as before. No behaviour change — pure dead-code removal and de-duplication.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

### A — Dead queue removal (`DDPClient.kt`)

`queueMethodCall`, `queuedMethodCalls`, `hasQueuedMethodCalls`, `flushQueuedMethodCalls`, `clearQueuedMethodCalls`, and the `QueuedMethodCall` data class are deleted. A pre-flight `grep -rn queueMethodCall android/` confirmed no producer ever called `queueMethodCall`; the queue was permanently empty. `flushPendingQueuedSignalsIfNeeded` in `VoipNotification.kt` (which only ever returned `false`) and its one call site are also removed.

### B — `deviceId()` helper (`VoipNotification.kt`)

`Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)` appeared four times. Extracted into `private fun deviceId(context: Context): String` in the companion object; all four call sites now invoke it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined VoIP call handling by removing method call buffering mechanism.
  * Consolidated device identifier retrieval for VoIP notification operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->