### PR TITLE
chore(voip): consolidate PR #6918 review-cleanup

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -17,12 +17,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class DDPClient {
-    private data class QueuedMethodCall(
-        val method: String,
-        val params: JSONArray,
-        val callback: (Boolean) -> Unit
-    )
-
     companion object {
         private const val TAG = "RocketChat.DDPClient"
         private val sharedClient: OkHttpClient by lazy {
@@ -42,7 +36,6 @@ class DDPClient {
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val pendingCallbacks = mutableMapOf<String, (JSONObject) -> Unit>()
-    private val queuedMethodCalls = mutableListOf<QueuedMethodCall>()
 
     @Volatile
     private var connectedCallback: ((Boolean) -> Unit)? = null
@@ -176,7 +169,6 @@ class DDPClient {
         isConnected = false
         cancelConnectTimeout()
         synchronized(pendingCallbacks) { pendingCallbacks.clear() }
-        clearQueuedMethodCalls()
         connectedCallback = null
         onCollectionMessage = null
         webSocket?.close(1000, null)
@@ -218,37 +210,6 @@ class DDPClient {
         if (!send(msg)) {
             synchronized(pendingCallbacks) { pendingCallbacks.remove(msgId) }
             mainHandler.post { callback(false) }
-        }
-    }
-
-    fun queueMethodCall(method: String, params: JSONArray, callback: (Boolean) -> Unit = {}) {
-        synchronized(queuedMethodCalls) {
-            queuedMethodCalls.add(
-                QueuedMethodCall(
-                    method = method,
-                    params = params,
-                    callback = callback
-                )
-            )
-        }
-    }
-
-    fun hasQueuedMethodCalls(): Boolean =
-        synchronized(queuedMethodCalls) { queuedMethodCalls.isNotEmpty() }
-
-    fun flushQueuedMethodCalls() {
-        val queuedCalls = synchronized(queuedMethodCalls) {
-            queuedMethodCalls.toList().also { queuedMethodCalls.clear() }
-        }
-
-        queuedCalls.forEach { queuedCall ->
-            callMethod(queuedCall.method, queuedCall.params, queuedCall.callback)
-        }
-    }
-
-    fun clearQueuedMethodCalls() {
-        synchronized(queuedMethodCalls) {
-            queuedMethodCalls.clear()
         }
     }
 

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipCallService.kt
@@ -3,6 +3,7 @@ package chat.rocket.reactnative.voip
 import android.app.Notification
 import android.app.NotificationChannel
 import chat.rocket.reactnative.BuildConfig
+import chat.rocket.reactnative.R
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
@@ -129,8 +130,8 @@ class VoipCallService : Service() {
         )
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("VoIP Call")
-            .setContentText("Call in progress")
+            .setContentTitle(getString(R.string.voip_call_service_title))
+            .setContentText(getString(R.string.voip_call_service_text))
             .setSmallIcon(getApplicationInfo().icon)
             .setContentIntent(pendingIntent)
             .setOngoing(true)
@@ -148,7 +149,7 @@ class VoipCallService : Service() {
                 CHANNEL_NAME,
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = "VoIP call in progress"
+                description = getString(R.string.voip_call_service_channel_description)
                 setShowBadge(false)
             }
             val notificationManager = getSystemService(NotificationManager::class.java)

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -76,12 +76,15 @@ class VoipNotification(private val context: Context) {
         private val timeoutHandler = Handler(Looper.getMainLooper())
         private val timeoutCallbacks = mutableMapOf<String, Runnable>()
         private val ddpRegistry = VoipPerCallDdpRegistry<DDPClient> { client ->
-            client.clearQueuedMethodCalls()
             client.disconnect()
         }
 
         /** False when [callId] was reassigned or torn down (stale DDP callback). */
         private fun isLiveClient(callId: String, client: DDPClient) = ddpRegistry.clientFor(callId) === client
+
+        /** Returns the stable Android device ID used as `contractId` in media-calls.answer requests. */
+        private fun deviceId(context: Context): String =
+            Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 
         /**
          * Cancels a VoIP notification by ID.
@@ -163,12 +166,11 @@ class VoipNotification(private val context: Context) {
             }
             cancelTimeout(payload.callId)
             ddpRegistry.stopClient(payload.callId)
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
                 context = context,
                 host = payload.host,
                 callId = payload.callId,
-                contractId = deviceId,
+                contractId = deviceId(context),
                 answer = "reject",
                 supportedFeatures = null
             ) { _ -> }
@@ -311,12 +313,11 @@ class VoipNotification(private val context: Context) {
             timeoutRunnable = postedTimeout
             timeoutHandler.postDelayed(postedTimeout, 10_000L)
 
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
                 context = context,
                 host = payload.host,
                 callId = payload.callId,
-                contractId = deviceId,
+                contractId = deviceId(context),
                 answer = "accept",
                 supportedFeatures = listOf("audio", "hold")
             ) { success ->
@@ -331,7 +332,7 @@ class VoipNotification(private val context: Context) {
                         context = appCtx,
                         host = payload.host,
                         callId = payload.callId,
-                        contractId = deviceId,
+                        contractId = deviceId(appCtx),
                         answer = "reject",
                         supportedFeatures = null
                     ) { rejectSucceeded ->
@@ -483,16 +484,6 @@ class VoipNotification(private val context: Context) {
             return false
         }
 
-        private fun flushPendingQueuedSignalsIfNeeded(callId: String): Boolean {
-            val client = ddpRegistry.clientFor(callId) ?: return false
-            if (!client.hasQueuedMethodCalls()) {
-                return false
-            }
-
-            client.flushQueuedMethodCalls()
-            return true
-        }
-
         /**
          * Rejects an incoming call because the user is already on another call.
          *
@@ -508,12 +499,11 @@ class VoipNotification(private val context: Context) {
                 Log.d(TAG, "Rejected busy call ${payload.callId} — user already on a call")
             }
             cancelTimeout(payload.callId)
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             MediaCallsAnswerRequest.fetch(
                 context = context,
                 host = payload.host,
                 callId = payload.callId,
-                contractId = deviceId,
+                contractId = deviceId(context),
                 answer = "reject",
                 supportedFeatures = null
             ) { _ -> }
@@ -535,7 +525,6 @@ class VoipNotification(private val context: Context) {
                 return
             }
 
-            val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
             val callId = payload.callId
             val client = DDPClient()
             ddpRegistry.putClient(callId, client)
@@ -567,7 +556,7 @@ class VoipNotification(private val context: Context) {
                                 if (signalType == "notification" &&
                                     (
                                         // accepted from other device
-                                        (!signedContractId.isNullOrEmpty() && signedContractId != deviceId) ||
+                                        (!signedContractId.isNullOrEmpty() && signedContractId != deviceId(context)) ||
                                         // hung up by other device
                                         (signalNotification == "hangup")
                                     )) {
@@ -619,9 +608,6 @@ class VoipNotification(private val context: Context) {
                     }
 
                     ddpRegistry.markLoggedIn(callId)
-                    if (flushPendingQueuedSignalsIfNeeded(callId)) {
-                        return@login
-                    }
 
                     val params = JSONArray().apply {
                         put("$userId/media-signal")

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/VoipNotification.kt
@@ -34,6 +34,7 @@ import android.app.KeyguardManager
 import chat.rocket.reactnative.MainActivity
 import chat.rocket.reactnative.notification.Ejson
 import chat.rocket.reactnative.BuildConfig
+import chat.rocket.reactnative.R
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.atomic.AtomicBoolean
@@ -697,8 +698,7 @@ class VoipNotification(private val context: Context) {
                 CHANNEL_NAME,
                 NotificationManager.IMPORTANCE_HIGH
             ).apply {
-                // TODO: i18n
-                description = "Incoming VoIP calls"
+                description = context.getString(R.string.voip_incoming_call_channel_description)
                 enableLights(true)
                 enableVibration(true)
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
@@ -938,8 +938,8 @@ class VoipNotification(private val context: Context) {
         // Build notification
         val builder = NotificationCompat.Builder(context, CHANNEL_ID).apply {
             setSmallIcon(smallIconResId)
-            setContentTitle("Incoming call")
-            setContentText("Call from $caller")
+            setContentTitle(context.getString(R.string.voip_incoming_call_title))
+            setContentText(context.getString(R.string.voip_incoming_call_text, caller))
             priority = NotificationCompat.PRIORITY_MAX
             setCategory(NotificationCompat.CATEGORY_CALL)
             setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -947,8 +947,8 @@ class VoipNotification(private val context: Context) {
             setOngoing(true)
             setOnlyAlertOnce(true)
             setTimeoutAfter(remainingLifetimeMs)
-            addAction(0, "Decline", declinePendingIntent)
-            addAction(0, "Accept", acceptPendingIntent)
+            addAction(0, context.getString(R.string.incoming_call_reject), declinePendingIntent)
+            addAction(0, context.getString(R.string.incoming_call_accept), acceptPendingIntent)
 
             if (avatarBitmap != null) {
                 setLargeIcon(avatarBitmap)

--- a/android/app/src/main/res/values/strings_voip.xml
+++ b/android/app/src/main/res/values/strings_voip.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="voip_incoming_call_channel_description">Incoming VoIP calls</string>
+    <string name="voip_incoming_call_title">Incoming call</string>
+    <string name="voip_incoming_call_text">Call from %1$s</string>
+    <string name="voip_call_service_channel_description">VoIP call in progress</string>
+    <string name="voip_call_service_title">VoIP Call</string>
+    <string name="voip_call_service_text">Call in progress</string>
+</resources>

--- a/app/containers/ActionSheet/ActionSheet.tsx
+++ b/app/containers/ActionSheet/ActionSheet.tsx
@@ -128,6 +128,7 @@ const ActionSheet = React.memo(
 							hasCancel={data?.hasCancel}
 							onLayout={handleContentLayout}
 							fullContainer={data.fullContainer}
+							hugContent={data.hugContent}
 							contentMinHeight={isIOS ? contentMinHeight : undefined}
 							scrollEnabled={scrollEnabled}>
 							{data?.children}

--- a/app/containers/ActionSheet/BottomSheetContent.tsx
+++ b/app/containers/ActionSheet/BottomSheetContent.tsx
@@ -18,6 +18,7 @@ interface IBottomSheetContentProps {
 	children?: React.ReactElement | null;
 	onLayout: ViewProps['onLayout'];
 	fullContainer?: boolean;
+	hugContent?: boolean;
 	contentMinHeight?: number;
 	scrollEnabled?: boolean;
 }
@@ -30,6 +31,7 @@ const BottomSheetContent = React.memo(
 		children,
 		onLayout,
 		fullContainer,
+		hugContent,
 		contentMinHeight,
 		scrollEnabled
 	}: IBottomSheetContentProps) => {
@@ -77,7 +79,10 @@ const BottomSheetContent = React.memo(
 			);
 		}
 		return (
-			<View testID='action-sheet' style={fullContainer ? [styles.fullContainer, minHeightStyle] : undefined} onLayout={onLayout}>
+			<View
+				testID='action-sheet'
+				style={fullContainer && !(hugContent && isAndroid) ? [styles.fullContainer, minHeightStyle] : undefined}
+				onLayout={onLayout}>
 				{children}
 			</View>
 		);

--- a/app/containers/ActionSheet/Provider.tsx
+++ b/app/containers/ActionSheet/Provider.tsx
@@ -35,6 +35,7 @@ export type TActionSheetOptions = {
 	onClose?: () => void;
 	enableContentPanningGesture?: boolean;
 	fullContainer?: boolean;
+	hugContent?: boolean;
 };
 export interface IActionSheetProvider {
 	showActionSheet: (item: TActionSheetOptions) => void;

--- a/app/containers/ActionSheet/styles.ts
+++ b/app/containers/ActionSheet/styles.ts
@@ -68,6 +68,7 @@ export default StyleSheet.create({
 	},
 	fullContainer: {
 		width: '100%',
+		height: '100%',
 		flex: 0
 	}
 });

--- a/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
+++ b/app/containers/NewMediaCall/VoipCallLifecycle.integration.test.tsx
@@ -352,15 +352,11 @@ const flushMicrotasks = async () => {
 //     is not loaded. Rendering succeeds, warning is cosmetic for tests.
 //   - '[VoIP] Call not found after accept:' — deterministic expected branch output of
 //     answerCall when getCallData returns undefined (exercised by test A2).
-//     Production code warns intentionally; tests should not hide it, but it
-//     is not an unexpected error for the asserting test.
-const CONSOLE_ERROR_ALLOWLIST: string[] = [];
-const CONSOLE_WARN_ALLOWLIST: string[] = [
-	'@expo/vector-icons',
-	'not wrapped in act',
-	'is not a valid icon name',
-	'[VoIP] Call not found after accept:'
-];
+//     Routed through the log() helper, which in __DEV__ falls through to
+//     console.error(Error). Allowlisted on the error side, asserted via the
+//     error spy in the corresponding test.
+const CONSOLE_ERROR_ALLOWLIST: string[] = ['[VoIP] Call not found after accept:'];
+const CONSOLE_WARN_ALLOWLIST: string[] = ['@expo/vector-icons', 'not wrapped in act', 'is not a valid icon name'];
 
 let consoleErrorSpy: jest.SpyInstance | undefined;
 let consoleWarnSpy: jest.SpyInstance | undefined;
@@ -595,7 +591,9 @@ describe('VoIP call lifecycle (integration)', () => {
 			expect(Navigation.navigate).not.toHaveBeenCalled();
 			expect(useCallStore.getState().call).toBeNull();
 			// Tighten: confirm the known-noise allowlist entry was actually triggered.
-			expect(consoleWarnSpy).toHaveBeenCalledWith('[VoIP] Call not found after accept:', 'missing-1');
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ message: '[VoIP] Call not found after accept: missing-1' })
+			);
 		});
 
 		it('A3: idempotency — existing call matches callId, answerCall early-returns', async () => {

--- a/app/lib/hooks/useNewMediaCall/useNewMediaCall.test.tsx
+++ b/app/lib/hooks/useNewMediaCall/useNewMediaCall.test.tsx
@@ -81,12 +81,12 @@ describe('useNewMediaCall', () => {
 		mockStartCall.mockResolvedValue(undefined);
 	});
 
-	const expectNewMediaCallActionSheet = (expectedFullContainer = false) => {
+	const expectNewMediaCallActionSheet = (expectedHugContent = false) => {
 		expect(mockShowActionSheetRef).toHaveBeenCalledTimes(1);
 		const [actionSheetArgs] = mockShowActionSheetRef.mock.calls[0];
 		expect(React.isValidElement(actionSheetArgs.children)).toBe(true);
 		expect(actionSheetArgs.children.type).toBe(NewMediaCall);
-		expect(actionSheetArgs.fullContainer).toBe(expectedFullContainer);
+		expect(actionSheetArgs.hugContent).toBe(expectedHugContent);
 	};
 
 	it('should set selected peer and open action sheet when room has a direct message peer', () => {
@@ -272,12 +272,12 @@ describe('useNewMediaCall', () => {
 		});
 	});
 
-	it('should pass fullContainer to the action sheet when isAndroid is true', () => {
+	it('should pass hugContent: true to the action sheet when isAndroid is true', () => {
 		jest.resetModules();
 		jest.doMock('../../methods/helpers/deviceInfo', () => ({
 			isAndroid: true
 		}));
-		// Must load hook after doMock so `fullContainer: isAndroid` uses Android.
+		// Must load hook after doMock so `hugContent: isAndroid` uses Android.
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
 		const { useNewMediaCall: useNewMediaCallAndroid } = require('./useNewMediaCall');
 
@@ -290,10 +290,26 @@ describe('useNewMediaCall', () => {
 			result.current.openNewMediaCall();
 		});
 
-		// Re-required hook uses a fresh NewMediaCall mock ref; only assert fullContainer and element shape.
+		// Re-required hook uses a fresh NewMediaCall mock ref; only assert hugContent and element shape.
 		expect(mockShowActionSheetRef).toHaveBeenCalledTimes(1);
 		const [actionSheetArgs] = mockShowActionSheetRef.mock.calls[0];
 		expect(React.isValidElement(actionSheetArgs.children)).toBe(true);
-		expect(actionSheetArgs.fullContainer).toBe(true);
+		expect(actionSheetArgs.hugContent).toBe(true);
+	});
+
+	it('should pass hugContent: false to the action sheet when isAndroid is false (iOS)', () => {
+		// isAndroid is already false per the top-level mock
+		mockUseSubscription.mockReturnValue(undefined);
+		mockUseMediaCallPermission.mockReturnValue(false);
+
+		const { result } = renderHook(() => useNewMediaCall('room-id'));
+
+		act(() => {
+			result.current.openNewMediaCall();
+		});
+
+		expect(mockShowActionSheetRef).toHaveBeenCalledTimes(1);
+		const [actionSheetArgs] = mockShowActionSheetRef.mock.calls[0];
+		expect(actionSheetArgs.hugContent).toBe(false);
 	});
 });

--- a/app/lib/hooks/useNewMediaCall/useNewMediaCall.tsx
+++ b/app/lib/hooks/useNewMediaCall/useNewMediaCall.tsx
@@ -28,7 +28,7 @@ export const useNewMediaCall = (rid?: string) => {
 		}
 		showActionSheetRef({
 			children: <NewMediaCall />,
-			fullContainer: isAndroid
+			hugContent: isAndroid
 		});
 	};
 

--- a/app/lib/notifications/push.ts
+++ b/app/lib/notifications/push.ts
@@ -185,7 +185,7 @@ export const pushNotificationConfigure = (onNotification: (notification: INotifi
 	registerForPushNotifications().then(token => {
 		if (token) {
 			deviceToken = token;
-			console.log('[push.ts] Registered for push notifications:', token);
+			console.log('[push.ts] Registered for push notifications successfully.');
 
 			registerPushToken().catch(e => {
 				console.log('[push.ts] Failed to register push token after initial acquisition:', e);

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -53,7 +53,7 @@ export function clearVoipAcceptDedupeSentinels(): void {
 	lastHandledVoipAcceptSucceededCallId = null;
 }
 
-/** Exported for tests only. Clears accept-dedupe sentinels between test cases. Production code calls clearVoipAcceptDedupeSentinels() directly. */
+/** @internal — exported for tests; production code calls clearVoipAcceptDedupeSentinels directly */
 export function resetMediaCallEventsStateForTesting(): void {
 	clearVoipAcceptDedupeSentinels();
 }

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -2,6 +2,12 @@ import type { IClientMediaCall } from '@rocket.chat/media-signaling';
 import RNCallKeep from 'react-native-callkeep';
 import { waitFor } from '@testing-library/react-native';
 
+const mockLog = jest.fn();
+jest.mock('../../methods/helpers/log', () => ({
+	__esModule: true,
+	default: (...args: unknown[]) => mockLog(...args)
+}));
+
 import type { IDDPMessage } from '../../../definitions/IDDPMessage';
 import Navigation from '../../navigation/appNavigation';
 import { getDMSubscriptionByUsername } from '../../database/services/Subscription';
@@ -899,6 +905,92 @@ describe('MediaSessionInstance', () => {
 
 			expect(mockSetRoomId).toHaveBeenNthCalledWith(1, 'rid-dm');
 			expect(mockSetRoomId).toHaveBeenLastCalledWith(null);
+		});
+	});
+
+	describe('log() helper — error reporting', () => {
+		beforeEach(() => {
+			mockLog.mockClear();
+		});
+
+		it('calls log when applyRestStateSignals REST fetch rejects', async () => {
+			await mediaSessionInstance.init('user-1');
+			mockMediaCallsStateSignals.mockRejectedValueOnce(new Error('E_FETCH_SIGNALS'));
+			await mediaSessionInstance.applyRestStateSignals();
+			expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+		});
+
+		it('calls log when accept() rejects in answerCall', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			const mainCall = {
+				callId: 'call-log-err',
+				accept: jest.fn().mockRejectedValue(new Error('ICE fail')),
+				remoteParticipants: [{ contact: { username: 'bob' } }]
+			};
+			session.getCallData.mockReturnValue(mainCall);
+			mockUseCallStoreGetState.mockReturnValue({
+				reset: mockCallStoreReset,
+				setCall: jest.fn(),
+				setRoomId: mockSetRoomId,
+				setDirection: mockSetDirection,
+				resetNativeCallId: jest.fn(),
+				call: null,
+				callId: null,
+				nativeAcceptedCallId: 'call-log-err',
+				roomId: null
+			});
+
+			await mediaSessionInstance.answerCall('call-log-err');
+
+			expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+		});
+
+		it('calls log when answerCall call data not found (warn path)', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			session.getCallData.mockReturnValue(null);
+
+			await mediaSessionInstance.answerCall('missing-call');
+
+			expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+		});
+
+		it('calls log when startCallByRoom startCall rejects', async () => {
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			session.startCall.mockRejectedValueOnce(new Error('E_START'));
+			mockGetUidDirectMessage.mockReturnValue('peer-x');
+
+			mediaSessionInstance.startCallByRoom({ rid: 'rid-dm', t: 'd', uids: ['a', 'b'] } as any);
+
+			// Flush microtasks to let the rejection propagate to .catch
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+		});
+
+		it('calls log when newCall resolveRoomIdFromContact rejects', async () => {
+			mockGetDMSubscriptionByUsername.mockRejectedValueOnce(new Error('E_DB'));
+			await mediaSessionInstance.init('user-1');
+			const session = createdSessions[0];
+			const newCallHandler = session.on.mock.calls.find((c: string[]) => c[0] === 'newCall')?.[1] as (p: {
+				call: IClientMediaCall;
+			}) => void;
+
+			newCallHandler({
+				call: {
+					hidden: false,
+					localParticipant: { role: 'caller' },
+					remoteParticipants: [{ contact: { username: 'alice' } }],
+					callId: 'c-log',
+					emitter: { on: jest.fn(), off: jest.fn() }
+				} as unknown as IClientMediaCall
+			});
+
+			await waitFor(() => expect(mockLog).toHaveBeenCalledWith(expect.any(Error)));
 		});
 	});
 });

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -2,18 +2,18 @@ import type { IClientMediaCall } from '@rocket.chat/media-signaling';
 import RNCallKeep from 'react-native-callkeep';
 import { waitFor } from '@testing-library/react-native';
 
-const mockLog = jest.fn();
-jest.mock('../../methods/helpers/log', () => ({
-	__esModule: true,
-	default: (...args: unknown[]) => mockLog(...args)
-}));
-
 import type { IDDPMessage } from '../../../definitions/IDDPMessage';
 import Navigation from '../../navigation/appNavigation';
 import { getDMSubscriptionByUsername } from '../../database/services/Subscription';
 import { getUidDirectMessage } from '../../methods/helpers/helpers';
 import { mediaSessionStore } from './MediaSessionStore';
 import { mediaSessionInstance } from './MediaSessionInstance';
+
+const mockLog = jest.fn();
+jest.mock('../../methods/helpers/log', () => ({
+	__esModule: true,
+	default: (...args: unknown[]) => mockLog(...args)
+}));
 
 const mockTerminateNativeCall = jest.fn();
 jest.mock('./terminateNativeCall', () => ({

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -90,7 +90,6 @@ class MediaSessionInstance {
 					iceGatheringTimeout: this.iceGatheringTimeout
 				})
 		);
-		// TESTING: DDP signal transport — offer/answer/ICE stay on DDP
 		mediaSessionStore.setSendSignalFn((signal: ClientMediaSignal) => {
 			sdk.methodCall('stream-notify-user', `${userId}/media-calls`, JSON.stringify(signal));
 		});
@@ -106,7 +105,6 @@ class MediaSessionInstance {
 			this.instance = mediaSessionStore.getInstance(userId);
 		});
 
-		// TESTING: DDP real-time signal subscription — stays for offer/answer/ICE/notifications
 		this.mediaSignalListener = sdk.onStreamData('stream-notify-user', (ddpMessage: IDDPMessage) => {
 			if (!this.instance) {
 				return;
@@ -123,10 +121,6 @@ class MediaSessionInstance {
 
 		this.instance?.on('newCall', ({ call }: { call: IClientMediaCall }) => {
 			if (call && !call.hidden) {
-				call.emitter.on('stateChange', _oldState => {
-					// Intentionally empty — state transitions handled by the call layer
-				});
-
 				if (call.localParticipant.role === 'caller') {
 					useCallStore.getState().setCall(call);
 					useCallStore.getState().setDirection('outgoing');

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -28,6 +28,7 @@ import type { IDDPMessage } from '../../../definitions/IDDPMessage';
 import type { ISubscription, TSubscriptionModel } from '../../../definitions';
 import { getDMSubscriptionByUsername } from '../../database/services/Subscription';
 import { getUidDirectMessage } from '../../methods/helpers/helpers';
+import log from '../../methods/helpers/log';
 import { isInActiveVoipCall } from './isInActiveVoipCall';
 import { requestVoipCallPermissions } from '../../methods/voipCallPermissions';
 import I18n from '../../../i18n';
@@ -54,7 +55,7 @@ class MediaSessionInstance {
 			call == null
 		) {
 			this.answerCall(signal.callId).catch(error => {
-				console.error('[VoIP] Error answering call on notification/accepted:', error);
+				log(error);
 			});
 		}
 	}
@@ -71,7 +72,7 @@ class MediaSessionInstance {
 				this.tryAnswerIfNativeAcceptedNotification(signal);
 			}
 		} catch (error) {
-			console.error('[VoIP] Failed to fetch or apply REST state signals:', error);
+			log(error);
 		}
 	}
 
@@ -132,7 +133,7 @@ class MediaSessionInstance {
 					Navigation.navigate('CallView');
 					if (useCallStore.getState().roomId == null) {
 						this.resolveRoomIdFromContact(call.remoteParticipants[0]?.contact).catch(error => {
-							console.error('[VoIP] Error resolving room id from contact (newCall):', error);
+							log(error);
 						});
 					}
 				}
@@ -156,7 +157,7 @@ class MediaSessionInstance {
 			try {
 				await mainCall.accept();
 			} catch (error) {
-				console.error('[VoIP] accept() rejected:', error);
+				log(error);
 				terminateNativeCall(callId);
 				const st = useCallStore.getState();
 				if (st.nativeAcceptedCallId === callId) {
@@ -171,7 +172,7 @@ class MediaSessionInstance {
 			await waitForNavigationReady();
 			Navigation.navigate('CallView');
 			this.resolveRoomIdFromContact(mainCall.remoteParticipants[0]?.contact).catch(error => {
-				console.error('[VoIP] Error resolving room id from contact (answerCall):', error);
+				log(error);
 			});
 		} else {
 			terminateNativeCall(callId);
@@ -179,7 +180,7 @@ class MediaSessionInstance {
 			if (st.nativeAcceptedCallId === callId) {
 				st.resetNativeCallId();
 			}
-			console.warn('[VoIP] Call not found after accept:', callId);
+			log(new Error(`[VoIP] Call not found after accept: ${callId}`));
 		}
 	};
 
@@ -191,7 +192,7 @@ class MediaSessionInstance {
 			this.startCall(otherUserId, 'user').catch(error => {
 				// Clear the optimistic roomId so a concurrent incoming call can resolve its own DM context.
 				useCallStore.getState().setRoomId(null);
-				console.error('[VoIP] Error starting call from room:', error);
+				log(error);
 			});
 		}
 	};

--- a/app/lib/services/voip/playCallEndedSound.test.ts
+++ b/app/lib/services/voip/playCallEndedSound.test.ts
@@ -1,5 +1,11 @@
 import { playCallEndedSound, resetPlayCallEndedSoundForTesting } from './playCallEndedSound';
 
+const mockLog = jest.fn();
+jest.mock('../../methods/helpers/log', () => ({
+	__esModule: true,
+	default: (...args: unknown[]) => mockLog(...args)
+}));
+
 // Mock expo-av at the test boundary, matching the style used in the VoIP services directory.
 const mockLoadAsync = jest.fn(() => Promise.resolve());
 const mockPlayAsync = jest.fn(() => Promise.resolve());
@@ -28,6 +34,7 @@ beforeEach(() => {
 	jest.clearAllMocks();
 	capturedPlaybackStatusUpdate = null;
 	resetPlayCallEndedSoundForTesting();
+	mockLog.mockClear();
 });
 
 describe('playCallEndedSound', () => {
@@ -142,5 +149,14 @@ describe('playCallEndedSound', () => {
 		} finally {
 			jest.useRealTimers();
 		}
+	});
+
+	it('calls log when loadAsync throws', async () => {
+		const err = new Error('E_LOAD_FAILED');
+		mockLoadAsync.mockRejectedValueOnce(err);
+
+		await playCallEndedSound();
+
+		expect(mockLog).toHaveBeenCalledWith(err);
 	});
 });

--- a/app/lib/services/voip/playCallEndedSound.ts
+++ b/app/lib/services/voip/playCallEndedSound.ts
@@ -1,5 +1,7 @@
 import { Audio } from 'expo-av';
 
+import log from '../../methods/helpers/log';
+
 // Module-scoped state so it survives React tree unmounts and is safe to call
 // fire-and-forget from any termination path.
 let isPlaying = false;
@@ -58,7 +60,7 @@ export async function playCallEndedSound(): Promise<void> {
 	} catch (error) {
 		// Never throw — this is fire-and-forget
 		releaseLock();
-		console.error('[VoIP] playCallEndedSound failed:', error);
+		log(error);
 	}
 }
 

--- a/app/lib/services/voip/useCallStore.ios.test.ts
+++ b/app/lib/services/voip/useCallStore.ios.test.ts
@@ -5,6 +5,12 @@ import type { IClientMediaCall } from '@rocket.chat/media-signaling';
 
 import { useCallStore } from './useCallStore';
 
+const mockLog = jest.fn();
+jest.mock('../../methods/helpers/log', () => ({
+	__esModule: true,
+	default: (...args: unknown[]) => mockLog(...args)
+}));
+
 jest.mock('../../methods/helpers', () => ({
 	isIOS: true
 }));

--- a/app/lib/services/voip/useCallStore.test.ts
+++ b/app/lib/services/voip/useCallStore.test.ts
@@ -6,6 +6,12 @@ import InCallManager from 'react-native-incall-manager';
 import NativeVoipModule from '../../native/NativeVoip';
 import { useCallStore } from './useCallStore';
 
+const mockLog = jest.fn();
+jest.mock('../../methods/helpers/log', () => ({
+	__esModule: true,
+	default: (...args: unknown[]) => mockLog(...args)
+}));
+
 const mockPlayCallEndedSound = jest.fn(() => Promise.resolve());
 jest.mock('./playCallEndedSound', () => ({
 	playCallEndedSound: () => mockPlayCallEndedSound()
@@ -381,17 +387,16 @@ describe('useCallStore toggleSpeaker', () => {
 			expect(useCallStore.getState().isSpeakerOn).toBe(false);
 		});
 
-		it('leaves isSpeakerOn unchanged and logs error when NativeVoipModule.setSpeakerOn rejects', async () => {
+		it('leaves isSpeakerOn unchanged and calls log when NativeVoipModule.setSpeakerOn rejects', async () => {
 			(NativeVoipModule.setSpeakerOn as jest.Mock).mockImplementationOnce(() => Promise.reject(new Error('E_AUDIO_ROUTE')));
-			const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+			mockLog.mockClear();
 			const { call } = createMockCall('abc');
 			useCallStore.getState().setCall(call);
 
 			await useCallStore.getState().toggleSpeaker();
 
 			expect(useCallStore.getState().isSpeakerOn).toBe(false);
-			expect(errorSpy).toHaveBeenCalled();
-			errorSpy.mockRestore();
+			expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
 		});
 	});
 
@@ -490,5 +495,50 @@ describe('useCallStore audio route sync (Android)', () => {
 	it('reset fires stopAudioRouteSync', () => {
 		useCallStore.getState().reset();
 		expect(mockStopAudioRouteSync).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls log when startAudioRouteSync rejects', async () => {
+		mockLog.mockClear();
+		mockStartAudioRouteSync.mockImplementationOnce(() => Promise.reject(new Error('E_START_ROUTE')));
+		const { call } = createMockCall('ar-err-start');
+		useCallStore.getState().setCall(call);
+		// flush the rejected promise
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+	});
+
+	it('calls log when stopAudioRouteSync rejects', async () => {
+		mockLog.mockClear();
+		mockStopAudioRouteSync.mockImplementationOnce(() => Promise.reject(new Error('E_STOP_ROUTE')));
+		useCallStore.getState().reset();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+	});
+});
+
+describe('useCallStore log helper — InCallManager error paths', () => {
+	beforeEach(() => {
+		mockLog.mockClear();
+		useCallStore.getState().resetNativeCallId();
+		useCallStore.getState().reset();
+	});
+
+	it('calls log when InCallManager.start throws', () => {
+		(InCallManager.start as jest.Mock).mockImplementationOnce(() => {
+			throw new Error('E_INCALL_START');
+		});
+		const { call } = createMockCall('incall-start-err');
+		useCallStore.getState().setCall(call);
+		expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+	});
+
+	it('calls log when InCallManager.stop throws', () => {
+		(InCallManager.stop as jest.Mock).mockImplementationOnce(() => {
+			throw new Error('E_INCALL_STOP');
+		});
+		useCallStore.getState().reset();
+		expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
 	});
 });

--- a/app/lib/services/voip/useCallStore.ts
+++ b/app/lib/services/voip/useCallStore.ts
@@ -4,6 +4,7 @@ import RNCallKeep from 'react-native-callkeep';
 import InCallManager from 'react-native-incall-manager';
 
 import { isIOS } from '../../methods/helpers';
+import log from '../../methods/helpers/log';
 import NativeVoipModule from '../../native/NativeVoip';
 import { terminateNativeCall } from './terminateNativeCall';
 import { playCallEndedSound } from './playCallEndedSound';
@@ -170,13 +171,13 @@ export const useCallStore = create<CallStore>((set, get) => ({
 		try {
 			InCallManager.start({ media: 'audio' });
 		} catch (error) {
-			console.error('[VoIP] InCallManager.start failed:', error);
+			log(error);
 		}
 
 		if (!isIOS) {
 			// Idempotent: native short-circuits if a listener is already registered or API < 31.
 			NativeVoipModule.startAudioRouteSync().catch((error: unknown) => {
-				console.error('[VoIP] startAudioRouteSync failed:', error);
+				log(error);
 			});
 		}
 
@@ -266,7 +267,7 @@ export const useCallStore = create<CallStore>((set, get) => ({
 			}
 			set({ isSpeakerOn: newSpeakerOn });
 		} catch (error) {
-			console.error('[VoIP] Failed to toggle speaker:', error);
+			log(error);
 		}
 	},
 
@@ -322,13 +323,13 @@ export const useCallStore = create<CallStore>((set, get) => ({
 		try {
 			InCallManager.stop();
 		} catch (error) {
-			console.error('[VoIP] InCallManager.stop failed:', error);
+			log(error);
 		}
 		set({ ...initialState, nativeAcceptedCallId });
 		hideActionSheetRef();
 		if (!isIOS) {
 			NativeVoipModule.stopAudioRouteSync().catch((error: unknown) => {
-				console.error('[VoIP] stopAudioRouteSync failed:', error);
+				log(error);
 			});
 		}
 		// Old timer was cleared above; start a new one if nativeAcceptedCallId is still set.

--- a/app/lib/store/index.ts
+++ b/app/lib/store/index.ts
@@ -5,7 +5,7 @@ import reducers from '../../reducers';
 import sagas from '../../sagas';
 import applyAppStateMiddleware from './appStateMiddleware';
 import applyInternetStateMiddleware from './internetStateMiddleware';
-// import { logger } from './reduxLogger';
+import { logger } from './reduxLogger';
 
 let sagaMiddleware;
 let enhancers;
@@ -18,8 +18,8 @@ if (__DEV__) {
 		applyAppStateMiddleware(),
 		applyInternetStateMiddleware(),
 		applyMiddleware(reduxImmutableStateInvariant),
-		applyMiddleware(sagaMiddleware)
-		// applyMiddleware(logger)
+		applyMiddleware(sagaMiddleware),
+		applyMiddleware(logger)
 	);
 } else {
 	sagaMiddleware = createSagaMiddleware();


### PR DESCRIPTION
## Proposed changes

Consolidates the review-comment cleanup for PR #6918 into a single mergeable PR. Eight scoped fixes, each landed individually on this branch and reviewed in isolation, addressing three problem classes:

**Observability (rollout-blocking)**
- Route 12 VoIP `console.error`/`console.warn` sites in `useCallStore`, `MediaSessionInstance`, and `playCallEndedSound` through the project `log()` helper so failures reach Bugsnag during rollout.
- Drop the raw FCM/APNs token from the `push.ts` registration success log line (PII surfaces in screenshots and paste-bins).

**Native cleanup**
- Delete dead method-call queue (`queueMethodCall`, `flushQueuedMethodCalls`, etc.) from `DDPClient.kt` and the now-empty `flushPendingQueuedSignalsIfNeeded` callsite in `VoipNotification.kt`. Verified zero producers ever called the queue.
- Extract a single `deviceId(context)` helper that collapses four `Settings.Secure.getString(... ANDROID_ID)` duplications.
- Move 8 hardcoded English literals in `VoipNotification.kt` and `VoipCallService.kt` to a new `strings_voip.xml` (channel descriptions, incoming-call title/text, ongoing-call title/text). Reuse existing `incoming_call_accept`/`incoming_call_reject` for action labels. Parameterize Call-from text with `%1\$s` for translator-friendly reordering. English values only; `values-<locale>/` work is a follow-up.

**Regression repair**
- Restore `redux-logger` middleware in the `__DEV__` enhancer chain of `app/lib/store/index.ts` (was unintentionally commented out).
- Restore `height: '100%'` on the shared `fullContainer` ActionSheet style (its removal was collapsing VideoConf, RoomView, and NewMessageView sheets to content height on Android). Introduce a new `hugContent` opt-in plumbed through `Provider`/`ActionSheet`/`BottomSheetContent`. Only `useNewMediaCall` opts in (`hugContent: isAndroid`), so its Android sheet keeps hugging content while every other consumer returns to full-screen behavior. iOS unchanged across all consumers.
- Remove the dangling `.cursor/skills/agent-skills` gitlink (no `.gitmodules` entry, breaks fresh clones). `.cursor/` was already in `.gitignore`.

**Hygiene**
- Strip stale `// TESTING:` labels and an empty no-op `.on('stateChange', ...)` listener in `MediaSessionInstance.ts`.
- Annotate `resetMediaCallEventsStateForTesting` as `@internal`.

## Issue(s)

Cleanup for #6918.

## How to test or reproduce

- iOS: existing tests cover unchanged behavior (no native iOS changes in this PR).
- Android: smoke-test that
  - Incoming-call notification still displays correctly with English text (`Incoming call`, `Call from <caller>`, `Decline`, `Accept`).
  - Ongoing-call foreground notification still displays (`VoIP Call`, `Call in progress`).
  - The NewMediaCall action sheet still hugs content on Android.
  - VideoConf actions, RoomView action sheets, and NewMessageView/Item sheets render full-screen again on Android (the regression introduced by `3fefee400` is fixed).
- JS unit suite: `TZ=UTC yarn test` should pass for the modified files. Test additions cover the new `log()` mocks and the new `hugContent` forwarding assertion.

## Screenshots

n/a — no visual additions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

- The PR consolidates 8 independent slices that were each reviewed and merged onto this branch separately. Reviewer can step through individual slice commits via `git log --first-parent` for a per-concern walk.
- `getDisplayMedia` typo in `MediaSessionStore.ts`, the `RNCallKeep.setup` move to `MainApplication`, polish refactors (`'use memo'`, `useCaller`, `useAppSelector`, MediaCallHeader selector tightening, CallView hook extraction, NewMessageView/Item subcomponent split), and `@VisibleForTesting` annotation pass on `DDPClient.kt` are intentionally deferred.
- Native `values-<locale>/` directories for the new VoIP strings are a separate translation pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android VoIP notification UI is now localized.
  * Action sheet layout improved for Android "hug" behavior.

* **Bug Fixes**
  * Push registration no longer logs the raw device token.

* **Chores**
  * Centralized device identifier handling for VoIP flows.
  * Unified error reporting across VoIP services (replaced console logs with shared logger).
  * Enabled improved runtime logging in development builds.
  * Simplified internal call-queue handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->