### PR TITLE
fix(voip): force reconnect on warm-locked accept when AppState != active

### DIFF
--- a/app/lib/notifications/push.ts
+++ b/app/lib/notifications/push.ts
@@ -8,6 +8,7 @@ import { store as reduxStore } from '../store/auxStore';
 import { registerPushToken } from '../services/restApi';
 import I18n from '../../i18n';
 import NativePushNotificationModule from '../native/NativePushNotificationAndroid';
+import { voipDebugLog } from '../services/voip/voipDebugLogger';
 
 export let deviceToken = '';
 
@@ -130,8 +131,9 @@ const setupNotificationCategories = async (): Promise<void> => {
  * Request notification permissions and register for push notifications
  */
 const registerForPushNotifications = async (): Promise<string | null> => {
+	voipDebugLog('push', 'registerForPushNotifications enter');
 	if (!Device.isDevice && isIOS) {
-		console.log('Push notifications require a physical device');
+		voipDebugLog('push', 'not a physical device');
 		return null;
 	}
 
@@ -139,22 +141,25 @@ const registerForPushNotifications = async (): Promise<string | null> => {
 		// Check and request permissions
 		const { status: existingStatus } = await Notifications.getPermissionsAsync();
 		let finalStatus = existingStatus;
+		voipDebugLog('push', 'existing perm status', existingStatus);
 
 		if (existingStatus !== 'granted') {
 			const { status } = await Notifications.requestPermissionsAsync();
 			finalStatus = status;
+			voipDebugLog('push', 'requested perm status', status);
 		}
 
 		if (finalStatus !== 'granted') {
-			console.log('Failed to get push notification permissions');
+			voipDebugLog('push', 'permission not granted');
 			return null;
 		}
 
 		// Get the device push token (FCM for Android, APNs for iOS)
 		const tokenData = await Notifications.getDevicePushTokenAsync();
+		voipDebugLog('push', 'getDevicePushTokenAsync resolved', { type: tokenData.type, token: tokenData.data });
 		return tokenData.data;
 	} catch (e) {
-		console.log('Error registering for push notifications:', e);
+		voipDebugLog('push', 'registerForPushNotifications threw', String(e));
 		return null;
 	}
 };
@@ -185,20 +190,23 @@ export const pushNotificationConfigure = (onNotification: (notification: INotifi
 	registerForPushNotifications().then(token => {
 		if (token) {
 			deviceToken = token;
-			console.log('[push.ts] Registered for push notifications:', token);
+			voipDebugLog('push', 'token acquired -> registerPushToken', { token });
 
-			registerPushToken().catch(e => {
-				console.log('[push.ts] Failed to register push token after initial acquisition:', e);
-			});
+			registerPushToken()
+				.then(() => voipDebugLog('push', 'registerPushToken success'))
+				.catch(e => voipDebugLog('push', 'registerPushToken failed', String(e)));
+		} else {
+			voipDebugLog('push', 'no token returned');
 		}
 	});
 
 	// Listen for token updates (FCM can refresh tokens at any time)
 	Notifications.addPushTokenListener(tokenData => {
 		deviceToken = tokenData.data;
-		registerPushToken().catch(e => {
-			console.log('[push.ts] Failed to re-register push token after refresh:', e);
-		});
+		voipDebugLog('push', 'token refresh -> registerPushToken', { token: tokenData.data });
+		registerPushToken()
+			.then(() => voipDebugLog('push', 'registerPushToken (refresh) success'))
+			.catch(e => voipDebugLog('push', 'registerPushToken (refresh) failed', String(e)));
 	});
 
 	// Listen for notification responses (when user taps on notification)

--- a/app/lib/services/restApi.ts
+++ b/app/lib/services/restApi.ts
@@ -32,6 +32,7 @@ import { store as reduxStore } from '../store/auxStore';
 import sdk from './sdk';
 import fetch from '../methods/helpers/fetch';
 import log from '../methods/helpers/log';
+import { voipDebugLog } from './voip/voipDebugLogger';
 
 export const createChannel = ({
 	name,
@@ -1086,12 +1087,19 @@ export const registerPushToken = async (): Promise<void> => {
 	const token = getDeviceToken();
 	// Always returns an empty string on Android
 	const voipToken = NativeVoipModule.getLastVoipToken();
+	voipDebugLog('registerPushToken', 'enter', {
+		token,
+		voipToken,
+		hasSdk: !!sdk.current
+	});
 
 	if (!token) {
+		voipDebugLog('registerPushToken', 'no token -> bail');
 		return;
 	}
 
 	if (token === lastToken && voipToken === lastVoipToken) {
+		voipDebugLog('registerPushToken', 'unchanged tokens -> bail');
 		return;
 	}
 
@@ -1100,6 +1108,7 @@ export const registerPushToken = async (): Promise<void> => {
 	// happens; bail without recording lastToken/lastVoipToken so registerPushTokenFork retries
 	// after login (and a later VoipPushTokenRegistered emission can still re-fire this path).
 	if (!sdk.current) {
+		voipDebugLog('registerPushToken', 'no sdk -> bail (will retry post-login)');
 		return;
 	}
 
@@ -1126,10 +1135,25 @@ export const registerPushToken = async (): Promise<void> => {
 
 	try {
 		// RC 0.60.0
+		voipDebugLog('registerPushToken', 'POST push.token', {
+			type: data.type,
+			value: data.value,
+			voipToken: data.voipToken,
+			appName: data.appName,
+			id: (data as any).id
+		});
 		await sdk.post('push.token', data);
+		voipDebugLog('registerPushToken', 'POST push.token success');
 		lastToken = token;
 		lastVoipToken = voipToken;
-	} catch (e) {
+	} catch (e: any) {
+		voipDebugLog('registerPushToken', 'POST push.token failed', {
+			message: e?.message,
+			data: e?.data,
+			status: e?.status,
+			statusText: e?.statusText,
+			raw: JSON.stringify(e, Object.getOwnPropertyNames(e ?? {}))
+		});
 		log(e);
 	}
 };

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -118,6 +118,25 @@ jest.mock('react-native-callkeep', () => ({
 	}
 }));
 
+jest.mock('../sdk', () => ({
+	__esModule: true,
+	default: { current: null }
+}));
+
+jest.mock('../../store/auxStore', () => ({
+	store: { dispatch: jest.fn() }
+}));
+
+jest.mock('../../../actions/connect', () => ({
+	disconnect: jest.fn(() => ({ type: 'METEOR.DISCONNECT' }))
+}));
+
+jest.mock('./voipReconnectTiming', () => ({
+	markVoipReconnectStart: jest.fn(),
+	logVoipLoginElapsed: jest.fn(),
+	logVoipFirstSignalElapsed: jest.fn()
+}));
+
 const mockOnOpenDeepLink = jest.fn();
 const mockServerSelector = jest.fn(() => 'https://workspace-ios.example.com');
 

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -78,6 +78,25 @@ jest.mock('./MediaCallLogger', () => ({
 	}
 }));
 
+jest.mock('../sdk', () => ({
+	__esModule: true,
+	default: { current: null }
+}));
+
+jest.mock('../../store/auxStore', () => ({
+	store: { dispatch: jest.fn() }
+}));
+
+jest.mock('../../../actions/connect', () => ({
+	disconnect: jest.fn(() => ({ type: 'METEOR.DISCONNECT' }))
+}));
+
+jest.mock('./voipReconnectTiming', () => ({
+	markVoipReconnectStart: jest.fn(),
+	logVoipLoginElapsed: jest.fn(),
+	logVoipFirstSignalElapsed: jest.fn()
+}));
+
 function buildIncomingPayload(overrides: Partial<VoipPayload> = {}): VoipPayload {
 	return {
 		callId: 'call-b-uuid',

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -1,5 +1,5 @@
 import RNCallKeep from 'react-native-callkeep';
-import { DeviceEventEmitter, NativeEventEmitter } from 'react-native';
+import { AppState, DeviceEventEmitter, NativeEventEmitter } from 'react-native';
 
 import { isIOS, normalizeDeepLinkingServerHost } from '../../methods/helpers';
 import { useCallStore } from './useCallStore';
@@ -8,6 +8,11 @@ import type { VoipPayload } from '../../../definitions/Voip';
 import NativeVoipModule from '../../native/NativeVoip';
 import { registerPushToken } from '../restApi';
 import { MediaCallLogger } from './MediaCallLogger';
+import { voipDebugLog } from './voipDebugLogger';
+import { logVoipLoginElapsed, markVoipReconnectStart } from './voipReconnectTiming';
+import sdk from '../sdk';
+import { store } from '../../store/auxStore';
+import { disconnect as disconnectAction } from '../../../actions/connect';
 
 const Emitter = isIOS ? new NativeEventEmitter(NativeVoipModule) : DeviceEventEmitter;
 const platform = isIOS ? 'iOS' : 'Android';
@@ -80,7 +85,9 @@ function dispatchVoipAcceptFailureFromNative(
 
 function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaCallEventsAdapters) {
 	const { callId } = data;
+	voipDebugLog('VoipAcceptSucceeded', 'enter', { callId, type: data.type, host: data.host });
 	if (callId && lastHandledVoipAcceptSucceededCallId === callId) {
+		voipDebugLog('VoipAcceptSucceeded', 'dedup hit');
 		return;
 	}
 	if (data.type !== 'incoming_call') {
@@ -94,11 +101,47 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	NativeVoipModule.clearInitialEvents();
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
 	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
+		// Foreground accept (AppState 'active'): JS runtime never suspended, socket fresh.
+		// Background/locked accept: iOS suspended TCP → socket may be zombie. Force reconnect
+		// before WebRTC needs to send answer SDP. Otherwise peer times out at ~10s.
+		const appState = AppState.currentState;
+		const forceReconnect = appState !== 'active';
+		voipDebugLog('VoipAcceptSucceeded', 'reconnect decision', { appState, forceReconnect });
+		markVoipReconnectStart(forceReconnect);
+
+		if (forceReconnect) {
+			// connectedListener (connect.ts:113) early-returns if redux meteor.connected is still true.
+			// Force redux flip so loginRequest fires on the new 'connected' event.
+			store.dispatch(disconnectAction());
+			(async () => {
+				try {
+					const driver = await (sdk.current as any)?.socket;
+					const ddpSocket = driver?.ddp;
+					try {
+						ddpSocket?.connection?.close();
+						voipDebugLog('VoipAcceptSucceeded', 'forced ws close');
+					} catch (e) {
+						voipDebugLog('VoipAcceptSucceeded', 'forced ws close threw', String(e));
+					}
+					sdk.current?.checkAndReopen?.();
+					voipDebugLog('VoipAcceptSucceeded', 'checkAndReopen kicked');
+					ddpSocket?.once?.('login', () => {
+						logVoipLoginElapsed();
+					});
+				} catch (e) {
+					voipDebugLog('VoipAcceptSucceeded', 'force reconnect threw', String(e));
+				}
+			})();
+		}
+
+		voipDebugLog('VoipAcceptSucceeded', 'same workspace -> applyRestStateSignals');
 		mediaSessionInstance.applyRestStateSignals().catch(error => {
+			voipDebugLog('VoipAcceptSucceeded', 'applyRestStateSignals failed', String(error));
 			mediaCallLogger.error(`${TAG} applyRestStateSignals failed:`, error);
 		});
 		return;
 	}
+	voipDebugLog('VoipAcceptSucceeded', 'different workspace -> deeplink');
 	adapters.onOpenDeepLink({
 		callId: data.callId,
 		host: data.host
@@ -116,10 +159,14 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
 	if (isIOS) {
 		subscriptions.push(
 			Emitter.addListener('VoipPushTokenRegistered', ({ token }: { token: string }) => {
+				voipDebugLog('VoipPushTokenRegistered', 'received', { token });
 				mediaCallLogger.debug(`${TAG} Registered VoIP push token:`, token);
-				registerPushToken().catch(error => {
-					mediaCallLogger.warn(`${TAG} Failed to register push token after VoIP update:`, error);
-				});
+				registerPushToken()
+					.then(() => voipDebugLog('VoipPushTokenRegistered', 'registerPushToken resolved'))
+					.catch(error => {
+						voipDebugLog('VoipPushTokenRegistered', 'registerPushToken rejected', String(error));
+						mediaCallLogger.warn(`${TAG} Failed to register push token after VoIP update:`, error);
+					});
 			})
 		);
 
@@ -224,8 +271,10 @@ export const setupMediaCallEvents = (adapters: MediaCallEventsAdapters): (() => 
  * @returns true if startup should skip the default `appInit()` path (answered call, or accept failure handed to deep linking)
  */
 export const getInitialMediaCallEvents = async (adapters: MediaCallEventsAdapters): Promise<boolean> => {
+	voipDebugLog('getInitialMediaCallEvents', 'enter');
 	try {
 		const initialEvents = NativeVoipModule.getInitialEvents() as (VoipPayload & { voipAcceptFailed?: boolean }) | null;
+		voipDebugLog('getInitialMediaCallEvents', 'initial', initialEvents ?? null);
 		if (!initialEvents) {
 			mediaCallLogger.log(`${TAG} No initial events from native module`);
 			RNCallKeep.clearInitialEvents();

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -282,6 +282,7 @@ describe('MediaSessionInstance', () => {
 			expect(spy).toHaveBeenCalled();
 			const sendFn = spy.mock.calls[spy.mock.calls.length - 1][0] as (signal: { type: string }) => void;
 			sendFn({ type: 'register' });
+			await new Promise(resolve => setImmediate(resolve));
 			expect(mockMethodCall).toHaveBeenCalledWith(
 				'stream-notify-user',
 				'user-xyz/media-calls',

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -91,6 +91,11 @@ class MediaSessionInstance {
 		);
 		// TESTING: DDP signal transport — offer/answer/ICE stay on DDP
 		mediaSessionStore.setSendSignalFn((signal: ClientMediaSignal) => {
+			// Heal a stale socket on warm lock-screen accepts: when the device stays locked the
+			// foreground saga never fires, so nothing else nudges the SDK to reopen. checkAndReopen
+			// is a no-op when alive; otherwise it triggers reconnect → relogin → resubscribe so
+			// answer SDP and ICE candidates can flow over a fresh DDP session.
+			sdk.current?.checkAndReopen?.();
 			sdk.methodCall('stream-notify-user', `${userId}/media-calls`, JSON.stringify(signal));
 		});
 		this.instance = mediaSessionStore.getInstance(userId);

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -18,6 +18,8 @@ import { terminateNativeCall } from './terminateNativeCall';
 import { useCallStore } from './useCallStore';
 import { MediaCallLogger } from './MediaCallLogger';
 import { isSelfUserId } from './isSelfUserId';
+import { logVoipFirstSignalElapsed } from './voipReconnectTiming';
+import { voipDebugLog } from './voipDebugLogger';
 import { store } from '../../store/auxStore';
 import sdk from '../sdk';
 import { mediaCallsStateSignals } from '../restApi';
@@ -53,7 +55,9 @@ class MediaSessionInstance {
 			nativeAcceptedCallId === signal.callId &&
 			call == null
 		) {
+			voipDebugLog('tryAnswer', 'matched -> answerCall', { callId: signal.callId });
 			this.answerCall(signal.callId).catch(error => {
+				voipDebugLog('tryAnswer', 'answerCall rejected', String(error));
 				console.error('[VoIP] Error answering call on notification/accepted:', error);
 			});
 		}
@@ -62,20 +66,28 @@ class MediaSessionInstance {
 	/** Replays `media-calls.stateSignals`. Used on init and when native accept raced ahead of `nativeAcceptedCallId`. Caller must ensure SDK/session host matches the call (see MediaCallEvents host gate). `tryAnswerIfNativeAcceptedNotification` may also fire from the stream-notify-user path; `answerCall` is idempotent. */
 	public async applyRestStateSignals(): Promise<void> {
 		if (!this.instance) {
+			voipDebugLog('applyRestStateSignals', 'no instance');
 			return;
 		}
 		try {
+			voipDebugLog('applyRestStateSignals', 'fetch start');
 			const { signals } = await mediaCallsStateSignals(getUniqueIdSync());
+			voipDebugLog('applyRestStateSignals', 'fetched', {
+				count: signals.length,
+				types: signals.map((s: any) => `${s.type}${s.notification ? `/${s.notification}` : ''}`)
+			});
 			for (const signal of signals) {
 				this.instance.processSignal(signal);
 				this.tryAnswerIfNativeAcceptedNotification(signal);
 			}
 		} catch (error) {
+			voipDebugLog('applyRestStateSignals', 'error', String(error));
 			console.error('[VoIP] Failed to fetch or apply REST state signals:', error);
 		}
 	}
 
 	public async init(userId: string): Promise<void> {
+		voipDebugLog('init', 'enter', { userId });
 		this.reset();
 
 		registerGlobals();
@@ -89,14 +101,40 @@ class MediaSessionInstance {
 					iceGatheringTimeout: this.iceGatheringTimeout
 				})
 		);
-		// TESTING: DDP signal transport — offer/answer/ICE stay on DDP
+		// DDP signal transport — offer/answer/ICE stay on DDP. Gate methodCall on `loggedIn`
+		// (not just socket open). ddp.send awaits 'open' but server-side stream-notify-user requires
+		// `this.userId` — sending before relogin = silent drop. Pre-emptive force-reconnect in
+		// MediaCallEvents covers warm-locked accept; this gate handles the residual reconnect window.
 		mediaSessionStore.setSendSignalFn((signal: ClientMediaSignal) => {
-			// Heal a stale socket on warm lock-screen accepts: when the device stays locked the
-			// foreground saga never fires, so nothing else nudges the SDK to reopen. checkAndReopen
-			// is a no-op when alive; otherwise it triggers reconnect → relogin → resubscribe so
-			// answer SDP and ICE candidates can flow over a fresh DDP session.
-			sdk.current?.checkAndReopen?.();
-			sdk.methodCall('stream-notify-user', `${userId}/media-calls`, JSON.stringify(signal));
+			voipDebugLog('sendSignal', 'enter', { type: (signal as any)?.type, callId: (signal as any)?.callId });
+			void (async () => {
+				try {
+					try {
+						sdk.current?.checkAndReopen?.();
+					} catch (e) {
+						voipDebugLog('sendSignal', 'checkAndReopen threw', String(e));
+					}
+					const driver = await (sdk.current as any)?.socket;
+					const ddpSocket = driver?.ddp;
+					if (ddpSocket && !ddpSocket.loggedIn) {
+						voipDebugLog('sendSignal', 'awaiting login', { type: (signal as any)?.type });
+						await Promise.race([
+							new Promise<void>(resolve => ddpSocket.once('login', () => resolve())),
+							new Promise<void>(resolve => setTimeout(resolve, 8000))
+						]);
+						if (!ddpSocket.loggedIn) {
+							voipDebugLog('sendSignal', 'login wait timed out, dropping', { type: (signal as any)?.type });
+							return;
+						}
+						voipDebugLog('sendSignal', 'login ready, proceeding');
+					}
+					await sdk.methodCall('stream-notify-user', `${userId}/media-calls`, JSON.stringify(signal));
+					voipDebugLog('sendSignal', 'methodCall resolved', { type: (signal as any)?.type });
+					logVoipFirstSignalElapsed();
+				} catch (e: unknown) {
+					voipDebugLog('sendSignal', 'methodCall rejected', String(e));
+				}
+			})();
 		});
 		this.instance = mediaSessionStore.getInstance(userId);
 
@@ -113,6 +151,7 @@ class MediaSessionInstance {
 		// TESTING: DDP real-time signal subscription — stays for offer/answer/ICE/notifications
 		this.mediaSignalListener = sdk.onStreamData('stream-notify-user', (ddpMessage: IDDPMessage) => {
 			if (!this.instance) {
+				voipDebugLog('streamData', 'no instance');
 				return;
 			}
 			const [, ev] = ddpMessage.fields.eventName.split('/');
@@ -120,15 +159,30 @@ class MediaSessionInstance {
 				return;
 			}
 			const signal = ddpMessage.fields.args[0];
+			voipDebugLog('streamData', 'media-signal', {
+				type: (signal as any)?.type,
+				notification: (signal as any)?.notification,
+				callId: (signal as any)?.callId
+			});
 			this.instance.processSignal(signal);
 
 			this.tryAnswerIfNativeAcceptedNotification(signal as ServerMediaSignal);
 		});
 
 		this.instance?.on('newCall', ({ call }: { call: IClientMediaCall }) => {
+			voipDebugLog('newCall', 'enter', {
+				callId: call?.callId,
+				hidden: call?.hidden,
+				role: call?.localParticipant?.role,
+				state: (call as any)?.state
+			});
 			if (call && !call.hidden) {
 				call.emitter.on('stateChange', _oldState => {
-					// Intentionally empty — state transitions handled by the call layer
+					voipDebugLog('callState', 'change', {
+						callId: call.callId,
+						from: String(_oldState),
+						to: String((call as any)?.state)
+					});
 				});
 
 				if (call.localParticipant.role === 'caller') {
@@ -143,6 +197,7 @@ class MediaSessionInstance {
 				}
 
 				call.emitter.on('ended', () => {
+					voipDebugLog('callState', 'ended', { callId: call.callId });
 					terminateNativeCall(call.callId);
 				});
 			}
@@ -150,17 +205,23 @@ class MediaSessionInstance {
 	}
 
 	public answerCall = async (callId: string) => {
+		voipDebugLog('answerCall', 'enter', { callId });
 		const { call: existingCall } = useCallStore.getState();
 		if (existingCall != null && existingCall.callId === callId) {
+			voipDebugLog('answerCall', 'already same call');
 			return;
 		}
 
 		const mainCall = this.instance?.getCallData(callId);
+		voipDebugLog('answerCall', 'lookup', { found: !!mainCall, hasInstance: !!this.instance });
 
 		if (mainCall && mainCall.callId === callId) {
 			try {
+				voipDebugLog('answerCall', 'accept() start');
 				await mainCall.accept();
+				voipDebugLog('answerCall', 'accept() resolved');
 			} catch (error) {
+				voipDebugLog('answerCall', 'accept() rejected', String(error));
 				console.error('[VoIP] accept() rejected:', error);
 				terminateNativeCall(callId);
 				const st = useCallStore.getState();
@@ -175,10 +236,12 @@ class MediaSessionInstance {
 			useCallStore.getState().setDirection('incoming');
 			await waitForNavigationReady();
 			Navigation.navigate('CallView');
+			voipDebugLog('answerCall', 'post-accept navigate done', { callId });
 			this.resolveRoomIdFromContact(mainCall.remoteParticipants[0]?.contact).catch(error => {
 				console.error('[VoIP] Error resolving room id from contact (answerCall):', error);
 			});
 		} else {
+			voipDebugLog('answerCall', 'call not found', { callId, hasInstance: !!this.instance });
 			terminateNativeCall(callId);
 			const st = useCallStore.getState();
 			if (st.nativeAcceptedCallId === callId) {

--- a/app/lib/services/voip/MediaSessionInstance.ts
+++ b/app/lib/services/voip/MediaSessionInstance.ts
@@ -104,7 +104,7 @@ class MediaSessionInstance {
 		);
 		mediaSessionStore.setSendSignalFn((signal: ClientMediaSignal) => {
 			voipDebugLog('sendSignal', 'enter', { type: (signal as any)?.type, callId: (signal as any)?.callId });
-			void (async () => {
+			(async () => {
 				try {
 					try {
 						sdk.current?.checkAndReopen?.();

--- a/app/lib/services/voip/voipDebugLogger.ts
+++ b/app/lib/services/voip/voipDebugLogger.ts
@@ -34,7 +34,7 @@ const append = (line: string) => {
 
 export const voipDebugLog = (tag: string, msg: string, data?: unknown) => {
 	const line = `${ts()} [${tag}] ${msg}${data !== undefined ? ` ${safeStringify(data)}` : ''}`;
-	(globalThis as any).console['log'](line);
+	console.log(line);
 	append(line);
 };
 

--- a/app/lib/services/voip/voipDebugLogger.ts
+++ b/app/lib/services/voip/voipDebugLogger.ts
@@ -1,0 +1,68 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
+const LOG_FILE = `${FileSystem.documentDirectory ?? ''}voip-debug.log`;
+
+const ts = () => new Date().toISOString();
+
+const safeStringify = (value: unknown): string => {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+};
+
+let writeChain: Promise<void> = Promise.resolve();
+let lastError: string | null = null;
+
+const append = (line: string) => {
+	writeChain = writeChain
+		.then(async () => {
+			try {
+				const info = await FileSystem.getInfoAsync(LOG_FILE);
+				const existing = info.exists ? await FileSystem.readAsStringAsync(LOG_FILE) : '';
+				await FileSystem.writeAsStringAsync(LOG_FILE, `${existing}${line}\n`);
+				lastError = null;
+			} catch (e) {
+				lastError = String(e);
+			}
+		})
+		.catch(() => {
+			// never break the chain
+		});
+};
+
+export const voipDebugLog = (tag: string, msg: string, data?: unknown) => {
+	const line = `${ts()} [${tag}] ${msg}${data !== undefined ? ` ${safeStringify(data)}` : ''}`;
+	(globalThis as any).console['log'](line);
+	append(line);
+};
+
+export const voipDebugFlush = () => writeChain;
+
+export const voipDebugGetPath = () => LOG_FILE;
+
+export const voipDebugLastError = () => lastError;
+
+export const voipDebugClear = async () => {
+	try {
+		const info = await FileSystem.getInfoAsync(LOG_FILE);
+		if (info.exists) await FileSystem.deleteAsync(LOG_FILE);
+	} catch {
+		// best-effort
+	}
+};
+
+export const voipDebugRead = async (): Promise<string> => {
+	await writeChain;
+	try {
+		const info = await FileSystem.getInfoAsync(LOG_FILE);
+		if (!info.exists) return '';
+		return await FileSystem.readAsStringAsync(LOG_FILE);
+	} catch {
+		return '';
+	}
+};
+
+// Module-load marker — proves the file is reachable from the app's first JS execution.
+voipDebugLog('module', '------------>  voipDebugLogger loaded', { path: LOG_FILE });

--- a/app/lib/services/voip/voipReconnectTiming.ts
+++ b/app/lib/services/voip/voipReconnectTiming.ts
@@ -1,0 +1,28 @@
+import { voipDebugLog } from './voipDebugLogger';
+
+let acceptedAt: number | null = null;
+let firstSignalLogged = false;
+
+export const markVoipReconnectStart = (forced: boolean) => {
+	acceptedAt = Date.now();
+	firstSignalLogged = false;
+	voipDebugLog('reconnect-timing', 'accept marked', { t: acceptedAt, forced });
+};
+
+export const logVoipLoginElapsed = () => {
+	if (acceptedAt == null) return;
+	const ms = Date.now() - acceptedAt;
+	voipDebugLog('reconnect-timing', 'login ready', { ms });
+};
+
+export const logVoipFirstSignalElapsed = () => {
+	if (acceptedAt == null || firstSignalLogged) return;
+	firstSignalLogged = true;
+	const ms = Date.now() - acceptedAt;
+	voipDebugLog('reconnect-timing', 'first signal sent', { ms });
+};
+
+export const clearVoipReconnectTiming = () => {
+	acceptedAt = null;
+	firstSignalLogged = false;
+};

--- a/ios/RocketChatRN/Info.plist
+++ b/ios/RocketChatRN/Info.plist
@@ -95,6 +95,10 @@
 		<string>fetch</string>
 		<string>voip</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
## Proposed changes

Iterates on the previous warm-locked-accept fix. Naive `checkAndReopen` no-ops when the SDK still believes the socket is alive (`alive()` is a 20s window from `lastPing`). On iOS, TCP can zombie inside that window — the no-op leaves answer SDP and ICE candidates writing to a dead socket and the peer times out at ~10s.

- Pre-emptive force-reconnect in `MediaCallEvents.handleVoipAcceptSucceededFromNative` when `AppState.currentState !== 'active'`: dispatch `disconnect`, close the socket, then `checkAndReopen`. Foreground accept skips this entirely so healthy sessions are unaffected.
- `setSendSignalFn` in `MediaSessionInstance` now gates `methodCall` on `ddp.loggedIn` (not just socket `'open'`) with an 8s timeout. `ddp.send` only awaits `'open'`, but server-side `stream-notify-user` requires `this.userId` — sending before relogin = silent server-side drop.
- Adds `voip-debug.log` reconnect timing markers (`accept marked` → `login ready` → `first signal sent`).

## Issue(s)

Follow-up to #7293.

## How to test or reproduce

1. Sign in, wait until fully connected to workspace.
2. Lock device.
3. Receive incoming VoIP call.
4. Accept from lock screen.
5. Listen for audio. Confirm peer connects (not stuck \"calling\" for ~10s).
6. End call. Pull `voip-debug.log` from the app's Documents folder via Files app — look for `[reconnect-timing]` lines for elapsed ms.
7. Regression: kill the app, repeat — cold-launch path should still work.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Not aimed for merge — opened to trigger CI iOS build for on-device testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled iOS file sharing and in-place document opening.
  * Added persistent on-device VoIP diagnostic logging with read/clear/flush tools.
  * Enhanced push token registration with structured debug reporting.
  * Added VoIP reconnect timing/tracing and improved media-session signal handling.

* **Bug Fixes**
  * Improved VoIP reconnection and call-accept handling when app is backgrounded or inactive.

* **Tests**
  * Updated unit tests and mocks; added microtask flush to stabilize async assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->