### PR TITLE
fix: reconnect immediately on foreground after long background

### DIFF
--- a/app/sagas/state.js
+++ b/app/sagas/state.js
@@ -19,13 +19,15 @@ const appHasComeBackToForeground = function* appHasComeBackToForeground() {
 	if (appRoot !== RootEnum.ROOT_INSIDE) {
 		return;
 	}
-	const isReady = yield isAuthAndConnected();
-	if (!isReady) {
+	const login = yield select(state => state.login);
+	if (!login.isAuthenticated) {
 		return;
 	}
 	try {
 		const server = yield select(state => state.server.server);
 		yield localAuthenticate(server);
+		// Always reconnect on foreground; gating on meteor.connected would skip
+		// the call precisely when the socket died silently in background.
 		checkAndReopen();
 		// Check for pending notification when app comes to foreground (Android - notification tap while in background)
 		checkPendingNotification().catch(e => {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"use-deep-compare-effect": "1.6.1",
 		"xregexp": "5.0.2",
 		"yup": "0.32.11",
-		"zustand": "^5.0.10"
+		"zustand": "5.0.10"
 	},
 	"resolutions": {
 		"ua-parser-js": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"use-deep-compare-effect": "1.6.1",
 		"xregexp": "5.0.2",
 		"yup": "0.32.11",
-		"zustand": "5.0.10"
+		"zustand": "^5.0.10"
 	},
 	"resolutions": {
 		"ua-parser-js": "1.0.2",

--- a/patches/@rocket.chat+sdk+1.3.3-mobile.patch
+++ b/patches/@rocket.chat+sdk+1.3.3-mobile.patch
@@ -2,7 +2,51 @@ diff --git a/node_modules/@rocket.chat/sdk/lib/drivers/ddp.ts b/node_modules/@ro
 index 19d31ae..d5295b5 100644
 --- a/node_modules/@rocket.chat/sdk/lib/drivers/ddp.ts
 +++ b/node_modules/@rocket.chat/sdk/lib/drivers/ddp.ts
-@@ -549,7 +549,9 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
+@@ -175,15 +175,36 @@
+     return Promise.resolve()
+   }
+ 
+-  // Call open directly, so it skips openTimeout
++  // Tear down any existing socket and reopen unconditionally. The `connected`
++  // getter trusts `readyState === 1 && alive()` — both can lie after iOS
++  // background suspend (zombie WebSocket still reporting OPEN, lastPing still
++  // inside the alive window because of a server message just before suspend).
++  // Forcing teardown + resetting lastPing guarantees a fresh connection.
+   checkAndReopen = () => {
+-    if (!this.connected) {
+-      if (this.openTimeout) {
+-        clearTimeout(this.openTimeout as any)
+-        delete this.openTimeout
+-      }
+-      this.open()
++    this.lastPing = 0
++    if (this.openTimeout) {
++      clearTimeout(this.openTimeout as any)
++      delete this.openTimeout
+     }
++    if (this.pingTimeout) {
++      clearTimeout(this.pingTimeout as any)
++      delete this.pingTimeout
++    }
++    if (this.connection) {
++      try {
++        // Detach handlers before close so the orphaned socket can't trigger
++        // another reopen() race against the open() we're about to start.
++        this.connection.onopen = null as any
++        this.connection.onmessage = null as any
++        this.connection.onerror = null as any
++        this.connection.onclose = null as any
++        this.connection.close(userDisconnectCloseCode)
++      } catch (e) {
++        this.logger.debug(`[ddp] checkAndReopen close error: ${(e as Error).message}`)
++      }
++      this.connection = undefined
++    }
++    this.open()
+   }
+ 
+   /** Clear connection and try to connect again. */
+@@ -549,7 +570,9 @@
        'uiInteraction',
        'e2ekeyRequest',
        'userData',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13841,7 +13841,7 @@ yup@0.32.11:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
 
-zustand@5.0.10:
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.10.tgz#4db510c0c4c25a5f1ae43227b307ddf1641a3210"
-  integrity sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==
+zustand@^5.0.10:
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.12.tgz#ed36f647aa89965c4019b671dfc23ef6c6e3af8c"
+  integrity sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13841,7 +13841,7 @@ yup@0.32.11:
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
 
-zustand@^5.0.10:
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.12.tgz#ed36f647aa89965c4019b671dfc23ef6c6e3af8c"
-  integrity sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==
+zustand@5.0.10:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.10.tgz#4db510c0c4c25a5f1ae43227b307ddf1641a3210"
+  integrity sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==


### PR DESCRIPTION
## Proposed changes

Fixes a class of reconnection bugs where users see "Waiting for network" forever (or for many tens of seconds) after the app returns from a long background — a common report on iOS especially.

Two stacked root causes:

**1. Saga gate paradox** (`app/sagas/state.js`). `appHasComeBackToForeground` bailed when `meteor.connected === false` — but that flag is exactly `false` precisely when reconnect is needed. The handler was silently skipping `checkAndReopen()` in the very state that required it. Recovery fell entirely on the SDK's internal `setTimeout reopen` loop, which iOS can starve while suspended.

Fix: gate only on `login.isAuthenticated`. `checkAndReopen` is now always invoked on FOREGROUND.

**2. Zombie socket fools `checkAndReopen`** (SDK patch `@rocket.chat/sdk` `lib/drivers/ddp.ts`). `Socket.checkAndReopen` no-ops when `connected === true`. The `connected` getter is `readyState === 1 && alive()`. After iOS suspend:
- `readyState` can stay `1` even though the underlying TCP is dead.
- `alive()` window is `lastPing + 40s`; a server message just before suspend keeps `alive()` true on resume.

Result: a dead-but-still-OPEN WebSocket. `checkAndReopen` saw "connected" and did nothing. The next `send({msg:'ping'})` hit the zombie — the `try/catch` only logs, the awaited `'pong'` never fires, no `reopen()` ever scheduled. **Forever waiting.**

Fix: `checkAndReopen` now unconditionally tears down the existing connection (handlers detached first so the orphan can't race a reopen), zeroes `lastPing`, and calls `open()`. Worst case it churns one extra socket on healthy resumes; best case it heals the stuck-forever cases.

## Issue(s)

Internal report: app sometimes never reconnects after long background; "Waiting for network" persists indefinitely.

## How to test or reproduce

1. Open the app, log in, confirm connected (no "Waiting for network").
2. Send the app to background (Home button / lock screen).
3. Wait 10+ minutes (longer if on Wi-Fi without idle disconnect; shorter on flaky cellular).
4. Bring the app to foreground.
5. **Before the fix**: subtitle frequently stays at "Waiting for network" for tens of seconds or never recovers; messages do not arrive.
6. **After the fix**: socket tears down + reopens within ~1s of foreground; subtitle returns to normal; presence syncs.

Repeat on iOS and Android. Try via PushKit/CallKit wake paths if available.

## Screenshots

N/A — behavior change only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Both fixes are minimal and tightly scoped. Additional follow-ups (not in this PR) that came out of the diagnosis and would further harden the recovery path:

- Add an `open()` handshake timeout in the SDK so a hung WebSocket connect on suspended iOS doesn't wait for OS-level TCP timeout.
- Re-fire FOREGROUND on `AppState change` even when `currentState === 'active'` after a long gap (PushKit wake can flip AppState invisibly, locking out future foreground events).
- Bridge NetInfo `isConnected: false → true` to `checkAndReopen` for network-blip recovery without depending on AppState.
- Foreground heartbeat saga as a safety net.

Targeted at `feat.voip-lib-new` (PR #6918) per the source of these reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved foreground reconnection so the app reliably restores sessions and reconnects sockets after returning from background.

* **New Features**
  * Added handling for media signal and media call events to enhance real-time media behavior.

* **Chores**
  * Pinned a dependency to a specific version to ensure consistent installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->