### PR TITLE
fix(voip): reconnect SDK on lock-screen CallKit native accept

### DIFF
--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -89,7 +89,7 @@ jest.mock('../restApi', () => ({
 }));
 
 jest.mock('../connect', () => ({
-	checkAndReopen: jest.fn()
+	checkAndReopen: jest.fn(() => Promise.resolve())
 }));
 
 jest.mock('./MediaCallLogger', () => {

--- a/app/lib/services/voip/MediaCallEvents.ios.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.ios.test.ts
@@ -88,6 +88,10 @@ jest.mock('../restApi', () => ({
 	registerPushToken: jest.fn(() => Promise.resolve())
 }));
 
+jest.mock('../connect', () => ({
+	checkAndReopen: jest.fn()
+}));
+
 jest.mock('./MediaCallLogger', () => {
 	const log = jest.fn();
 	const debug = jest.fn();

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -69,6 +69,10 @@ jest.mock('../restApi', () => ({
 	registerPushToken: jest.fn(() => Promise.resolve())
 }));
 
+jest.mock('../connect', () => ({
+	checkAndReopen: jest.fn()
+}));
+
 jest.mock('./MediaCallLogger', () => ({
 	MediaCallLogger: class {
 		log = jest.fn();
@@ -157,6 +161,67 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 				expect(mockSetNativeAcceptedCallId).toHaveBeenCalledWith('same-ws-call');
 				expect(mediaSessionInstance.applyRestStateSignals).toHaveBeenCalledTimes(1);
 				expect(mockOnOpenDeepLink).not.toHaveBeenCalled();
+			});
+
+			it('triggers SDK reconnect via checkAndReopen when host matches active workspace', () => {
+				const { checkAndReopen } = jest.requireMock('../connect');
+				mockServerSelector.mockReturnValueOnce('https://workspace-a.example.com');
+				const payload = buildIncomingPayload({
+					callId: 'reopen-trigger-call',
+					host: 'https://workspace-a.example.com'
+				});
+
+				DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+
+				expect(checkAndReopen).toHaveBeenCalledTimes(1);
+			});
+
+			it('does not trigger SDK reconnect when host belongs to a different workspace', () => {
+				const { checkAndReopen } = jest.requireMock('../connect');
+				const payload = buildIncomingPayload({
+					callId: 'cross-ws-call',
+					host: 'https://workspace-b.open.rocket.chat'
+				});
+
+				DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+
+				expect(checkAndReopen).not.toHaveBeenCalled();
+			});
+
+			it('triggers SDK reconnect only once for duplicate VoipAcceptSucceeded with the same callId', () => {
+				const { checkAndReopen } = jest.requireMock('../connect');
+				mockServerSelector.mockReturnValue('https://workspace-a.example.com');
+				const payload = buildIncomingPayload({
+					callId: 'reopen-dedupe',
+					host: 'https://workspace-a.example.com'
+				});
+
+				DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+				DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+
+				expect(checkAndReopen).toHaveBeenCalledTimes(1);
+			});
+
+			it('triggers SDK reconnect before replaying REST state signals', () => {
+				const { checkAndReopen } = jest.requireMock('../connect');
+				const { mediaSessionInstance } = jest.requireMock('./MediaSessionInstance');
+				const callOrder: string[] = [];
+				(checkAndReopen as jest.Mock).mockImplementationOnce(() => {
+					callOrder.push('checkAndReopen');
+				});
+				(mediaSessionInstance.applyRestStateSignals as jest.Mock).mockImplementationOnce(() => {
+					callOrder.push('applyRestStateSignals');
+					return Promise.resolve();
+				});
+				mockServerSelector.mockReturnValueOnce('https://workspace-a.example.com');
+				const payload = buildIncomingPayload({
+					callId: 'reopen-order',
+					host: 'https://workspace-a.example.com'
+				});
+
+				DeviceEventEmitter.emit('VoipAcceptSucceeded', payload);
+
+				expect(callOrder).toEqual(['checkAndReopen', 'applyRestStateSignals']);
 			});
 
 			it('does not open deep link or set native id when type is not incoming_call', () => {

--- a/app/lib/services/voip/MediaCallEvents.test.ts
+++ b/app/lib/services/voip/MediaCallEvents.test.ts
@@ -70,7 +70,7 @@ jest.mock('../restApi', () => ({
 }));
 
 jest.mock('../connect', () => ({
-	checkAndReopen: jest.fn()
+	checkAndReopen: jest.fn(() => Promise.resolve())
 }));
 
 jest.mock('./MediaCallLogger', () => ({
@@ -190,7 +190,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 
 			it('triggers SDK reconnect only once for duplicate VoipAcceptSucceeded with the same callId', () => {
 				const { checkAndReopen } = jest.requireMock('../connect');
-				mockServerSelector.mockReturnValue('https://workspace-a.example.com');
+				mockServerSelector.mockReturnValueOnce('https://workspace-a.example.com');
 				const payload = buildIncomingPayload({
 					callId: 'reopen-dedupe',
 					host: 'https://workspace-a.example.com'
@@ -208,6 +208,7 @@ describe('MediaCallEvents cross-server accept (slice 3)', () => {
 				const callOrder: string[] = [];
 				(checkAndReopen as jest.Mock).mockImplementationOnce(() => {
 					callOrder.push('checkAndReopen');
+					return Promise.resolve();
 				});
 				(mediaSessionInstance.applyRestStateSignals as jest.Mock).mockImplementationOnce(() => {
 					callOrder.push('applyRestStateSignals');

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -96,7 +96,7 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
 	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
 		mediaCallLogger.debug(`${TAG} Triggering SDK reconnect on native accept`);
-		checkAndReopen().catch(error => {
+		checkAndReopen().catch((error: unknown) => {
 			mediaCallLogger.error(`${TAG} checkAndReopen failed:`, error);
 		});
 		mediaSessionInstance.applyRestStateSignals().catch(error => {

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -6,6 +6,7 @@ import { useCallStore } from './useCallStore';
 import { mediaSessionInstance } from './MediaSessionInstance';
 import type { VoipPayload } from '../../../definitions/Voip';
 import NativeVoipModule from '../../native/NativeVoip';
+import { checkAndReopen } from '../connect';
 import { registerPushToken } from '../restApi';
 import { MediaCallLogger } from './MediaCallLogger';
 
@@ -94,6 +95,8 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	NativeVoipModule.clearInitialEvents();
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
 	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
+		mediaCallLogger.debug(`${TAG} Triggering SDK reconnect on native accept`);
+		checkAndReopen();
 		mediaSessionInstance.applyRestStateSignals().catch(error => {
 			mediaCallLogger.error(`${TAG} applyRestStateSignals failed:`, error);
 		});

--- a/app/lib/services/voip/MediaCallEvents.ts
+++ b/app/lib/services/voip/MediaCallEvents.ts
@@ -96,7 +96,9 @@ function handleVoipAcceptSucceededFromNative(data: VoipPayload, adapters: MediaC
 	useCallStore.getState().setNativeAcceptedCallId(data.callId);
 	if (data.host && isVoipIncomingHostCurrentWorkspace(data.host, adapters.getActiveServerUrl)) {
 		mediaCallLogger.debug(`${TAG} Triggering SDK reconnect on native accept`);
-		checkAndReopen();
+		checkAndReopen().catch(error => {
+			mediaCallLogger.error(`${TAG} checkAndReopen failed:`, error);
+		});
 		mediaSessionInstance.applyRestStateSignals().catch(error => {
 			mediaCallLogger.error(`${TAG} applyRestStateSignals failed:`, error);
 		});


### PR DESCRIPTION
## Proposed changes

Stacks on #7297. When CallKit accepts a VoIP call from the lock screen, the app stays backgrounded — `APP_STATE.FOREGROUND` never transitions, so the foreground-reconnect saga added in #7297 never fires. The DDP socket can be a zombie (kept-alive `readyState=OPEN`, but TCP dead after a long iOS suspend), and any outgoing SDP/ICE sends triggered by `applyRestStateSignals()` are silently swallowed.

This adds a parallel reconnect trigger inside `handleVoipAcceptSucceededFromNative`: when the accepted call's host matches the active workspace, call `checkAndReopen()` (fire-and-forget) before replaying REST state signals. Same primitive as the saga, just driven from the VOIP accept path instead of the app-state listener.

The behavior depends on #7297's unconditional teardown — without that patch `checkAndReopen` no-ops against the zombie socket (the pre-#7297 implementation only opens when `!this.connected`).

## Issue(s)

Follow-up to #7297 — covers the lock-screen accept scenario that PR did not.

## How to test or reproduce

1. Open the app, make sure you are on the same workspace as the caller.
2. Lock the device and wait long enough for iOS to suspend the JS runtime (a couple of minutes is usually enough).
3. Have another user place a VOIP call to your account.
4. Accept the call from the iOS lock-screen CallKit UI without unlocking.
5. The call should connect — audio flows in both directions, signaling completes. Without the fix, the call stays in a connecting state because SDP/ICE messages cannot be sent over the dead socket.

## Screenshots

N/A — logging only on the JS side.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Cross-platform (`MediaCallEvents.test.ts`) covers four cases: same-workspace fires `checkAndReopen` once, cross-workspace does not fire, duplicate `callId` deliveries dedupe, and `checkAndReopen` is invoked before `applyRestStateSignals`. The iOS test file (`MediaCallEvents.ios.test.ts`) gets the matching `'../connect'` mock so the new import does not break its module graph.

Considered (and rejected) alternatives:
- Synthesizing an `APP_STATE.FOREGROUND` redux dispatch from the accept path — would re-run `localAuthenticate` (biometric prompt) and `setUserPresenceOnline`, both wrong for a backgrounded lock-screen accept.
- Triggering the reopen on the native side (Swift) — `checkAndReopen` lives in the JS SDK, so the trigger has to cross the bridge anyway; doing it from JS keeps the concern in one place.

No native code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests that mock reconnection behavior and verify reconnection is attempted only for calls from the active workspace, only once for duplicate accept events, and occurs before restoring media session state.

* **Bug Fixes**
  * Ensure the client attempts reconnection for accepted calls from your workspace, invokes it before restoring media session state, and logs errors without altering existing accept/failure flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->