### PR TITLE
fix: deeplink auth losing room navigation when entering from outside stack

### DIFF
--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -1,0 +1,355 @@
+// ─── Boundary mocks — must appear before any import that triggers the module ───
+
+jest.mock('../../lib/methods/userPreferences', () => ({
+	__esModule: true,
+	default: {
+		getString: jest.fn()
+	}
+}));
+
+jest.mock('../../lib/database/services/Server', () => ({
+	getServerById: jest.fn()
+}));
+
+jest.mock('../../lib/methods/canOpenRoom', () => ({
+	canOpenRoom: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getServerInfo', () => ({
+	getServerInfo: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/goRoom', () => ({
+	goRoom: jest.fn(),
+	navigateToRoom: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
+	localAuthenticate: jest.fn()
+}));
+
+jest.mock('../../lib/services/connect', () => ({
+	loginOAuthOrSso: jest.fn()
+}));
+
+jest.mock('../../lib/services/sdk', () => ({
+	__esModule: true,
+	default: {
+		current: {
+			client: {
+				host: ''
+			}
+		}
+	}
+}));
+
+jest.mock('../../lib/services/restApi', () => ({
+	notifyUser: jest.fn()
+}));
+
+jest.mock('../../lib/methods/videoConf', () => ({
+	videoConfJoin: jest.fn()
+}));
+
+jest.mock('../../lib/services/voip/resetVoipState', () => ({
+	resetVoipState: jest.fn()
+}));
+
+jest.mock('../../lib/navigation/appNavigation', () => ({
+	__esModule: true,
+	default: {
+		navigate: jest.fn(),
+		dispatch: jest.fn(),
+		getCurrentRoute: jest.fn(),
+		setParams: jest.fn()
+	},
+	waitForNavigationReady: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('i18n-js', () => ({
+	__esModule: true,
+	default: { t: (k: string) => k }
+}));
+
+// Mock helpers to avoid auxStore (getUidDirectMessage / getRoomTitle call reduxStore.getState())
+jest.mock('../../lib/methods/helpers', () => ({
+	getUidDirectMessage: jest.fn(() => null),
+	normalizeDeepLinkingServerHost: jest.fn((host: string) => host)
+}));
+
+// react-native-callkeep is manually mocked at __mocks__/react-native-callkeep.js
+
+// ─── Real imports (after mocks) ───────────────────────────────────────────────
+
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import { deepLinkingOpen } from '../../actions/deepLinking';
+import { loginSuccess } from '../../actions/login';
+import { selectServerSuccess } from '../../actions/server';
+import { appStart } from '../../actions/app';
+import { RootEnum } from '../../definitions';
+import reducers from '../../reducers';
+import deepLinkingRoot from '../deepLinking';
+import UserPreferences from '../../lib/methods/userPreferences';
+import { getServerById } from '../../lib/database/services/Server';
+import { canOpenRoom } from '../../lib/methods/canOpenRoom';
+import { getServerInfo } from '../../lib/methods/getServerInfo';
+import { goRoom } from '../../lib/methods/helpers/goRoom';
+import { waitForNavigationReady } from '../../lib/navigation/appNavigation';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Drains pending saga microtasks so all synchronous saga steps complete. */
+async function flushSagaMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+type PreloadedState = Parameters<typeof createStore>[1];
+
+function setupStore(preloadedState?: PreloadedState) {
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(reducers, preloadedState, applyMiddleware(sagaMiddleware));
+	sagaMiddleware.run(deepLinkingRoot);
+	return store;
+}
+
+// ─── Factories ────────────────────────────────────────────────────────────────
+
+const HOST = 'https://open.rocket.chat';
+const TOKEN = 'auth-token-abc';
+
+/** Base deep-link params factory — host only. Extend per test. */
+const makeParams = (overrides: Record<string, any> = {}) => ({
+	host: HOST,
+	...overrides
+});
+
+/** Params for the unknown-server-with-token path (F4 tests). */
+const makeParamsWithToken = (overrides: Record<string, any> = {}) =>
+	makeParams({ token: TOKEN, path: 'channel/general', ...overrides });
+
+/** Server record stub as returned by getServerById / selectServerSuccess. */
+const makeServerRecord = (overrides: Record<string, any> = {}) => ({
+	id: HOST,
+	version: '6.0.0',
+	...overrides
+});
+
+/** Stored user token stub as returned by UserPreferences.getString(TOKEN_KEY-host). */
+const makeStoredUser = () => TOKEN;
+
+// ─── Group F4 — Regression race (new server + token + room path) ──────────────
+
+describe('deepLinking saga — F4 regression race (new server + token + room path)', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+
+		// Reset all mocks
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(canOpenRoom).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(goRoom).mockReset();
+		jest.mocked(waitForNavigationReady).mockReset();
+
+		// Default: unknown server (no current server match, no serverRecord)
+		// getString(CURRENT_SERVER) → different server, getString(TOKEN_KEY-host) → null
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return 'https://other.server.com';
+			// token for this host — not set (unknown server path)
+			return null;
+		});
+		jest.mocked(getServerById).mockResolvedValue(null);
+
+		// getServerInfo succeeds → unknown-server-with-token path
+		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
+
+		// canOpenRoom returns a room object
+		jest.mocked(canOpenRoom).mockResolvedValue({ rid: 'room-1', name: 'general', t: 'c' } as any);
+
+		// waitForNavigationReady resolves immediately
+		jest.mocked(waitForNavigationReady).mockResolvedValue(undefined);
+
+		// goRoom resolves immediately
+		jest.mocked(goRoom).mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	/**
+	 * F4a — Regression positive: full chain, dispatch SERVER.SELECT_SUCCESS,
+	 * LOGIN.SUCCESS, then APP.START(ROOT_INSIDE). Assert goRoom called exactly
+	 * once, sequenced after the APP.START dispatch.
+	 */
+	it('F4a: calls goRoom exactly once after APP.START(ROOT_INSIDE) completes the chain', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+
+		// Advance past the delay(1000) in the saga
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		// Saga is now waiting for SERVER.SELECT_SUCCESS
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Saga is now waiting for LOGIN.SUCCESS
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// Saga has dispatched appReady and selected state.app.root.
+		// Root is NOT yet ROOT_INSIDE (reducer hasn't seen ROOT_INSIDE yet),
+		// so saga is waiting for APP.START(ROOT_INSIDE).
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		// Now dispatch APP.START(ROOT_INSIDE) — this satisfies the take.
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4b — Regression negative: dispatch SERVER.SELECT_SUCCESS, LOGIN.SUCCESS.
+	 * Flush microtasks. Assert goRoom NOT yet called.
+	 * Then dispatch APP.START(ROOT_INSIDE). Flush. Assert goRoom called once.
+	 */
+	it('F4b: goRoom is NOT called between LOGIN.SUCCESS and APP.START(ROOT_INSIDE)', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// KEY ASSERTION: goRoom must NOT have been called yet
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		// Now release the saga by dispatching APP.START(ROOT_INSIDE)
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4c — Early-exit branch: the saga selects state.app.root after LOGIN.SUCCESS.
+	 * If root === ROOT_INSIDE at that moment, the take is skipped and goRoom fires
+	 * immediately. We achieve this by dispatching APP.START(ROOT_INSIDE) synchronously
+	 * before flushing, so the reducer updates the root before the saga's select runs.
+	 */
+	it('F4c: skips the APP.START take when state.app.root is already ROOT_INSIDE at select time', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Dispatch LOGIN.SUCCESS AND APP.START(ROOT_INSIDE) synchronously before any flush.
+		// The reducer processes both dispatches before the saga's select runs,
+		// so the select sees ROOT_INSIDE and skips the take.
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// goRoom should fire immediately — the take was skipped by the select short-circuit
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4d — Wrong-root rejection: dispatch APP.START(ROOT_OUTSIDE) — wrong root.
+	 * Assert goRoom NOT called. Then dispatch APP.START(ROOT_INSIDE). Assert goRoom
+	 * called once.
+	 */
+	it('F4d: APP.START(ROOT_OUTSIDE) does not satisfy the take; APP.START(ROOT_INSIDE) does', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// Dispatch wrong root — saga's take predicate filters this out
+		store.dispatch(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+		await flushSagaMicrotasks();
+
+		// goRoom must NOT have been called
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		// Now dispatch correct root — satisfies the take
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4e — Multiple APP.START: after the take fires once, dispatch a second
+	 * APP.START(ROOT_INSIDE). Assert goRoom still called only once (saga is past
+	 * the take, takeLatest has not been retriggered).
+	 */
+	it('F4e: a second APP.START(ROOT_INSIDE) after navigation does not re-trigger goRoom', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// First APP.START(ROOT_INSIDE) — fires the take
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+
+		// Second APP.START(ROOT_INSIDE) — saga is done, no re-trigger
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// Still exactly once
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -126,7 +126,7 @@ const makeParams = (overrides: Record<string, any> = {}) => ({
 	...overrides
 });
 
-/** Params for the unknown-server-with-token path (F4 tests). */
+/** Params for the unknown-server-with-token path. */
 const makeParamsWithToken = (overrides: Record<string, any> = {}) =>
 	makeParams({ token: TOKEN, path: 'channel/general', ...overrides });
 
@@ -140,9 +140,9 @@ const makeServerRecord = (overrides: Record<string, any> = {}) => ({
 /** Stored user token stub as returned by UserPreferences.getString(TOKEN_KEY-host). */
 const makeStoredUser = () => TOKEN;
 
-// ─── Group F4 — Regression race (new server + token + room path) ──────────────
+// ─── Regression race (new server + token + room path) ──────────────
 
-describe('deepLinking saga — F4 regression race (new server + token + room path)', () => {
+describe('deepLinking saga — Regression race (new server + token + room path)', () => {
 	beforeEach(() => {
 		jest.useFakeTimers();
 
@@ -181,11 +181,11 @@ describe('deepLinking saga — F4 regression race (new server + token + room pat
 	});
 
 	/**
-	 * F4a — Regression positive: full chain, dispatch SERVER.SELECT_SUCCESS,
+	 * Regression positive: full chain, dispatch SERVER.SELECT_SUCCESS,
 	 * LOGIN.SUCCESS, then APP.START(ROOT_INSIDE). Assert goRoom called exactly
 	 * once, sequenced after the APP.START dispatch.
 	 */
-	it('F4a: calls goRoom exactly once after APP.START(ROOT_INSIDE) completes the chain', async () => {
+	it('calls goRoom exactly once after APP.START(ROOT_INSIDE) completes the chain', async () => {
 		const store = setupStore();
 		const params = makeParamsWithToken();
 
@@ -222,11 +222,11 @@ describe('deepLinking saga — F4 regression race (new server + token + room pat
 	});
 
 	/**
-	 * F4b — Regression negative: dispatch SERVER.SELECT_SUCCESS, LOGIN.SUCCESS.
+	 * Regression negative: dispatch SERVER.SELECT_SUCCESS, LOGIN.SUCCESS.
 	 * Flush microtasks. Assert goRoom NOT yet called.
 	 * Then dispatch APP.START(ROOT_INSIDE). Flush. Assert goRoom called once.
 	 */
-	it('F4b: goRoom is NOT called between LOGIN.SUCCESS and APP.START(ROOT_INSIDE)', async () => {
+	it('goRoom is NOT called between LOGIN.SUCCESS and APP.START(ROOT_INSIDE)', async () => {
 		const store = setupStore();
 		const params = makeParamsWithToken();
 
@@ -253,12 +253,12 @@ describe('deepLinking saga — F4 regression race (new server + token + room pat
 	});
 
 	/**
-	 * F4c — Early-exit branch: the saga selects state.app.root after LOGIN.SUCCESS.
+	 * Early-exit branch: the saga selects state.app.root after LOGIN.SUCCESS.
 	 * If root === ROOT_INSIDE at that moment, the take is skipped and goRoom fires
 	 * immediately. We achieve this by dispatching APP.START(ROOT_INSIDE) synchronously
 	 * before flushing, so the reducer updates the root before the saga's select runs.
 	 */
-	it('F4c: skips the APP.START take when state.app.root is already ROOT_INSIDE at select time', async () => {
+	it('skips the APP.START take when state.app.root is already ROOT_INSIDE at select time', async () => {
 		const store = setupStore();
 		const params = makeParamsWithToken();
 
@@ -283,11 +283,11 @@ describe('deepLinking saga — F4 regression race (new server + token + room pat
 	});
 
 	/**
-	 * F4d — Wrong-root rejection: dispatch APP.START(ROOT_OUTSIDE) — wrong root.
+	 * Wrong-root rejection: dispatch APP.START(ROOT_OUTSIDE) — wrong root.
 	 * Assert goRoom NOT called. Then dispatch APP.START(ROOT_INSIDE). Assert goRoom
 	 * called once.
 	 */
-	it('F4d: APP.START(ROOT_OUTSIDE) does not satisfy the take; APP.START(ROOT_INSIDE) does', async () => {
+	it('APP.START(ROOT_OUTSIDE) does not satisfy the take; APP.START(ROOT_INSIDE) does', async () => {
 		const store = setupStore();
 		const params = makeParamsWithToken();
 
@@ -318,11 +318,11 @@ describe('deepLinking saga — F4 regression race (new server + token + room pat
 	});
 
 	/**
-	 * F4e — Multiple APP.START: after the take fires once, dispatch a second
+	 * Multiple APP.START: after the take fires once, dispatch a second
 	 * APP.START(ROOT_INSIDE). Assert goRoom still called only once (saga is past
 	 * the take, takeLatest has not been retriggered).
 	 */
-	it('F4e: a second APP.START(ROOT_INSIDE) after navigation does not re-trigger goRoom', async () => {
+	it('a second APP.START(ROOT_INSIDE) after navigation does not re-trigger goRoom', async () => {
 		const store = setupStore();
 		const params = makeParamsWithToken();
 

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -235,6 +235,12 @@ const handleOpen = function* handleOpen({ params }) {
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);
 			yield put(appReady({}));
+			// Wait for the login saga's appStart(ROOT_INSIDE) before navigating, so
+			// InsideStack is mounted and goRoom dispatches into the correct stack.
+			const currentRoot = yield select(state => state.app.root);
+			if (currentRoot !== RootEnum.ROOT_INSIDE) {
+				yield take(action => action.type === types.APP.START && action.root === RootEnum.ROOT_INSIDE);
+			}
 			yield completeDeepLinkNavigation(params);
 		} else {
 			yield handleInviteLink({ params, requireLogin: true });


### PR DESCRIPTION
## Proposed changes

When a deep link with `userId`/`token`/`path` lands on an unknown server, the deeplink saga used to wait for `LOGIN.SUCCESS` and then immediately call `goRoom` while `app.root` was still `ROOT_OUTSIDE`. The login saga's `appStart(ROOT_INSIDE)` only fires later inside `handleLoginSuccess`, after the deeplink saga had already dispatched navigation into the still-mounted `OutsideStack` — losing it when `InsideStack` later mounted at its default `RoomsListView`.

This change waits for the `APP.START` action with `root === ROOT_INSIDE` before navigating, so `goRoom` dispatches into the correct stack.

## Issue(s)

https://rocketchat.atlassian.net/browse/VMUX-116

## How to test or reproduce

1. Fresh app install (no servers configured).
2. Open a deep link like `rocketchat://auth?host=mobile.qa.rocket.chat&userId=<uid>&token=<token>&path=group/<roomname>`.
3. Expected: app authenticates and lands directly inside the target room.
4. Before this fix: app authenticated but landed on `RoomsListView` instead.

Covered by Maestro `.maestro/tests/assorted/deeplink.yaml` step "should authenticate and navigate".

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Verified locally on Android emulator: the failing Maestro flow `assorted/deeplink.yaml` ("should authenticate and navigate") now passes, and the full test (10 steps) runs green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deep-link resume with auth tokens now waits until the app is fully initialized (inside root) before navigating, preventing premature navigation and missed room openings.

* **Tests**
  * Added a comprehensive regression test suite validating deep-link login sequencing and navigation timing to avoid duplicate or premature room navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->