### PR TITLE
test: cover handleClickCallPush + handleNavigateCallRoom in deep linking saga

### DIFF
--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -1,0 +1,355 @@
+// ─── Boundary mocks — must appear before any import that triggers the module ───
+
+jest.mock('../../lib/methods/userPreferences', () => ({
+	__esModule: true,
+	default: {
+		getString: jest.fn()
+	}
+}));
+
+jest.mock('../../lib/database/services/Server', () => ({
+	getServerById: jest.fn()
+}));
+
+jest.mock('../../lib/methods/canOpenRoom', () => ({
+	canOpenRoom: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getServerInfo', () => ({
+	getServerInfo: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/goRoom', () => ({
+	goRoom: jest.fn(),
+	navigateToRoom: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
+	localAuthenticate: jest.fn()
+}));
+
+jest.mock('../../lib/services/connect', () => ({
+	loginOAuthOrSso: jest.fn()
+}));
+
+jest.mock('../../lib/services/sdk', () => ({
+	__esModule: true,
+	default: {
+		current: {
+			client: {
+				host: ''
+			}
+		}
+	}
+}));
+
+jest.mock('../../lib/services/restApi', () => ({
+	notifyUser: jest.fn()
+}));
+
+jest.mock('../../lib/methods/videoConf', () => ({
+	videoConfJoin: jest.fn()
+}));
+
+jest.mock('../../lib/services/voip/resetVoipState', () => ({
+	resetVoipState: jest.fn()
+}));
+
+jest.mock('../../lib/navigation/appNavigation', () => ({
+	__esModule: true,
+	default: {
+		navigate: jest.fn(),
+		dispatch: jest.fn(),
+		getCurrentRoute: jest.fn(),
+		setParams: jest.fn()
+	},
+	waitForNavigationReady: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('i18n-js', () => ({
+	__esModule: true,
+	default: { t: (k: string) => k }
+}));
+
+// Mock helpers to avoid auxStore (getUidDirectMessage / getRoomTitle call reduxStore.getState())
+jest.mock('../../lib/methods/helpers', () => ({
+	getUidDirectMessage: jest.fn(() => null),
+	normalizeDeepLinkingServerHost: jest.fn((host: string) => host)
+}));
+
+// react-native-callkeep is manually mocked at __mocks__/react-native-callkeep.js
+
+// ─── Real imports (after mocks) ───────────────────────────────────────────────
+
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import { deepLinkingOpen } from '../../actions/deepLinking';
+import { loginSuccess } from '../../actions/login';
+import { selectServerSuccess } from '../../actions/server';
+import { appStart } from '../../actions/app';
+import { RootEnum } from '../../definitions';
+import reducers from '../../reducers';
+import deepLinkingRoot from '../deepLinking';
+import UserPreferences from '../../lib/methods/userPreferences';
+import { getServerById } from '../../lib/database/services/Server';
+import { canOpenRoom } from '../../lib/methods/canOpenRoom';
+import { getServerInfo } from '../../lib/methods/getServerInfo';
+import { goRoom } from '../../lib/methods/helpers/goRoom';
+import { waitForNavigationReady } from '../../lib/navigation/appNavigation';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Drains pending saga microtasks so all synchronous saga steps complete. */
+async function flushSagaMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+type PreloadedState = Parameters<typeof createStore>[1];
+
+function setupStore(preloadedState?: PreloadedState) {
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(reducers, preloadedState, applyMiddleware(sagaMiddleware));
+	sagaMiddleware.run(deepLinkingRoot);
+	return store;
+}
+
+// ─── Factories ────────────────────────────────────────────────────────────────
+
+const HOST = 'https://open.rocket.chat';
+const TOKEN = 'auth-token-abc';
+
+/** Base deep-link params factory — host only. Extend per test. */
+const makeParams = (overrides: Record<string, any> = {}) => ({
+	host: HOST,
+	...overrides
+});
+
+/** Params for the unknown-server-with-token path (F4 tests). */
+const makeParamsWithToken = (overrides: Record<string, any> = {}) =>
+	makeParams({ token: TOKEN, path: 'channel/general', ...overrides });
+
+/** Server record stub as returned by getServerById / selectServerSuccess. */
+const makeServerRecord = (overrides: Record<string, any> = {}) => ({
+	id: HOST,
+	version: '6.0.0',
+	...overrides
+});
+
+/** Stored user token stub as returned by UserPreferences.getString(TOKEN_KEY-host). */
+const makeStoredUser = () => TOKEN;
+
+// ─── Group F4 — Regression race (new server + token + room path) ──────────────
+
+describe('deepLinking saga — F4 regression race (new server + token + room path)', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+
+		// Reset all mocks
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(canOpenRoom).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(goRoom).mockReset();
+		jest.mocked(waitForNavigationReady).mockReset();
+
+		// Default: unknown server (no current server match, no serverRecord)
+		// getString(CURRENT_SERVER) → different server, getString(TOKEN_KEY-host) → null
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return 'https://other.server.com';
+			// token for this host — not set (unknown server path)
+			return null;
+		});
+		jest.mocked(getServerById).mockResolvedValue(null);
+
+		// getServerInfo succeeds → unknown-server-with-token path
+		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
+
+		// canOpenRoom returns a room object
+		jest.mocked(canOpenRoom).mockResolvedValue({ rid: 'room-1', name: 'general', t: 'c' } as any);
+
+		// waitForNavigationReady resolves immediately
+		jest.mocked(waitForNavigationReady).mockResolvedValue(undefined);
+
+		// goRoom resolves immediately
+		jest.mocked(goRoom).mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	/**
+	 * F4a — Regression positive: full chain, dispatch SERVER.SELECT_SUCCESS,
+	 * LOGIN.SUCCESS, then APP.START(ROOT_INSIDE). Assert goRoom called exactly
+	 * once, sequenced after the APP.START dispatch.
+	 */
+	it('F4a: calls goRoom exactly once after APP.START(ROOT_INSIDE) completes the chain', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+
+		// Advance past the delay(1000) in the saga
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		// Saga is now waiting for SERVER.SELECT_SUCCESS
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Saga is now waiting for LOGIN.SUCCESS
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// Saga has dispatched appReady and selected state.app.root.
+		// Root is NOT yet ROOT_INSIDE (reducer hasn't seen ROOT_INSIDE yet),
+		// so saga is waiting for APP.START(ROOT_INSIDE).
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		// Now dispatch APP.START(ROOT_INSIDE) — this satisfies the take.
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4b — Regression negative: dispatch SERVER.SELECT_SUCCESS, LOGIN.SUCCESS.
+	 * Flush microtasks. Assert goRoom NOT yet called.
+	 * Then dispatch APP.START(ROOT_INSIDE). Flush. Assert goRoom called once.
+	 */
+	it('F4b: goRoom is NOT called between LOGIN.SUCCESS and APP.START(ROOT_INSIDE)', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// KEY ASSERTION: goRoom must NOT have been called yet
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		// Now release the saga by dispatching APP.START(ROOT_INSIDE)
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4c — Early-exit branch: the saga selects state.app.root after LOGIN.SUCCESS.
+	 * If root === ROOT_INSIDE at that moment, the take is skipped and goRoom fires
+	 * immediately. We achieve this by dispatching APP.START(ROOT_INSIDE) synchronously
+	 * before flushing, so the reducer updates the root before the saga's select runs.
+	 */
+	it('F4c: skips the APP.START take when state.app.root is already ROOT_INSIDE at select time', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Dispatch LOGIN.SUCCESS AND APP.START(ROOT_INSIDE) synchronously before any flush.
+		// The reducer processes both dispatches before the saga's select runs,
+		// so the select sees ROOT_INSIDE and skips the take.
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// goRoom should fire immediately — the take was skipped by the select short-circuit
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4d — Wrong-root rejection: dispatch APP.START(ROOT_OUTSIDE) — wrong root.
+	 * Assert goRoom NOT called. Then dispatch APP.START(ROOT_INSIDE). Assert goRoom
+	 * called once.
+	 */
+	it('F4d: APP.START(ROOT_OUTSIDE) does not satisfy the take; APP.START(ROOT_INSIDE) does', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// Dispatch wrong root — saga's take predicate filters this out
+		store.dispatch(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+		await flushSagaMicrotasks();
+
+		// goRoom must NOT have been called
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		// Now dispatch correct root — satisfies the take
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * F4e — Multiple APP.START: after the take fires once, dispatch a second
+	 * APP.START(ROOT_INSIDE). Assert goRoom still called only once (saga is past
+	 * the take, takeLatest has not been retriggered).
+	 */
+	it('F4e: a second APP.START(ROOT_INSIDE) after navigation does not re-trigger goRoom', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		// First APP.START(ROOT_INSIDE) — fires the take
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+
+		// Second APP.START(ROOT_INSIDE) — saga is done, no re-trigger
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// Still exactly once
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/sagas/__tests__/deepLinking.videoConf.test.ts
+++ b/app/sagas/__tests__/deepLinking.videoConf.test.ts
@@ -1,0 +1,574 @@
+// ─── Boundary mocks — must appear before any import that triggers the module ───
+
+jest.mock('../../lib/methods/userPreferences', () => ({
+	__esModule: true,
+	default: {
+		getString: jest.fn()
+	}
+}));
+
+jest.mock('../../lib/database/services/Server', () => ({
+	getServerById: jest.fn()
+}));
+
+jest.mock('../../lib/methods/canOpenRoom', () => ({
+	canOpenRoom: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getServerInfo', () => ({
+	getServerInfo: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/goRoom', () => ({
+	goRoom: jest.fn(),
+	navigateToRoom: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
+	localAuthenticate: jest.fn()
+}));
+
+jest.mock('../../lib/services/connect', () => ({
+	loginOAuthOrSso: jest.fn()
+}));
+
+jest.mock('../../lib/services/sdk', () => ({
+	__esModule: true,
+	default: {
+		current: {
+			client: {
+				host: ''
+			}
+		}
+	}
+}));
+
+jest.mock('../../lib/services/restApi', () => ({
+	notifyUser: jest.fn()
+}));
+
+jest.mock('../../lib/methods/videoConf', () => ({
+	videoConfJoin: jest.fn()
+}));
+
+jest.mock('../../lib/services/voip/resetVoipState', () => ({
+	resetVoipState: jest.fn()
+}));
+
+jest.mock('../../lib/navigation/appNavigation', () => ({
+	__esModule: true,
+	default: {
+		navigate: jest.fn(),
+		dispatch: jest.fn(),
+		getCurrentRoute: jest.fn(),
+		setParams: jest.fn()
+	},
+	waitForNavigationReady: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('i18n-js', () => ({
+	__esModule: true,
+	default: { t: (k: string) => k }
+}));
+
+// Mock helpers to avoid auxStore (getUidDirectMessage / getRoomTitle call reduxStore.getState())
+jest.mock('../../lib/methods/helpers', () => ({
+	getUidDirectMessage: jest.fn(() => null),
+	normalizeDeepLinkingServerHost: jest.fn((host: string) => host)
+}));
+
+// Database mock — expose mockSubsCollection so per-test can control find()
+// Note: variable must be prefixed with `mock` (case-insensitive) to be accessible inside jest.mock() factory
+const mockSubsCollection = { find: jest.fn() };
+jest.mock('../../lib/database', () => ({
+	__esModule: true,
+	default: {
+		active: { get: jest.fn(() => mockSubsCollection) }
+	}
+}));
+
+// react-native-callkeep is manually mocked at __mocks__/react-native-callkeep.js
+
+// ─── Real imports (after mocks) ───────────────────────────────────────────────
+
+import { AnyAction, applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import { deepLinkingClickCallPush } from '../../actions/deepLinking';
+import { loginSuccess } from '../../actions/login';
+import { selectServerSuccess } from '../../actions/server';
+import { appStart } from '../../actions/app';
+import { RootEnum } from '../../definitions';
+import reducers from '../../reducers';
+import deepLinkingRoot from '../deepLinking';
+import UserPreferences from '../../lib/methods/userPreferences';
+import { getServerById } from '../../lib/database/services/Server';
+import { getServerInfo } from '../../lib/methods/getServerInfo';
+import { localAuthenticate } from '../../lib/methods/helpers/localAuthentication';
+import { navigateToRoom } from '../../lib/methods/helpers/goRoom';
+import { notifyUser } from '../../lib/services/restApi';
+import { videoConfJoin } from '../../lib/methods/videoConf';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Drains pending saga microtasks so all synchronous saga steps complete. */
+async function flushSagaMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+type PreloadedState = Parameters<typeof createStore>[1];
+
+/**
+ * Creates a Redux store with saga middleware plus a collector middleware that
+ * records every action dispatched (both user-triggered and saga put()).
+ */
+function setupStore(preloadedState?: PreloadedState) {
+	const dispatched: AnyAction[] = [];
+	const collectorMiddleware = () => (next: any) => (action: any) => {
+		dispatched.push(action);
+		return next(action);
+	};
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(reducers, preloadedState, applyMiddleware(collectorMiddleware, sagaMiddleware));
+	sagaMiddleware.run(deepLinkingRoot);
+	return { store, dispatched };
+}
+
+// ─── Factories ────────────────────────────────────────────────────────────────
+
+const HOST = 'https://open.rocket.chat';
+const TOKEN = 'auth-token-abc';
+const RID = 'room-rid-1';
+const CALL_ID = 'call-id-42';
+const CALLER = { _id: 'uid-1' };
+
+/** Base call-push params factory. Extend per test. */
+const makeParams = (overrides: Record<string, any> = {}) => ({
+	host: HOST,
+	rid: RID,
+	callId: CALL_ID,
+	caller: CALLER,
+	event: 'accept',
+	...overrides
+});
+
+/** Server record stub returned by getServerById. */
+const makeServerRecord = (overrides: Record<string, any> = {}) => ({
+	id: HOST,
+	version: '6.0.0',
+	...overrides
+});
+
+/** Room stub returned by mockSubsCollection.find(). */
+const makeRoom = (overrides: Record<string, any> = {}) => ({
+	rid: RID,
+	t: 'c',
+	name: 'general',
+	...overrides
+});
+
+// ─── Group A — no host short-circuit ─────────────────────────────────────────
+
+describe('handleClickCallPush — Group A: no host', () => {
+	beforeEach(() => {
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(navigateToRoom).mockReset();
+		jest.mocked(notifyUser).mockReset();
+		jest.mocked(videoConfJoin).mockReset();
+		mockSubsCollection.find.mockReset();
+	});
+
+	it('A1: returns immediately when params.host is empty — no dispatch, no nav, no videoConfJoin', async () => {
+		const { store, dispatched } = setupStore();
+		store.dispatch(deepLinkingClickCallPush({ host: '', rid: RID, callId: CALL_ID, caller: CALLER, event: 'accept' }));
+		await flushSagaMicrotasks();
+
+		// Only the OPEN_VIDEO_CONF trigger action itself should be in dispatched
+		expect(dispatched).toHaveLength(1);
+		expect(dispatched[0].type).toBe('DEEP_LINKING_OPEN_VIDEO_CONF');
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+		expect(jest.mocked(notifyUser)).not.toHaveBeenCalled();
+		expect(jest.mocked(videoConfJoin)).not.toHaveBeenCalled();
+	});
+});
+
+// ─── Group B — same server ───────────────────────────────────────────────────
+
+describe('handleClickCallPush — Group B: same server', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(localAuthenticate).mockReset();
+		jest.mocked(navigateToRoom).mockReset();
+		jest.mocked(notifyUser).mockReset();
+		jest.mocked(videoConfJoin).mockReset();
+		mockSubsCollection.find.mockReset();
+
+		// Same server, has token
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return HOST;
+			if (key === `TOKEN-${HOST}`) return TOKEN;
+			return TOKEN; // any TOKEN_KEY-host lookup
+		});
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		jest.mocked(navigateToRoom).mockResolvedValue(undefined);
+		jest.mocked(notifyUser).mockResolvedValue(undefined);
+		jest.mocked(videoConfJoin).mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('B1: already connected → goes straight to handleNavigateCallRoom without localAuthenticate', async () => {
+		// Pre-seed state with connected=true
+		const preloadedState = {
+			server: { connected: true }
+		} as PreloadedState;
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+
+		const { store } = setupStore(preloadedState);
+		store.dispatch(deepLinkingClickCallPush(makeParams()));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// localAuthenticate should NOT have been called
+		expect(jest.mocked(localAuthenticate)).not.toHaveBeenCalled();
+		// navigateToRoom should have been called with the room
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	it('B2: not connected → localAuthenticate, selectServerRequest, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
+		// Pre-seed state with connected=false (default)
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(deepLinkingClickCallPush(makeParams()));
+		await flushSagaMicrotasks();
+
+		// Should have called localAuthenticate
+		expect(jest.mocked(localAuthenticate)).toHaveBeenCalledWith(HOST);
+
+		// Should have dispatched selectServerRequest
+		const selectServerAction = dispatched.find((a: AnyAction) => a.type === 'SERVER_SELECT_REQUEST');
+		expect(selectServerAction).toBeDefined();
+		expect(selectServerAction?.fetchVersion).toBe(true);
+		expect(selectServerAction?.changeServer).toBe(false);
+
+		// navigateToRoom should NOT have been called yet (waiting for LOGIN.SUCCESS)
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+
+		// Dispatch LOGIN.SUCCESS to unblock the saga
+		store.dispatch(loginSuccess({ id: 'user-1', token: TOKEN } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ─── Group C — known different server ────────────────────────────────────────
+
+describe('handleClickCallPush — Group C: known different server', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(localAuthenticate).mockReset();
+		jest.mocked(navigateToRoom).mockReset();
+		jest.mocked(notifyUser).mockReset();
+		jest.mocked(videoConfJoin).mockReset();
+		mockSubsCollection.find.mockReset();
+
+		// Different server but known (serverRecord exists, user token exists)
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return 'https://other.server.com';
+			return TOKEN; // has token for target host
+		});
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		jest.mocked(navigateToRoom).mockResolvedValue(undefined);
+		jest.mocked(notifyUser).mockResolvedValue(undefined);
+		jest.mocked(videoConfJoin).mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('C1: localAuthenticate, selectServerRequest with changeServer=true, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(deepLinkingClickCallPush(makeParams()));
+		await flushSagaMicrotasks();
+
+		// Should have called localAuthenticate
+		expect(jest.mocked(localAuthenticate)).toHaveBeenCalledWith(HOST);
+
+		// selectServerRequest should have changeServer=true (4th arg)
+		const selectServerAction = dispatched.find((a: AnyAction) => a.type === 'SERVER_SELECT_REQUEST');
+		expect(selectServerAction).toBeDefined();
+		expect(selectServerAction?.fetchVersion).toBe(true);
+		expect(selectServerAction?.changeServer).toBe(true);
+
+		// navigateToRoom should NOT have been called yet (waiting for LOGIN.SUCCESS)
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+
+		// Dispatch LOGIN.SUCCESS
+		store.dispatch(loginSuccess({ id: 'user-1', token: TOKEN } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ─── Group D — unknown server ─────────────────────────────────────────────────
+
+describe('handleClickCallPush — Group D: unknown server', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(localAuthenticate).mockReset();
+		jest.mocked(navigateToRoom).mockReset();
+		jest.mocked(notifyUser).mockReset();
+		jest.mocked(videoConfJoin).mockReset();
+		mockSubsCollection.find.mockReset();
+
+		// Unknown server: no token, no serverRecord
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return 'https://other.server.com';
+			return null; // no user token for target host
+		});
+		jest.mocked(getServerById).mockResolvedValue(null);
+		jest.mocked(navigateToRoom).mockResolvedValue(undefined);
+		jest.mocked(notifyUser).mockResolvedValue(undefined);
+		jest.mocked(videoConfJoin).mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('D1: getServerInfo fails → fallbackNavigation, no appStart(ROOT_OUTSIDE)', async () => {
+		jest.mocked(getServerInfo).mockResolvedValue({ success: false } as any);
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(deepLinkingClickCallPush(makeParams()));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// fallbackNavigation only dispatches appInit() when currentRoot is falsy
+		// No appStart(ROOT_OUTSIDE) should be dispatched
+		const rootOutsideAction = dispatched.find(
+			(a: AnyAction) => a.type === 'APP_START' && a.root === RootEnum.ROOT_OUTSIDE
+		);
+		expect(rootOutsideAction).toBeUndefined();
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+		expect(jest.mocked(notifyUser)).not.toHaveBeenCalled();
+		expect(jest.mocked(videoConfJoin)).not.toHaveBeenCalled();
+	});
+
+	it('D2: getServerInfo ok + token → appStart(ROOT_OUTSIDE), serverInitAdd, delay(1000), NewServer emit, waits SELECT_SUCCESS, loginRequest, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
+		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
+		// Override: token exists
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return 'https://other.server.com';
+			return null; // no pre-stored token for this host — token comes from params
+		});
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+
+		const paramsWithToken = makeParams({ token: TOKEN });
+		const { store, dispatched } = setupStore();
+		store.dispatch(deepLinkingClickCallPush(paramsWithToken));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		// appStart(ROOT_OUTSIDE) should have been dispatched
+		const rootOutsideAction = dispatched.find(
+			(a: AnyAction) => a.type === 'APP_START' && a.root === RootEnum.ROOT_OUTSIDE
+		);
+		expect(rootOutsideAction).toBeDefined();
+
+		// serverInitAdd should have been dispatched
+		const serverInitAddAction = dispatched.find((a: AnyAction) => a.type === 'SERVER_INIT_ADD');
+		expect(serverInitAddAction).toBeDefined();
+
+		// navigateToRoom should NOT have been called yet (waiting for SELECT_SUCCESS)
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+
+		// Dispatch SERVER.SELECT_SUCCESS
+		store.dispatch(selectServerSuccess({ server: HOST, version: '6.0.0', name: 'open.rocket.chat' }));
+		await flushSagaMicrotasks();
+
+		// loginRequest should have been dispatched with { resume: token }
+		const loginRequestAction = dispatched.find((a: AnyAction) => a.type === 'LOGIN_REQUEST');
+		expect(loginRequestAction).toBeDefined();
+		expect(loginRequestAction?.credentials?.resume).toBe(TOKEN);
+
+		// navigateToRoom still not called (waiting for LOGIN.SUCCESS)
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+
+		// Dispatch LOGIN.SUCCESS
+		store.dispatch(loginSuccess({ id: 'user-1', token: TOKEN } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	it('D3: getServerInfo ok + no token → no further action after NewServer emit', async () => {
+		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(deepLinkingClickCallPush(makeParams({ token: undefined }))); // no token in params
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		// appStart(ROOT_OUTSIDE) dispatched
+		const rootOutsideAction = dispatched.find(
+			(a: AnyAction) => a.type === 'APP_START' && a.root === RootEnum.ROOT_OUTSIDE
+		);
+		expect(rootOutsideAction).toBeDefined();
+
+		// No loginRequest
+		const loginRequestAction = dispatched.find((a: AnyAction) => a.type === 'LOGIN_REQUEST');
+		expect(loginRequestAction).toBeUndefined();
+
+		// No navigateToRoom
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+	});
+});
+
+// ─── Group E — handleNavigateCallRoom downstream ─────────────────────────────
+
+describe('handleClickCallPush — Group E: handleNavigateCallRoom downstream', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(localAuthenticate).mockReset();
+		jest.mocked(navigateToRoom).mockReset();
+		jest.mocked(notifyUser).mockReset();
+		jest.mocked(videoConfJoin).mockReset();
+		mockSubsCollection.find.mockReset();
+
+		// Same server, connected — simplest path to reach handleNavigateCallRoom
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return HOST;
+			return TOKEN;
+		});
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		jest.mocked(navigateToRoom).mockResolvedValue(undefined);
+		jest.mocked(notifyUser).mockResolvedValue(undefined);
+		jest.mocked(videoConfJoin).mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('E1: always dispatches appStart(ROOT_INSIDE) before subscription lookup', async () => {
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+		const preloadedState = { server: { connected: true } } as PreloadedState;
+		const { store, dispatched } = setupStore(preloadedState);
+
+		store.dispatch(deepLinkingClickCallPush(makeParams()));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		const rootInsideAction = dispatched.find(
+			(a: AnyAction) => a.type === 'APP_START' && a.root === RootEnum.ROOT_INSIDE
+		);
+		expect(rootInsideAction).toBeDefined();
+		// appStart(ROOT_INSIDE) must appear BEFORE navigateToRoom is called
+		const rootInsideIdx = dispatched.indexOf(rootInsideAction!);
+		expect(rootInsideIdx).toBeGreaterThanOrEqual(0);
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	it('E2: event=accept → notifyUser(accepted) AND videoConfJoin called', async () => {
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+		const preloadedState = { server: { connected: true } } as PreloadedState;
+		const { store } = setupStore(preloadedState);
+
+		store.dispatch(deepLinkingClickCallPush(makeParams({ event: 'accept' })));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(notifyUser)).toHaveBeenCalledTimes(1);
+		expect(jest.mocked(notifyUser)).toHaveBeenCalledWith(`${CALLER._id}/video-conference`, {
+			action: 'accepted',
+			params: { uid: CALLER._id, rid: RID, callId: CALL_ID }
+		});
+		expect(jest.mocked(videoConfJoin)).toHaveBeenCalledTimes(1);
+		expect(jest.mocked(videoConfJoin)).toHaveBeenCalledWith(CALL_ID, true, false, true);
+	});
+
+	it('E3: event=decline → notifyUser(rejected) but NO videoConfJoin', async () => {
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+		const preloadedState = { server: { connected: true } } as PreloadedState;
+		const { store } = setupStore(preloadedState);
+
+		store.dispatch(deepLinkingClickCallPush(makeParams({ event: 'decline' })));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(notifyUser)).toHaveBeenCalledTimes(1);
+		expect(jest.mocked(notifyUser)).toHaveBeenCalledWith(`${CALLER._id}/video-conference`, {
+			action: 'rejected',
+			params: { uid: CALLER._id, rid: RID, callId: CALL_ID }
+		});
+		expect(jest.mocked(videoConfJoin)).not.toHaveBeenCalled();
+	});
+
+	it('E4: isMasterDetail=true → navigateToRoom called with isMasterDetail: true', async () => {
+		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
+		const preloadedState = {
+			server: { connected: true },
+			app: { isMasterDetail: true }
+		} as PreloadedState;
+		const { store } = setupStore(preloadedState);
+
+		store.dispatch(deepLinkingClickCallPush(makeParams()));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+		const [callArgs] = jest.mocked(navigateToRoom).mock.calls;
+		expect(callArgs[0]).toMatchObject({ isMasterDetail: true });
+	});
+
+	it('E5: subscription not found → caught; appStart(ROOT_INSIDE) still dispatched, no navigateToRoom/notifyUser/videoConfJoin', async () => {
+		// mockSubsCollection.find rejects
+		mockSubsCollection.find.mockRejectedValueOnce(new Error('record not found'));
+		const preloadedState = { server: { connected: true } } as PreloadedState;
+		const { store, dispatched } = setupStore(preloadedState);
+
+		store.dispatch(deepLinkingClickCallPush(makeParams()));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// appStart(ROOT_INSIDE) was still dispatched (it fires before the find)
+		const rootInsideAction = dispatched.find(
+			(a: AnyAction) => a.type === 'APP_START' && a.root === RootEnum.ROOT_INSIDE
+		);
+		expect(rootInsideAction).toBeDefined();
+
+		// No room nav, no notify, no join
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+		expect(jest.mocked(notifyUser)).not.toHaveBeenCalled();
+		expect(jest.mocked(videoConfJoin)).not.toHaveBeenCalled();
+	});
+});

--- a/app/sagas/__tests__/deepLinking.videoConf.test.ts
+++ b/app/sagas/__tests__/deepLinking.videoConf.test.ts
@@ -168,9 +168,9 @@ const makeRoom = (overrides: Record<string, any> = {}) => ({
 	...overrides
 });
 
-// ─── Group A — no host short-circuit ─────────────────────────────────────────
+// ─── no host short-circuit ────────────────────────────────────────────────────
 
-describe('handleClickCallPush — Group A: no host', () => {
+describe('handleClickCallPush — no host', () => {
 	beforeEach(() => {
 		jest.mocked(UserPreferences.getString).mockReset();
 		jest.mocked(getServerById).mockReset();
@@ -181,7 +181,7 @@ describe('handleClickCallPush — Group A: no host', () => {
 		mockSubsCollection.find.mockReset();
 	});
 
-	it('A1: returns immediately when params.host is empty — no dispatch, no nav, no videoConfJoin', async () => {
+	it('returns immediately when params.host is empty — no dispatch, no nav, no videoConfJoin', async () => {
 		const { store, dispatched } = setupStore();
 		store.dispatch(deepLinkingClickCallPush({ host: '', rid: RID, callId: CALL_ID, caller: CALLER, event: 'accept' }));
 		await flushSagaMicrotasks();
@@ -195,9 +195,9 @@ describe('handleClickCallPush — Group A: no host', () => {
 	});
 });
 
-// ─── Group B — same server ───────────────────────────────────────────────────
+// ─── same server ─────────────────────────────────────────────────────────────
 
-describe('handleClickCallPush — Group B: same server', () => {
+describe('handleClickCallPush — same server', () => {
 	beforeEach(() => {
 		jest.useFakeTimers();
 		jest.mocked(UserPreferences.getString).mockReset();
@@ -225,7 +225,7 @@ describe('handleClickCallPush — Group B: same server', () => {
 		jest.useRealTimers();
 	});
 
-	it('B1: already connected → goes straight to handleNavigateCallRoom without localAuthenticate', async () => {
+	it('already connected → goes straight to handleNavigateCallRoom without localAuthenticate', async () => {
 		// Pre-seed state with connected=true
 		const preloadedState = {
 			server: { connected: true }
@@ -243,7 +243,7 @@ describe('handleClickCallPush — Group B: same server', () => {
 		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
 	});
 
-	it('B2: not connected → localAuthenticate, selectServerRequest, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
+	it('not connected → localAuthenticate, selectServerRequest, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
 		// Pre-seed state with connected=false (default)
 		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
 
@@ -272,9 +272,9 @@ describe('handleClickCallPush — Group B: same server', () => {
 	});
 });
 
-// ─── Group C — known different server ────────────────────────────────────────
+// ─── known different server ───────────────────────────────────────────────────
 
-describe('handleClickCallPush — Group C: known different server', () => {
+describe('handleClickCallPush — known different server', () => {
 	beforeEach(() => {
 		jest.useFakeTimers();
 		jest.mocked(UserPreferences.getString).mockReset();
@@ -301,7 +301,7 @@ describe('handleClickCallPush — Group C: known different server', () => {
 		jest.useRealTimers();
 	});
 
-	it('C1: localAuthenticate, selectServerRequest with changeServer=true, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
+	it('localAuthenticate, selectServerRequest with changeServer=true, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
 		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
 
 		const { store, dispatched } = setupStore();
@@ -329,9 +329,9 @@ describe('handleClickCallPush — Group C: known different server', () => {
 	});
 });
 
-// ─── Group D — unknown server ─────────────────────────────────────────────────
+// ─── unknown server ────────────────────────────────────────────────────────────
 
-describe('handleClickCallPush — Group D: unknown server', () => {
+describe('handleClickCallPush — unknown server', () => {
 	beforeEach(() => {
 		jest.useFakeTimers();
 		jest.mocked(UserPreferences.getString).mockReset();
@@ -358,7 +358,7 @@ describe('handleClickCallPush — Group D: unknown server', () => {
 		jest.useRealTimers();
 	});
 
-	it('D1: getServerInfo fails → fallbackNavigation, no appStart(ROOT_OUTSIDE)', async () => {
+	it('getServerInfo fails → fallbackNavigation, no appStart(ROOT_OUTSIDE)', async () => {
 		jest.mocked(getServerInfo).mockResolvedValue({ success: false } as any);
 
 		const { store, dispatched } = setupStore();
@@ -377,7 +377,7 @@ describe('handleClickCallPush — Group D: unknown server', () => {
 		expect(jest.mocked(videoConfJoin)).not.toHaveBeenCalled();
 	});
 
-	it('D2: getServerInfo ok + token → appStart(ROOT_OUTSIDE), serverInitAdd, delay(1000), NewServer emit, waits SELECT_SUCCESS, loginRequest, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
+	it('getServerInfo ok + token → appStart(ROOT_OUTSIDE), serverInitAdd, delay(1000), NewServer emit, waits SELECT_SUCCESS, loginRequest, waits LOGIN.SUCCESS, then navigateToRoom', async () => {
 		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
 		// Override: token exists
 		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
@@ -426,7 +426,7 @@ describe('handleClickCallPush — Group D: unknown server', () => {
 		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
 	});
 
-	it('D3: getServerInfo ok + no token → no further action after NewServer emit', async () => {
+	it('getServerInfo ok + no token → no further action after NewServer emit', async () => {
 		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
 
 		const { store, dispatched } = setupStore();
@@ -450,9 +450,9 @@ describe('handleClickCallPush — Group D: unknown server', () => {
 	});
 });
 
-// ─── Group E — handleNavigateCallRoom downstream ─────────────────────────────
+// ─── handleNavigateCallRoom downstream ───────────────────────────────────────
 
-describe('handleClickCallPush — Group E: handleNavigateCallRoom downstream', () => {
+describe('handleClickCallPush — handleNavigateCallRoom downstream', () => {
 	beforeEach(() => {
 		jest.useFakeTimers();
 		jest.mocked(UserPreferences.getString).mockReset();
@@ -479,7 +479,7 @@ describe('handleClickCallPush — Group E: handleNavigateCallRoom downstream', (
 		jest.useRealTimers();
 	});
 
-	it('E1: always dispatches appStart(ROOT_INSIDE) before subscription lookup', async () => {
+	it('always dispatches appStart(ROOT_INSIDE) before subscription lookup', async () => {
 		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
 		const preloadedState = { server: { connected: true } } as PreloadedState;
 		const { store, dispatched } = setupStore(preloadedState);
@@ -498,7 +498,7 @@ describe('handleClickCallPush — Group E: handleNavigateCallRoom downstream', (
 		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
 	});
 
-	it('E2: event=accept → notifyUser(accepted) AND videoConfJoin called', async () => {
+	it('event=accept → notifyUser(accepted) AND videoConfJoin called', async () => {
 		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
 		const preloadedState = { server: { connected: true } } as PreloadedState;
 		const { store } = setupStore(preloadedState);
@@ -516,7 +516,7 @@ describe('handleClickCallPush — Group E: handleNavigateCallRoom downstream', (
 		expect(jest.mocked(videoConfJoin)).toHaveBeenCalledWith(CALL_ID, true, false, true);
 	});
 
-	it('E3: event=decline → notifyUser(rejected) but NO videoConfJoin', async () => {
+	it('event=decline → notifyUser(rejected) but NO videoConfJoin', async () => {
 		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
 		const preloadedState = { server: { connected: true } } as PreloadedState;
 		const { store } = setupStore(preloadedState);
@@ -533,7 +533,7 @@ describe('handleClickCallPush — Group E: handleNavigateCallRoom downstream', (
 		expect(jest.mocked(videoConfJoin)).not.toHaveBeenCalled();
 	});
 
-	it('E4: isMasterDetail=true → navigateToRoom called with isMasterDetail: true', async () => {
+	it('isMasterDetail=true → navigateToRoom called with isMasterDetail: true', async () => {
 		mockSubsCollection.find.mockResolvedValueOnce(makeRoom());
 		const preloadedState = {
 			server: { connected: true },
@@ -550,7 +550,7 @@ describe('handleClickCallPush — Group E: handleNavigateCallRoom downstream', (
 		expect(callArgs[0]).toMatchObject({ isMasterDetail: true });
 	});
 
-	it('E5: subscription not found → caught; appStart(ROOT_INSIDE) still dispatched, no navigateToRoom/notifyUser/videoConfJoin', async () => {
+	it('subscription not found → caught; appStart(ROOT_INSIDE) still dispatched, no navigateToRoom/notifyUser/videoConfJoin', async () => {
 		// mockSubsCollection.find rejects
 		mockSubsCollection.find.mockRejectedValueOnce(new Error('record not found'));
 		const preloadedState = { server: { connected: true } } as PreloadedState;

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -235,6 +235,12 @@ const handleOpen = function* handleOpen({ params }) {
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);
 			yield put(appReady({}));
+			// Wait for the login saga's appStart(ROOT_INSIDE) before navigating, so
+			// InsideStack is mounted and goRoom dispatches into the correct stack.
+			const currentRoot = yield select(state => state.app.root);
+			if (currentRoot !== RootEnum.ROOT_INSIDE) {
+				yield take(action => action.type === types.APP.START && action.root === RootEnum.ROOT_INSIDE);
+			}
 			yield completeDeepLinkNavigation(params);
 		} else {
 			yield handleInviteLink({ params, requireLogin: true });


### PR DESCRIPTION
## Proposed changes

Adds a new isolated test file `app/sagas/__tests__/deepLinking.videoConf.test.ts` covering every branch of `handleClickCallPush` and the downstream `handleNavigateCallRoom` in `app/sagas/deepLinking.js`. Mirrors the harness/mock conventions established by the slice-1 test file (`deepLinking.test.ts`) and adds a controllable `app/lib/database` mock so subscription lookup can be driven per test.

The 12 cases lock down current behavior across:

- **Group A (no host)** — `params.host` empty short-circuits with no dispatches/nav/join.
- **Group B (same server)** — connected → straight to nav; not connected → `localAuthenticate` + `selectServerRequest(host, version, true)` + wait `LOGIN.SUCCESS` + nav.
- **Group C (known different server)** — `localAuthenticate` + `selectServerRequest(host, version, true, true)` + wait `LOGIN.SUCCESS` + nav.
- **Group D (unknown server)** — `getServerInfo` fail → `fallbackNavigation` (no `voipAcceptFailed` branch in this handler, unlike `handleOpen`); `getServerInfo` ok with token → `appStart(ROOT_OUTSIDE)` + `serverInitAdd` + `delay(1000)` + `NewServer emit` + wait `SERVER.SELECT_SUCCESS` + `loginRequest({ resume })` + wait `LOGIN.SUCCESS` + nav (note: this branch lacks `appReady`/`take(APP.START)` ordering; that is `handleOpen`-only); `getServerInfo` ok no token → no further action.
- **Group E (`handleNavigateCallRoom`)** — always dispatches `appStart(ROOT_INSIDE)` before subscription lookup; `accept` → `notifyUser('accepted')` + `videoConfJoin(callId, true, false, true)`; `decline` → `notifyUser('rejected')` only; `isMasterDetail=true` propagated to `navigateToRoom`; subscription `find` rejection caught/logged with `appStart(ROOT_INSIDE)` still dispatched.

No edits to `app/sagas/deepLinking.js`. No new package dependencies.

> **Note on base branch:** This PR targets `fix/deeplink-auth-room-nav` to stack onto the slice-1 harness. Once #7304 merges to `develop`, base will be re-targeted to `develop`.

## Issue(s)

Part of the deep-linking saga test suite — see `.scratch/deeplinking-saga-tests/` for the parent PRD and slice breakdown.

## How to test or reproduce

```bash
TZ=UTC yarn test app/sagas/__tests__/deepLinking.videoConf.test.ts
```

All 12 cases should pass. The console.error noise on case E5 is expected — it is the saga's `log(e)` catch on the rejected subscription `find`.

## Screenshots

N/A (test-only change).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Test isolation: this file is standalone — separate `describe` blocks, its own mock surface (adds `app/lib/database` mock with `mockSubsCollection.find` controllable per test). Uses the same collector-middleware pattern from slices 04/05 to assert saga-`put()` actions, since `put()` does not flow through `store.dispatch` overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite covering deep-linking video conference call flows: server-selection and authentication branches (same, known different, unknown servers), navigation sequencing, delayed/resumed login flows, notification accept/decline payloads, conditional join behavior, master-detail propagation, subscription lookup and safe-abort scenarios, and timer-driven steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->