### PR TITLE
chore: Bump version to 4.73.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode VERSIONCODE as Integer
-        versionName "4.72.0"
+        versionName "4.73.0"
         vectorDrawables.useSupportLibrary = true
         manifestPlaceholders = [BugsnagAPIKey: BugsnagAPIKey as String]
         resValue "string", "rn_config_reader_custom_package", "chat.rocket.reactnative"

--- a/ios/RocketChatRN.xcodeproj/project.pbxproj
+++ b/ios/RocketChatRN.xcodeproj/project.pbxproj
@@ -3035,7 +3035,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 4.72.0;
+				MARKETING_VERSION = 4.73.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
@@ -3088,7 +3088,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 4.72.0;
+				MARKETING_VERSION = 4.73.0;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = chat.rocket.reactnative.NotificationService;

--- a/ios/RocketChatRN/Info.plist
+++ b/ios/RocketChatRN/Info.plist
@@ -28,7 +28,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.72.0</string>
+	<string>4.73.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/ShareRocketChatRN/Info.plist
+++ b/ios/ShareRocketChatRN/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.72.0</string>
+	<string>4.73.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>KeychainGroup</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocket-chat-reactnative",
-	"version": "4.72.0",
+	"version": "4.73.0",
 	"private": true,
 	"packageManager": "yarn@1.22.22",
 	"scripts": {


### PR DESCRIPTION
## Proposed changes

Bump version to 4.73.0 across `package.json`, `android/app/build.gradle`, iOS `Info.plist` (app + share extension), and `MARKETING_VERSION` in the Xcode project (RocketChatRN + NotificationService).

## Issue(s)

https://rocketchat.atlassian.net/browse/CORE-2167

## How to test or reproduce

- `cat package.json | grep version` -> `4.73.0`
- `grep versionName android/app/build.gradle` -> `4.73.0`
- `grep CFBundleShortVersionString -A1 ios/RocketChatRN/Info.plist ios/ShareRocketChatRN/Info.plist` -> `4.73.0`
- `grep MARKETING_VERSION ios/RocketChatRN.xcodeproj/project.pbxproj` -> two `4.73.0` entries (RocketChatRN, NotificationService)

## Screenshots

N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Release-only version bump. No code or behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped app version from 4.72.0 to 4.73.0 across all platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->