### PR TITLE
fix: restore sidebar-view testID visibility for Maestro

### DIFF
--- a/app/views/SidebarView/index.tsx
+++ b/app/views/SidebarView/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { type DrawerNavigationProp } from '@react-navigation/drawer';
-import { ScrollView } from 'react-native';
+import { ScrollView, View } from 'react-native';
 
 import scrollPersistTaps from '../../lib/methods/helpers/scrollPersistTaps';
 import styles from './styles';
@@ -25,13 +25,15 @@ const SidebarView = ({ navigation }: { navigation: DrawerNavigationProp<DrawerPa
 	}, [navigation]);
 
 	return (
-		<ScrollView testID='sidebar-view' style={styles.container} {...scrollPersistTaps}>
-			<Profile navigation={navigation} />
-			<SupportedVersionsWarnItem />
-			<CustomStatus />
-			<Stacks currentScreen={currentScreen} />
-			<Admin currentScreen={currentScreen} />
-		</ScrollView>
+		<View testID='sidebar-view' style={styles.container}>
+			<ScrollView style={styles.container} {...scrollPersistTaps}>
+				<Profile navigation={navigation} />
+				<SupportedVersionsWarnItem />
+				<CustomStatus />
+				<Stacks currentScreen={currentScreen} />
+				<Admin currentScreen={currentScreen} />
+			</ScrollView>
+		</View>
 	);
 };
 


### PR DESCRIPTION
## Proposed changes

PR #6918 (Voice support, cd2faa00a) collapsed the `SidebarView` wrapper — `testID='sidebar-view'` moved from a `SafeAreaView` onto the `ScrollView`. On Android, React Native's `ScrollView` does **not** propagate `testID` to the native accessibility tree, so Maestro can no longer find the element. The `SafeAreaView` (a regular `View`) did.

**Evidence:** `maestro hierarchy` on a fresh `app-experimental-release.apk` shows `sidebar-profile`, `sidebar-chats`, `sidebar-settings`, etc. present in the tree, but `sidebar-view` absent. Wrapping the `ScrollView` in a plain `View` that carries the testID restores accessibility-tree visibility without changing the layout (both use `styles.container` → `flex: 1`).

**Affected flows** (13 of them wait on `sidebar-view`):
- `profile.yaml`, `status.yaml`, `setting.yaml`, `user-preferences.yaml`
- `change-avatar.yaml`, `i18n.yaml`
- `e2ee/utils/navigate-to-e2ee-security.yaml`
- `assorted/utils/check-server.yaml`, `assorted/utils/nav-to-language.yaml`

## Issue(s)

Unblocks shard 8 (Android) on #7311 — surfaces a real regression that #7311's CI stabilization work exposed.

## How to test or reproduce

1. Boot an Android emulator (e.g. `Medium_Phone_API_36`).
2. Install `app-experimental-release.apk`.
3. Run `maestro test .maestro/tests/assorted/profile.yaml --include-tags=test-8` with Maestro 2.5.1.

Before this fix: flow fails ~1m 33s in with `Assertion is false: id: sidebar-view is visible`.
After this fix: flow progresses past the sidebar step and gets ~3m 49s deep into the Profile flow (matching CI's failure point on #7311, which is a separate password-sheet issue tracked elsewhere).

You can also verify directly: `maestro --device emulator-5554 hierarchy | grep sidebar-view` returns 0 matches on develop, returns the testID on this branch.

## Screenshots

n/a — accessibility-tree change, no visual diff.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — covered by existing Maestro flows that were broken
- [ ] I have added necessary documentation (if applicable) — n/a
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Recommend landing #7311 first (it stabilizes the CI scaffolding that lets these flows actually run). With #7311 in place, this fix will turn shard 8's `sidebar-view` assertion green; the password-sheet failure visible in #7311's shard 8 logs is a separate issue not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the sidebar component's internal structure for improved code organization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7319)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->