### PR TITLE
fix: render Attachment file name in Thread Message preview when body is empty

### DIFF
--- a/app/containers/message/Content.test.tsx
+++ b/app/containers/message/Content.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react-native';
+
+import Content from './Content';
+import MessageContext from './Context';
+import { setUser } from '../../actions/login';
+import { mockedStore } from '../../reducers/mockedStore';
+import { type IMessageContent } from './interfaces';
+
+mockedStore.dispatch(
+	setUser({
+		settings: {
+			preferences: {
+				convertAsciiEmoji: true
+			}
+		}
+	})
+);
+
+const baseProps: Partial<IMessageContent> = {
+	_id: 'msg-1',
+	isTemp: false,
+	isInfo: false,
+	isThreadRoom: false,
+	isEdited: false,
+	isEncrypted: false,
+	isIgnored: false,
+	isTranslated: false,
+	isHeader: false,
+	hasError: false,
+	getCustomEmoji: jest.fn(),
+	navToRoomInfo: jest.fn()
+};
+
+const renderContent = (overrides: Partial<IMessageContent> & { attachments?: any[]; autoTranslateLanguage?: string }) =>
+	render(
+		<Provider store={mockedStore}>
+			<MessageContext.Provider
+				value={{
+					user: { username: 'john' },
+					onLinkPress: jest.fn()
+				}}>
+				<Content {...(baseProps as IMessageContent)} {...(overrides as IMessageContent)} />
+			</MessageContext.Provider>
+		</Provider>
+	);
+
+describe('Content preview branch — Thread Message Attachment fallback', () => {
+	test('renders the Attachment title as a preview line when msg is empty and an image-type Attachment has only a title', () => {
+		const { getByText } = renderContent({
+			tmid: '1',
+			msg: '',
+			attachments: [{ image_url: '/file-upload/abc/example.png', title: 'example.png' }]
+		});
+		expect(getByText('example.png')).toBeTruthy();
+	});
+
+	test('renders the Attachment title when msg is empty and a file-type Attachment has only title + title_link', () => {
+		const { getByText } = renderContent({
+			tmid: '1',
+			msg: '',
+			attachments: [{ title: 'presentation.pptx', title_link: '/file-upload/abc/presentation.pptx' }]
+		});
+		expect(getByText('presentation.pptx')).toBeTruthy();
+	});
+
+	test('renders the Attachment description (not the title) when description is set on the first Attachment', () => {
+		const { getByText, queryByText } = renderContent({
+			tmid: '1',
+			msg: '',
+			attachments: [{ title: 'report.pdf', description: 'Q1 financial report' }]
+		});
+		expect(getByText('Q1 financial report')).toBeTruthy();
+		expect(queryByText('report.pdf')).toBeNull();
+	});
+
+	test('renders the translated caption when autoTranslateLanguage matches a translation on the Attachment', () => {
+		const { getByText, queryByText } = renderContent({
+			tmid: '1',
+			msg: '',
+			autoTranslateLanguage: 'pt-BR',
+			attachments: [
+				{
+					title: 'photo.png',
+					description: 'A nice photo',
+					translations: { 'pt-BR': 'Uma bela foto' }
+				}
+			]
+		});
+		expect(getByText('Uma bela foto')).toBeTruthy();
+		expect(queryByText('A nice photo')).toBeNull();
+	});
+
+	test('renders the message body and NOT the file name when msg is non-empty (body wins over Attachment)', () => {
+		const { getByText, queryByText } = renderContent({
+			tmid: '1',
+			msg: 'Here is the file',
+			attachments: [{ title: 'secret.pptx' }]
+		});
+		expect(getByText('Here is the file')).toBeTruthy();
+		expect(queryByText('secret.pptx')).toBeNull();
+	});
+
+	test('renders "Encrypted message" with no file-name leak when the Thread Message preview is encrypted', () => {
+		const { getByTestId, queryByText } = renderContent({
+			tmid: '1',
+			msg: '',
+			isEncrypted: true,
+			attachments: [{ title: 'leak.png' }]
+		});
+		expect(getByTestId('message-encrypted')).toBeTruthy();
+		expect(queryByText('leak.png')).toBeNull();
+	});
+
+	test('does NOT render an Attachment-derived fallback for non-preview Messages (no tmid)', () => {
+		const { queryByText } = renderContent({
+			msg: '',
+			attachments: [{ title: 'outside-thread.png' }]
+		});
+		expect(queryByText('outside-thread.png')).toBeNull();
+	});
+
+	test('uses only the first Attachment for a multi-Attachment Thread Message preview', () => {
+		const { getByText, queryByText } = renderContent({
+			tmid: '1',
+			msg: '',
+			attachments: [{ title: 'first.png' }, { title: 'second.png' }]
+		});
+		expect(getByText('first.png')).toBeTruthy();
+		expect(queryByText('second.png')).toBeNull();
+	});
+});

--- a/app/containers/message/Content.test.tsx
+++ b/app/containers/message/Content.test.tsx
@@ -46,6 +46,18 @@ const renderContent = (overrides: Partial<IMessageContent> & { attachments?: any
 		</Provider>
 	);
 
+const tree = (overrides: Partial<IMessageContent> & { attachments?: any[]; autoTranslateLanguage?: string }) => (
+	<Provider store={mockedStore}>
+		<MessageContext.Provider
+			value={{
+				user: { username: 'john' },
+				onLinkPress: jest.fn()
+			}}>
+			<Content {...(baseProps as IMessageContent)} {...(overrides as IMessageContent)} />
+		</MessageContext.Provider>
+	</Provider>
+);
+
 describe('Content preview branch — Thread Message Attachment fallback', () => {
 	test('renders the Attachment title as a preview line when msg is empty and an image-type Attachment has only a title', () => {
 		const { getByText } = renderContent({
@@ -129,5 +141,21 @@ describe('Content preview branch — Thread Message Attachment fallback', () => 
 		});
 		expect(getByText('first.png')).toBeTruthy();
 		expect(queryByText('second.png')).toBeNull();
+	});
+
+	test('re-renders the preview when an Attachment arrives after mount (no msg change)', () => {
+		const { queryByText, rerender } = render(tree({ tmid: '1', msg: '', attachments: [] }));
+		expect(queryByText('late.png')).toBeNull();
+		rerender(tree({ tmid: '1', msg: '', attachments: [{ title: 'late.png' }] }));
+		expect(queryByText('late.png')).toBeTruthy();
+	});
+
+	test('re-renders the preview when autoTranslateLanguage changes (no msg change)', () => {
+		const attachments = [{ title: 'photo.png', description: 'A nice photo', translations: { 'pt-BR': 'Uma bela foto' } }];
+		const { getByText, queryByText, rerender } = render(tree({ tmid: '1', msg: '', attachments }));
+		expect(getByText('A nice photo')).toBeTruthy();
+		rerender(tree({ tmid: '1', msg: '', attachments, autoTranslateLanguage: 'pt-BR' }));
+		expect(getByText('Uma bela foto')).toBeTruthy();
+		expect(queryByText('A nice photo')).toBeNull();
 	});
 });

--- a/app/containers/message/Content.tsx
+++ b/app/containers/message/Content.tsx
@@ -106,6 +106,15 @@ const Content = React.memo(
 		if (prevProps.isIgnored !== nextProps.isIgnored) {
 			return false;
 		}
+		if (prevProps.tmid !== nextProps.tmid) {
+			return false;
+		}
+		if (prevProps.isThreadRoom !== nextProps.isThreadRoom) {
+			return false;
+		}
+		if (prevProps.autoTranslateLanguage !== nextProps.autoTranslateLanguage) {
+			return false;
+		}
 		if (!dequal(prevProps.md, nextProps.md)) {
 			return false;
 		}
@@ -113,6 +122,9 @@ const Content = React.memo(
 			return false;
 		}
 		if (!dequal(prevProps.channels, nextProps.channels)) {
+			return false;
+		}
+		if (!dequal(prevProps.attachments, nextProps.attachments)) {
 			return false;
 		}
 		return true;

--- a/app/containers/message/Content.tsx
+++ b/app/containers/message/Content.tsx
@@ -6,7 +6,7 @@ import I18n from '../../i18n';
 import styles from './styles';
 import Markdown, { MarkdownPreview } from '../markdown';
 import User from './User';
-import { messageHaveAuthorName, getInfoMessage } from './utils';
+import { messageHaveAuthorName, getInfoMessage, getPreviewMessageFromAttachment } from './utils';
 import MessageContext from './Context';
 import { type IMessageContent } from './interfaces';
 import { useTheme } from '../../theme';
@@ -53,7 +53,12 @@ const Content = React.memo(
 				</Text>
 			);
 		} else if (isPreview) {
-			content = <MarkdownPreview testID={`message-preview-${props.msg}`} msg={props.msg} />;
+			const previewMsg =
+				props.msg ||
+				(props.attachments?.length
+					? getPreviewMessageFromAttachment(props.attachments[0], props.autoTranslateLanguage)
+					: undefined);
+			content = previewMsg ? <MarkdownPreview testID={`message-preview-${previewMsg}`} msg={previewMsg} /> : null;
 		} else if (props.msg) {
 			content = (
 				<Markdown

--- a/app/containers/message/Message.stories.tsx
+++ b/app/containers/message/Message.stories.tsx
@@ -1552,6 +1552,37 @@ export const MessageWithThread = () => (
 			]}
 			isThreadReply
 		/>
+		<Message
+			tmid='1'
+			tmsg='Thread with image attachment'
+			attachments={[
+				{
+					title: 'example.png',
+					image_url: '/file-upload/c4wcNhrbXJLBvAJtN/example.png'
+				}
+			]}
+			isThreadReply
+		/>
+		<Message
+			tmid='1'
+			tmsg='Thread with file attachment'
+			attachments={[
+				{
+					title: 'presentation.pptx',
+					title_link: '/file-upload/c4wcNhrbXJLBvAJtN/presentation.pptx'
+				}
+			]}
+			isThreadReply
+		/>
+		<Message
+			tmid='1'
+			tmsg='Thread with multiple attachments'
+			attachments={[
+				{ title: 'first-file.pdf', title_link: '/file-upload/c4wcNhrbXJLBvAJtN/first-file.pdf' },
+				{ title: 'second-file.pdf', title_link: '/file-upload/c4wcNhrbXJLBvAJtN/second-file.pdf' }
+			]}
+			isThreadReply
+		/>
 	</>
 );
 
@@ -1572,6 +1603,37 @@ export const MessageWithThreadLargeFont = () => (
 					description: 'This is a description :nyan_rocket:',
 					audio_url: '/file-upload/c4wcNhrbXJLBvAJtN/1535569819516.aac'
 				}
+			]}
+			isThreadReply
+		/>
+		<MessageLargeFont
+			tmid='1'
+			tmsg='Thread with image attachment'
+			attachments={[
+				{
+					title: 'example.png',
+					image_url: '/file-upload/c4wcNhrbXJLBvAJtN/example.png'
+				}
+			]}
+			isThreadReply
+		/>
+		<MessageLargeFont
+			tmid='1'
+			tmsg='Thread with file attachment'
+			attachments={[
+				{
+					title: 'presentation.pptx',
+					title_link: '/file-upload/c4wcNhrbXJLBvAJtN/presentation.pptx'
+				}
+			]}
+			isThreadReply
+		/>
+		<MessageLargeFont
+			tmid='1'
+			tmsg='Thread with multiple attachments'
+			attachments={[
+				{ title: 'first-file.pdf', title_link: '/file-upload/c4wcNhrbXJLBvAJtN/first-file.pdf' },
+				{ title: 'second-file.pdf', title_link: '/file-upload/c4wcNhrbXJLBvAJtN/second-file.pdf' }
 			]}
 			isThreadReply
 		/>

--- a/app/containers/message/__snapshots__/Message.test.tsx.snap
+++ b/app/containers/message/__snapshots__/Message.test.tsx.snap
@@ -98213,7 +98213,1309 @@ exports[`Story Snapshots: MessageWithThread should match snapshot 1`] = `
                     >
                       <View
                         testID="message-content-"
-                      />
+                      >
+                        <Text
+                          accessibilityLabel="This is a description :nyan_rocket:"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-This is a description :nyan_rocket:"
+                        >
+                          This is a description :nyan_rocket:
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r5q»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r5q»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-Thread with image attachment"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="Thread with image attachment"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-Thread with image attachment"
+                  >
+                    Thread with image attachment
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 20,
+                            "width": 20,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={20}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 20,
+                                  "width": 20,
+                                }
+                              }
+                              transition={null}
+                              width={20}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r5q»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="example.png"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-example.png"
+                        >
+                          example.png
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r5r»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r5r»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-Thread with file attachment"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="Thread with file attachment"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-Thread with file attachment"
+                  >
+                    Thread with file attachment
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 20,
+                            "width": 20,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={20}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 20,
+                                  "width": 20,
+                                }
+                              }
+                              transition={null}
+                              width={20}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r5r»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="presentation.pptx"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-presentation.pptx"
+                        >
+                          presentation.pptx
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r5s»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r5s»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-Thread with multiple attachments"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="Thread with multiple attachments"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-Thread with multiple attachments"
+                  >
+                    Thread with multiple attachments
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 20,
+                            "width": 20,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={20}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 20,
+                                  "width": 20,
+                                }
+                              }
+                              transition={null}
+                              width={20}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r5s»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="first-file.pdf"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-first-file.pdf"
+                        >
+                          first-file.pdf
+                        </Text>
+                      </View>
                     </View>
                   </A11yIndexView>
                 </View>
@@ -98237,13 +99539,13 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
 >
   <View>
     <A11yOrderView
-      orderKey="«r5q»"
+      orderKey="«r5t»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r5q»"
+        orderKey="«r5t»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -98334,7 +99636,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r5q»"
+                  orderKey="«r5t»"
                 >
                   <View
                     accessible={true}
@@ -99035,13 +100337,13 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r5r»"
+      orderKey="«r5u»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r5r»"
+        orderKey="«r5u»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -99409,7 +100711,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r5r»"
+                    orderKey="«r5u»"
                     style={
                       {
                         "flex": 1,
@@ -99461,13 +100763,13 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r5s»"
+      orderKey="«r5v»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r5s»"
+        orderKey="«r5v»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -99835,7 +101137,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r5s»"
+                    orderKey="«r5v»"
                     style={
                       {
                         "flex": 1,
@@ -99887,13 +101189,13 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r5t»"
+      orderKey="«r60»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r5t»"
+        orderKey="«r60»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -100261,7 +101563,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r5t»"
+                    orderKey="«r60»"
                     style={
                       {
                         "flex": 1,
@@ -100313,13 +101615,13 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r5u»"
+      orderKey="«r61»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r5u»"
+        orderKey="«r61»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -100687,7 +101989,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r5u»"
+                    orderKey="«r61»"
                     style={
                       {
                         "flex": 1,
@@ -100739,13 +102041,13 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r5v»"
+      orderKey="«r62»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r5v»"
+        orderKey="«r62»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -101113,7 +102415,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r5v»"
+                    orderKey="«r62»"
                     style={
                       {
                         "flex": 1,
@@ -101165,13 +102467,13 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r60»"
+      orderKey="«r63»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r60»"
+        orderKey="«r63»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -101539,7 +102841,7 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r60»"
+                    orderKey="«r63»"
                     style={
                       {
                         "flex": 1,
@@ -101556,7 +102858,1309 @@ exports[`Story Snapshots: MessageWithThreadLargeFont should match snapshot 1`] =
                     >
                       <View
                         testID="message-content-"
-                      />
+                      >
+                        <Text
+                          accessibilityLabel="This is a description :nyan_rocket:"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-This is a description :nyan_rocket:"
+                        >
+                          This is a description :nyan_rocket:
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r64»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r64»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-Thread with image attachment"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="Thread with image attachment"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-Thread with image attachment"
+                  >
+                    Thread with image attachment
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 26,
+                            "width": 26,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={26}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=52",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 26,
+                                  "width": 26,
+                                }
+                              }
+                              transition={null}
+                              width={26}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r64»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="example.png"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-example.png"
+                        >
+                          example.png
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r65»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r65»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-Thread with file attachment"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="Thread with file attachment"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-Thread with file attachment"
+                  >
+                    Thread with file attachment
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 26,
+                            "width": 26,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={26}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=52",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 26,
+                                  "width": 26,
+                                }
+                              }
+                              transition={null}
+                              width={26}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r65»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="presentation.pptx"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-presentation.pptx"
+                        >
+                          presentation.pptx
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r66»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r66»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-Thread with multiple attachments"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="Thread with multiple attachments"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-Thread with multiple attachments"
+                  >
+                    Thread with multiple attachments
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 26,
+                            "width": 26,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={26}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=52",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 26,
+                                  "width": 26,
+                                }
+                              }
+                              transition={null}
+                              width={26}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r66»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="first-file.pdf"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-first-file.pdf"
+                        >
+                          first-file.pdf
+                        </Text>
+                      </View>
                     </View>
                   </A11yIndexView>
                 </View>
@@ -101580,13 +104184,13 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r61»"
+      orderKey="«r67»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r61»"
+        orderKey="«r67»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -101677,7 +104281,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r61»"
+                  orderKey="«r67»"
                 >
                   <View
                     accessible={true}
@@ -102029,7 +104633,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r62»"
+      orderKey="«r68»"
     >
       <View
         accessibilityLabel="JD 10:00:00 AM Message translated into English"
@@ -102051,7 +104655,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
           importantForAccessibility="yes"
           orderFocusType={0}
           orderIndex={2}
-          orderKey="«r62»"
+          orderKey="«r68»"
         >
           <View
             accessible={true}
@@ -102670,13 +105274,13 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r63»"
+      orderKey="«r69»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r63»"
+        orderKey="«r69»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -102767,7 +105371,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r63»"
+                  orderKey="«r69»"
                 >
                   <View
                     accessible={true}
@@ -103119,7 +105723,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r64»"
+      orderKey="«r6a»"
     >
       <View
         accessibilityLabel="John Doe 10:00:00 AM Message translated into English"
@@ -103141,7 +105745,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
           importantForAccessibility="yes"
           orderFocusType={0}
           orderIndex={2}
-          orderKey="«r64»"
+          orderKey="«r6a»"
         >
           <View
             accessible={true}
@@ -103760,13 +106364,13 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r65»"
+      orderKey="«r6b»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r65»"
+        orderKey="«r6b»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -103857,7 +106461,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r65»"
+                  orderKey="«r6b»"
                 >
                   <View
                     accessible={true}
@@ -104209,7 +106813,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r66»"
+      orderKey="«r6c»"
     >
       <View
         accessibilityLabel="John Doe With An Extremely Long Display Name That Should Definitely Be Truncated In Any Reasonable User Interface Layout 10:00:00 AM Message translated into English"
@@ -104231,7 +106835,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
           importantForAccessibility="yes"
           orderFocusType={0}
           orderIndex={2}
-          orderKey="«r66»"
+          orderKey="«r6c»"
         >
           <View
             accessible={true}
@@ -104863,13 +107467,13 @@ exports[`Story Snapshots: Pinned should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r67»"
+      orderKey="«r6d»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r67»"
+        orderKey="«r6d»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -104960,7 +107564,7 @@ exports[`Story Snapshots: Pinned should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r67»"
+                  orderKey="«r6d»"
                 >
                   <View
                     accessible={true}
@@ -105342,13 +107946,13 @@ exports[`Story Snapshots: Pinned should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r68»"
+      orderKey="«r6e»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r68»"
+        orderKey="«r6e»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -105439,7 +108043,7 @@ exports[`Story Snapshots: Pinned should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r68»"
+                  orderKey="«r6e»"
                 >
                   <View
                     accessible={true}
@@ -105601,13 +108205,13 @@ exports[`Story Snapshots: PinnedLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r69»"
+      orderKey="«r6f»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r69»"
+        orderKey="«r6f»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -105698,7 +108302,7 @@ exports[`Story Snapshots: PinnedLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r69»"
+                  orderKey="«r6f»"
                 >
                   <View
                     accessible={true}
@@ -106080,13 +108684,13 @@ exports[`Story Snapshots: PinnedLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6a»"
+      orderKey="«r6g»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6a»"
+        orderKey="«r6g»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -106177,7 +108781,7 @@ exports[`Story Snapshots: PinnedLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6a»"
+                  orderKey="«r6g»"
                 >
                   <View
                     accessible={true}
@@ -106339,13 +108943,13 @@ exports[`Story Snapshots: Reactions should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r6b»"
+      orderKey="«r6h»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6b»"
+        orderKey="«r6h»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -106436,7 +109040,7 @@ exports[`Story Snapshots: Reactions should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6b»"
+                  orderKey="«r6h»"
                 >
                   <View
                     accessible={true}
@@ -107332,13 +109936,13 @@ exports[`Story Snapshots: Reactions should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6c»"
+      orderKey="«r6i»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6c»"
+        orderKey="«r6i»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -107429,7 +110033,7 @@ exports[`Story Snapshots: Reactions should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6c»"
+                  orderKey="«r6i»"
                 >
                   <View
                     accessible={true}
@@ -108794,13 +111398,13 @@ exports[`Story Snapshots: ReactionsLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r6d»"
+      orderKey="«r6j»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6d»"
+        orderKey="«r6j»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -108891,7 +111495,7 @@ exports[`Story Snapshots: ReactionsLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6d»"
+                  orderKey="«r6j»"
                 >
                   <View
                     accessible={true}
@@ -109787,13 +112391,13 @@ exports[`Story Snapshots: ReactionsLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6e»"
+      orderKey="«r6k»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6e»"
+        orderKey="«r6k»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -109884,7 +112488,7 @@ exports[`Story Snapshots: ReactionsLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6e»"
+                  orderKey="«r6k»"
                 >
                   <View
                     accessible={true}
@@ -111249,13 +113853,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
 >
   <View>
     <A11yOrderView
-      orderKey="«r6f»"
+      orderKey="«r6l»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6f»"
+        orderKey="«r6l»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -111346,7 +113950,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6f»"
+                  orderKey="«r6l»"
                 >
                   <View
                     accessible={true}
@@ -112047,13 +114651,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6g»"
+      orderKey="«r6m»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6g»"
+        orderKey="«r6m»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -112304,7 +114908,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r6g»"
+                    orderKey="«r6m»"
                     style={
                       {
                         "flex": 1,
@@ -112356,13 +114960,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6h»"
+      orderKey="«r6n»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6h»"
+        orderKey="«r6n»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -112613,7 +115217,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r6h»"
+                    orderKey="«r6n»"
                     style={
                       {
                         "flex": 1,
@@ -112665,13 +115269,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6i»"
+      orderKey="«r6o»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6i»"
+        orderKey="«r6o»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -112922,7 +115526,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r6i»"
+                    orderKey="«r6o»"
                     style={
                       {
                         "flex": 1,
@@ -112939,7 +115543,31 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButton should m
                     >
                       <View
                         testID="message-content-"
-                      />
+                      >
+                        <Text
+                          accessibilityLabel="This is a description"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-This is a description"
+                        >
+                          This is a description
+                        </Text>
+                      </View>
                     </View>
                   </A11yIndexView>
                 </View>
@@ -112963,13 +115591,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
 >
   <View>
     <A11yOrderView
-      orderKey="«r6j»"
+      orderKey="«r6p»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6j»"
+        orderKey="«r6p»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -113060,7 +115688,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6j»"
+                  orderKey="«r6p»"
                 >
                   <View
                     accessible={true}
@@ -113761,13 +116389,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6k»"
+      orderKey="«r6q»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6k»"
+        orderKey="«r6q»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -114018,1966 +116646,6 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadButtonLargeFont
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r6k»"
-                    style={
-                      {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                          "marginLeft": 10,
-                        }
-                      }
-                    >
-                      <View
-                        testID="message-content-I'm fine!"
-                      >
-                        <Text
-                          accessibilityLabel="I'm fine!"
-                          numberOfLines={1}
-                          style={
-                            [
-                              {
-                                "backgroundColor": "transparent",
-                                "fontFamily": "Inter",
-                                "fontSize": 16,
-                                "fontWeight": "400",
-                                "lineHeight": 22,
-                                "textAlign": "left",
-                              },
-                              {
-                                "color": "#2F343D",
-                                "lineHeight": undefined,
-                              },
-                            ]
-                          }
-                          testID="message-preview-I'm fine!"
-                        >
-                          I'm fine!
-                        </Text>
-                      </View>
-                    </View>
-                  </A11yIndexView>
-                </View>
-              </View>
-            </View>
-          </View>
-        </ExternalKeyboardView>
-      </A11yIndexView>
-    </A11yOrderView>
-    <A11yOrderView
-      orderKey="«r6l»"
-    >
-      <A11yIndexView
-        importantForAccessibility="yes"
-        orderFocusType={0}
-        orderIndex={1}
-        orderKey="«r6l»"
-      >
-        <ExternalKeyboardView
-          canBeFocused={true}
-          enableA11yFocus={false}
-          enableContextMenu={true}
-          group={false}
-          haloEffect={true}
-          hasKeyDownPress={false}
-          hasKeyUpPress={true}
-          hasOnFocusChanged={true}
-          lockFocus={0}
-          onContextMenuPress={[Function]}
-          onFocusChange={[Function]}
-          onKeyUpPress={[Function]}
-          orderIndex={-1}
-          screenAutoA11yFocusDelay={300}
-          style={
-            [
-              undefined,
-              undefined,
-            ]
-          }
-        >
-          <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": undefined,
-                "borderRadius": undefined,
-                "margin": undefined,
-                "marginBottom": undefined,
-                "marginEnd": undefined,
-                "marginHorizontal": undefined,
-                "marginLeft": undefined,
-                "marginRight": undefined,
-                "marginStart": undefined,
-                "marginTop": undefined,
-                "marginVertical": undefined,
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              style={{}}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexDirection": "column",
-                      "gap": 8,
-                      "paddingHorizontal": 12,
-                      "paddingVertical": 4,
-                      "width": "100%",
-                    },
-                    {
-                      "marginTop": 4,
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityLabel="diego.mello 10:00:00 AM  thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
-                  accessible={true}
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                      {},
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 46.800000000000004,
-                      }
-                    }
-                  >
-                    <View
-                      accessible={true}
-                      style={
-                        [
-                          {
-                            "borderRadius": 4,
-                            "height": 26,
-                            "width": 26,
-                          },
-                          undefined,
-                        ]
-                      }
-                      testID="avatar"
-                    >
-                      <ExternalKeyboardView
-                        canBeFocused={true}
-                        enableA11yFocus={false}
-                        enableContextMenu={false}
-                        group={false}
-                        haloEffect={true}
-                        hasKeyDownPress={false}
-                        hasKeyUpPress={true}
-                        hasOnFocusChanged={true}
-                        lockFocus={0}
-                        onContextMenuPress={[Function]}
-                        onFocusChange={[Function]}
-                        onKeyUpPress={[Function]}
-                        orderIndex={-1}
-                        screenAutoA11yFocusDelay={300}
-                        style={
-                          [
-                            undefined,
-                            undefined,
-                          ]
-                        }
-                      >
-                        <RNGestureHandlerButton
-                          activeOpacity={1}
-                          collapsable={false}
-                          delayLongPress={600}
-                          enabled={true}
-                          handlerTag={-1}
-                          handlerType="NativeViewGestureHandler"
-                          innerRef={null}
-                          onActiveStateChange={[Function]}
-                          onGestureHandlerEvent={[Function]}
-                          onGestureHandlerStateChange={[Function]}
-                          onPress={[Function]}
-                          rippleColor="#E4E7EA"
-                          style={
-                            [
-                              {
-                                "backgroundColor": undefined,
-                                "borderRadius": undefined,
-                                "margin": undefined,
-                                "marginBottom": undefined,
-                                "marginEnd": undefined,
-                                "marginHorizontal": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginStart": undefined,
-                                "marginTop": undefined,
-                                "marginVertical": undefined,
-                              },
-                              {
-                                "cursor": undefined,
-                              },
-                            ]
-                          }
-                          underlayColor="#E4E7EA"
-                        >
-                          <View
-                            collapsable={false}
-                            style={
-                              {
-                                "backgroundColor": "#E4E7EA",
-                                "borderBottomLeftRadius": undefined,
-                                "borderBottomRightRadius": undefined,
-                                "borderRadius": undefined,
-                                "borderTopLeftRadius": undefined,
-                                "borderTopRightRadius": undefined,
-                                "bottom": 0,
-                                "left": 0,
-                                "opacity": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                          />
-                          <View
-                            accessibilityLabel="diego.mello's avatar"
-                            accessible={true}
-                            style={{}}
-                          >
-                            <ViewManagerAdapter_ExpoImage
-                              borderRadius={4}
-                              containerViewRef={{"current":"Object"}}
-                              contentFit="cover"
-                              contentPosition={
-                                {
-                                  "left": "50%",
-                                  "top": "50%",
-                                }
-                              }
-                              height={26}
-                              nativeViewRef={{"current":"NativeComponent"}}
-                              onError={[Function]}
-                              onLoad={[Function]}
-                              onLoadStart={[Function]}
-                              onProgress={[Function]}
-                              placeholder={[]}
-                              priority="high"
-                              source={
-                                [
-                                  {
-                                    "headers": {
-                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
-                                    },
-                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=52",
-                                  },
-                                ]
-                              }
-                              style={
-                                {
-                                  "borderRadius": 4,
-                                  "height": 26,
-                                  "width": 26,
-                                }
-                              }
-                              transition={null}
-                              width={26}
-                            />
-                          </View>
-                        </RNGestureHandlerButton>
-                      </ExternalKeyboardView>
-                    </View>
-                  </View>
-                  <A11yIndexView
-                    accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                    importantForAccessibility="yes"
-                    orderFocusType={0}
-                    orderIndex={2}
-                    orderKey="«r6l»"
-                    style={
-                      {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                          "marginLeft": 10,
-                        }
-                      }
-                    >
-                      <View
-                        testID="message-content-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                      >
-                        <Text
-                          accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                          numberOfLines={1}
-                          style={
-                            [
-                              {
-                                "backgroundColor": "transparent",
-                                "fontFamily": "Inter",
-                                "fontSize": 16,
-                                "fontWeight": "400",
-                                "lineHeight": 22,
-                                "textAlign": "left",
-                              },
-                              {
-                                "color": "#2F343D",
-                                "lineHeight": undefined,
-                              },
-                            ]
-                          }
-                          testID="message-preview-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                        >
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                        </Text>
-                      </View>
-                    </View>
-                  </A11yIndexView>
-                </View>
-              </View>
-            </View>
-          </View>
-        </ExternalKeyboardView>
-      </A11yIndexView>
-    </A11yOrderView>
-    <A11yOrderView
-      orderKey="«r6m»"
-    >
-      <A11yIndexView
-        importantForAccessibility="yes"
-        orderFocusType={0}
-        orderIndex={1}
-        orderKey="«r6m»"
-      >
-        <ExternalKeyboardView
-          canBeFocused={true}
-          enableA11yFocus={false}
-          enableContextMenu={true}
-          group={false}
-          haloEffect={true}
-          hasKeyDownPress={false}
-          hasKeyUpPress={true}
-          hasOnFocusChanged={true}
-          lockFocus={0}
-          onContextMenuPress={[Function]}
-          onFocusChange={[Function]}
-          onKeyUpPress={[Function]}
-          orderIndex={-1}
-          screenAutoA11yFocusDelay={300}
-          style={
-            [
-              undefined,
-              undefined,
-            ]
-          }
-        >
-          <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": undefined,
-                "borderRadius": undefined,
-                "margin": undefined,
-                "marginBottom": undefined,
-                "marginEnd": undefined,
-                "marginHorizontal": undefined,
-                "marginLeft": undefined,
-                "marginRight": undefined,
-                "marginStart": undefined,
-                "marginTop": undefined,
-                "marginVertical": undefined,
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              style={{}}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexDirection": "column",
-                      "gap": 8,
-                      "paddingHorizontal": 12,
-                      "paddingVertical": 4,
-                      "width": "100%",
-                    },
-                    {
-                      "marginTop": 4,
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityLabel="diego.mello 10:00:00 AM  thread message undefined.  "
-                  accessible={true}
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                      {},
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 46.800000000000004,
-                      }
-                    }
-                  >
-                    <View
-                      accessible={true}
-                      style={
-                        [
-                          {
-                            "borderRadius": 4,
-                            "height": 26,
-                            "width": 26,
-                          },
-                          undefined,
-                        ]
-                      }
-                      testID="avatar"
-                    >
-                      <ExternalKeyboardView
-                        canBeFocused={true}
-                        enableA11yFocus={false}
-                        enableContextMenu={false}
-                        group={false}
-                        haloEffect={true}
-                        hasKeyDownPress={false}
-                        hasKeyUpPress={true}
-                        hasOnFocusChanged={true}
-                        lockFocus={0}
-                        onContextMenuPress={[Function]}
-                        onFocusChange={[Function]}
-                        onKeyUpPress={[Function]}
-                        orderIndex={-1}
-                        screenAutoA11yFocusDelay={300}
-                        style={
-                          [
-                            undefined,
-                            undefined,
-                          ]
-                        }
-                      >
-                        <RNGestureHandlerButton
-                          activeOpacity={1}
-                          collapsable={false}
-                          delayLongPress={600}
-                          enabled={true}
-                          handlerTag={-1}
-                          handlerType="NativeViewGestureHandler"
-                          innerRef={null}
-                          onActiveStateChange={[Function]}
-                          onGestureHandlerEvent={[Function]}
-                          onGestureHandlerStateChange={[Function]}
-                          onPress={[Function]}
-                          rippleColor="#E4E7EA"
-                          style={
-                            [
-                              {
-                                "backgroundColor": undefined,
-                                "borderRadius": undefined,
-                                "margin": undefined,
-                                "marginBottom": undefined,
-                                "marginEnd": undefined,
-                                "marginHorizontal": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginStart": undefined,
-                                "marginTop": undefined,
-                                "marginVertical": undefined,
-                              },
-                              {
-                                "cursor": undefined,
-                              },
-                            ]
-                          }
-                          underlayColor="#E4E7EA"
-                        >
-                          <View
-                            collapsable={false}
-                            style={
-                              {
-                                "backgroundColor": "#E4E7EA",
-                                "borderBottomLeftRadius": undefined,
-                                "borderBottomRightRadius": undefined,
-                                "borderRadius": undefined,
-                                "borderTopLeftRadius": undefined,
-                                "borderTopRightRadius": undefined,
-                                "bottom": 0,
-                                "left": 0,
-                                "opacity": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                          />
-                          <View
-                            accessibilityLabel="diego.mello's avatar"
-                            accessible={true}
-                            style={{}}
-                          >
-                            <ViewManagerAdapter_ExpoImage
-                              borderRadius={4}
-                              containerViewRef={{"current":"Object"}}
-                              contentFit="cover"
-                              contentPosition={
-                                {
-                                  "left": "50%",
-                                  "top": "50%",
-                                }
-                              }
-                              height={26}
-                              nativeViewRef={{"current":"NativeComponent"}}
-                              onError={[Function]}
-                              onLoad={[Function]}
-                              onLoadStart={[Function]}
-                              onProgress={[Function]}
-                              placeholder={[]}
-                              priority="high"
-                              source={
-                                [
-                                  {
-                                    "headers": {
-                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
-                                    },
-                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=52",
-                                  },
-                                ]
-                              }
-                              style={
-                                {
-                                  "borderRadius": 4,
-                                  "height": 26,
-                                  "width": 26,
-                                }
-                              }
-                              transition={null}
-                              width={26}
-                            />
-                          </View>
-                        </RNGestureHandlerButton>
-                      </ExternalKeyboardView>
-                    </View>
-                  </View>
-                  <A11yIndexView
-                    accessibilityLabel=""
-                    importantForAccessibility="yes"
-                    orderFocusType={0}
-                    orderIndex={2}
-                    orderKey="«r6m»"
-                    style={
-                      {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                          "marginLeft": 10,
-                        }
-                      }
-                    >
-                      <View
-                        testID="message-content-"
-                      />
-                    </View>
-                  </A11yIndexView>
-                </View>
-              </View>
-            </View>
-          </View>
-        </ExternalKeyboardView>
-      </A11yIndexView>
-    </A11yOrderView>
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should match snapshot 1`] = `
-<RCTScrollView
-  style={
-    {
-      "backgroundColor": "#FFFFFF",
-    }
-  }
->
-  <View>
-    <A11yOrderView
-      orderKey="«r6n»"
-    >
-      <A11yIndexView
-        importantForAccessibility="yes"
-        orderFocusType={0}
-        orderIndex={1}
-        orderKey="«r6n»"
-      >
-        <ExternalKeyboardView
-          canBeFocused={true}
-          enableA11yFocus={false}
-          enableContextMenu={true}
-          group={false}
-          haloEffect={true}
-          hasKeyDownPress={false}
-          hasKeyUpPress={true}
-          hasOnFocusChanged={true}
-          lockFocus={0}
-          onContextMenuPress={[Function]}
-          onFocusChange={[Function]}
-          onKeyUpPress={[Function]}
-          orderIndex={-1}
-          screenAutoA11yFocusDelay={300}
-          style={
-            [
-              undefined,
-              undefined,
-            ]
-          }
-        >
-          <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": undefined,
-                "borderRadius": undefined,
-                "margin": undefined,
-                "marginBottom": undefined,
-                "marginEnd": undefined,
-                "marginHorizontal": undefined,
-                "marginLeft": undefined,
-                "marginRight": undefined,
-                "marginStart": undefined,
-                "marginTop": undefined,
-                "marginVertical": undefined,
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              style={{}}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexDirection": "column",
-                      "gap": 8,
-                      "paddingHorizontal": 12,
-                      "paddingVertical": 4,
-                      "width": "100%",
-                    },
-                    {
-                      "marginTop": 4,
-                    },
-                  ]
-                }
-              >
-                <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 10,
-                    }
-                  }
-                  testID="message-thread-replied-on-How are you?"
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 36,
-                      }
-                    }
-                  >
-                    <Text
-                      allowFontScaling={false}
-                      selectable={false}
-                      style={
-                        [
-                          {
-                            "color": "#095AD2",
-                            "fontSize": 20,
-                          },
-                          [
-                            {
-                              "lineHeight": 20,
-                            },
-                            undefined,
-                          ],
-                          {
-                            "fontFamily": "custom",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          {},
-                        ]
-                      }
-                    >
-                      
-                    </Text>
-                  </View>
-                  <Text
-                    accessibilityLabel="How are you?"
-                    numberOfLines={1}
-                    style={
-                      [
-                        {
-                          "backgroundColor": "transparent",
-                          "fontFamily": "Inter",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                          "lineHeight": 22,
-                          "textAlign": "left",
-                        },
-                        {
-                          "color": "#2F343D",
-                          "lineHeight": undefined,
-                        },
-                        {
-                          "backgroundColor": "transparent",
-                          "flex": 1,
-                          "fontFamily": "Inter",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                          "textAlign": "left",
-                        },
-                        {
-                          "color": "#095AD2",
-                        },
-                      ]
-                    }
-                    testID="markdown-preview-How are you?"
-                  >
-                    How are you?
-                  </Text>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "justifyContent": "center",
-                        "marginLeft": 4,
-                        "marginRight": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      allowFontScaling={false}
-                      selectable={false}
-                      style={
-                        [
-                          {
-                            "color": "#6C727A",
-                            "fontSize": 20,
-                          },
-                          [
-                            {
-                              "lineHeight": 20,
-                            },
-                            undefined,
-                          ],
-                          {
-                            "fontFamily": "custom",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          {},
-                        ]
-                      }
-                    >
-                      
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message I'm fine!.  "
-                  accessible={true}
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                      {},
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 36,
-                      }
-                    }
-                  >
-                    <View
-                      accessible={true}
-                      style={
-                        [
-                          {
-                            "borderRadius": 4,
-                            "height": 20,
-                            "width": 20,
-                          },
-                          undefined,
-                        ]
-                      }
-                      testID="avatar"
-                    >
-                      <ExternalKeyboardView
-                        canBeFocused={true}
-                        enableA11yFocus={false}
-                        enableContextMenu={false}
-                        group={false}
-                        haloEffect={true}
-                        hasKeyDownPress={false}
-                        hasKeyUpPress={true}
-                        hasOnFocusChanged={true}
-                        lockFocus={0}
-                        onContextMenuPress={[Function]}
-                        onFocusChange={[Function]}
-                        onKeyUpPress={[Function]}
-                        orderIndex={-1}
-                        screenAutoA11yFocusDelay={300}
-                        style={
-                          [
-                            undefined,
-                            undefined,
-                          ]
-                        }
-                      >
-                        <RNGestureHandlerButton
-                          activeOpacity={1}
-                          collapsable={false}
-                          delayLongPress={600}
-                          enabled={true}
-                          handlerTag={-1}
-                          handlerType="NativeViewGestureHandler"
-                          innerRef={null}
-                          onActiveStateChange={[Function]}
-                          onGestureHandlerEvent={[Function]}
-                          onGestureHandlerStateChange={[Function]}
-                          onPress={[Function]}
-                          rippleColor="#E4E7EA"
-                          style={
-                            [
-                              {
-                                "backgroundColor": undefined,
-                                "borderRadius": undefined,
-                                "margin": undefined,
-                                "marginBottom": undefined,
-                                "marginEnd": undefined,
-                                "marginHorizontal": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginStart": undefined,
-                                "marginTop": undefined,
-                                "marginVertical": undefined,
-                              },
-                              {
-                                "cursor": undefined,
-                              },
-                            ]
-                          }
-                          underlayColor="#E4E7EA"
-                        >
-                          <View
-                            collapsable={false}
-                            style={
-                              {
-                                "backgroundColor": "#E4E7EA",
-                                "borderBottomLeftRadius": undefined,
-                                "borderBottomRightRadius": undefined,
-                                "borderRadius": undefined,
-                                "borderTopLeftRadius": undefined,
-                                "borderTopRightRadius": undefined,
-                                "bottom": 0,
-                                "left": 0,
-                                "opacity": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                          />
-                          <View
-                            accessibilityLabel="diego.mello's avatar"
-                            accessible={true}
-                            style={{}}
-                          >
-                            <ViewManagerAdapter_ExpoImage
-                              borderRadius={4}
-                              containerViewRef={{"current":"Object"}}
-                              contentFit="cover"
-                              contentPosition={
-                                {
-                                  "left": "50%",
-                                  "top": "50%",
-                                }
-                              }
-                              height={20}
-                              nativeViewRef={{"current":"NativeComponent"}}
-                              onError={[Function]}
-                              onLoad={[Function]}
-                              onLoadStart={[Function]}
-                              onProgress={[Function]}
-                              placeholder={[]}
-                              priority="high"
-                              source={
-                                [
-                                  {
-                                    "headers": {
-                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
-                                    },
-                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
-                                  },
-                                ]
-                              }
-                              style={
-                                {
-                                  "borderRadius": 4,
-                                  "height": 20,
-                                  "width": 20,
-                                }
-                              }
-                              transition={null}
-                              width={20}
-                            />
-                          </View>
-                        </RNGestureHandlerButton>
-                      </ExternalKeyboardView>
-                    </View>
-                  </View>
-                  <A11yIndexView
-                    accessibilityLabel="I'm fine!"
-                    importantForAccessibility="yes"
-                    orderFocusType={0}
-                    orderIndex={2}
-                    orderKey="«r6n»"
-                    style={
-                      {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                          "marginLeft": 10,
-                        }
-                      }
-                    >
-                      <View
-                        testID="message-content-I'm fine!"
-                      >
-                        <Text
-                          accessibilityLabel="I'm fine!"
-                          numberOfLines={1}
-                          style={
-                            [
-                              {
-                                "backgroundColor": "transparent",
-                                "fontFamily": "Inter",
-                                "fontSize": 16,
-                                "fontWeight": "400",
-                                "lineHeight": 22,
-                                "textAlign": "left",
-                              },
-                              {
-                                "color": "#2F343D",
-                                "lineHeight": undefined,
-                              },
-                            ]
-                          }
-                          testID="message-preview-I'm fine!"
-                        >
-                          I'm fine!
-                        </Text>
-                      </View>
-                    </View>
-                  </A11yIndexView>
-                </View>
-              </View>
-            </View>
-          </View>
-        </ExternalKeyboardView>
-      </A11yIndexView>
-    </A11yOrderView>
-    <A11yOrderView
-      orderKey="«r6o»"
-    >
-      <A11yIndexView
-        importantForAccessibility="yes"
-        orderFocusType={0}
-        orderIndex={1}
-        orderKey="«r6o»"
-      >
-        <ExternalKeyboardView
-          canBeFocused={true}
-          enableA11yFocus={false}
-          enableContextMenu={true}
-          group={false}
-          haloEffect={true}
-          hasKeyDownPress={false}
-          hasKeyUpPress={true}
-          hasOnFocusChanged={true}
-          lockFocus={0}
-          onContextMenuPress={[Function]}
-          onFocusChange={[Function]}
-          onKeyUpPress={[Function]}
-          orderIndex={-1}
-          screenAutoA11yFocusDelay={300}
-          style={
-            [
-              undefined,
-              undefined,
-            ]
-          }
-        >
-          <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": undefined,
-                "borderRadius": undefined,
-                "margin": undefined,
-                "marginBottom": undefined,
-                "marginEnd": undefined,
-                "marginHorizontal": undefined,
-                "marginLeft": undefined,
-                "marginRight": undefined,
-                "marginStart": undefined,
-                "marginTop": undefined,
-                "marginVertical": undefined,
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              style={{}}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexDirection": "column",
-                      "gap": 8,
-                      "paddingHorizontal": 12,
-                      "paddingVertical": 4,
-                      "width": "100%",
-                    },
-                    {
-                      "marginTop": 4,
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityLabel="diego.mello 10:00:00 AM  thread message Cool!.  "
-                  accessible={true}
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                      {},
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 36,
-                      }
-                    }
-                  >
-                    <View
-                      accessible={true}
-                      style={
-                        [
-                          {
-                            "borderRadius": 4,
-                            "height": 20,
-                            "width": 20,
-                          },
-                          undefined,
-                        ]
-                      }
-                      testID="avatar"
-                    >
-                      <ExternalKeyboardView
-                        canBeFocused={true}
-                        enableA11yFocus={false}
-                        enableContextMenu={false}
-                        group={false}
-                        haloEffect={true}
-                        hasKeyDownPress={false}
-                        hasKeyUpPress={true}
-                        hasOnFocusChanged={true}
-                        lockFocus={0}
-                        onContextMenuPress={[Function]}
-                        onFocusChange={[Function]}
-                        onKeyUpPress={[Function]}
-                        orderIndex={-1}
-                        screenAutoA11yFocusDelay={300}
-                        style={
-                          [
-                            undefined,
-                            undefined,
-                          ]
-                        }
-                      >
-                        <RNGestureHandlerButton
-                          activeOpacity={1}
-                          collapsable={false}
-                          delayLongPress={600}
-                          enabled={true}
-                          handlerTag={-1}
-                          handlerType="NativeViewGestureHandler"
-                          innerRef={null}
-                          onActiveStateChange={[Function]}
-                          onGestureHandlerEvent={[Function]}
-                          onGestureHandlerStateChange={[Function]}
-                          onPress={[Function]}
-                          rippleColor="#E4E7EA"
-                          style={
-                            [
-                              {
-                                "backgroundColor": undefined,
-                                "borderRadius": undefined,
-                                "margin": undefined,
-                                "marginBottom": undefined,
-                                "marginEnd": undefined,
-                                "marginHorizontal": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginStart": undefined,
-                                "marginTop": undefined,
-                                "marginVertical": undefined,
-                              },
-                              {
-                                "cursor": undefined,
-                              },
-                            ]
-                          }
-                          underlayColor="#E4E7EA"
-                        >
-                          <View
-                            collapsable={false}
-                            style={
-                              {
-                                "backgroundColor": "#E4E7EA",
-                                "borderBottomLeftRadius": undefined,
-                                "borderBottomRightRadius": undefined,
-                                "borderRadius": undefined,
-                                "borderTopLeftRadius": undefined,
-                                "borderTopRightRadius": undefined,
-                                "bottom": 0,
-                                "left": 0,
-                                "opacity": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                          />
-                          <View
-                            accessibilityLabel="diego.mello's avatar"
-                            accessible={true}
-                            style={{}}
-                          >
-                            <ViewManagerAdapter_ExpoImage
-                              borderRadius={4}
-                              containerViewRef={{"current":"Object"}}
-                              contentFit="cover"
-                              contentPosition={
-                                {
-                                  "left": "50%",
-                                  "top": "50%",
-                                }
-                              }
-                              height={20}
-                              nativeViewRef={{"current":"NativeComponent"}}
-                              onError={[Function]}
-                              onLoad={[Function]}
-                              onLoadStart={[Function]}
-                              onProgress={[Function]}
-                              placeholder={[]}
-                              priority="high"
-                              source={
-                                [
-                                  {
-                                    "headers": {
-                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
-                                    },
-                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
-                                  },
-                                ]
-                              }
-                              style={
-                                {
-                                  "borderRadius": 4,
-                                  "height": 20,
-                                  "width": 20,
-                                }
-                              }
-                              transition={null}
-                              width={20}
-                            />
-                          </View>
-                        </RNGestureHandlerButton>
-                      </ExternalKeyboardView>
-                    </View>
-                  </View>
-                  <A11yIndexView
-                    accessibilityLabel="Cool!"
-                    importantForAccessibility="yes"
-                    orderFocusType={0}
-                    orderIndex={2}
-                    orderKey="«r6o»"
-                    style={
-                      {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                          "marginLeft": 10,
-                        }
-                      }
-                    >
-                      <View
-                        testID="message-content-Cool!"
-                      >
-                        <Text
-                          accessibilityLabel="Cool!"
-                          numberOfLines={1}
-                          style={
-                            [
-                              {
-                                "backgroundColor": "transparent",
-                                "fontFamily": "Inter",
-                                "fontSize": 16,
-                                "fontWeight": "400",
-                                "lineHeight": 22,
-                                "textAlign": "left",
-                              },
-                              {
-                                "color": "#2F343D",
-                                "lineHeight": undefined,
-                              },
-                            ]
-                          }
-                          testID="message-preview-Cool!"
-                        >
-                          Cool!
-                        </Text>
-                      </View>
-                    </View>
-                  </A11yIndexView>
-                </View>
-              </View>
-            </View>
-          </View>
-        </ExternalKeyboardView>
-      </A11yIndexView>
-    </A11yOrderView>
-    <A11yOrderView
-      orderKey="«r6p»"
-    >
-      <A11yIndexView
-        importantForAccessibility="yes"
-        orderFocusType={0}
-        orderIndex={1}
-        orderKey="«r6p»"
-      >
-        <ExternalKeyboardView
-          canBeFocused={true}
-          enableA11yFocus={false}
-          enableContextMenu={true}
-          group={false}
-          haloEffect={true}
-          hasKeyDownPress={false}
-          hasKeyUpPress={true}
-          hasOnFocusChanged={true}
-          lockFocus={0}
-          onContextMenuPress={[Function]}
-          onFocusChange={[Function]}
-          onKeyUpPress={[Function]}
-          orderIndex={-1}
-          screenAutoA11yFocusDelay={300}
-          style={
-            [
-              undefined,
-              undefined,
-            ]
-          }
-        >
-          <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": undefined,
-                "borderRadius": undefined,
-                "margin": undefined,
-                "marginBottom": undefined,
-                "marginEnd": undefined,
-                "marginHorizontal": undefined,
-                "marginLeft": undefined,
-                "marginRight": undefined,
-                "marginStart": undefined,
-                "marginTop": undefined,
-                "marginVertical": undefined,
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              style={{}}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexDirection": "column",
-                      "gap": 8,
-                      "paddingHorizontal": 12,
-                      "paddingVertical": 4,
-                      "width": "100%",
-                    },
-                    {
-                      "marginTop": 4,
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityLabel="diego.mello 10:00:00 AM  thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
-                  accessible={true}
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                      {},
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 36,
-                      }
-                    }
-                  >
-                    <View
-                      accessible={true}
-                      style={
-                        [
-                          {
-                            "borderRadius": 4,
-                            "height": 20,
-                            "width": 20,
-                          },
-                          undefined,
-                        ]
-                      }
-                      testID="avatar"
-                    >
-                      <ExternalKeyboardView
-                        canBeFocused={true}
-                        enableA11yFocus={false}
-                        enableContextMenu={false}
-                        group={false}
-                        haloEffect={true}
-                        hasKeyDownPress={false}
-                        hasKeyUpPress={true}
-                        hasOnFocusChanged={true}
-                        lockFocus={0}
-                        onContextMenuPress={[Function]}
-                        onFocusChange={[Function]}
-                        onKeyUpPress={[Function]}
-                        orderIndex={-1}
-                        screenAutoA11yFocusDelay={300}
-                        style={
-                          [
-                            undefined,
-                            undefined,
-                          ]
-                        }
-                      >
-                        <RNGestureHandlerButton
-                          activeOpacity={1}
-                          collapsable={false}
-                          delayLongPress={600}
-                          enabled={true}
-                          handlerTag={-1}
-                          handlerType="NativeViewGestureHandler"
-                          innerRef={null}
-                          onActiveStateChange={[Function]}
-                          onGestureHandlerEvent={[Function]}
-                          onGestureHandlerStateChange={[Function]}
-                          onPress={[Function]}
-                          rippleColor="#E4E7EA"
-                          style={
-                            [
-                              {
-                                "backgroundColor": undefined,
-                                "borderRadius": undefined,
-                                "margin": undefined,
-                                "marginBottom": undefined,
-                                "marginEnd": undefined,
-                                "marginHorizontal": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginStart": undefined,
-                                "marginTop": undefined,
-                                "marginVertical": undefined,
-                              },
-                              {
-                                "cursor": undefined,
-                              },
-                            ]
-                          }
-                          underlayColor="#E4E7EA"
-                        >
-                          <View
-                            collapsable={false}
-                            style={
-                              {
-                                "backgroundColor": "#E4E7EA",
-                                "borderBottomLeftRadius": undefined,
-                                "borderBottomRightRadius": undefined,
-                                "borderRadius": undefined,
-                                "borderTopLeftRadius": undefined,
-                                "borderTopRightRadius": undefined,
-                                "bottom": 0,
-                                "left": 0,
-                                "opacity": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                          />
-                          <View
-                            accessibilityLabel="diego.mello's avatar"
-                            accessible={true}
-                            style={{}}
-                          >
-                            <ViewManagerAdapter_ExpoImage
-                              borderRadius={4}
-                              containerViewRef={{"current":"Object"}}
-                              contentFit="cover"
-                              contentPosition={
-                                {
-                                  "left": "50%",
-                                  "top": "50%",
-                                }
-                              }
-                              height={20}
-                              nativeViewRef={{"current":"NativeComponent"}}
-                              onError={[Function]}
-                              onLoad={[Function]}
-                              onLoadStart={[Function]}
-                              onProgress={[Function]}
-                              placeholder={[]}
-                              priority="high"
-                              source={
-                                [
-                                  {
-                                    "headers": {
-                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
-                                    },
-                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
-                                  },
-                                ]
-                              }
-                              style={
-                                {
-                                  "borderRadius": 4,
-                                  "height": 20,
-                                  "width": 20,
-                                }
-                              }
-                              transition={null}
-                              width={20}
-                            />
-                          </View>
-                        </RNGestureHandlerButton>
-                      </ExternalKeyboardView>
-                    </View>
-                  </View>
-                  <A11yIndexView
-                    accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                    importantForAccessibility="yes"
-                    orderFocusType={0}
-                    orderIndex={2}
-                    orderKey="«r6p»"
-                    style={
-                      {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                          "marginLeft": 10,
-                        }
-                      }
-                    >
-                      <View
-                        testID="message-content-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                      >
-                        <Text
-                          accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                          numberOfLines={1}
-                          style={
-                            [
-                              {
-                                "backgroundColor": "transparent",
-                                "fontFamily": "Inter",
-                                "fontSize": 16,
-                                "fontWeight": "400",
-                                "lineHeight": 22,
-                                "textAlign": "left",
-                              },
-                              {
-                                "color": "#2F343D",
-                                "lineHeight": undefined,
-                              },
-                            ]
-                          }
-                          testID="message-preview-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-                        >
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                        </Text>
-                      </View>
-                    </View>
-                  </A11yIndexView>
-                </View>
-              </View>
-            </View>
-          </View>
-        </ExternalKeyboardView>
-      </A11yIndexView>
-    </A11yOrderView>
-    <A11yOrderView
-      orderKey="«r6q»"
-    >
-      <A11yIndexView
-        importantForAccessibility="yes"
-        orderFocusType={0}
-        orderIndex={1}
-        orderKey="«r6q»"
-      >
-        <ExternalKeyboardView
-          canBeFocused={true}
-          enableA11yFocus={false}
-          enableContextMenu={true}
-          group={false}
-          haloEffect={true}
-          hasKeyDownPress={false}
-          hasKeyUpPress={true}
-          hasOnFocusChanged={true}
-          lockFocus={0}
-          onContextMenuPress={[Function]}
-          onFocusChange={[Function]}
-          onKeyUpPress={[Function]}
-          orderIndex={-1}
-          screenAutoA11yFocusDelay={300}
-          style={
-            [
-              undefined,
-              undefined,
-            ]
-          }
-        >
-          <View
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": false,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            accessibilityValue={
-              {
-                "max": undefined,
-                "min": undefined,
-                "now": undefined,
-                "text": undefined,
-              }
-            }
-            accessible={true}
-            collapsable={false}
-            focusable={true}
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            style={
-              {
-                "backgroundColor": undefined,
-                "borderRadius": undefined,
-                "margin": undefined,
-                "marginBottom": undefined,
-                "marginEnd": undefined,
-                "marginHorizontal": undefined,
-                "marginLeft": undefined,
-                "marginRight": undefined,
-                "marginStart": undefined,
-                "marginTop": undefined,
-                "marginVertical": undefined,
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              style={{}}
-            >
-              <View
-                style={
-                  [
-                    {
-                      "flexDirection": "column",
-                      "gap": 8,
-                      "paddingHorizontal": 12,
-                      "paddingVertical": 4,
-                      "width": "100%",
-                    },
-                    {
-                      "marginTop": 4,
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessibilityLabel="diego.mello 10:00:00 AM  thread message undefined.  "
-                  accessible={true}
-                  style={
-                    [
-                      {
-                        "flexDirection": "row",
-                      },
-                      {},
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 36,
-                      }
-                    }
-                  >
-                    <View
-                      accessible={true}
-                      style={
-                        [
-                          {
-                            "borderRadius": 4,
-                            "height": 20,
-                            "width": 20,
-                          },
-                          undefined,
-                        ]
-                      }
-                      testID="avatar"
-                    >
-                      <ExternalKeyboardView
-                        canBeFocused={true}
-                        enableA11yFocus={false}
-                        enableContextMenu={false}
-                        group={false}
-                        haloEffect={true}
-                        hasKeyDownPress={false}
-                        hasKeyUpPress={true}
-                        hasOnFocusChanged={true}
-                        lockFocus={0}
-                        onContextMenuPress={[Function]}
-                        onFocusChange={[Function]}
-                        onKeyUpPress={[Function]}
-                        orderIndex={-1}
-                        screenAutoA11yFocusDelay={300}
-                        style={
-                          [
-                            undefined,
-                            undefined,
-                          ]
-                        }
-                      >
-                        <RNGestureHandlerButton
-                          activeOpacity={1}
-                          collapsable={false}
-                          delayLongPress={600}
-                          enabled={true}
-                          handlerTag={-1}
-                          handlerType="NativeViewGestureHandler"
-                          innerRef={null}
-                          onActiveStateChange={[Function]}
-                          onGestureHandlerEvent={[Function]}
-                          onGestureHandlerStateChange={[Function]}
-                          onPress={[Function]}
-                          rippleColor="#E4E7EA"
-                          style={
-                            [
-                              {
-                                "backgroundColor": undefined,
-                                "borderRadius": undefined,
-                                "margin": undefined,
-                                "marginBottom": undefined,
-                                "marginEnd": undefined,
-                                "marginHorizontal": undefined,
-                                "marginLeft": undefined,
-                                "marginRight": undefined,
-                                "marginStart": undefined,
-                                "marginTop": undefined,
-                                "marginVertical": undefined,
-                              },
-                              {
-                                "cursor": undefined,
-                              },
-                            ]
-                          }
-                          underlayColor="#E4E7EA"
-                        >
-                          <View
-                            collapsable={false}
-                            style={
-                              {
-                                "backgroundColor": "#E4E7EA",
-                                "borderBottomLeftRadius": undefined,
-                                "borderBottomRightRadius": undefined,
-                                "borderRadius": undefined,
-                                "borderTopLeftRadius": undefined,
-                                "borderTopRightRadius": undefined,
-                                "bottom": 0,
-                                "left": 0,
-                                "opacity": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              }
-                            }
-                          />
-                          <View
-                            accessibilityLabel="diego.mello's avatar"
-                            accessible={true}
-                            style={{}}
-                          >
-                            <ViewManagerAdapter_ExpoImage
-                              borderRadius={4}
-                              containerViewRef={{"current":"Object"}}
-                              contentFit="cover"
-                              contentPosition={
-                                {
-                                  "left": "50%",
-                                  "top": "50%",
-                                }
-                              }
-                              height={20}
-                              nativeViewRef={{"current":"NativeComponent"}}
-                              onError={[Function]}
-                              onLoad={[Function]}
-                              onLoadStart={[Function]}
-                              onProgress={[Function]}
-                              placeholder={[]}
-                              priority="high"
-                              source={
-                                [
-                                  {
-                                    "headers": {
-                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
-                                    },
-                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
-                                  },
-                                ]
-                              }
-                              style={
-                                {
-                                  "borderRadius": 4,
-                                  "height": 20,
-                                  "width": 20,
-                                }
-                              }
-                              transition={null}
-                              width={20}
-                            />
-                          </View>
-                        </RNGestureHandlerButton>
-                      </ExternalKeyboardView>
-                    </View>
-                  </View>
-                  <A11yIndexView
-                    accessibilityLabel=""
-                    importantForAccessibility="yes"
-                    orderFocusType={0}
-                    orderIndex={2}
                     orderKey="«r6q»"
                     style={
                       {
@@ -115994,8 +116662,32 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should ma
                       }
                     >
                       <View
-                        testID="message-content-"
-                      />
+                        testID="message-content-I'm fine!"
+                      >
+                        <Text
+                          accessibilityLabel="I'm fine!"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-I'm fine!"
+                        >
+                          I'm fine!
+                        </Text>
+                      </View>
                     </View>
                   </A11yIndexView>
                 </View>
@@ -116005,19 +116697,6 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should ma
         </ExternalKeyboardView>
       </A11yIndexView>
     </A11yOrderView>
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont should match snapshot 1`] = `
-<RCTScrollView
-  style={
-    {
-      "backgroundColor": "#FFFFFF",
-    }
-  }
->
-  <View>
     <A11yOrderView
       orderKey="«r6r»"
     >
@@ -116114,124 +116793,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                 }
               >
                 <View
-                  style={
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                      "gap": 10,
-                    }
-                  }
-                  testID="message-thread-replied-on-How are you?"
-                >
-                  <View
-                    style={
-                      {
-                        "alignItems": "flex-end",
-                        "width": 46.800000000000004,
-                      }
-                    }
-                  >
-                    <Text
-                      allowFontScaling={false}
-                      selectable={false}
-                      style={
-                        [
-                          {
-                            "color": "#095AD2",
-                            "fontSize": 26,
-                          },
-                          [
-                            {
-                              "lineHeight": 26,
-                            },
-                            undefined,
-                          ],
-                          {
-                            "fontFamily": "custom",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          {},
-                        ]
-                      }
-                    >
-                      
-                    </Text>
-                  </View>
-                  <Text
-                    accessibilityLabel="How are you?"
-                    numberOfLines={1}
-                    style={
-                      [
-                        {
-                          "backgroundColor": "transparent",
-                          "fontFamily": "Inter",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                          "lineHeight": 22,
-                          "textAlign": "left",
-                        },
-                        {
-                          "color": "#2F343D",
-                          "lineHeight": undefined,
-                        },
-                        {
-                          "backgroundColor": "transparent",
-                          "flex": 1,
-                          "fontFamily": "Inter",
-                          "fontSize": 16,
-                          "fontWeight": "400",
-                          "textAlign": "left",
-                        },
-                        {
-                          "color": "#095AD2",
-                        },
-                      ]
-                    }
-                    testID="markdown-preview-How are you?"
-                  >
-                    How are you?
-                  </Text>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "justifyContent": "center",
-                        "marginLeft": 4,
-                        "marginRight": 4,
-                      }
-                    }
-                  >
-                    <Text
-                      allowFontScaling={false}
-                      selectable={false}
-                      style={
-                        [
-                          {
-                            "color": "#6C727A",
-                            "fontSize": 26,
-                          },
-                          [
-                            {
-                              "lineHeight": 26,
-                            },
-                            undefined,
-                          ],
-                          {
-                            "fontFamily": "custom",
-                            "fontStyle": "normal",
-                            "fontWeight": "normal",
-                          },
-                          {},
-                        ]
-                      }
-                    >
-                      
-                    </Text>
-                  </View>
-                </View>
-                <View
-                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message I'm fine!.  "
+                  accessibilityLabel="diego.mello 10:00:00 AM  thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
                   accessible={true}
                   style={
                     [
@@ -116389,7 +116951,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                     </View>
                   </View>
                   <A11yIndexView
-                    accessibilityLabel="I'm fine!"
+                    accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
@@ -116409,10 +116971,10 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                       }
                     >
                       <View
-                        testID="message-content-I'm fine!"
+                        testID="message-content-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
                       >
                         <Text
-                          accessibilityLabel="I'm fine!"
+                          accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
                           numberOfLines={1}
                           style={
                             [
@@ -116430,9 +116992,9 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                               },
                             ]
                           }
-                          testID="message-preview-I'm fine!"
+                          testID="message-preview-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
                         >
-                          I'm fine!
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
                         </Text>
                       </View>
                     </View>
@@ -116540,6 +117102,2120 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                 }
               >
                 <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 26,
+                            "width": 26,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={26}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=52",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 26,
+                                  "width": 26,
+                                }
+                              }
+                              transition={null}
+                              width={26}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r6s»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="This is a description"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-This is a description"
+                        >
+                          This is a description
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReply should match snapshot 1`] = `
+<RCTScrollView
+  style={
+    {
+      "backgroundColor": "#FFFFFF",
+    }
+  }
+>
+  <View>
+    <A11yOrderView
+      orderKey="«r6t»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r6t»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-How are you?"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="How are you?"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-How are you?"
+                  >
+                    How are you?
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 20,
+                          },
+                          [
+                            {
+                              "lineHeight": 20,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message I'm fine!.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 20,
+                            "width": 20,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={20}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 20,
+                                  "width": 20,
+                                }
+                              }
+                              transition={null}
+                              width={20}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel="I'm fine!"
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r6t»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-I'm fine!"
+                      >
+                        <Text
+                          accessibilityLabel="I'm fine!"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-I'm fine!"
+                        >
+                          I'm fine!
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r6u»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r6u»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  thread message Cool!.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 20,
+                            "width": 20,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={20}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 20,
+                                  "width": 20,
+                                }
+                              }
+                              transition={null}
+                              width={20}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel="Cool!"
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r6u»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-Cool!"
+                      >
+                        <Text
+                          accessibilityLabel="Cool!"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-Cool!"
+                        >
+                          Cool!
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r6v»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r6v»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  thread message Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua..  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 20,
+                            "width": 20,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={20}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 20,
+                                  "width": 20,
+                                }
+                              }
+                              transition={null}
+                              width={20}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r6v»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                      >
+                        <Text
+                          accessibilityLabel="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                        >
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r70»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r70»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  thread message undefined.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 36,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 20,
+                            "width": 20,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={20}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=40",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 20,
+                                  "width": 20,
+                                }
+                              }
+                              transition={null}
+                              width={20}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel=""
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r70»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-"
+                      >
+                        <Text
+                          accessibilityLabel="This is a description"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-This is a description"
+                        >
+                          This is a description
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont should match snapshot 1`] = `
+<RCTScrollView
+  style={
+    {
+      "backgroundColor": "#FFFFFF",
+    }
+  }
+>
+  <View>
+    <A11yOrderView
+      orderKey="«r71»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r71»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 10,
+                    }
+                  }
+                  testID="message-thread-replied-on-How are you?"
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#095AD2",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    accessibilityLabel="How are you?"
+                    numberOfLines={1}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "lineHeight": 22,
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#2F343D",
+                          "lineHeight": undefined,
+                        },
+                        {
+                          "backgroundColor": "transparent",
+                          "flex": 1,
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "400",
+                          "textAlign": "left",
+                        },
+                        {
+                          "color": "#095AD2",
+                        },
+                      ]
+                    }
+                    testID="markdown-preview-How are you?"
+                  >
+                    How are you?
+                  </Text>
+                  <View
+                    style={
+                      {
+                        "alignItems": "center",
+                        "justifyContent": "center",
+                        "marginLeft": 4,
+                        "marginRight": 4,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      selectable={false}
+                      style={
+                        [
+                          {
+                            "color": "#6C727A",
+                            "fontSize": 26,
+                          },
+                          [
+                            {
+                              "lineHeight": 26,
+                            },
+                            undefined,
+                          ],
+                          {
+                            "fontFamily": "custom",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                </View>
+                <View
+                  accessibilityLabel="diego.mello 10:00:00 AM  replying to thread message I'm fine!.  "
+                  accessible={true}
+                  style={
+                    [
+                      {
+                        "flexDirection": "row",
+                      },
+                      {},
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "alignItems": "flex-end",
+                        "width": 46.800000000000004,
+                      }
+                    }
+                  >
+                    <View
+                      accessible={true}
+                      style={
+                        [
+                          {
+                            "borderRadius": 4,
+                            "height": 26,
+                            "width": 26,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="avatar"
+                    >
+                      <ExternalKeyboardView
+                        canBeFocused={true}
+                        enableA11yFocus={false}
+                        enableContextMenu={false}
+                        group={false}
+                        haloEffect={true}
+                        hasKeyDownPress={false}
+                        hasKeyUpPress={true}
+                        hasOnFocusChanged={true}
+                        lockFocus={0}
+                        onContextMenuPress={[Function]}
+                        onFocusChange={[Function]}
+                        onKeyUpPress={[Function]}
+                        orderIndex={-1}
+                        screenAutoA11yFocusDelay={300}
+                        style={
+                          [
+                            undefined,
+                            undefined,
+                          ]
+                        }
+                      >
+                        <RNGestureHandlerButton
+                          activeOpacity={1}
+                          collapsable={false}
+                          delayLongPress={600}
+                          enabled={true}
+                          handlerTag={-1}
+                          handlerType="NativeViewGestureHandler"
+                          innerRef={null}
+                          onActiveStateChange={[Function]}
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          onPress={[Function]}
+                          rippleColor="#E4E7EA"
+                          style={
+                            [
+                              {
+                                "backgroundColor": undefined,
+                                "borderRadius": undefined,
+                                "margin": undefined,
+                                "marginBottom": undefined,
+                                "marginEnd": undefined,
+                                "marginHorizontal": undefined,
+                                "marginLeft": undefined,
+                                "marginRight": undefined,
+                                "marginStart": undefined,
+                                "marginTop": undefined,
+                                "marginVertical": undefined,
+                              },
+                              {
+                                "cursor": undefined,
+                              },
+                            ]
+                          }
+                          underlayColor="#E4E7EA"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "backgroundColor": "#E4E7EA",
+                                "borderBottomLeftRadius": undefined,
+                                "borderBottomRightRadius": undefined,
+                                "borderRadius": undefined,
+                                "borderTopLeftRadius": undefined,
+                                "borderTopRightRadius": undefined,
+                                "bottom": 0,
+                                "left": 0,
+                                "opacity": 0,
+                                "position": "absolute",
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                          />
+                          <View
+                            accessibilityLabel="diego.mello's avatar"
+                            accessible={true}
+                            style={{}}
+                          >
+                            <ViewManagerAdapter_ExpoImage
+                              borderRadius={4}
+                              containerViewRef={{"current":"Object"}}
+                              contentFit="cover"
+                              contentPosition={
+                                {
+                                  "left": "50%",
+                                  "top": "50%",
+                                }
+                              }
+                              height={26}
+                              nativeViewRef={{"current":"NativeComponent"}}
+                              onError={[Function]}
+                              onLoad={[Function]}
+                              onLoadStart={[Function]}
+                              onProgress={[Function]}
+                              placeholder={[]}
+                              priority="high"
+                              source={
+                                [
+                                  {
+                                    "headers": {
+                                      "User-Agent": "RC Mobile; ios unknown; vunknown (unknown)",
+                                    },
+                                    "uri": "https://open.rocket.chat/avatar/diego.mello?format=png&size=52",
+                                  },
+                                ]
+                              }
+                              style={
+                                {
+                                  "borderRadius": 4,
+                                  "height": 26,
+                                  "width": 26,
+                                }
+                              }
+                              transition={null}
+                              width={26}
+                            />
+                          </View>
+                        </RNGestureHandlerButton>
+                      </ExternalKeyboardView>
+                    </View>
+                  </View>
+                  <A11yIndexView
+                    accessibilityLabel="I'm fine!"
+                    importantForAccessibility="yes"
+                    orderFocusType={0}
+                    orderIndex={2}
+                    orderKey="«r71»"
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                          "marginLeft": 10,
+                        }
+                      }
+                    >
+                      <View
+                        testID="message-content-I'm fine!"
+                      >
+                        <Text
+                          accessibilityLabel="I'm fine!"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-I'm fine!"
+                        >
+                          I'm fine!
+                        </Text>
+                      </View>
+                    </View>
+                  </A11yIndexView>
+                </View>
+              </View>
+            </View>
+          </View>
+        </ExternalKeyboardView>
+      </A11yIndexView>
+    </A11yOrderView>
+    <A11yOrderView
+      orderKey="«r72»"
+    >
+      <A11yIndexView
+        importantForAccessibility="yes"
+        orderFocusType={0}
+        orderIndex={1}
+        orderKey="«r72»"
+      >
+        <ExternalKeyboardView
+          canBeFocused={true}
+          enableA11yFocus={false}
+          enableContextMenu={true}
+          group={false}
+          haloEffect={true}
+          hasKeyDownPress={false}
+          hasKeyUpPress={true}
+          hasOnFocusChanged={true}
+          lockFocus={0}
+          onContextMenuPress={[Function]}
+          onFocusChange={[Function]}
+          onKeyUpPress={[Function]}
+          orderIndex={-1}
+          screenAutoA11yFocusDelay={300}
+          style={
+            [
+              undefined,
+              undefined,
+            ]
+          }
+        >
+          <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginEnd": undefined,
+                "marginHorizontal": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginStart": undefined,
+                "marginTop": undefined,
+                "marginVertical": undefined,
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={{}}
+            >
+              <View
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                      "gap": 8,
+                      "paddingHorizontal": 12,
+                      "paddingVertical": 4,
+                      "width": "100%",
+                    },
+                    {
+                      "marginTop": 4,
+                    },
+                  ]
+                }
+              >
+                <View
                   accessibilityLabel="diego.mello 10:00:00 AM  thread message Cool!.  "
                   accessible={true}
                   style={
@@ -116702,7 +119378,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r6s»"
+                    orderKey="«r72»"
                     style={
                       {
                         "flex": 1,
@@ -116754,13 +119430,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6t»"
+      orderKey="«r73»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6t»"
+        orderKey="«r73»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -117011,7 +119687,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r6t»"
+                    orderKey="«r73»"
                     style={
                       {
                         "flex": 1,
@@ -117063,13 +119739,13 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r6u»"
+      orderKey="«r74»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6u»"
+        orderKey="«r74»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -117320,7 +119996,7 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                     importantForAccessibility="yes"
                     orderFocusType={0}
                     orderIndex={2}
-                    orderKey="«r6u»"
+                    orderKey="«r74»"
                     style={
                       {
                         "flex": 1,
@@ -117337,7 +120013,31 @@ exports[`Story Snapshots: SequentialThreadMessagesFollowingThreadReplyLargeFont 
                     >
                       <View
                         testID="message-content-"
-                      />
+                      >
+                        <Text
+                          accessibilityLabel="This is a description"
+                          numberOfLines={1}
+                          style={
+                            [
+                              {
+                                "backgroundColor": "transparent",
+                                "fontFamily": "Inter",
+                                "fontSize": 16,
+                                "fontWeight": "400",
+                                "lineHeight": 22,
+                                "textAlign": "left",
+                              },
+                              {
+                                "color": "#2F343D",
+                                "lineHeight": undefined,
+                              },
+                            ]
+                          }
+                          testID="message-preview-This is a description"
+                        >
+                          This is a description
+                        </Text>
+                      </View>
                     </View>
                   </A11yIndexView>
                 </View>
@@ -117361,13 +120061,13 @@ exports[`Story Snapshots: ShowButtonAsAttachment should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r6v»"
+      orderKey="«r75»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r6v»"
+        orderKey="«r75»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -117458,7 +120158,7 @@ exports[`Story Snapshots: ShowButtonAsAttachment should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r6v»"
+                  orderKey="«r75»"
                 >
                   <View
                     accessible={true}
@@ -117884,13 +120584,13 @@ exports[`Story Snapshots: ShowButtonAsAttachment should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r70»"
+      orderKey="«r76»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r70»"
+        orderKey="«r76»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -117981,7 +120681,7 @@ exports[`Story Snapshots: ShowButtonAsAttachment should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r70»"
+                  orderKey="«r76»"
                 >
                   <View
                     accessible={true}
@@ -118585,13 +121285,13 @@ exports[`Story Snapshots: ShowButtonAsAttachmentLargeFont should match snapshot 
 >
   <View>
     <A11yOrderView
-      orderKey="«r71»"
+      orderKey="«r77»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r71»"
+        orderKey="«r77»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -118682,7 +121382,7 @@ exports[`Story Snapshots: ShowButtonAsAttachmentLargeFont should match snapshot 
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r71»"
+                  orderKey="«r77»"
                 >
                   <View
                     accessible={true}
@@ -119108,13 +121808,13 @@ exports[`Story Snapshots: ShowButtonAsAttachmentLargeFont should match snapshot 
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r72»"
+      orderKey="«r78»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r72»"
+        orderKey="«r78»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -119205,7 +121905,7 @@ exports[`Story Snapshots: ShowButtonAsAttachmentLargeFont should match snapshot 
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r72»"
+                  orderKey="«r78»"
                 >
                   <View
                     accessible={true}
@@ -119809,13 +122509,13 @@ exports[`Story Snapshots: StaticAvatar should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r73»"
+      orderKey="«r79»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r73»"
+        orderKey="«r79»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -119906,7 +122606,7 @@ exports[`Story Snapshots: StaticAvatar should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r73»"
+                  orderKey="«r79»"
                 >
                   <View
                     accessible={true}
@@ -120271,13 +122971,13 @@ exports[`Story Snapshots: StaticAvatarLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r74»"
+      orderKey="«r7a»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r74»"
+        orderKey="«r7a»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -120368,7 +123068,7 @@ exports[`Story Snapshots: StaticAvatarLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r74»"
+                  orderKey="«r7a»"
                 >
                   <View
                     accessible={true}
@@ -120733,7 +123433,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r75»"
+      orderKey="«r7b»"
     >
       <View
         style={
@@ -120916,7 +123616,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r75»"
+            orderKey="«r7b»"
             style={
               {
                 "flex": 1,
@@ -120978,7 +123678,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r76»"
+      orderKey="«r7c»"
     >
       <View
         style={
@@ -121161,7 +123861,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r76»"
+            orderKey="«r7c»"
             style={
               {
                 "flex": 1,
@@ -121223,7 +123923,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r77»"
+      orderKey="«r7d»"
     >
       <View
         style={
@@ -121406,7 +124106,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r77»"
+            orderKey="«r7d»"
             style={
               {
                 "flex": 1,
@@ -121471,7 +124171,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r78»"
+      orderKey="«r7e»"
     >
       <View
         style={
@@ -121654,7 +124354,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r78»"
+            orderKey="«r7e»"
             style={
               {
                 "flex": 1,
@@ -121716,7 +124416,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r79»"
+      orderKey="«r7f»"
     >
       <View
         style={
@@ -121899,7 +124599,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r79»"
+            orderKey="«r7f»"
             style={
               {
                 "flex": 1,
@@ -121961,7 +124661,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7a»"
+      orderKey="«r7g»"
     >
       <View
         style={
@@ -122144,7 +124844,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7a»"
+            orderKey="«r7g»"
             style={
               {
                 "flex": 1,
@@ -122206,7 +124906,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7b»"
+      orderKey="«r7h»"
     >
       <View
         style={
@@ -122389,7 +125089,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7b»"
+            orderKey="«r7h»"
             style={
               {
                 "flex": 1,
@@ -122451,7 +125151,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7c»"
+      orderKey="«r7i»"
     >
       <View
         style={
@@ -122634,7 +125334,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7c»"
+            orderKey="«r7i»"
             style={
               {
                 "flex": 1,
@@ -122696,7 +125396,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7d»"
+      orderKey="«r7j»"
     >
       <View
         style={
@@ -122879,7 +125579,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7d»"
+            orderKey="«r7j»"
             style={
               {
                 "flex": 1,
@@ -122941,7 +125641,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7e»"
+      orderKey="«r7k»"
     >
       <View
         style={
@@ -123124,7 +125824,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7e»"
+            orderKey="«r7k»"
             style={
               {
                 "flex": 1,
@@ -123186,7 +125886,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7f»"
+      orderKey="«r7l»"
     >
       <View
         style={
@@ -123369,7 +126069,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7f»"
+            orderKey="«r7l»"
             style={
               {
                 "flex": 1,
@@ -123431,7 +126131,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7g»"
+      orderKey="«r7m»"
     >
       <View
         style={
@@ -123614,7 +126314,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7g»"
+            orderKey="«r7m»"
             style={
               {
                 "flex": 1,
@@ -123676,7 +126376,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7h»"
+      orderKey="«r7n»"
     >
       <View
         style={
@@ -123859,7 +126559,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7h»"
+            orderKey="«r7n»"
             style={
               {
                 "flex": 1,
@@ -123921,7 +126621,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7i»"
+      orderKey="«r7o»"
     >
       <View
         style={
@@ -124104,7 +126804,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7i»"
+            orderKey="«r7o»"
             style={
               {
                 "flex": 1,
@@ -124166,7 +126866,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7j»"
+      orderKey="«r7p»"
     >
       <View
         style={
@@ -124349,7 +127049,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7j»"
+            orderKey="«r7p»"
             style={
               {
                 "flex": 1,
@@ -124411,7 +127111,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7k»"
+      orderKey="«r7q»"
     >
       <View
         style={
@@ -124594,7 +127294,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7k»"
+            orderKey="«r7q»"
             style={
               {
                 "flex": 1,
@@ -124656,7 +127356,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7l»"
+      orderKey="«r7r»"
     >
       <View
         style={
@@ -124839,7 +127539,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7l»"
+            orderKey="«r7r»"
             style={
               {
                 "flex": 1,
@@ -124901,7 +127601,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7m»"
+      orderKey="«r7s»"
     >
       <View
         style={
@@ -125084,7 +127784,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7m»"
+            orderKey="«r7s»"
             style={
               {
                 "flex": 1,
@@ -125146,7 +127846,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7n»"
+      orderKey="«r7t»"
     >
       <View
         style={
@@ -125329,7 +128029,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7n»"
+            orderKey="«r7t»"
             style={
               {
                 "flex": 1,
@@ -125391,7 +128091,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7o»"
+      orderKey="«r7u»"
     >
       <View
         style={
@@ -125574,7 +128274,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7o»"
+            orderKey="«r7u»"
             style={
               {
                 "flex": 1,
@@ -125636,7 +128336,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7p»"
+      orderKey="«r7v»"
     >
       <View
         style={
@@ -125819,7 +128519,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7p»"
+            orderKey="«r7v»"
             style={
               {
                 "flex": 1,
@@ -125881,7 +128581,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7q»"
+      orderKey="«r80»"
     >
       <View
         style={
@@ -126064,7 +128764,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7q»"
+            orderKey="«r80»"
             style={
               {
                 "flex": 1,
@@ -126126,7 +128826,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7r»"
+      orderKey="«r81»"
     >
       <View
         style={
@@ -126309,7 +129009,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7r»"
+            orderKey="«r81»"
             style={
               {
                 "flex": 1,
@@ -126371,7 +129071,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7s»"
+      orderKey="«r82»"
     >
       <View
         style={
@@ -126554,7 +129254,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7s»"
+            orderKey="«r82»"
             style={
               {
                 "flex": 1,
@@ -126616,7 +129316,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7t»"
+      orderKey="«r83»"
     >
       <View
         style={
@@ -126799,7 +129499,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7t»"
+            orderKey="«r83»"
             style={
               {
                 "flex": 1,
@@ -126861,7 +129561,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r7u»"
+      orderKey="«r84»"
     >
       <View
         style={
@@ -127044,7 +129744,7 @@ exports[`Story Snapshots: SystemMessages should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7u»"
+            orderKey="«r84»"
             style={
               {
                 "flex": 1,
@@ -127097,7 +129797,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r7v»"
+      orderKey="«r85»"
     >
       <View
         style={
@@ -127280,7 +129980,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r7v»"
+            orderKey="«r85»"
             style={
               {
                 "flex": 1,
@@ -127342,7 +130042,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r80»"
+      orderKey="«r86»"
     >
       <View
         style={
@@ -127525,7 +130225,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r80»"
+            orderKey="«r86»"
             style={
               {
                 "flex": 1,
@@ -127587,7 +130287,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r81»"
+      orderKey="«r87»"
     >
       <View
         style={
@@ -127770,7 +130470,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r81»"
+            orderKey="«r87»"
             style={
               {
                 "flex": 1,
@@ -127835,7 +130535,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r82»"
+      orderKey="«r88»"
     >
       <View
         style={
@@ -128018,7 +130718,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r82»"
+            orderKey="«r88»"
             style={
               {
                 "flex": 1,
@@ -128080,7 +130780,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r83»"
+      orderKey="«r89»"
     >
       <View
         style={
@@ -128263,7 +130963,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r83»"
+            orderKey="«r89»"
             style={
               {
                 "flex": 1,
@@ -128325,7 +131025,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r84»"
+      orderKey="«r8a»"
     >
       <View
         style={
@@ -128508,7 +131208,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r84»"
+            orderKey="«r8a»"
             style={
               {
                 "flex": 1,
@@ -128570,7 +131270,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r85»"
+      orderKey="«r8b»"
     >
       <View
         style={
@@ -128753,7 +131453,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r85»"
+            orderKey="«r8b»"
             style={
               {
                 "flex": 1,
@@ -128815,7 +131515,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r86»"
+      orderKey="«r8c»"
     >
       <View
         style={
@@ -128998,7 +131698,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r86»"
+            orderKey="«r8c»"
             style={
               {
                 "flex": 1,
@@ -129060,7 +131760,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r87»"
+      orderKey="«r8d»"
     >
       <View
         style={
@@ -129243,7 +131943,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r87»"
+            orderKey="«r8d»"
             style={
               {
                 "flex": 1,
@@ -129305,7 +132005,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r88»"
+      orderKey="«r8e»"
     >
       <View
         style={
@@ -129488,7 +132188,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r88»"
+            orderKey="«r8e»"
             style={
               {
                 "flex": 1,
@@ -129550,7 +132250,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r89»"
+      orderKey="«r8f»"
     >
       <View
         style={
@@ -129733,7 +132433,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r89»"
+            orderKey="«r8f»"
             style={
               {
                 "flex": 1,
@@ -129795,7 +132495,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8a»"
+      orderKey="«r8g»"
     >
       <View
         style={
@@ -129978,7 +132678,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8a»"
+            orderKey="«r8g»"
             style={
               {
                 "flex": 1,
@@ -130040,7 +132740,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8b»"
+      orderKey="«r8h»"
     >
       <View
         style={
@@ -130223,7 +132923,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8b»"
+            orderKey="«r8h»"
             style={
               {
                 "flex": 1,
@@ -130285,7 +132985,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8c»"
+      orderKey="«r8i»"
     >
       <View
         style={
@@ -130468,7 +133168,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8c»"
+            orderKey="«r8i»"
             style={
               {
                 "flex": 1,
@@ -130530,7 +133230,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8d»"
+      orderKey="«r8j»"
     >
       <View
         style={
@@ -130713,7 +133413,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8d»"
+            orderKey="«r8j»"
             style={
               {
                 "flex": 1,
@@ -130775,7 +133475,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8e»"
+      orderKey="«r8k»"
     >
       <View
         style={
@@ -130958,7 +133658,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8e»"
+            orderKey="«r8k»"
             style={
               {
                 "flex": 1,
@@ -131020,7 +133720,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8f»"
+      orderKey="«r8l»"
     >
       <View
         style={
@@ -131203,7 +133903,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8f»"
+            orderKey="«r8l»"
             style={
               {
                 "flex": 1,
@@ -131265,7 +133965,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8g»"
+      orderKey="«r8m»"
     >
       <View
         style={
@@ -131448,7 +134148,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8g»"
+            orderKey="«r8m»"
             style={
               {
                 "flex": 1,
@@ -131510,7 +134210,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8h»"
+      orderKey="«r8n»"
     >
       <View
         style={
@@ -131693,7 +134393,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8h»"
+            orderKey="«r8n»"
             style={
               {
                 "flex": 1,
@@ -131755,7 +134455,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8i»"
+      orderKey="«r8o»"
     >
       <View
         style={
@@ -131938,7 +134638,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8i»"
+            orderKey="«r8o»"
             style={
               {
                 "flex": 1,
@@ -132000,7 +134700,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8j»"
+      orderKey="«r8p»"
     >
       <View
         style={
@@ -132183,7 +134883,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8j»"
+            orderKey="«r8p»"
             style={
               {
                 "flex": 1,
@@ -132245,7 +134945,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8k»"
+      orderKey="«r8q»"
     >
       <View
         style={
@@ -132428,7 +135128,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8k»"
+            orderKey="«r8q»"
             style={
               {
                 "flex": 1,
@@ -132490,7 +135190,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8l»"
+      orderKey="«r8r»"
     >
       <View
         style={
@@ -132673,7 +135373,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8l»"
+            orderKey="«r8r»"
             style={
               {
                 "flex": 1,
@@ -132735,7 +135435,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8m»"
+      orderKey="«r8s»"
     >
       <View
         style={
@@ -132918,7 +135618,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8m»"
+            orderKey="«r8s»"
             style={
               {
                 "flex": 1,
@@ -132980,7 +135680,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8n»"
+      orderKey="«r8t»"
     >
       <View
         style={
@@ -133163,7 +135863,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8n»"
+            orderKey="«r8t»"
             style={
               {
                 "flex": 1,
@@ -133225,7 +135925,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r8o»"
+      orderKey="«r8u»"
     >
       <View
         style={
@@ -133408,7 +136108,7 @@ exports[`Story Snapshots: SystemMessagesLargeFont should match snapshot 1`] = `
             importantForAccessibility="yes"
             orderFocusType={0}
             orderIndex={2}
-            orderKey="«r8o»"
+            orderKey="«r8u»"
             style={
               {
                 "flex": 1,
@@ -133461,13 +136161,13 @@ exports[`Story Snapshots: Temp should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r8p»"
+      orderKey="«r8v»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r8p»"
+        orderKey="«r8v»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -133558,7 +136258,7 @@ exports[`Story Snapshots: Temp should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r8p»"
+                  orderKey="«r8v»"
                 >
                   <View
                     accessible={true}
@@ -133928,13 +136628,13 @@ exports[`Story Snapshots: TempLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r8q»"
+      orderKey="«r90»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r8q»"
+        orderKey="«r90»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -134025,7 +136725,7 @@ exports[`Story Snapshots: TempLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r8q»"
+                  orderKey="«r90»"
                 >
                   <View
                     accessible={true}
@@ -134395,13 +137095,13 @@ exports[`Story Snapshots: ThumbnailFromServer should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r8r»"
+      orderKey="«r91»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r8r»"
+        orderKey="«r91»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -134492,7 +137192,7 @@ exports[`Story Snapshots: ThumbnailFromServer should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r8r»"
+                  orderKey="«r91»"
                 >
                   <View
                     accessible={true}
@@ -135068,13 +137768,13 @@ exports[`Story Snapshots: ThumbnailFromServerLargeFont should match snapshot 1`]
 >
   <View>
     <A11yOrderView
-      orderKey="«r8s»"
+      orderKey="«r92»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r8s»"
+        orderKey="«r92»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -135165,7 +137865,7 @@ exports[`Story Snapshots: ThumbnailFromServerLargeFont should match snapshot 1`]
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r8s»"
+                  orderKey="«r92»"
                 >
                   <View
                     accessible={true}
@@ -135741,13 +138441,13 @@ exports[`Story Snapshots: TimeFormat should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r8t»"
+      orderKey="«r93»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r8t»"
+        orderKey="«r93»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -135838,7 +138538,7 @@ exports[`Story Snapshots: TimeFormat should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r8t»"
+                  orderKey="«r93»"
                 >
                   <View
                     accessible={true}
@@ -136203,13 +138903,13 @@ exports[`Story Snapshots: TimeFormatLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r8u»"
+      orderKey="«r94»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r8u»"
+        orderKey="«r94»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -136300,7 +139000,7 @@ exports[`Story Snapshots: TimeFormatLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r8u»"
+                  orderKey="«r94»"
                 >
                   <View
                     accessible={true}
@@ -136665,13 +139365,13 @@ exports[`Story Snapshots: Translated should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r8v»"
+      orderKey="«r95»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r8v»"
+        orderKey="«r95»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -136763,7 +139463,7 @@ exports[`Story Snapshots: Translated should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r8v»"
+                  orderKey="«r95»"
                 >
                   <View
                     accessible={true}
@@ -137163,13 +139863,13 @@ exports[`Story Snapshots: TranslatedLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r90»"
+      orderKey="«r96»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r90»"
+        orderKey="«r96»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -137261,7 +139961,7 @@ exports[`Story Snapshots: TranslatedLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r90»"
+                  orderKey="«r96»"
                 >
                   <View
                     accessible={true}
@@ -137661,13 +140361,13 @@ exports[`Story Snapshots: TwoShortCustomFieldsWithMarkdown should match snapshot
 >
   <View>
     <A11yOrderView
-      orderKey="«r91»"
+      orderKey="«r97»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r91»"
+        orderKey="«r97»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -137758,7 +140458,7 @@ exports[`Story Snapshots: TwoShortCustomFieldsWithMarkdown should match snapshot
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r91»"
+                  orderKey="«r97»"
                 >
                   <View
                     accessible={true}
@@ -138839,13 +141539,13 @@ exports[`Story Snapshots: TwoShortCustomFieldsWithMarkdownLargeFont should match
 >
   <View>
     <A11yOrderView
-      orderKey="«r92»"
+      orderKey="«r98»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r92»"
+        orderKey="«r98»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -138936,7 +141636,7 @@ exports[`Story Snapshots: TwoShortCustomFieldsWithMarkdownLargeFont should match
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r92»"
+                  orderKey="«r98»"
                 >
                   <View
                     accessible={true}
@@ -140017,13 +142717,13 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r93»"
+      orderKey="«r99»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r93»"
+        orderKey="«r99»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -140114,7 +142814,7 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r93»"
+                  orderKey="«r99»"
                 >
                   <View
                     accessible={true}
@@ -140603,13 +143303,13 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r94»"
+      orderKey="«r9a»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r94»"
+        orderKey="«r9a»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -140700,7 +143400,7 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r94»"
+                  orderKey="«r9a»"
                 >
                   <View
                     accessible={true}
@@ -141194,13 +143894,13 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r95»"
+      orderKey="«r9b»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r95»"
+        orderKey="«r9b»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -141291,7 +143991,7 @@ exports[`Story Snapshots: URL should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r95»"
+                  orderKey="«r9b»"
                 >
                   <View
                     accessible={true}
@@ -141462,13 +144162,13 @@ exports[`Story Snapshots: URLImagePreview should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r96»"
+      orderKey="«r9c»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r96»"
+        orderKey="«r9c»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -141559,7 +144259,7 @@ exports[`Story Snapshots: URLImagePreview should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r96»"
+                  orderKey="«r9c»"
                 >
                   <View
                     accessible={true}
@@ -141950,13 +144650,13 @@ exports[`Story Snapshots: URLImagePreview should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r97»"
+      orderKey="«r9d»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r97»"
+        orderKey="«r9d»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -142047,7 +144747,7 @@ exports[`Story Snapshots: URLImagePreview should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r97»"
+                  orderKey="«r9d»"
                 >
                   <View
                     accessible={true}
@@ -142394,13 +145094,13 @@ exports[`Story Snapshots: URLImagePreviewLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r98»"
+      orderKey="«r9e»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r98»"
+        orderKey="«r9e»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -142491,7 +145191,7 @@ exports[`Story Snapshots: URLImagePreviewLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r98»"
+                  orderKey="«r9e»"
                 >
                   <View
                     accessible={true}
@@ -142882,13 +145582,13 @@ exports[`Story Snapshots: URLImagePreviewLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r99»"
+      orderKey="«r9f»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r99»"
+        orderKey="«r9f»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -142979,7 +145679,7 @@ exports[`Story Snapshots: URLImagePreviewLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r99»"
+                  orderKey="«r9f»"
                 >
                   <View
                     accessible={true}
@@ -143326,13 +146026,13 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r9a»"
+      orderKey="«r9g»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9a»"
+        orderKey="«r9g»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -143423,7 +146123,7 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9a»"
+                  orderKey="«r9g»"
                 >
                   <View
                     accessible={true}
@@ -143912,13 +146612,13 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9b»"
+      orderKey="«r9h»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9b»"
+        orderKey="«r9h»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -144009,7 +146709,7 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9b»"
+                  orderKey="«r9h»"
                 >
                   <View
                     accessible={true}
@@ -144503,13 +147203,13 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9c»"
+      orderKey="«r9i»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9c»"
+        orderKey="«r9i»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -144600,7 +147300,7 @@ exports[`Story Snapshots: URLLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9c»"
+                  orderKey="«r9i»"
                 >
                   <View
                     accessible={true}
@@ -144771,13 +147471,13 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r9d»"
+      orderKey="«r9j»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9d»"
+        orderKey="«r9j»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -144868,7 +147568,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9d»"
+                  orderKey="«r9j»"
                 >
                   <View
                     accessible={true}
@@ -145220,7 +147920,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9e»"
+      orderKey="«r9k»"
     >
       <View
         accessibilityLabel="jd 10:00:00 AM Message translated into English"
@@ -145242,7 +147942,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
           importantForAccessibility="yes"
           orderFocusType={0}
           orderIndex={2}
-          orderKey="«r9e»"
+          orderKey="«r9k»"
         >
           <View
             accessible={true}
@@ -145861,13 +148561,13 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9f»"
+      orderKey="«r9l»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9f»"
+        orderKey="«r9l»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -145958,7 +148658,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9f»"
+                  orderKey="«r9l»"
                 >
                   <View
                     accessible={true}
@@ -146310,7 +149010,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9g»"
+      orderKey="«r9m»"
     >
       <View
         accessibilityLabel="john.doe 10:00:00 AM Message translated into English"
@@ -146332,7 +149032,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
           importantForAccessibility="yes"
           orderFocusType={0}
           orderIndex={2}
-          orderKey="«r9g»"
+          orderKey="«r9m»"
         >
           <View
             accessible={true}
@@ -146951,13 +149651,13 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
       </View>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9h»"
+      orderKey="«r9n»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9h»"
+        orderKey="«r9n»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -147048,7 +149748,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9h»"
+                  orderKey="«r9n»"
                 >
                   <View
                     accessible={true}
@@ -147400,7 +150100,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9i»"
+      orderKey="«r9o»"
     >
       <View
         accessibilityLabel="johndoeverylongusernamejohndoeverylongusernamejohndoeverylongusernamejohndoeverylongusernamejohndoeverylongusername 10:00:00 AM Message translated into English"
@@ -147422,7 +150122,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
           importantForAccessibility="yes"
           orderFocusType={0}
           orderIndex={2}
-          orderKey="«r9i»"
+          orderKey="«r9o»"
         >
           <View
             accessible={true}
@@ -148054,13 +150754,13 @@ exports[`Story Snapshots: WithAlias should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r9j»"
+      orderKey="«r9p»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9j»"
+        orderKey="«r9p»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -148151,7 +150851,7 @@ exports[`Story Snapshots: WithAlias should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9j»"
+                  orderKey="«r9p»"
                 >
                   <View
                     accessible={true}
@@ -148522,13 +151222,13 @@ exports[`Story Snapshots: WithAlias should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9k»"
+      orderKey="«r9q»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9k»"
+        orderKey="«r9q»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -148619,7 +151319,7 @@ exports[`Story Snapshots: WithAlias should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9k»"
+                  orderKey="«r9q»"
                 >
                   <View
                     accessible={true}
@@ -149003,13 +151703,13 @@ exports[`Story Snapshots: WithAliasLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r9l»"
+      orderKey="«r9r»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9l»"
+        orderKey="«r9r»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -149100,7 +151800,7 @@ exports[`Story Snapshots: WithAliasLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9l»"
+                  orderKey="«r9r»"
                 >
                   <View
                     accessible={true}
@@ -149471,13 +152171,13 @@ exports[`Story Snapshots: WithAliasLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9m»"
+      orderKey="«r9s»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9m»"
+        orderKey="«r9s»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -149568,7 +152268,7 @@ exports[`Story Snapshots: WithAliasLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9m»"
+                  orderKey="«r9s»"
                 >
                   <View
                     accessible={true}
@@ -149952,13 +152652,13 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r9n»"
+      orderKey="«r9t»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9n»"
+        orderKey="«r9t»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -150049,7 +152749,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9n»"
+                  orderKey="«r9t»"
                 >
                   <View
                     accessible={true}
@@ -150684,13 +153384,13 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9o»"
+      orderKey="«r9u»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9o»"
+        orderKey="«r9u»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -150781,7 +153481,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9o»"
+                  orderKey="«r9u»"
                 >
                   <View
                     accessible={true}
@@ -151139,13 +153839,13 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9p»"
+      orderKey="«r9v»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9p»"
+        orderKey="«r9v»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -151236,7 +153936,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9p»"
+                  orderKey="«r9v»"
                 >
                   <View
                     accessible={true}
@@ -151833,13 +154533,13 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9q»"
+      orderKey="«ra0»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9q»"
+        orderKey="«ra0»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -151930,7 +154630,7 @@ exports[`Story Snapshots: WithAudio should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9q»"
+                  orderKey="«ra0»"
                 >
                   <View
                     accessible={true}
@@ -152815,13 +155515,13 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«r9r»"
+      orderKey="«ra1»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9r»"
+        orderKey="«ra1»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -152912,7 +155612,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9r»"
+                  orderKey="«ra1»"
                 >
                   <View
                     accessible={true}
@@ -153547,13 +156247,13 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9s»"
+      orderKey="«ra2»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9s»"
+        orderKey="«ra2»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -153644,7 +156344,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9s»"
+                  orderKey="«ra2»"
                 >
                   <View
                     accessible={true}
@@ -153763,13 +156463,13 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9t»"
+      orderKey="«ra3»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9t»"
+        orderKey="«ra3»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -153860,7 +156560,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9t»"
+                  orderKey="«ra3»"
                 >
                   <View
                     accessible={true}
@@ -154218,13 +156918,13 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9u»"
+      orderKey="«ra4»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9u»"
+        orderKey="«ra4»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -154315,7 +157015,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9u»"
+                  orderKey="«ra4»"
                 >
                   <View
                     accessible={true}
@@ -154618,13 +157318,13 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«r9v»"
+      orderKey="«ra5»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«r9v»"
+        orderKey="«ra5»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -154715,7 +157415,7 @@ exports[`Story Snapshots: WithAudioLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«r9v»"
+                  orderKey="«ra5»"
                 >
                   <View
                     accessible={true}
@@ -155659,13 +158359,13 @@ exports[`Story Snapshots: WithFile should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«ra0»"
+      orderKey="«ra6»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra0»"
+        orderKey="«ra6»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -155756,7 +158456,7 @@ exports[`Story Snapshots: WithFile should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra0»"
+                  orderKey="«ra6»"
                 >
                   <View
                     accessible={true}
@@ -156299,13 +158999,13 @@ exports[`Story Snapshots: WithFile should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«ra1»"
+      orderKey="«ra7»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra1»"
+        orderKey="«ra7»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -156396,7 +159096,7 @@ exports[`Story Snapshots: WithFile should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra1»"
+                  orderKey="«ra7»"
                 >
                   <View
                     accessible={true}
@@ -156961,13 +159661,13 @@ exports[`Story Snapshots: WithFileLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«ra2»"
+      orderKey="«ra8»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra2»"
+        orderKey="«ra8»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -157058,7 +159758,7 @@ exports[`Story Snapshots: WithFileLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra2»"
+                  orderKey="«ra8»"
                 >
                   <View
                     accessible={true}
@@ -157601,13 +160301,13 @@ exports[`Story Snapshots: WithFileLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«ra3»"
+      orderKey="«ra9»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra3»"
+        orderKey="«ra9»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -157698,7 +160398,7 @@ exports[`Story Snapshots: WithFileLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra3»"
+                  orderKey="«ra9»"
                 >
                   <View
                     accessible={true}
@@ -158021,13 +160721,13 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«ra4»"
+      orderKey="«raa»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra4»"
+        orderKey="«raa»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -158118,7 +160818,7 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra4»"
+                  orderKey="«raa»"
                 >
                   <View
                     accessible={true}
@@ -158685,13 +161385,13 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«ra5»"
+      orderKey="«rab»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra5»"
+        orderKey="«rab»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -158782,7 +161482,7 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra5»"
+                  orderKey="«rab»"
                 >
                   <View
                     accessible={true}
@@ -159833,13 +162533,13 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«ra6»"
+      orderKey="«rac»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra6»"
+        orderKey="«rac»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -159930,7 +162630,7 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra6»"
+                  orderKey="«rac»"
                 >
                   <View
                     accessible={true}
@@ -160608,13 +163308,13 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«ra7»"
+      orderKey="«rad»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra7»"
+        orderKey="«rad»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -160705,7 +163405,7 @@ exports[`Story Snapshots: WithImage should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra7»"
+                  orderKey="«rad»"
                 >
                   <View
                     accessible={true}
@@ -161272,13 +163972,13 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«ra8»"
+      orderKey="«rae»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra8»"
+        orderKey="«rae»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -161369,7 +164069,7 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra8»"
+                  orderKey="«rae»"
                 >
                   <View
                     accessible={true}
@@ -161892,13 +164592,13 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«ra9»"
+      orderKey="«raf»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«ra9»"
+        orderKey="«raf»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -161989,7 +164689,7 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«ra9»"
+                  orderKey="«raf»"
                 >
                   <View
                     accessible={true}
@@ -162279,13 +164979,13 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«raa»"
+      orderKey="«rag»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«raa»"
+        orderKey="«rag»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -162376,7 +165076,7 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«raa»"
+                  orderKey="«rag»"
                 >
                   <View
                     accessible={true}
@@ -163054,13 +165754,13 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«rab»"
+      orderKey="«rah»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«rab»"
+        orderKey="«rah»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -163151,7 +165851,7 @@ exports[`Story Snapshots: WithImageLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«rab»"
+                  orderKey="«rah»"
                 >
                   <View
                     accessible={true}
@@ -163718,13 +166418,13 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«rac»"
+      orderKey="«rai»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«rac»"
+        orderKey="«rai»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -163815,7 +166515,7 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«rac»"
+                  orderKey="«rai»"
                 >
                   <View
                     accessible={true}
@@ -164342,13 +167042,13 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«rad»"
+      orderKey="«raj»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«rad»"
+        orderKey="«raj»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -164439,7 +167139,7 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«rad»"
+                  orderKey="«raj»"
                 >
                   <View
                     accessible={true}
@@ -164689,13 +167389,13 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«rae»"
+      orderKey="«rak»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«rae»"
+        orderKey="«rak»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -164786,7 +167486,7 @@ exports[`Story Snapshots: WithVideo should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«rae»"
+                  orderKey="«rak»"
                 >
                   <View
                     accessible={true}
@@ -165413,13 +168113,13 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«raf»"
+      orderKey="«ral»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«raf»"
+        orderKey="«ral»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -165510,7 +168210,7 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«raf»"
+                  orderKey="«ral»"
                 >
                   <View
                     accessible={true}
@@ -166037,13 +168737,13 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«rag»"
+      orderKey="«ram»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«rag»"
+        orderKey="«ram»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -166134,7 +168834,7 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«rag»"
+                  orderKey="«ram»"
                 >
                   <View
                     accessible={true}
@@ -166562,13 +169262,13 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
       </A11yIndexView>
     </A11yOrderView>
     <A11yOrderView
-      orderKey="«rah»"
+      orderKey="«ran»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«rah»"
+        orderKey="«ran»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -166659,7 +169359,7 @@ exports[`Story Snapshots: WithVideoLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«rah»"
+                  orderKey="«ran»"
                 >
                   <View
                     accessible={true}
@@ -167286,13 +169986,13 @@ exports[`Story Snapshots: WithoutHeader should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«rai»"
+      orderKey="«rao»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«rai»"
+        orderKey="«rao»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -167383,7 +170083,7 @@ exports[`Story Snapshots: WithoutHeader should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«rai»"
+                  orderKey="«rao»"
                 >
                   <View
                     accessible={true}
@@ -167515,13 +170215,13 @@ exports[`Story Snapshots: WithoutHeaderLargeFont should match snapshot 1`] = `
 >
   <View>
     <A11yOrderView
-      orderKey="«raj»"
+      orderKey="«rap»"
     >
       <A11yIndexView
         importantForAccessibility="yes"
         orderFocusType={0}
         orderIndex={1}
-        orderKey="«raj»"
+        orderKey="«rap»"
       >
         <ExternalKeyboardView
           canBeFocused={true}
@@ -167612,7 +170312,7 @@ exports[`Story Snapshots: WithoutHeaderLargeFont should match snapshot 1`] = `
                   importantForAccessibility="yes"
                   orderFocusType={0}
                   orderIndex={2}
-                  orderKey="«raj»"
+                  orderKey="«rap»"
                 >
                   <View
                     accessible={true}

--- a/app/containers/message/interfaces.ts
+++ b/app/containers/message/interfaces.ts
@@ -71,6 +71,8 @@ export interface IMessageContent {
 	isHeader: boolean;
 	isTranslated: boolean;
 	pinned?: boolean;
+	attachments?: IAttachment[];
+	autoTranslateLanguage?: string;
 }
 
 export interface IMessageEmoji {

--- a/app/containers/message/utils.test.ts
+++ b/app/containers/message/utils.test.ts
@@ -1,0 +1,34 @@
+import { getPreviewMessageFromAttachment } from './utils';
+
+describe('getPreviewMessageFromAttachment', () => {
+	test('returns the Attachment title when only title is set', () => {
+		expect(getPreviewMessageFromAttachment({ title: 'example.png' })).toBe('example.png');
+	});
+
+	test('returns the Attachment description when description is set (description wins over title)', () => {
+		expect(getPreviewMessageFromAttachment({ title: 'example.png', description: 'A nice photo' })).toBe('A nice photo');
+	});
+
+	test('returns the translated caption when translateLanguage matches (translation wins over description and title)', () => {
+		expect(
+			getPreviewMessageFromAttachment(
+				{ title: 'example.png', description: 'A nice photo', translations: { 'pt-BR': 'Uma bela foto' } },
+				'pt-BR'
+			)
+		).toBe('Uma bela foto');
+	});
+
+	test('returns undefined when nothing is set', () => {
+		expect(getPreviewMessageFromAttachment({})).toBeUndefined();
+	});
+
+	test('falls back to description when translateLanguage is set but no matching translation exists', () => {
+		expect(getPreviewMessageFromAttachment({ description: 'A nice photo', translations: { fr: 'Belle photo' } }, 'pt-BR')).toBe(
+			'A nice photo'
+		);
+	});
+
+	test('returns the Attachment title when only title is set even if translateLanguage is provided', () => {
+		expect(getPreviewMessageFromAttachment({ title: 'example.png' }, 'pt-BR')).toBe('example.png');
+	});
+});

--- a/app/containers/message/utils.ts
+++ b/app/containers/message/utils.ts
@@ -211,3 +211,13 @@ export const getMessageFromAttachment = (attachment: IAttachment, translateLangu
 	}
 	return msg;
 };
+
+export const getPreviewMessageFromAttachment = (attachment: IAttachment, translateLanguage?: string): string | undefined => {
+	if (translateLanguage) {
+		const translated = attachment.translations?.[translateLanguage];
+		if (translated) {
+			return translated;
+		}
+	}
+	return attachment.description ?? attachment.title;
+};


### PR DESCRIPTION
## Proposed changes

When a Thread Message with no text body (`msg` empty) but one or more Attachments is rendered inline in the parent Room view (the abbreviated thread-reply preview row beneath the parent Message), the row showed only a small avatar with no body content — file name, caption, and image preview were all missing. This affected every Attachment type (`.pptx`, `.png`, audio, video, generic files).

This PR fixes the inline preview branch only. The dedicated Thread view continues to render the full Attachment.

Changes:
- New pure helper `getPreviewMessageFromAttachment(attachment, translateLanguage)` in `app/containers/message/utils.ts` returns the best single-line preview string for one Attachment: translated caption > description > title > undefined.
- `Content.tsx`'s `isPreview` branch now falls back to the helper's result via `MarkdownPreview` when `msg` is empty and `attachments` has at least one entry. The encrypted branch fires first, so "Encrypted message" continues to render with no file-name leak.
- `IMessageContent` widened with optional `attachments?: IAttachment[]` and `autoTranslateLanguage?: string`. `Message.tsx` already forwards `{...props}` to `Content`, so no rewiring is needed at the call site.
- `getMessageFromAttachment` is left untouched — Full Attachment and Quote renderers depend on its existing "description / translation only" semantics.
- For multi-Attachment Thread replies, only the first Attachment is used for the preview text.

## Issue(s)

https://rocketchat.atlassian.net/browse/SUP-1041

## How to test or reproduce

1. In a Channel, send a parent message that opens a Thread.
2. From inside the Thread, upload a file with no caption (e.g. `presentation.pptx`, `example.png`, an audio clip) and check "also send to channel" so the Thread reply renders inline in the parent Room.
3. Back in the parent Room view, the inline Thread reply row now shows the file name (or the caption you typed, if any). Previously it was an empty avatar row.
4. Open the dedicated Thread view — unchanged; the full Attachment card / image preview / audio player still renders as before.
5. Repeat with a caption + auto-translate enabled on the Room and verify the translated caption appears inline.
6. Repeat in an end-to-end encrypted Room — the inline row continues to show "Encrypted message" with no file-name leak.

Storybook coverage was extended (`MessageWithThread`, `MessageWithThreadLargeFont`) with `.png`, `.pptx`, and multi-Attachment cases alongside the existing audio case.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

- Jest coverage: 6 unit tests for the helper (precedence and fallback rules) and 8 unit tests for `Content.tsx`'s preview rendering (image-title, file-title, description wins, translation wins, body wins over Attachment, encrypted no leak, non-preview no fallback, multi-Attachment first-only).
- The `removeQuote` filter in `Attachments.tsx` (which can drop bare file Attachments outside threads) is an adjacent gap that is intentionally out of scope for this fix.

[SUP-1041]: https://rocketchat.atlassian.net/browse/SUP-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread message previews now derive text from attachments (description > title), use only the first attachment, respect auto-translation, and hide filenames for encrypted messages.
  * Previews re-render when attachments are added or when auto-translation language changes.

* **Tests**
  * Expanded tests for attachment preview precedence, translation selection, encrypted UI, and re-render behavior.

* **Documentation**
  * Storybook examples added for thread messages with image and file attachments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7323)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->