### PR TITLE
fix: do not encrypt messages when workspace E2E is disabled

### DIFF
--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -1,0 +1,143 @@
+// Bypass the global mock of `app/lib/encryption` declared in jest.setup.js by
+// importing directly from the file. We exercise the real `encryptMessage` here.
+import encryption from './encryption';
+
+jest.unmock('./encryption');
+
+// Heavy native deps and helpers are not relevant to encryptMessage's branching;
+// stub them so the module can be loaded in jsdom/node without a native runtime.
+jest.mock('@rocket.chat/mobile-crypto', () => ({
+	pbkdf2Hash: jest.fn(),
+	aesEncrypt: jest.fn(),
+	aesDecrypt: jest.fn(),
+	randomBytes: jest.fn(),
+	rsaGenerateKeys: jest.fn(),
+	rsaImportKey: jest.fn(),
+	rsaExportKey: jest.fn(),
+	calculateFileChecksum: jest.fn(),
+	aesGcmDecrypt: jest.fn(),
+	aesGcmEncrypt: jest.fn()
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+	deleteAsync: jest.fn()
+}));
+
+jest.mock('../services/restApi', () => ({
+	e2eSetUserPublicAndPrivateKeys: jest.fn(),
+	e2eRequestSubscriptionKeys: jest.fn(),
+	fetchUsersWaitingForGroupKey: jest.fn(),
+	provideUsersSuggestedGroupKeys: jest.fn()
+}));
+
+jest.mock('../methods/userPreferences', () => ({
+	__esModule: true,
+	default: { getString: jest.fn(), setString: jest.fn(), removeItem: jest.fn() }
+}));
+
+jest.mock('../methods/helpers/protectedFunction', () => ({
+	__esModule: true,
+	default: (fn: any) => fn
+}));
+
+const mockGetState = jest.fn();
+jest.mock('../store/auxStore', () => ({
+	store: {
+		getState: () => mockGetState()
+	}
+}));
+
+const mockSubFind = jest.fn();
+jest.mock('../database', () => ({
+	__esModule: true,
+	default: {
+		active: {
+			get: () => ({ find: (rid: string) => mockSubFind(rid) })
+		}
+	}
+}));
+
+const mockRoomEncrypt = jest.fn();
+const mockHasSessionKey = jest.fn();
+const mockHandshake = jest.fn().mockResolvedValue(undefined);
+jest.mock('./room', () => ({
+	__esModule: true,
+	default: jest.fn().mockImplementation(() => ({
+		handshake: mockHandshake,
+		hasSessionKey: () => mockHasSessionKey(),
+		encrypt: (m: any) => mockRoomEncrypt(m)
+	}))
+}));
+
+const baseMessage = { _id: 'm1', rid: 'r1', msg: 'hello' } as any;
+
+describe('Encryption.encryptMessage', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		// fresh handshake mock since clearAllMocks resets the implementation default
+		mockHandshake.mockResolvedValue(undefined);
+		// Force getRoomInstance to rebuild the EncryptionRoom on every test by
+		// clearing any cached instance from the singleton.
+		(encryption as any).roomInstances = {};
+	});
+
+	it('returns the plain message when workspace E2E is disabled, even if the local subscription is flagged as encrypted', async () => {
+		// This is the regression case: web does not encrypt when E2E_Enable is off
+		// at the workspace level. Mobile must do the same to avoid sending an
+		// undefined message downstream when the local subscription has a stale
+		// `encrypted: true` flag and no session key is available.
+		mockGetState.mockReturnValue({ settings: { E2E_Enable: false } });
+		mockSubFind.mockResolvedValue({ encrypted: true });
+		mockHasSessionKey.mockReturnValue(false);
+
+		const result = await encryption.encryptMessage(baseMessage);
+
+		expect(result).toBe(baseMessage);
+		expect(mockSubFind).not.toHaveBeenCalled();
+		expect(mockRoomEncrypt).not.toHaveBeenCalled();
+	});
+
+	it('returns the plain message when the local subscription is not encrypted', async () => {
+		mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+		mockSubFind.mockResolvedValue({ encrypted: false });
+
+		const result = await encryption.encryptMessage(baseMessage);
+
+		expect(result).toBe(baseMessage);
+		expect(mockRoomEncrypt).not.toHaveBeenCalled();
+	});
+
+	it('returns undefined when the room is encrypted but no session key is available', async () => {
+		mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+		mockSubFind.mockResolvedValue({ encrypted: true });
+		mockHasSessionKey.mockReturnValue(false);
+
+		const result = await encryption.encryptMessage(baseMessage);
+
+		expect(result).toBeUndefined();
+		expect(mockRoomEncrypt).not.toHaveBeenCalled();
+	});
+
+	it('encrypts the message when the room is encrypted and a session key is available', async () => {
+		mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+		mockSubFind.mockResolvedValue({ encrypted: true });
+		mockHasSessionKey.mockReturnValue(true);
+		const encrypted = { ...baseMessage, t: 'e2e', msg: 'cipher' };
+		mockRoomEncrypt.mockReturnValue(encrypted);
+
+		const result = await encryption.encryptMessage(baseMessage);
+
+		expect(result).toBe(encrypted);
+		expect(mockRoomEncrypt).toHaveBeenCalledWith(baseMessage);
+	});
+
+	it('falls back to the plain message when the subscription lookup throws', async () => {
+		mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+		mockSubFind.mockRejectedValue(new Error('not found'));
+
+		const result = await encryption.encryptMessage(baseMessage);
+
+		expect(result).toBe(baseMessage);
+		expect(mockRoomEncrypt).not.toHaveBeenCalled();
+	});
+});

--- a/app/lib/encryption/encryption.ts
+++ b/app/lib/encryption/encryption.ts
@@ -527,6 +527,13 @@ class Encryption {
 		const db = database.active;
 		const subCollection = db.get('subscriptions');
 
+		// If workspace-level E2E is disabled, send the message unencrypted regardless of
+		// any stale `encrypted: true` flag on the local subscription record.
+		const e2eeEnabled = store.getState().settings.E2E_Enable;
+		if (!e2eeEnabled) {
+			return message;
+		}
+
 		try {
 			// Find the subscription
 			const subRecord = await subCollection.find(rid);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
`encryptMessage` only checked the per-subscription `encrypted` flag, so a room with a stale `encrypted: true` value on the local subscription would still attempt to encrypt messages even when the workspace-level setting `E2E_Enable` was disabled. Since no session key was available, `encryptMessage` returned `undefined`, which then caused `sendMessageCall` to crash when destructuring `_id`, leaving the local message stuck in the `TEMP` state (preventing the user from sending messages).
This PR aligns mobile behavior with web behavior: when `E2E_Enable` is `false` at the workspace level, `encryptMessage`
now short-circuits and returns the plain message regardless of the local subscription flag.

Added unit tests covering the new branch, as well as the existing
`encryptMessage` branches:

* subscription not encrypted
* no session key available
* happy path
* subscription lookup error

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/SUP-994

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
**Pre-requisites:** a workspace where `E2E_Enable` is **off** at
  admin settings, and a DM whose local subscription has `encrypted:
   true` (typically a DM that was previously encrypted, or one
  stamped encrypted server-side).

  **Before the fix:**
  1. Open the DM on mobile.
  2. Type any message and tap send.
  3. The message stays as "sending" (TEMP) and never reaches the server.

  **After the fix:**
  1. Open the same DM on mobile.
  2. Type any message and tap send.
  3. Message is delivered as plain text — matching web's payload  (`{ _id, rid, msg }`, no `t: 'e2e'`).

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated end-to-end encryption behavior to respect workspace-level security settings. Messages are now encrypted only when encryption is enabled at the workspace level, ensuring consistent protection across conversations.

* **Tests**
  * Added test coverage for message encryption behavior, validating workspace settings, subscription encryption status, and session key handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7324)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->