### PR TITLE
Fix mobile notification sound

### DIFF
--- a/app/containers/InAppNotification/index.tsx
+++ b/app/containers/InAppNotification/index.tsx
@@ -48,7 +48,8 @@ const InAppNotification = memo(() => {
 
 			const sub = payload?.rid ? await getSubscriptionByRoomId(payload.rid) : null;
 			if (sub?.audioNotificationValue) {
-				playNotificationSound(sub.audioNotificationValue);
+				// eslint-disable-next-line no-void
+				void playNotificationSound(sub.audioNotificationValue);
 			}
 
 			if (payload?.name && payload?.message) {

--- a/app/containers/InAppNotification/index.tsx
+++ b/app/containers/InAppNotification/index.tsx
@@ -10,6 +10,8 @@ import { getActiveRoute } from '../../lib/methods/helpers/navigation';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 import { setInAppFeedback } from '../../actions/inAppFeedback';
 import I18n from '../../i18n';
+import { getSubscriptionByRoomId } from '../../lib/database/services/Subscription';
+import { playNotificationSound } from '../../lib/methods/helpers/playNotificationSound';
 
 export const INAPP_NOTIFICATION_EMITTER = 'NotificationInApp';
 
@@ -21,7 +23,7 @@ const InAppNotification = memo(() => {
 
 	const dispatch = useDispatch();
 
-	const show = (
+	const show = async (
 		notification: INotifierComponent['notification'] & {
 			customComponent?: ElementType;
 			customTime?: number;
@@ -42,6 +44,11 @@ const InAppNotification = memo(() => {
 				const msgId = payload._id;
 				dispatch(setInAppFeedback(msgId));
 				return;
+			}
+
+			const sub = payload?.rid ? await getSubscriptionByRoomId(payload.rid) : null;
+			if (sub?.audioNotificationValue) {
+				playNotificationSound(sub.audioNotificationValue);
 			}
 
 			if (payload?.name && payload?.message) {

--- a/app/definitions/IRoom.ts
+++ b/app/definitions/IRoom.ts
@@ -247,6 +247,7 @@ export interface IRoomNotifications {
 	muteGroupMentions?: boolean;
 	hideUnreadStatus?: boolean;
 	audioNotificationsValue?: string;
+	audioNotificationValue?: string;
 	desktopNotifications?: TNotifications;
 	mobilePushNotifications?: TNotifications;
 	emailNotifications?: TNotifications;

--- a/app/definitions/IRoom.ts
+++ b/app/definitions/IRoom.ts
@@ -62,6 +62,8 @@ export interface IRoom {
 	onHold?: boolean;
 	waitingResponse?: boolean;
 	federated?: boolean;
+	audioNotificationsValue?: string;
+	audioNotificationValue?: string;
 }
 
 export interface IRoomSettings {
@@ -238,6 +240,8 @@ export interface IServerRoom extends IRocketChatRecord {
 
 	isLastOwner?: boolean;
 	federated?: boolean;
+	audioNotificationsValue?: string;
+	audioNotificationValue?: string;
 	abacAttributes?: { key: string; values: string[] }[];
 }
 

--- a/app/definitions/ISubscription.ts
+++ b/app/definitions/ISubscription.ts
@@ -115,6 +115,7 @@ export interface ISubscription {
 	threadMessages: RelationModified<TThreadMessageModel>;
 	uploads: RelationModified<TUploadModel>;
 	disableNotifications?: boolean;
+	audioNotificationValue?: string;
 	federated?: boolean;
 	abacAttributes?: { key: string; values: string[] }[];
 	federation?: {

--- a/app/definitions/ISubscription.ts
+++ b/app/definitions/ISubscription.ts
@@ -179,7 +179,7 @@ export interface IServerSubscription extends IRocketChatRecord {
 
 	code?: unknown;
 	archived?: unknown;
-	audioNotificationValue?: unknown;
+	audioNotificationValue?: string;
 	desktopNotifications?: unknown;
 	mobilePushNotifications?: unknown;
 	emailNotifications?: unknown;

--- a/app/lib/database/model/Subscription.js
+++ b/app/lib/database/model/Subscription.js
@@ -161,6 +161,8 @@ export default class Subscription extends Model {
 
 	@json('inviter', sanitizer) inviter;
 
+	@field('audio_notification_value') audioNotificationValue;
+
 	asPlain() {
 		return {
 			_id: this._id,
@@ -231,7 +233,8 @@ export default class Subscription extends Model {
 			abacAttributes: this.abacAttributes,
 			federation: this.federation,
 			status: this.status,
-			inviter: this.inviter
+			inviter: this.inviter,
+			audioNotificationValue: this.audioNotificationValue
 		};
 	}
 }

--- a/app/lib/database/model/migrations.js
+++ b/app/lib/database/model/migrations.js
@@ -345,6 +345,15 @@ export default schemaMigrations({
 					]
 				})
 			]
+		},
+		{
+			toVersion: 29,
+			steps: [
+				addColumns({
+					table: 'subscriptions',
+					columns: [{ name: 'audio_notification_value', type: 'string', isOptional: true }]
+				})
+			]
 		}
 	]
 });

--- a/app/lib/database/schema/app.js
+++ b/app/lib/database/schema/app.js
@@ -1,7 +1,7 @@
 import { appSchema, tableSchema } from '@nozbe/watermelondb';
 
 export default appSchema({
-	version: 28,
+	version: 29,
 	tables: [
 		tableSchema({
 			name: 'subscriptions',
@@ -74,7 +74,8 @@ export default appSchema({
 				{ name: 'abac_attributes', type: 'string', isOptional: true },
 				{ name: 'federation', type: 'string', isOptional: true },
 				{ name: 'status', type: 'string', isOptional: true },
-				{ name: 'inviter', type: 'string', isOptional: true }
+				{ name: 'inviter', type: 'string', isOptional: true },
+				{ name: 'audio_notification_value', type: 'string', isOptional: true }
 			]
 		}),
 		tableSchema({

--- a/app/lib/methods/helpers/mergeSubscriptionsRooms.ts
+++ b/app/lib/methods/helpers/mergeSubscriptionsRooms.ts
@@ -110,6 +110,12 @@ export const merge = (
 		if (room && 'federation' in room) {
 			mergedSubscription.federation = room.federation;
 		}
+		if (room && 'audioNotificationValue' in room) {
+			mergedSubscription.audioNotificationValue = room.audioNotificationValue;
+		}
+		if (room && 'audioNotificationsValue' in room) {
+			mergedSubscription.audioNotificationValue = room.audioNotificationsValue;
+		}
 	}
 
 	if (!mergedSubscription.name) {

--- a/app/lib/methods/helpers/mergeSubscriptionsRooms.ts
+++ b/app/lib/methods/helpers/mergeSubscriptionsRooms.ts
@@ -112,8 +112,7 @@ export const merge = (
 		}
 		if (room && 'audioNotificationValue' in room) {
 			mergedSubscription.audioNotificationValue = room.audioNotificationValue;
-		}
-		if (room && 'audioNotificationsValue' in room) {
+		} else if (room && 'audioNotificationsValue' in room) {
 			mergedSubscription.audioNotificationValue = room.audioNotificationsValue;
 		}
 	}

--- a/app/lib/methods/helpers/playNotificationSound.ts
+++ b/app/lib/methods/helpers/playNotificationSound.ts
@@ -1,0 +1,59 @@
+import { Audio } from 'expo-av';
+
+import log from './log';
+
+const sounds: Record<string, any> = {
+	'beep Beep': require('../../containers/Ringer/call-ended.mp3'),
+	'ding Ding': require('../../containers/Ringer/call-ended.mp3'),
+	'chelle Chelle': require('../../containers/Ringer/call-ended.mp3'),
+	'droplet Droplet': require('../../containers/Ringer/call-ended.mp3'),
+	'highbell Highbell': require('../../containers/Ringer/call-ended.mp3'),
+	'seasons Seasons': require('../../containers/Ringer/call-ended.mp3')
+};
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const DEFAULT_SOUND = require('../../containers/Ringer/call-ended.mp3');
+
+// Watchdog prevents memory leaks if didJustFinish never fires (rare OS preemption).
+const WATCHDOG_MS = 5000;
+
+export const playNotificationSound = async (soundName: string): Promise<void> => {
+	if (!soundName || soundName === 'none' || soundName === 'none None') {
+		return;
+	}
+
+	try {
+		const asset = sounds[soundName] || DEFAULT_SOUND;
+		const { sound } = await Audio.Sound.createAsync(asset);
+
+		let watchdog: ReturnType<typeof setTimeout> | null = null;
+
+		const cleanup = () => {
+			if (watchdog) {
+				clearTimeout(watchdog);
+				watchdog = null;
+			}
+		};
+
+		sound.setOnPlaybackStatusUpdate(status => {
+			if (status.isLoaded && status.didJustFinish) {
+				cleanup();
+				sound.unloadAsync().catch(() => {
+					// best-effort unload
+				});
+			}
+		});
+
+		await sound.playAsync();
+
+		// Watchdog releases sound if didJustFinish never fires (e.g., OS interruption).
+		watchdog = setTimeout(() => {
+			cleanup();
+			sound.unloadAsync().catch(() => {
+				// best-effort unload
+			});
+		}, WATCHDOG_MS);
+	} catch (error) {
+		log(error);
+	}
+};

--- a/app/lib/methods/helpers/playNotificationSound.ts
+++ b/app/lib/methods/helpers/playNotificationSound.ts
@@ -1,59 +1,67 @@
 import { Audio } from 'expo-av';
 
-import log from './log';
+const RINGTONE_SOUND = require('../../../containers/Ringer/ringtone.mp3');
+const CALL_ENDED_SOUND = require('../../../containers/Ringer/call-ended.mp3');
 
 const sounds: Record<string, any> = {
-	'beep Beep': require('../../containers/Ringer/call-ended.mp3'),
-	'ding Ding': require('../../containers/Ringer/call-ended.mp3'),
-	'chelle Chelle': require('../../containers/Ringer/call-ended.mp3'),
-	'droplet Droplet': require('../../containers/Ringer/call-ended.mp3'),
-	'highbell Highbell': require('../../containers/Ringer/call-ended.mp3'),
-	'seasons Seasons': require('../../containers/Ringer/call-ended.mp3')
+	0: CALL_ENDED_SOUND,
+	default: CALL_ENDED_SOUND,
+	beep: RINGTONE_SOUND,
+	ding: CALL_ENDED_SOUND,
+	chelle: RINGTONE_SOUND,
+	droplet: CALL_ENDED_SOUND,
+	highbell: RINGTONE_SOUND,
+	seasons: RINGTONE_SOUND
 };
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const DEFAULT_SOUND = require('../../containers/Ringer/call-ended.mp3');
+const DEFAULT_SOUND = CALL_ENDED_SOUND;
 
-// Watchdog prevents memory leaks if didJustFinish never fires (rare OS preemption).
 const WATCHDOG_MS = 5000;
 
+const normalizeSoundName = (soundName: string) => soundName.trim().split(' ')[0].toLowerCase();
+
 export const playNotificationSound = async (soundName: string): Promise<void> => {
-	if (!soundName || soundName === 'none' || soundName === 'none None') {
+	if (!soundName) {
+		return;
+	}
+
+	const normalized = normalizeSoundName(soundName);
+
+	if (!normalized || normalized === 'none') {
 		return;
 	}
 
 	try {
-		const asset = sounds[soundName] || DEFAULT_SOUND;
+		const asset = sounds[normalized] || DEFAULT_SOUND;
 		const { sound } = await Audio.Sound.createAsync(asset);
 
+		let unloaded = false;
 		let watchdog: ReturnType<typeof setTimeout> | null = null;
 
-		const cleanup = () => {
+		const unload = () => {
+			if (unloaded) {
+				return;
+			}
+			unloaded = true;
 			if (watchdog) {
 				clearTimeout(watchdog);
 				watchdog = null;
 			}
+			sound.unloadAsync().catch(() => {
+				// best-effort unload
+			});
 		};
 
 		sound.setOnPlaybackStatusUpdate(status => {
 			if (status.isLoaded && status.didJustFinish) {
-				cleanup();
-				sound.unloadAsync().catch(() => {
-					// best-effort unload
-				});
+				unload();
 			}
 		});
 
 		await sound.playAsync();
 
-		// Watchdog releases sound if didJustFinish never fires (e.g., OS interruption).
-		watchdog = setTimeout(() => {
-			cleanup();
-			sound.unloadAsync().catch(() => {
-				// best-effort unload
-			});
-		}, WATCHDOG_MS);
-	} catch (error) {
-		log(error);
+		watchdog = setTimeout(unload, WATCHDOG_MS);
+	} catch {
+		// best-effort notification sound
 	}
 };

--- a/app/lib/methods/helpers/playNotificationSound.ts
+++ b/app/lib/methods/helpers/playNotificationSound.ts
@@ -31,26 +31,27 @@ export const playNotificationSound = async (soundName: string): Promise<void> =>
 		return;
 	}
 
+	let sound: Audio.Sound | undefined;
+	let unloaded = false;
+	let watchdog: ReturnType<typeof setTimeout> | null = null;
+
+	const unload = () => {
+		if (unloaded || !sound) {
+			return;
+		}
+		unloaded = true;
+		if (watchdog) {
+			clearTimeout(watchdog);
+			watchdog = null;
+		}
+		sound.unloadAsync().catch(() => {
+			// best-effort unload
+		});
+	};
+
 	try {
 		const asset = sounds[normalized] || DEFAULT_SOUND;
-		const { sound } = await Audio.Sound.createAsync(asset);
-
-		let unloaded = false;
-		let watchdog: ReturnType<typeof setTimeout> | null = null;
-
-		const unload = () => {
-			if (unloaded) {
-				return;
-			}
-			unloaded = true;
-			if (watchdog) {
-				clearTimeout(watchdog);
-				watchdog = null;
-			}
-			sound.unloadAsync().catch(() => {
-				// best-effort unload
-			});
-		};
+		({ sound } = await Audio.Sound.createAsync(asset));
 
 		sound.setOnPlaybackStatusUpdate(status => {
 			if (status.isLoaded && status.didJustFinish) {
@@ -62,6 +63,7 @@ export const playNotificationSound = async (soundName: string): Promise<void> =>
 
 		watchdog = setTimeout(unload, WATCHDOG_MS);
 	} catch {
+		unload();
 		// best-effort notification sound
 	}
 };


### PR DESCRIPTION
## Summary

Fixes #7192 by enabling room-specific in-app notification sound playback using `audioNotificationValue`.

## Changes

* Persisted `audioNotificationValue` in local subscription storage
* Added WatermelonDB schema/model/migration support
* Updated subscription merge flow
* Added notification sound playback helper using `expo-av`
* Integrated room-specific sound playback into in-app notifications
* Added compatibility fallback for `audioNotificationsValue`
* Improved playback cleanup and normalization handling
* Updated related typings

## Notes

The mobile repository currently includes limited bundled notification sound assets, so existing bundled sounds are reused to validate room-specific playback behavior.

## Testing

Tested on Android:

* in-app notification banner display
* room-specific sound playback
* sound switching
* persistence across reloads
* no-sound preference handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio notifications for in-app alerts are now available.
  * Per-room/conversation sound selection is respected; the configured sound plays when a notification arrives (including a “none”/silent option).
  * Playback is handled reliably with automatic cleanup and safeguards to avoid lingering audio.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->