### PR TITLE
fix: prevent crash on Android devices without telecom feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import 'react-native-gesture-handler';
 import 'react-native-console-time-polyfill';
 import { AppRegistry, LogBox, PermissionsAndroid, Platform } from 'react-native';
 import RNCallKeep from 'react-native-callkeep';
+import DeviceInfo from 'react-native-device-info';
 
 import { name as appName } from './app.json';
 
@@ -22,7 +23,7 @@ if (process.env.USE_STORYBOOK) {
 
 	LogBox.ignoreAllLogs();
 
-	if (Platform.OS === 'android') {
+	if (Platform.OS === 'android' && DeviceInfo.hasSystemFeatureSync('android.software.telecom')) {
 		const options = {
 			android: {
 				// TODO: i18n

--- a/patches/react-native-callkeep+4.3.16.patch
+++ b/patches/react-native-callkeep+4.3.16.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/ca
 index 025480a..6a66858 100644
 --- a/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
 +++ b/node_modules/react-native-callkeep/android/src/main/java/io/wazo/callkeep/RNCallKeepModule.java
-@@ -221,7 +221,7 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
+@@ -221,7 +221,7 @@ public class RNCallKeepModule extends ReactContextBase
          ComponentName cName = new ComponentName(context, VoiceConnectionService.class);
          String appName = this.getApplicationName(context);
  
@@ -11,31 +11,65 @@ index 025480a..6a66858 100644
          telecomManager = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
      }
  
-@@ -434,11 +434,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
-         this.hasListeners = false;
-     }
+@@ -432,11 +432,6 @@ public class RNCallKeepModule extends ReactContextBase
+         Log.d(TAG, "[RNCallKeepModule] unregisterEvents");
  
+         this.hasListeners = false;
+-    }
+-
 -    @ReactMethod
 -    public void displayIncomingCall(String uuid, String number, String callerName) {
 -        this.displayIncomingCall(uuid, number, callerName, false, null);
--    }
--
-     @ReactMethod
-     public void displayIncomingCall(String uuid, String number, String callerName, boolean hasVideo) {
-         this.displayIncomingCall(uuid, number, callerName, hasVideo, null);
-@@ -483,11 +478,6 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
-         conn.onAnswer();
      }
  
--    @ReactMethod
+     @ReactMethod
+@@ -484,11 +479,6 @@ public class RNCallKeepModule extends ReactContextBase
+     }
+ 
+     @ReactMethod
 -    public void startCall(String uuid, String number, String callerName) {
 -        this.startCall(uuid, number, callerName, false, null);
 -    }
 -
-     @ReactMethod
+-    @ReactMethod
      public void startCall(String uuid, String number, String callerName, boolean hasVideo) {
          this.startCall(uuid, number, callerName, hasVideo, null);
-@@ -1196,9 +1186,14 @@ public class RNCallKeepModule extends ReactContextBaseJavaModule implements Life
+     }
+@@ -1125,6 +1115,18 @@ public class RNCallKeepModule extends ReactContextBase
+             Log.w(TAG, "[RNCallKeepModule][registerPhoneAccount] no react context found.");
+             return;
+         }
++
++        // Devices without android.software.telecom (e.g. Zebra TC21 and other
++        // rugged enterprise SKUs) ship without the Telecom subsystem. Calling
++        // telecomManager.registerPhoneAccount on them throws
++        // UnsupportedOperationException on the RN bridge thread and crashes
++        // the process. Skip registration on those devices — VoIP is not usable
++        // there anyway.
++        if (!context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_TELECOM)) {
++            Log.w(TAG, "[RNCallKeepModule] registerPhoneAccount skipped: device lacks FEATURE_TELECOM");
++            return;
++        }
++
+         String appName = this.getApplicationName(context);
+ 
+         PhoneAccount.Builder builder = new PhoneAccount.Builder(handle, appName);
+@@ -1145,7 +1147,13 @@ public class RNCallKeepModule extends ReactContextBase
+ 
+         telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+ 
+-        telecomManager.registerPhoneAccount(account);
++        try {
++            telecomManager.registerPhoneAccount(account);
++        } catch (UnsupportedOperationException e) {
++            Log.w(TAG, "[RNCallKeepModule] registerPhoneAccount: Telecom subsystem unavailable", e);
++        } catch (SecurityException e) {
++            Log.w(TAG, "[RNCallKeepModule] registerPhoneAccount: SecurityException registering PhoneAccount", e);
++        }
+     }
+ 
+     public void sendEventToJS(String eventName, @Nullable WritableMap params) {
+@@ -1196,9 +1204,14 @@ public class RNCallKeepModule extends ReactContextBase
              return true;
          }
  


### PR DESCRIPTION
## Proposed changes

`RNCallKeep.setup()` runs unconditionally from `index.js` on every Android boot and ends up calling `TelecomManager.registerPhoneAccount`. On devices that ship without the `android.software.telecom` system feature — e.g. Zebra TC21 and other rugged enterprise SKUs — that call throws `UnsupportedOperationException`. The exception lands on the RN bridge thread (`mqt_v_native`), so the `.catch(...)` attached to the JS-side `setup()` promise cannot intercept it and the process crashes immediately at startup.

Two layers of defense:

1. **JS-side gate (`index.js`)** — skip `RNCallKeep.setup()` when the device lacks `android.software.telecom`. Uses `react-native-device-info`'s `hasSystemFeatureSync` (a true blocking-synchronous bridge method, sub-millisecond), so the cold-start path that accepts FCM-driven calls is unaffected on telecom-capable devices. No new native module needed; `react-native-device-info` is already a dependency.
2. **Native patch (`patches/react-native-callkeep+4.3.16.patch`)** — `RNCallKeepModule.registerPhoneAccount` now checks `PackageManager.FEATURE_TELECOM` and returns early, with a `try/catch` around the underlying `telecomManager.registerPhoneAccount(...)` call. Kept as defense-in-depth for OEMs that misreport the feature and for any future call site that bypasses the JS gate.

The existing native `VoipNotification.kt` path already catches `Exception` around its own `registerPhoneAccount`, so no change is needed there. VoIP is not usable on these devices anyway — this just stops the boot crash so the rest of the app continues to function.

```
java.lang.UnsupportedOperationException: System does not support feature android.software.telecom
    at android.telecom.TelecomManager.registerPhoneAccount(TelecomManager.java:1530)
    at io.wazo.callkeep.RNCallKeepModule.registerPhoneAccount(RNCallKeepModule.java:1138)
    at io.wazo.callkeep.RNCallKeepModule.setup(RNCallKeepModule.java:390)
```

## Issue(s)

- https://rocketchat.atlassian.net/browse/SUP-1044

## How to test or reproduce

Reproduces deterministically on any Android device whose `adb shell pm list features` output does **not** include `android.software.telecom`. Confirmed on the Zebra TC21 (Android 13) in the linked ticket. After the fix, the app should boot cleanly on that device — no Telecom call is attempted from JS, and even if something else were to reach `RNCallKeepModule.registerPhoneAccount`, the native guard logs `[RNCallKeepModule] registerPhoneAccount skipped: device lacks FEATURE_TELECOM` instead of crashing.

A standard Android emulator (Pixel images) does include the telecom feature, so emulator builds are not a substitute repro — they only verify the no-regression case on telecom-capable devices.

## Screenshots

N/A — boot crash fix, no UI change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

No JS unit test added: the gate is a single boolean check against a native-platform predicate, with no good seam to test in isolation that would be more meaningful than just reading the code. The native patch re-applies cleanly against an unmodified `react-native-callkeep@4.3.16` tarball (verified with `patch -p1 --dry-run`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and error handling for incoming/outgoing call flows, preventing crashes on devices lacking telecom support.
  * Android initialization now runs only on devices with telecom feature, avoiding incorrect setup on unsupported platforms.
  * Safer phone-account registration and availability checks to handle security/unsupported failures gracefully.
  * Improved null-safety in call connections and fixed delayed event initialization on iOS to prevent lost events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->