### PR TITLE
chore(ci): point build workflows at renamed GitHub environments

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -13,7 +13,7 @@ jobs:
     name: Hold
     runs-on: ubuntu-latest
     if: ${{ inputs.trigger == 'pr' }}
-    environment: official_android_build
+    environment: android_build
     steps:
       - run: echo "Waiting for manual approval..."
 
@@ -58,7 +58,7 @@ jobs:
     name: Upload Hold
     runs-on: ubuntu-latest
     if: ${{ inputs.trigger == 'pr' }}
-    environment: upload_official_android
+    environment: upload_android
     needs: [build-android]
     outputs:
       BUILD_VERSION: ${{ needs.build-android.outputs.BUILD_VERSION }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,7 +13,7 @@ jobs:
     name: Hold
     runs-on: ubuntu-latest
     if: ${{ inputs.trigger == 'pr' }}
-    environment: official_ios_build
+    environment: ios_build
     steps:
       - run: echo "Waiting for manual approval..."
 
@@ -59,7 +59,7 @@ jobs:
     name: Upload Hold
     runs-on: ubuntu-latest
     if: ${{ inputs.trigger == 'pr' }}
-    environment: upload_official_ios
+    environment: upload_ios
     needs: [build-ios]
     steps:
       - run: echo "Waiting for manual approval..."


### PR DESCRIPTION
## Proposed changes

Follow-up to #7325 (NATIVE-1129). That PR renamed the four `official_*` GitHub Environments in repo settings (`official_android_build` → `android_build`, `upload_official_android` → `upload_android`, `official_ios_build` → `ios_build`, `upload_official_ios` → `upload_ios`) and flattened "official" naming across the codebase, but deferred the matching YAML edits so envs could be renamed in-place without a build-break window.

This PR points the workflow `environment:` refs at the renamed environments:

- `.github/workflows/build-android.yml` line 16 — `official_android_build` → `android_build`
- `.github/workflows/build-android.yml` line 61 — `upload_official_android` → `upload_android`
- `.github/workflows/build-ios.yml` line 16 — `official_ios_build` → `ios_build`
- `.github/workflows/build-ios.yml` line 62 — `upload_official_ios` → `upload_ios`

GitHub's environment rename preserves approval rules and bound secrets, so no secret re-entry or approver re-setup was needed. The `*_OFFICIAL`-suffixed CI secrets are kept as-is (see ADR 0007) — only environment names changed.

## Issue(s)

- [NATIVE-1129](https://rocketchat.atlassian.net/browse/NATIVE-1129) — Drop "official" naming across Android/iOS/CI

## How to test or reproduce

- The build hold jobs in this PR run resolve to the renamed environments (`android_build`, `ios_build`) and surface their approval prompts. Approving each gate proceeds to the matching `build-android` / `build-ios` job.
- After build completes, the upload hold jobs resolve to `upload_android` / `upload_ios`.
- Acceptance grep over the touched files returns nothing:
  ```bash
  rg -n 'official_(android|ios)_build|upload_official_' .github/workflows/build-android.yml .github/workflows/build-ios.yml
  ```

## Screenshots

N/A — CI plumbing only.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — N/A, YAML-only edit verified by the PR's own build run
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Scope is intentionally narrow: just the two checkboxes left open under #7325's "TBD: Follow-up: GitHub admin cleanup" section. The renamed envs already exist in repo settings; this PR closes the loop by updating the workflow YAML.

[NATIVE-1129]: https://rocketchat.atlassian.net/browse/NATIVE-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow environments for Android builds
  * Updated CI/CD workflow environments for iOS builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->