### PR TITLE
fix(android): set RC Mobile User-Agent on push notification avatar fetch

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/notification/NotificationHelper.java
@@ -56,21 +56,22 @@ public class NotificationHelper {
      * Build a Glide load model for an avatar URL, sending rc_token/rc_uid as HTTP request
      * headers via GlideUrl + LazyHeaders. The JS codebase appends these as query params
      * (getAvatarUrl.ts) for convenience; native uses headers because Glide supports it cleanly.
+     * Always includes the app User-Agent so server logs / WAF rules see "RC Mobile" instead
+     * of Glide's default Dalvik UA.
      */
     public static Object avatarLoadModel(String uri, @Nullable Ejson ejson) {
         if (uri == null || uri.isEmpty()) {
             return uri;
         }
+        LazyHeaders.Builder builder = new LazyHeaders.Builder()
+                .addHeader("User-Agent", getUserAgent());
         String rcToken = ejson != null ? ejson.token() : "";
         String rcUid = ejson != null ? ejson.userId() : "";
-        if (rcToken.isEmpty() || rcUid.isEmpty()) {
-            return uri;
+        if (!rcToken.isEmpty() && !rcUid.isEmpty()) {
+            builder.addHeader("rc_token", rcToken)
+                    .addHeader("rc_uid", rcUid);
         }
-        LazyHeaders headers = new LazyHeaders.Builder()
-                .addHeader("rc_token", rcToken)
-                .addHeader("rc_uid", rcUid)
-                .build();
-        return new GlideUrl(uri, headers);
+        return new GlideUrl(uri, builder.build());
     }
 
     /**

--- a/android/app/src/test/java/chat/rocket/reactnative/notification/NotificationHelperTest.kt
+++ b/android/app/src/test/java/chat/rocket/reactnative/notification/NotificationHelperTest.kt
@@ -1,0 +1,52 @@
+package chat.rocket.reactnative.notification
+
+import com.bumptech.glide.load.model.GlideUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression tests for [NotificationHelper.avatarLoadModel].
+ *
+ * Issue #7330: Android push notifications were fetching avatars without the
+ * app's "RC Mobile" User-Agent, surfacing the default Dalvik UA in server logs.
+ * The avatar loader must always attach the User-Agent header, regardless of
+ * whether auth credentials are present.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class NotificationHelperTest {
+
+    @Test
+    fun `avatarLoadModel includes RC Mobile User-Agent when ejson is null`() {
+        val loadModel = NotificationHelper.avatarLoadModel("https://example.com/avatar/foo", null)
+
+        assertTrue("Expected GlideUrl, got ${loadModel?.javaClass}", loadModel is GlideUrl)
+        val headers = (loadModel as GlideUrl).headers
+        val userAgent = headers["User-Agent"]
+        assertNotNull("User-Agent header must be present", userAgent)
+        assertTrue(
+            "User-Agent must start with 'RC Mobile' (got: $userAgent)",
+            userAgent!!.startsWith("RC Mobile")
+        )
+    }
+
+    @Test
+    fun `avatarLoadModel returns input unchanged when uri is null or empty`() {
+        assertEquals(null, NotificationHelper.avatarLoadModel(null, null))
+        assertEquals("", NotificationHelper.avatarLoadModel("", null))
+    }
+
+    @Test
+    fun `getUserAgent matches RC Mobile android format`() {
+        val ua = NotificationHelper.getUserAgent()
+        assertTrue(
+            "User-Agent should match 'RC Mobile; android <ver>; v<name> (<code>)' (got: $ua)",
+            Regex("^RC Mobile; android [^;]+; v[^ ]+ \\(\\d+\\)$").matches(ua)
+        )
+    }
+}


### PR DESCRIPTION
## Proposed changes

On Android, the avatar request embedded in a push notification was sent with the default Dalvik UA instead of the app's `RC Mobile; android <ver>; v<x> (<n>)` UA. Some workspaces' WAF / firewall rules reject those requests with HTTP 403:

```
"GET /api/v1/push.get ..." 200 ... "RC Mobile; android 14; v4.72.0 (108809)"
"GET /avatar/luca?..."     403 ... "Dalvik/2.1.0 (Linux; U; Android 14; ...)"
```

`NotificationHelper.avatarLoadModel()` was building a Glide `LazyHeaders` with only `rc_token` / `rc_uid` and no User-Agent, so Glide's default OkHttp client fell back to the Dalvik UA. iOS was already attaching the UA in `NotificationService.swift`.

This PR makes the helper always attach the app User-Agent and keep the auth headers conditional. The same helper is used by `IncomingCallActivity.loadAvatar`, so the VoIP incoming-call avatar is fixed at the same time.

## Issue(s)

- Closes #7330
- Jira: [NATIVE-1179](https://rocketchat.atlassian.net/browse/NATIVE-1179)

## How to test or reproduce

1. Build a Debug APK against a Rocket.Chat workspace whose proxy logs the request User-Agent.
2. Background the app and send a push-triggering DM to your account.
3. When the notification arrives, check the server access log for the `GET /avatar/<username>?format=png&size=100` request — UA should now be `RC Mobile; android <ver>; v<x> (<n>)`, not `Dalvik/...`.

A Robolectric unit test (`NotificationHelperTest.kt`) asserts that:
- `avatarLoadModel` always returns a `GlideUrl` with `User-Agent` set to the `RC Mobile` UA, even when no `Ejson` (auth) is present.
- `getUserAgent()` matches the `RC Mobile; android <ver>; v<name> (<code>)` format.

Run locally:

```
./gradlew :app:testDebugUnitTest --tests "chat.rocket.reactnative.notification.NotificationHelperTest"
```

## Screenshots

N/A — native header change, no UI impact.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

A wider follow-up will be filed to add a User-Agent interceptor to the shared `SSLPinningTurboModule.getSharedOkHttpClient()`, which would also cover `MediaCallsAnswerRequest` (VoIP accept/decline) and Expo Image loads. Kept out of this PR to keep the change tight to #7330.

[NATIVE-1179]: https://rocketchat.atlassian.net/browse/NATIVE-1179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar requests now always include the "RC Mobile" User-Agent and attach authentication headers only when both token and uid are present, improving avatar load reliability and header handling. Null or empty avatar URIs are preserved and returned unchanged.

* **Tests**
  * Added tests validating the "RC Mobile" User-Agent format and avatar loading behavior for null, empty, and authenticated cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->