### PR TITLE
fix(login): don't cancel login saga on 2s timeout (#7333)

### DIFF
--- a/app/sagas/login.js
+++ b/app/sagas/login.js
@@ -479,11 +479,17 @@ const root = function* root() {
 	while (true) {
 		const params = yield take(types.LOGIN.SUCCESS);
 		const loginSuccessTask = yield fork(handleLoginSuccess, params);
-		yield race({
+		// Only cancel handleLoginSuccess if a workspace switch interrupts it.
+		// Cancelling on the 2s timeout would rip the saga before it reaches
+		// appStart(ROOT_INSIDE), stranding users on the login screen when
+		// permissions/enterprise fetches run long (issue #7333).
+		const { selectRequest } = yield race({
 			selectRequest: take(types.SERVER.SELECT_REQUEST),
 			timeout: delay(2000)
 		});
-		yield cancel(loginSuccessTask);
+		if (selectRequest) {
+			yield cancel(loginSuccessTask);
+		}
 	}
 };
 export default root;


### PR DESCRIPTION
## Proposed changes

The `root()` watcher in `app/sagas/login.js` raced `SERVER.SELECT_REQUEST` against a 2-second `delay`, then `cancel`ed `handleLoginSuccess` **unconditionally** — whichever arm of the race won. The cancel was meant only as a guard against a workspace switch interrupting login mid-flow, but as written it imposed a hard 2-second deadline on the saga.

Inside `handleLoginSuccess`, two awaited REST calls run before `appStart(ROOT_INSIDE)`:

```js
yield call(fetchPermissions);
yield call(fetchEnterpriseModules, { user });
// …
yield put(appStart({ root: RootEnum.ROOT_INSIDE }));
```

On a slow network / fresh install / large permission set, those exceed 2s, the saga is cancelled before navigation, and the user is stranded on the login screen. A retry succeeds because permissions are cached and the server is warm. Matches the symptom in #7333 and the Android variant reported in the same thread (home stack flashes for ~1s, then bounces back to login).

Regression introduced by the VoIP feature PR (#6918), which switched the two fetches from `fork` to `call`. The follow-up VoIP PR (#7270) noted the 2s race in a comment and routed VoIP out via `spawn`, but didn't address the underlying foot-gun.

This PR makes the cancel conditional — only fires when `SERVER.SELECT_REQUEST` actually wins the race. The 2s `delay` continues to bound how long the watcher listens for a workspace switch; it no longer doubles as a deadline on `handleLoginSuccess`.

## Issue(s)

- Closes #7333
- Jira: [NATIVE-1180](https://rocketchat.atlassian.net/browse/NATIVE-1180)
- Follow-up: #7341 (saga unit-test coverage)

## How to test or reproduce

1. Fresh install or clear app data.
2. Use a workspace where `getPermissions` + `getEnterpriseModules` together take >2s on first call (slow network, cold server, or large permission set; you can also pin this locally by adding `yield delay(2500)` to `fetchPermissions` on `develop`).
3. Sign in (OAuth or password).
4. **Before fix:** login screen does not dismiss; second attempt succeeds.
5. **After fix:** login completes on first attempt regardless of fetch duration.

To verify the workspace-switch guard still works, dispatch `SERVER.SELECT_REQUEST` while `handleLoginSuccess` is in flight — the saga should still be cancelled.

## Screenshots

n/a — saga-level fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — `app/sagas/` has no unit-test harness today; tracked separately as #7341.
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Alternative considered: change `call(fetchPermissions)` / `call(fetchEnterpriseModules)` to `fork` (as suggested in the issue thread). That would also unblock navigation, but leaves the unconditional cancel in place — any future awaited step in `handleLoginSuccess` would silently reintroduce the bug. Fixing the cancel itself addresses the root cause.

[NATIVE-1180]: https://rocketchat.atlassian.net/browse/NATIVE-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the login flow could be prematurely cancelled during long-running permission or enterprise data fetches. The login sequence now avoids an unnecessary timeout cancellation and lets critical background fetches complete before proceeding, improving reliability when switching workspaces or handling slow responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->