### PR TITLE
chore(ci): drop iOS upload-hold gate from PR build flow

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -55,20 +55,10 @@ jobs:
           GOOGLE_SERVICES_IOS: ${{ secrets.GOOGLE_SERVICES_IOS }}
           BUILD_VERSION: ${{ steps.version.outputs.BUILD_VERSION }}
 
-  upload-hold:
-    name: Upload Hold
-    runs-on: ubuntu-latest
-    if: ${{ inputs.trigger == 'pr' }}
-    environment: upload_ios
-    needs: [build-ios]
-    steps:
-      - run: echo "Waiting for manual approval..."
-
   upload-ios:
     name: Upload
     runs-on: macos-26
-    needs: [upload-hold]
-    if: ${{ always() && (needs.upload-hold.result == 'success' || needs.upload-hold.result == 'skipped') }}
+    needs: [build-ios]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Proposed changes

After `build-hold` approval, `upload-ios` now runs automatically once `build-ios` succeeds — no second approval prompt.

- PR runs (`trigger == 'pr'`): `fastlane ios beta` calls `pilot()` without `distribute_external` / `groups` (no `changelog.txt` artifact), so the build lands for **TestFlight Internal Testers only** — no Beta App Review.
- Develop runs (`trigger == 'develop'`): **unchanged**. The changelog-present branch in the existing fastlane lane keeps publishing to External Testers.
- dSYM upload to Crashlytics + Bugsnag and the PR comment (`iOS Build Available — Rocket.Chat X.Y.Z`) are untouched.
- Android workflows are **untouched** — the two-gate Android PR flow is deliberately preserved (TestFlight has no equivalent of Play Store Internal App Sharing as a separate product).

Diff: `.github/workflows/build-ios.yml` only, +1 / −11. The `upload_ios` GitHub Environment becomes orphaned and will be retired separately by a maintainer via Settings → Environments.

## Issue(s)

- https://rocketchat.atlassian.net/browse/NATIVE-1181 — iOS PR builds: remove upload-hold gate (TestFlight Internal Testers only)
- Parent: https://rocketchat.atlassian.net/browse/NATIVE-1118 — Remove Experimental app

## How to test or reproduce

1. **PR happy path.** Open this PR, approve the `build-hold` gate. Expect `build-ios` to run, then `upload-ios` to start automatically without a second approval. Confirm an Internal Tester sees the build in TestFlight within ~15 min of `build-hold` approval. Verify the PR comment posts with the version + build number, and that `upload-ios` logs show successful dSYM uploads to Crashlytics and Bugsnag.
2. **Develop regression check.** After merge, observe the develop push run: `build-ios` → `upload-ios` (no gate change on develop) → build is distributed to the External Testers group with the generated changelog text, External Testers receive the standard notification, dSYMs upload. This is the critical regression check — if develop stops reaching External Testers, the public beta cadence breaks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — N/A; the repo has no actionlint / YAML-schema check on `.github/workflows/`, and prior CI workflow changes (e.g. #7335, #7325, #7322, #7321) were verified by observing real PR + develop runs rather than by automated tests.
- [x] I have added necessary documentation (if applicable) — decision recorded in the parent Jira NATIVE-1181 description.
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Asymmetry with Android (which keeps two gates) is intentional. Android's second gate gates a different *product* — Play Store internal/beta — separate from its `upload-internal` job, which pushes to Internal App Sharing. iOS has no analogous second product: TestFlight Internal Testers and External Testers consume the same uploaded build, distinguished only by the `distribute_external` / `groups` toggles in `pilot()`. A second iOS gate would gate nothing distinct.

When a PR build does need External Testers (rare), promote it manually via App Store Connect — open the build, add the External Testers group, fill the changelog, submit for Beta App Review. CI does not automate this.

Rollback strategy: revert this single commit. If develop stops reaching External Testers after merge, revert in one PR with a single-file change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the iOS build pipeline by removing a manual approval gate; iOS uploads now proceed automatically after the build stage and run on an updated macOS runner for faster processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->