### PR TITLE
chore: align local defaults with chat.rocket.{android,ios}

### DIFF
--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,2 +1,2 @@
 json_key_file("service_account.json") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
-package_name("chat.rocket.reactnative")
+package_name("chat.rocket.android")

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -35,7 +35,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 newArchEnabled=true
 
 # Application ID
-APPLICATION_ID=chat.rocket.reactnative
+APPLICATION_ID=chat.rocket.android
 
 # App properties
 VERSIONCODE=999999999

--- a/ios/GoogleService-Info.plist
+++ b/ios/GoogleService-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>115198584049-0efgfvm0oh9ap55g7epmqnjm27mq3j4e.apps.googleusercontent.com</string>
+	<string>115198584049-rprp4acma9j5fmf97vfv6f8nqb6bc9eq.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.115198584049-0efgfvm0oh9ap55g7epmqnjm27mq3j4e</string>
+	<string>com.googleusercontent.apps.115198584049-rprp4acma9j5fmf97vfv6f8nqb6bc9eq</string>
 	<key>API_KEY</key>
 	<string>AIzaSyDEMLMz0En0vwFBlLSQkQ9oyhmCMPcpZxc</string>
 	<key>GCM_SENDER_ID</key>
@@ -13,11 +13,11 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>chat.rocket.reactnative</string>
+	<string>chat.rocket.ios</string>
 	<key>PROJECT_ID</key>
 	<string>rocketchat-reactnative-test</string>
 	<key>STORAGE_BUCKET</key>
-	<string>rocketchat-reactnative-test.appspot.com</string>
+	<string>rocketchat-reactnative-test.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -29,7 +29,7 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:115198584049:ios:8be27b1f7c42a2ed</string>
+	<string>1:115198584049:ios:20f4a0bee53e7b4a9ab550</string>
 	<key>DATABASE_URL</key>
 	<string>https://rocketchat-reactnative-test.firebaseio.com</string>
 </dict>

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,4 +1,4 @@
-app_identifier "chat.rocket.reactnative" # The bundle identifier of your app
+app_identifier "chat.rocket.ios" # The bundle identifier of your app
 apple_id "diegolmello@gmail.com" # Your Apple email address
 
 team_id "S6UPZG7ZR3" # Developer Portal Team ID

--- a/push.apns
+++ b/push.apns
@@ -1,5 +1,5 @@
 {
-	"Simulator Target Bundle": "chat.rocket.reactnative",
+	"Simulator Target Bundle": "chat.rocket.ios",
 	"aps": {
 		"alert": {
 			"title": "Hey!",


### PR DESCRIPTION
## Proposed changes

After the Experimental/official flatten (NATIVE-1129), only `chat.rocket.android` and `chat.rocket.ios` ship. A handful of local-only identifiers still pointed at the old `chat.rocket.reactnative`. This caused local dev builds to collide with the Play Store internal beta on the same emulator (`INSTALL_FAILED_SHARED_USER_INCOMPATIBLE`). This PR aligns them.

- `android/gradle.properties` — `APPLICATION_ID` default → `chat.rocket.android` (CI already overrides; this only affects local dev installs)
- `android/fastlane/Appfile` — `package_name` → `chat.rocket.android`
- `ios/fastlane/Appfile` — `app_identifier` → `chat.rocket.ios`
- `ios/GoogleService-Info.plist` — regenerated (`BUNDLE_ID` / `GOOGLE_APP_ID` now `chat.rocket.ios`)
- `push.apns` — Simulator Target Bundle → `chat.rocket.ios`
- `.maestro/tests/room/reaction-picker-small-screen.yaml` — `appId` → `${APP_ID}` (matches every other maestro test)

Out of scope:
- The `chat.rocket.reactnative` Android namespace (`android/app/build.gradle:87`, `android/app/src/main/java/chat/rocket/reactnative/**`, `AndroidManifest android:name` refs) — class FQNs, independent of `applicationId`.
- The two CI workflow lines that re-write `APPLICATION_ID=chat.rocket.android` (`.github/actions/build-android/action.yml:66`, `.github/workflows/e2e-build-android.yml:75`) — both truncate `gradle.properties` before appending, so the lines aren't redundant.
- The orphan `clients[1]` Android block in `android/app/google-services.json` (handoff lists as optional follow-up).

## Issue(s)

- https://rocketchat.atlassian.net/browse/NATIVE-1182 (subtask of [NATIVE-1118](https://rocketchat.atlassian.net/browse/NATIVE-1118))

## How to test or reproduce

1. `pnpm android` (or `./gradlew :app:assembleDebug` from `android/`).
2. `aapt dump badging app/build/outputs/apk/debug/app-debug.apk | grep package` — should report `name='chat.rocket.android'`.
3. Install on an emulator that already has the Play Store internal beta — the dev build now replaces it cleanly (no `INSTALL_FAILED_SHARED_USER_INCOMPATIBLE`).

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

[NATIVE-1118]: https://rocketchat.atlassian.net/browse/NATIVE-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android application package identifier configuration
  * Updated iOS application bundle identifier configuration
  * Refreshed iOS Firebase service configuration with updated credentials and identifiers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->