### PR TITLE
fix(ci): restore iOS upload on develop after upload-hold removal

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -59,6 +59,7 @@ jobs:
     name: Upload
     runs-on: macos-26
     needs: [build-ios]
+    if: ${{ always() && needs.build-ios.result == 'success' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Proposed changes

Restores the `always()` guard on `upload-ios` that was accidentally dropped in #7344.

When `build-hold` is skipped on develop, GitHub Actions' default `success()` condition skips downstream jobs unless they opt in with `always()`. `build-ios` already uses that pattern; `upload-ios` lost it when `upload-hold` was removed. Android upload still has the equivalent guard via `upload-hold`.

PR builds are unchanged: `build-hold` still gates the build, and upload still runs automatically after a successful `build-ios` — no second approval gate is reintroduced.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
<!-- Note for AI: don't fill this section, it's for the human reviewer to fill. -->
https://rocketchat.atlassian.net/browse/NATIVE-1187

## How to test or reproduce

1. Merge to `develop` and confirm the next **Build Develop** run executes **Build iOS / Upload** after **Build iOS / Build** succeeds (not skipped).
2. Open a PR and approve **Build iOS / Hold**; confirm **Build iOS / Upload** still runs automatically after build without a second approval step.

## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Regression introduced by #7344. Last successful develop iOS upload before this regression: https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/26412690700

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved iOS build workflow reliability by ensuring upload steps run only after a successful build. This prevents upload attempts following failed builds, reduces unnecessary CI activity, and makes pipeline outcomes clearer and more predictable for teams relying on automated iOS artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RocketChat/Rocket.Chat.ReactNative/pull/7352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->