### PR TITLE
fix: Deeplink auth when host is already connected

### DIFF
--- a/app/lib/methods/helpers/normalizeDeepLinkingServerHost.ts
+++ b/app/lib/methods/helpers/normalizeDeepLinkingServerHost.ts
@@ -13,7 +13,7 @@ export function normalizeDeepLinkingServerHost(rawHost: string): string {
 		} else {
 			host = `https://${host}`;
 		}
-	} else {
+	} else if (!/^http:\/\/localhost(:\d+)?/.test(host)) {
 		host = host.replace('http://', 'https://');
 	}
 	if (host.slice(-1) === '/') {

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -97,6 +97,8 @@ import { canOpenRoom } from '../../lib/methods/canOpenRoom';
 import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { goRoom } from '../../lib/methods/helpers/goRoom';
 import { waitForNavigationReady } from '../../lib/navigation/appNavigation';
+import sdk from '../../lib/services/sdk';
+import EventEmitter from '../../lib/methods/helpers/events';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -351,5 +353,101 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 
 		// Still exactly once
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+});
+
+/**
+ * Scenario: The user opens the app for the first time on a workspace that the
+ * SDK websocket is already connected to (e.g. they registered a server), then
+ * a deeplink with an auth token arrives for that same host.
+ */
+describe('deepLinking saga — server already connected, should skip changing server', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(canOpenRoom).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(goRoom).mockReset();
+		jest.mocked(waitForNavigationReady).mockReset();
+
+		// A different server is currently set; no stored credentials for HOST.
+		// This ensures we reach the else-branch (different server path) and then
+		// fall through to the getServerInfo / hostAlreadyConnected check.
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return 'https://other.server.com';
+			return null;
+		});
+		jest.mocked(getServerById).mockResolvedValue(null);
+		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
+		jest.mocked(canOpenRoom).mockResolvedValue({ rid: 'room-1', name: 'general', t: 'c' } as any);
+		jest.mocked(waitForNavigationReady).mockResolvedValue(undefined);
+		jest.mocked(goRoom).mockResolvedValue(undefined);
+
+		// Key setup: SDK websocket is already open to HOST
+		(sdk.current as any).client.host = HOST;
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		// Reset so other describe blocks see the default empty host
+		(sdk.current as any).client.host = '';
+	});
+
+	/**
+	 * Regression positive: the full chain completes without SERVER.SELECT_SUCCESS.
+	 * Before the fix this would hang because selectServer dispatches SELECT_CANCEL
+	 * (not SELECT_SUCCESS) when the server is already connected.
+	 */
+	it('calls goRoom after LOGIN.SUCCESS + APP.START(ROOT_INSIDE) without needing SERVER.SELECT_SUCCESS', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
+		// Two flushes drain the getServerById and getServerInfo promise microtasks.
+		// No jest.advanceTimersByTimeAsync needed — delay(1000) is skipped when
+		// hostAlreadyConnected is true.
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// Saga must be parked at take(LOGIN.SUCCESS), not take(SERVER.SELECT_SUCCESS)
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		// Drive the rest of the chain WITHOUT dispatching selectServerSuccess
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
+
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * Side-effect guard: the saga must NOT emit a 'NewServer' event when the
+	 * SDK is already connected — doing so would trigger the selectServer saga,
+	 * which would dispatch SELECT_CANCEL and leave deeplink auth stuck.
+	 */
+	it('does not emit NewServer when the SDK is already connected to the deeplink host', async () => {
+		const emitSpy = jest.spyOn(EventEmitter, 'emit');
+
+		const store = setupStore();
+		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(emitSpy).not.toHaveBeenCalledWith('NewServer', expect.anything());
+
+		// Complete the flow to confirm the saga finishes correctly
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+		emitSpy.mockRestore();
 	});
 });

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -225,13 +225,19 @@ const handleOpen = function* handleOpen({ params }) {
 			yield fallbackNavigation();
 			return;
 		}
-		yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-		yield put(serverInitAdd(server));
-		yield delay(1000);
-		EventEmitter.emit('NewServer', { server: host });
+		// if the host is different from the current one, we need to connect to it before navigating
+		const hostAlreadyConnected = sdk.current?.client?.host === host;
+		if (!hostAlreadyConnected) {
+			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+			yield put(serverInitAdd(server));
+			yield delay(1000);
+			EventEmitter.emit('NewServer', { server: host });
+		}
 
 		if (params.token) {
-			yield take(types.SERVER.SELECT_SUCCESS);
+			if (!hostAlreadyConnected) {
+				yield take(types.SERVER.SELECT_SUCCESS);
+			}
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);
 			yield put(appReady({}));


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->

During deeplink authentication, the deeplink saga does not check whether the server is already connected. Instead, it always attempts to add the server as a new one.

This triggers the `selectServer` saga. Since the server is already connected, `selectServer` redirects the user directly into the app without performing login and dispatches `SERVER.SELECT_CANCEL`.

However, the deeplink saga is waiting for a `SERVER.SELECT_SUCCESS` action, which is never dispatched in this scenario, causing the deeplink authentication flow to break.

This PR fixes this by checking if server is already connected in deeplink saga, before attempting to add the server. If server is already connected it continues the login flow without trying to add new server or wait for `SERVER.SELECT_SUCCESS`

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Open App and add a workspace 
- App takes user to login page
- Now leave the app and use deeplink auth (link having userId and token)
- The deeplink gets stuck, doesn't log the user in properly
## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[PRM-49](https://rocketchat.atlassian.net/browse/PRM-49)


[PRM-49]: https://rocketchat.atlassian.net/browse/PRM-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deep linking preserves http://localhost (with optional port) instead of forcing HTTPS.
  * Avoids unnecessary server reconnections when navigating to links that target the currently connected host.
  * Continues to normalize other non-HTTPS hosts and trims trailing slashes from hosts.

* **Tests**
  * Added coverage for deep-link flow when already connected to the target host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->