### PR TITLE
perf(call): cut HeaderCallButton mount cost by consolidating call hooks

### DIFF
--- a/app/lib/hooks/useVideoConf/index.tsx
+++ b/app/lib/hooks/useVideoConf/index.tsx
@@ -1,4 +1,4 @@
-import { useCameraPermissions } from 'expo-camera';
+import { Camera } from 'expo-camera';
 import React, { useMemo } from 'react';
 
 import { useActionSheet } from '../../../containers/ActionSheet';
@@ -33,7 +33,6 @@ export const useVideoConf = (
 	const serverVersion = useAppSelector(state => state.server.version);
 	const { callEnabled, disabledTooltip, roomType } = useVideoConfCall(rid);
 
-	const [permission, requestPermission] = useCameraPermissions();
 	const { showActionSheet } = useActionSheet();
 
 	const isServer5OrNewer = useMemo(() => compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '5.0.0'), [serverVersion]);
@@ -66,9 +65,10 @@ export const useVideoConf = (
 					fullContainer: true
 				});
 
+				const permission = await Camera.getCameraPermissionsAsync();
 				if (!permission?.granted) {
 					try {
-						await requestPermission();
+						await Camera.requestCameraPermissionsAsync();
 						handleAndroidBltPermission();
 					} catch (error) {
 						log(error);

--- a/app/lib/hooks/useVideoConf/useVideoConfCall.ts
+++ b/app/lib/hooks/useVideoConf/useVideoConfCall.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { shallowEqual } from 'react-redux';
 
 import { SubscriptionType } from '../../../definitions';
 import { getUserSelector } from '../../../selectors/login';
@@ -8,7 +9,6 @@ import { compareServerVersion } from '../../methods/helpers/compareServerVersion
 import { isReadOnly } from '../../methods/helpers/isReadOnly';
 import { useAppSelector } from '../useAppSelector';
 import { usePermissions } from '../usePermissions';
-import { useSetting } from '../useSetting';
 
 export const useVideoConfCall = (
 	rid: string
@@ -17,18 +17,31 @@ export const useVideoConfCall = (
 	const [disabledTooltip, setDisabledTooltip] = useState(false);
 	const [roomType, setRoomType] = useState<SubscriptionType>();
 
+	// Read all call-related settings in a single subscription instead of one useSetting per key.
+	const settings = useAppSelector(
+		state => ({
+			jitsiEnabled: state.settings.Jitsi_Enabled,
+			jitsiEnableTeams: state.settings.Jitsi_Enable_Teams,
+			jitsiEnableChannels: state.settings.Jitsi_Enable_Channels,
+			videoConfEnableDMs: state.settings.VideoConf_Enable_DMs,
+			videoConfEnableChannels: state.settings.VideoConf_Enable_Channels,
+			videoConfEnableTeams: state.settings.VideoConf_Enable_Teams,
+			videoConfEnableGroups: state.settings.VideoConf_Enable_Groups,
+			omnichannelCallProvider: state.settings.Omnichannel_call_provider
+		}),
+		shallowEqual
+	);
+
 	// OLD SETTINGS
-	const jitsiEnabled = useSetting('Jitsi_Enabled');
-	const jitsiEnableTeams = useSetting('Jitsi_Enable_Teams');
-	const jitsiEnableChannels = useSetting('Jitsi_Enable_Channels');
+	const { jitsiEnabled, jitsiEnableTeams, jitsiEnableChannels } = settings;
 
 	// NEW SETTINGS
 	// Only disable video conf if the settings are explicitly FALSE - any falsy value counts as true
-	const enabledDMs = useSetting('VideoConf_Enable_DMs') !== false;
-	const enabledChannel = useSetting('VideoConf_Enable_Channels') !== false;
-	const enabledTeams = useSetting('VideoConf_Enable_Teams') !== false;
-	const enabledGroups = useSetting('VideoConf_Enable_Groups') !== false;
-	const enabledLiveChat = useSetting('Omnichannel_call_provider') === 'default-provider';
+	const enabledDMs = settings.videoConfEnableDMs !== false;
+	const enabledChannel = settings.videoConfEnableChannels !== false;
+	const enabledTeams = settings.videoConfEnableTeams !== false;
+	const enabledGroups = settings.videoConfEnableGroups !== false;
+	const enabledLiveChat = settings.omnichannelCallProvider === 'default-provider';
 
 	const serverVersion = useAppSelector(state => state.server.version);
 	const isServer5OrNewer = compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '5.0.0');

--- a/app/views/RoomView/components/HeaderCallButton.tsx
+++ b/app/views/RoomView/components/HeaderCallButton.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef } from 'react';
 import * as HeaderButton from '../../../containers/Header/components/HeaderButton';
 import { useVideoConf } from '../../../lib/hooks/useVideoConf';
 import { useNewMediaCall } from '../../../lib/hooks/useNewMediaCall';
-import { useIsInActiveVoipCall } from '../../../lib/services/voip/isInActiveVoipCall';
 
 const DOUBLE_TAP_WINDOW_MS = 300;
 
@@ -20,7 +19,6 @@ export const HeaderCallButton = ({
 
 	const { showInitCallActionSheet, callEnabled, disabledTooltip } = useVideoConf(rid);
 	const { openNewMediaCall, startCallImmediate, hasMediaCallPermission, isInActiveCall } = useNewMediaCall(rid);
-	const isInActiveVoipCall = useIsInActiveVoipCall();
 
 	const lastTapRef = useRef(0);
 	const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -67,7 +65,7 @@ export const HeaderCallButton = ({
 		return (
 			<HeaderButton.Item
 				accessibilityLabel={accessibilityLabel}
-				disabled={disabledTooltip || disabled || isInActiveVoipCall}
+				disabled={disabledTooltip || disabled || isInActiveCall}
 				iconName='phone'
 				onPress={showInitCallActionSheet}
 				testID='room-view-header-call'


### PR DESCRIPTION
## Proposed changes

`HeaderCallButton` (rendered in the RoomView navigation header) ran a heavy hook stack on **every mount**: ~12 redux `useSelector` calls (8 of them one-per-setting), a native `expo-camera` permission hook, and a duplicated zustand selector — none of which is needed in the first frame. Because React Navigation renders the header twice during the push transition, this work runs ×2 in the critical room-open commit.

This PR consolidates that per-mount work in the **shared** call hooks (behavior-preserving — same return values; every consumer benefits: RoomView header, Room Info, Room Actions, Sidebar, VideoConferenceEnded):

- **`useVideoConfCall`**: 8 separate `useSetting` reads → 1 `useAppSelector(..., shallowEqual)` (−7 store subscriptions)
- **`useVideoConf`**: reactive `useCameraPermissions()` → imperative `Camera.getCameraPermissionsAsync()` / `requestCameraPermissionsAsync()` at press time (removes a native-backed hook from every render; reads fresh permission at press instead of a reactive snapshot)
- **`HeaderCallButton`**: drop the duplicate `useIsInActiveVoipCall()` (reuse `isInActiveCall` from `useNewMediaCall`)

**Benchmark** (iOS sim, Argent React Profiler; warm, interleaved A/B) — `HeaderCallButton` self-time in the critical room-open commit, with `MessageTouchable` as a warmth control (flat across runs):

| | develop (n=3) | this PR (n=2) |
|---|---|---|
| `HeaderCallButton` self | 6.41 / 5.88 / 6.14 → **mean 6.14ms** | 1.25 / 2.68 → **mean 1.97ms** |

→ **−68% (~4.2ms warm)** in the component's own self-time, on the critical path; larger absolute saving on cold opens. (Profiling warm-up varies the commit *total* ~2.4× run-to-run, so per-component self-time is the trustworthy metric.)

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1195

Follow-up to NATIVE-1184 (markdown perf, #7348) from the same RoomView cold-open profiling.

## How to test or reproduce

- Open a room and verify the call button still appears in the header and opens the call action sheet (VoIP "New call" / videoconf start-call sheet).
- Start a videoconf call and confirm the camera permission is still requested when not yet granted.
- Exercise the other consumers of these hooks: Room Info, Room Actions, Sidebar, VideoConferenceEnded.

## Screenshots

_No visual change — header/call button render identically._

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The hooks are shared, so the change is internal and preserves each hook's public API and return values — verified by the existing `CallSection` and `RoomInfoButtons` snapshot tests (no snapshot changes) and on-device (VoIP call sheet still opens).

An alternative was considered: deferring `HeaderCallButton`'s mount past the room-open transition with `InteractionManager`. That only *relocated* the work (no net CPU saving) and added a late-appearing button plus an extra re-render commit, with a warm benefit within measurement noise. Consolidation was chosen instead because it reduces the work itself, stays on the critical path, and benefits every consumer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved camera permission flow during video calls for more reliable, async permission prompts.
  * Consolidated video-call settings loading into a single subscription to reduce delays and ensure consistency.
  * Streamlined active-call state handling in call controls for more accurate enable/disable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->