### PR TITLE
fix: re-subscribe rooms stream after forced socket reopen

### DIFF
--- a/app/lib/services/connect.test.ts
+++ b/app/lib/services/connect.test.ts
@@ -1,6 +1,7 @@
 import { connect, determineAuthType, disconnect } from './connect';
 import { mediaSessionInstance } from './voip/MediaSessionInstance';
 import { pendingHangups } from './voip/pendingHangups';
+import { unsubscribeRooms } from '../methods/subscribeRooms';
 
 jest.mock('./voip/MediaSessionInstance', () => ({
 	mediaSessionInstance: { reset: jest.fn(), drainPendingHangups: jest.fn() }
@@ -478,6 +479,36 @@ describe('connect — pendingHangups drain on reconnect', () => {
 		await flushMicrotasks();
 
 		expect(firstDrainStop).toHaveBeenCalled();
+	});
+});
+
+describe('connect — rooms subscription guard reset on close', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockOnStreamDataStops.length = 0;
+		mockStoreGetState.mockReturnValue({
+			meteor: { connected: false },
+			login: { user: null, isAuthenticated: false },
+			settings: {}
+		});
+	});
+
+	// Regression: a long background marks the DDP socket stale, so foregrounding triggers
+	// `checkAndReopen` → `forceReopen`, which wipes the SDK subscriptions and emits 'close' while
+	// bypassing `connect()`. The rooms-list `stream-notify-user` feed only re-subscribes when the
+	// module-level guard in `subscribeRooms` is clear, and `unsubscribeRooms()` is what clears it.
+	// If the 'close' handler stops calling `unsubscribeRooms()`, the guard stays set after reconnect
+	// and the rooms list silently stops updating (subscriptions/favorites/reads).
+	it('calls unsubscribeRooms when the socket "close" fires', async () => {
+		await connect({ server: 'https://example.com' });
+
+		// connect() itself calls unsubscribeRooms() once while tearing down prior listeners; ignore it.
+		(unsubscribeRooms as jest.Mock).mockClear();
+
+		const closeHandler = getHandlersByEvent('close')[0];
+		closeHandler();
+
+		expect(unsubscribeRooms).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/app/lib/services/connect.ts
+++ b/app/lib/services/connect.ts
@@ -132,6 +132,11 @@ function connect({ server, logoutOnError = false }: { server: string; logoutOnEr
 		let pendingHangupsDrainArmed = false;
 
 		closeListener = sdk.current.onStreamData('close', () => {
+			// Reset the rooms-subscription guard on every socket close. `forceReopen` (triggered by
+			// `checkAndReopen` after a long background) wipes the SDK subscriptions and emits 'close'
+			// but bypasses `connect()`, so without this the guard in `subscribeRooms` stays set and
+			// `stream-notify-user` is never re-subscribed — the rooms list silently stops updating.
+			unsubscribeRooms();
 			pendingHangupsDrainArmed = true;
 			store.dispatch(disconnectAction());
 		});


### PR DESCRIPTION
## Proposed changes

After the app sits in the background for a while the DDP socket goes stale, so foregrounding triggers `checkAndReopen` → `forceReopen`. `forceReopen` drops every SDK subscription and reopens the socket **without** going through `connect()`, so the module-level `roomsSubscription` guard in `subscribeRooms` stays set. The next `subscribeRooms()` therefore short-circuits and never re-subscribes `stream-notify-user`, and the rooms list silently stops reflecting subscription/favorite/read changes until a manual reconnect or app restart.

This resets that guard from the socket `'close'` listener (via `unsubscribeRooms()`) — the same teardown `connect()` already performs at startup — so the resume-login that follows the reopen re-subscribes `stream-notify-user`. `stream-notify-user` is the only stream behind that guard; the other streams (permissions, presence, settings, roles) call `sdk.subscribe(...)` unconditionally and were never affected.

## Issue(s)

https://rocketchat.atlassian.net/browse/SUP-1047

## How to test or reproduce

1. Log in and open the rooms list.
2. Background the app and cut connectivity (airplane mode) for ~60s so the DDP socket goes stale.
3. Restore connectivity and foreground the app.
4. From another client (or REST), trigger a `subscriptions-changed` event — e.g. favorite/unfavorite a room or mark one read.

- **Before:** the rooms list does not update; the change only appears after a manual reconnect / app restart.
- **After:** the rooms list updates in real time again.

Verified on an Android 16 emulator: after foregrounding, `subscribeRooms()` re-subscribes `stream-notify-user` and a favorite toggle then fires the handler and the WatermelonDB write. A regression test in `connect.test.ts` asserts the `'close'` listener calls `unsubscribeRooms()` (and fails if the call is removed).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The fix lives in the `'close'` listener rather than in `subscribeRooms` itself because `'close'` is already the place app state is reset for reconnect (it dispatches `disconnectAction()` to flip Redux `meteor.connected` → false). The SDK's `forceReopen` documents this contract: it emits `'close'` so `connect.ts` flips that state, otherwise the next `'connected'` short-circuits and the loginRequest → subscribeNotifyUser chain never re-runs. The `roomsSubscription` guard is just a second piece of "am I subscribed?" state that has to be reset in that same spot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery so subscriptions are properly reset when VoIP/SDK connections close and reopen, ensuring notifications and real-time updates are re-established after reconnects.

* **Tests**
  * Added a regression test that verifies cleanup and unsubscribe behavior during connection close events to prevent missed or duplicate subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->