### PR TITLE
chore: remove wt-specific worktree contract from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,6 @@ pnpm storybook:start       # Start Metro with Storybook UI
 pnpm storybook-generate    # Generate story snapshots
 ```
 
-## Worktree contract
-
-When using worktrees (`wt`), the post-start hook runs `pnpm install` only. `wt step copy-ignored` is opt-in and only used when the worktree will perform a native build (iOS/Android/Pods/Gradle/Bundler caches).
-
 ## Code Style
 
 - **Prettier**: tabs, single quotes, 130 char width, no trailing commas, arrow parens avoid, bracket same line


### PR DESCRIPTION
## Proposed changes

Removes the `## Worktree contract` section from `CLAUDE.md`.

That section documented the local `wt` (worktrunk) workflow and stated *"the post-start hook runs `pnpm install` only."* This is inaccurate under the Superset-provisioned worktree workflow now in use: fresh worktrees ship without `node_modules`/`ios/Pods` and nothing auto-installs them. The stale section misdirects any agent or contributor who lands in a bare worktree and runs `pnpm test`/`lint`/build. Generic worktree setup is intentionally no longer documented in the shared repo doc.

`AGENTS.md` symlinks to `CLAUDE.md`, so it is covered by the same change.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1197

## How to test or reproduce

Docs-only change. Confirm the `## Worktree contract` heading and paragraph no longer appear in `CLAUDE.md`, and that the surrounding sections (`# Storybook` commands → `## Code Style`) are intact.

## Screenshots

_N/A — documentation only._

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes _(docs-only; no code or tests affected, not run)_
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Part of retiring local `wt` worktree tooling in favor of Superset-provisioned worktrees. This PR only touches the now-inaccurate shared-doc section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the "Worktree contract" section from the documentation, eliminating guidance about worktree-related install/start behavior and optional worktree copy steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->