### PR TITLE
fix: frequently used emoji crash on non-ASCII record ids

### DIFF
--- a/app/lib/database/model/migrations.js
+++ b/app/lib/database/model/migrations.js
@@ -1,4 +1,4 @@
-import { addColumns, createTable, schemaMigrations } from '@nozbe/watermelondb/Schema/migrations';
+import { addColumns, createTable, schemaMigrations, unsafeExecuteSql } from '@nozbe/watermelondb/Schema/migrations';
 
 export default schemaMigrations({
 	migrations: [
@@ -344,6 +344,17 @@ export default schemaMigrations({
 						{ name: 'inviter', type: 'string', isOptional: true }
 					]
 				})
+			]
+		},
+		{
+			toVersion: 29,
+			steps: [
+				// NATIVE-1192: legacy rows used the emoji content / custom-emoji name as the
+				// record id. Non-ASCII ids (CJK, ZWJ sequences, ...) corrupt across the native
+				// SQLite/JSI bridge and crash every frequently-used emoji read. Drop only the
+				// rows whose id contains a non-printable-ASCII character; they regenerate
+				// naturally on next use. ASCII shortname ids (e.g. heart_eyes) are kept.
+				unsafeExecuteSql("DELETE FROM frequently_used_emojis WHERE id GLOB '*[^ -~]*';")
 			]
 		}
 	]

--- a/app/lib/database/model/migrations.js
+++ b/app/lib/database/model/migrations.js
@@ -349,11 +349,8 @@ export default schemaMigrations({
 		{
 			toVersion: 29,
 			steps: [
-				// NATIVE-1192: legacy rows used the emoji content / custom-emoji name as the
-				// record id. Non-ASCII ids (CJK, ZWJ sequences, ...) corrupt across the native
-				// SQLite/JSI bridge and crash every frequently-used emoji read. Drop only the
-				// rows whose id contains a non-printable-ASCII character; they regenerate
-				// naturally on next use. ASCII shortname ids (e.g. heart_eyes) are kept.
+				// Drop legacy rows whose id contains a non-printable-ASCII char: emoji content/names
+				// were used as ids and corrupt across the native bridge. ASCII ids (e.g. heart_eyes) are kept.
 				unsafeExecuteSql("DELETE FROM frequently_used_emojis WHERE id GLOB '*[^ -~]*';")
 			]
 		}

--- a/app/lib/database/schema/app.js
+++ b/app/lib/database/schema/app.js
@@ -1,7 +1,7 @@
 import { appSchema, tableSchema } from '@nozbe/watermelondb';
 
 export default appSchema({
-	version: 28,
+	version: 29,
 	tables: [
 		tableSchema({
 			name: 'subscriptions',

--- a/app/lib/hooks/useFrequentlyUsedEmoji.test.ts
+++ b/app/lib/hooks/useFrequentlyUsedEmoji.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useFrequentlyUsedEmoji } from './useFrequentlyUsedEmoji';
+import { getFrequentlyUsedEmojis } from '../methods/emojis';
+import { type IEmoji } from '../../definitions';
+
+// jest.setup.js stubs this hook globally for component tests; use the real one here.
+jest.mock('./useFrequentlyUsedEmoji', () => jest.requireActual('./useFrequentlyUsedEmoji'));
+jest.mock('../methods/emojis', () => ({
+	getFrequentlyUsedEmojis: jest.fn()
+}));
+
+const mockedGetFrequentlyUsedEmojis = jest.mocked(getFrequentlyUsedEmojis);
+
+const createDeferred = <T>() => {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>(res => {
+		resolve = res;
+	});
+
+	return { promise, resolve };
+};
+
+describe('useFrequentlyUsedEmoji', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('starts unloaded, then exposes the fetched emojis and flips loaded', async () => {
+		const deferred = createDeferred<IEmoji[]>();
+		mockedGetFrequentlyUsedEmojis.mockReturnValue(deferred.promise);
+
+		const { result } = renderHook(() => useFrequentlyUsedEmoji());
+
+		expect(result.current).toEqual({ frequentlyUsed: [], loaded: false });
+
+		await act(async () => {
+			deferred.resolve(['grinning']);
+			await deferred.promise;
+		});
+
+		await waitFor(() => expect(result.current.loaded).toBe(true));
+		expect(result.current.frequentlyUsed).toEqual(['grinning']);
+		expect(mockedGetFrequentlyUsedEmojis).toHaveBeenCalledWith(false);
+	});
+
+	it('refetches when withDefaultEmojis changes', async () => {
+		mockedGetFrequentlyUsedEmojis.mockResolvedValue([]);
+
+		const { result, rerender } = renderHook(
+			({ withDefaults }: { withDefaults: boolean }) => useFrequentlyUsedEmoji(withDefaults),
+			{
+				initialProps: { withDefaults: false }
+			}
+		);
+
+		await waitFor(() => expect(result.current.loaded).toBe(true));
+		expect(mockedGetFrequentlyUsedEmojis).toHaveBeenCalledWith(false);
+
+		rerender({ withDefaults: true });
+
+		await waitFor(() => expect(mockedGetFrequentlyUsedEmojis).toHaveBeenCalledWith(true));
+		expect(mockedGetFrequentlyUsedEmojis).toHaveBeenCalledTimes(2);
+	});
+});

--- a/app/lib/hooks/useFrequentlyUsedEmoji.ts
+++ b/app/lib/hooks/useFrequentlyUsedEmoji.ts
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Q } from '@nozbe/watermelondb';
 
-import database from '../database';
 import { type IEmoji } from '../../definitions';
-import { DEFAULT_EMOJIS } from '../constants/emojis';
+import { getFrequentlyUsedEmojis } from '../methods/emojis';
 
 export const useFrequentlyUsedEmoji = (
 	withDefaultEmojis = false
@@ -14,26 +12,12 @@ export const useFrequentlyUsedEmoji = (
 	const [frequentlyUsed, setFrequentlyUsed] = useState<IEmoji[]>([]);
 	const [loaded, setLoaded] = useState(false);
 	useEffect(() => {
-		const getFrequentlyUsedEmojis = async () => {
-			const db = database.active;
-			const frequentlyUsedRecords = await db.get('frequently_used_emojis').query(Q.sortBy('count', Q.desc)).fetch();
-			let frequentlyUsedEmojis = frequentlyUsedRecords.map(item => {
-				if (item.isCustom) {
-					return { name: item.content, extension: item.extension! }; // if isCustom is true, extension is not null
-				}
-				return item.content;
-			});
-
-			if (withDefaultEmojis && frequentlyUsedEmojis.length < DEFAULT_EMOJIS.length) {
-				frequentlyUsedEmojis = frequentlyUsedEmojis
-					.concat(DEFAULT_EMOJIS.filter(de => !frequentlyUsedEmojis.find(fue => typeof fue === 'string' && fue === de)))
-					.slice(0, DEFAULT_EMOJIS.length);
-			}
-
-			setFrequentlyUsed(frequentlyUsedEmojis);
+		const fetchFrequentlyUsedEmojis = async () => {
+			const emojis = await getFrequentlyUsedEmojis(withDefaultEmojis);
+			setFrequentlyUsed(emojis);
 			setLoaded(true);
 		};
-		getFrequentlyUsedEmojis();
-	}, []);
+		fetchFrequentlyUsedEmojis();
+	}, [withDefaultEmojis]);
 	return { frequentlyUsed, loaded };
 };

--- a/app/lib/methods/emojis.test.ts
+++ b/app/lib/methods/emojis.test.ts
@@ -1,0 +1,129 @@
+import database from '../database';
+import { DEFAULT_EMOJIS } from '../constants/emojis';
+import migrations from '../database/model/migrations';
+import appSchema from '../database/schema/app';
+import { addFrequentlyUsed, getFrequentlyUsedEmojis } from './emojis';
+
+jest.mock('../database', () => ({
+	__esModule: true,
+	default: {
+		active: {
+			get: jest.fn(),
+			write: jest.fn()
+		}
+	}
+}));
+jest.mock('./helpers/log', () => ({ __esModule: true, default: jest.fn() }));
+
+const mockGet = database.active.get as jest.Mock;
+const mockWrite = database.active.write as jest.Mock;
+
+let mockFetch: jest.Mock;
+let mockCreate: jest.Mock;
+let mockQuery: jest.Mock;
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	mockFetch = jest.fn().mockResolvedValue([]);
+	mockCreate = jest.fn();
+	mockQuery = jest.fn(() => ({ fetch: mockFetch }));
+	mockGet.mockReturnValue({ query: mockQuery, create: mockCreate });
+	mockWrite.mockImplementation((cb: () => Promise<void>) => cb());
+});
+
+describe('addFrequentlyUsed', () => {
+	// NATIVE-1192: the emoji content / custom-emoji name must never become the WatermelonDB
+	// record id. It can be non-ASCII and corrupt across the native bridge. We look up existing
+	// rows by the content field and let WatermelonDB own a safe, ASCII record id.
+	it('creates a new row by querying content + is_custom and never sets the emoji as the id', async () => {
+		mockFetch.mockResolvedValue([]);
+
+		await addFrequentlyUsed({ name: '大丈夫', extension: 'png' });
+
+		// dedup is a field query (two Q.where clauses), not a find-by-id on the content
+		expect(mockQuery).toHaveBeenCalledTimes(1);
+		expect(mockQuery.mock.calls[0]).toHaveLength(2);
+		expect(mockCreate).toHaveBeenCalledTimes(1);
+
+		// run the create builder and confirm it sets fields but no content-derived id / _raw
+		const record: any = {};
+		mockCreate.mock.calls[0][0](record);
+		expect(record.content).toBe('大丈夫');
+		expect(record.isCustom).toBe(true);
+		expect(record.extension).toBe('png');
+		expect(record.count).toBe(1);
+		expect(record.id).toBeUndefined();
+		expect(record._raw).toBeUndefined();
+	});
+
+	it('does not set a custom extension or id for a standard emoji', async () => {
+		mockFetch.mockResolvedValue([]);
+
+		await addFrequentlyUsed('grinning');
+
+		const record: any = {};
+		mockCreate.mock.calls[0][0](record);
+		expect(record.content).toBe('grinning');
+		expect(record.isCustom).toBe(false);
+		expect(record.extension).toBeUndefined();
+		expect(record.id).toBeUndefined();
+	});
+
+	it('increments count for an existing emoji instead of creating a duplicate', async () => {
+		const existing: any = { count: 3 };
+		existing.update = jest.fn((fn: (f: any) => void) => fn(existing));
+		mockFetch.mockResolvedValue([existing]);
+
+		await addFrequentlyUsed('grinning');
+
+		expect(mockCreate).not.toHaveBeenCalled();
+		expect(existing.update).toHaveBeenCalledTimes(1);
+		expect(existing.count).toBe(4);
+	});
+});
+
+describe('getFrequentlyUsedEmojis', () => {
+	it('maps standard and custom rows to the shapes the UI expects', async () => {
+		mockFetch.mockResolvedValue([
+			{ isCustom: false, content: 'grinning' },
+			{ isCustom: true, content: 'rocketchat', extension: 'png' }
+		]);
+
+		const result = await getFrequentlyUsedEmojis();
+
+		expect(result).toEqual(['grinning', { name: 'rocketchat', extension: 'png' }]);
+	});
+
+	// NATIVE-1192 crash consequence: a single legacy non-ASCII id desyncs the native bridge
+	// and rejects the whole fetch. The read path must degrade gracefully, never crash the
+	// emoji picker / composer search / reaction bar.
+	it('returns an empty list instead of throwing when the native bridge desyncs', async () => {
+		mockFetch.mockRejectedValue(
+			new Error("Record ID frequently_used_emojis#大丈夫 was sent over the bridge, but it's not cached")
+		);
+
+		await expect(getFrequentlyUsedEmojis()).resolves.toEqual([]);
+	});
+
+	it('falls back to the default emojis on a bridge error when defaults are requested', async () => {
+		mockFetch.mockRejectedValue(
+			new Error("Record ID frequently_used_emojis#大丈夫 was sent over the bridge, but it's not cached")
+		);
+
+		await expect(getFrequentlyUsedEmojis(true)).resolves.toEqual(DEFAULT_EMOJIS);
+	});
+});
+
+describe('frequently_used_emojis migration (NATIVE-1192)', () => {
+	it('bumps the schema to v29 with a matching migration', () => {
+		expect(appSchema.version).toBe(29);
+		expect((migrations as any).maxVersion).toBe(29);
+	});
+
+	it('v29 deletes only legacy rows whose id contains a non-printable-ASCII character', () => {
+		const v29 = (migrations as any).sortedMigrations.find((m: any) => m.toVersion === 29);
+		expect(v29).toBeDefined();
+		const sqls = (v29.steps as any[]).filter(s => s.type === 'sql').map(s => s.sql);
+		expect(sqls.some(sql => /DELETE FROM frequently_used_emojis/i.test(sql) && /\[\^ -~\]/.test(sql))).toBe(true);
+	});
+});

--- a/app/lib/methods/emojis.test.ts
+++ b/app/lib/methods/emojis.test.ts
@@ -32,20 +32,15 @@ beforeEach(() => {
 });
 
 describe('addFrequentlyUsed', () => {
-	// NATIVE-1192: the emoji content / custom-emoji name must never become the WatermelonDB
-	// record id. It can be non-ASCII and corrupt across the native bridge. We look up existing
-	// rows by the content field and let WatermelonDB own a safe, ASCII record id.
 	it('creates a new row by querying content + is_custom and never sets the emoji as the id', async () => {
 		mockFetch.mockResolvedValue([]);
 
 		await addFrequentlyUsed({ name: '大丈夫', extension: 'png' });
 
-		// dedup is a field query (two Q.where clauses), not a find-by-id on the content
 		expect(mockQuery).toHaveBeenCalledTimes(1);
 		expect(mockQuery.mock.calls[0]).toHaveLength(2);
 		expect(mockCreate).toHaveBeenCalledTimes(1);
 
-		// run the create builder and confirm it sets fields but no content-derived id / _raw
 		const record: any = {};
 		mockCreate.mock.calls[0][0](record);
 		expect(record.content).toBe('大丈夫');
@@ -94,9 +89,6 @@ describe('getFrequentlyUsedEmojis', () => {
 		expect(result).toEqual(['grinning', { name: 'rocketchat', extension: 'png' }]);
 	});
 
-	// NATIVE-1192 crash consequence: a single legacy non-ASCII id desyncs the native bridge
-	// and rejects the whole fetch. The read path must degrade gracefully, never crash the
-	// emoji picker / composer search / reaction bar.
 	it('returns an empty list instead of throwing when the native bridge desyncs', async () => {
 		mockFetch.mockRejectedValue(
 			new Error("Record ID frequently_used_emojis#大丈夫 was sent over the bridge, but it's not cached")
@@ -114,7 +106,7 @@ describe('getFrequentlyUsedEmojis', () => {
 	});
 });
 
-describe('frequently_used_emojis migration (NATIVE-1192)', () => {
+describe('frequently_used_emojis migration', () => {
 	it('bumps the schema to v29 with a matching migration', () => {
 		expect(appSchema.version).toBe(29);
 		expect((migrations as any).maxVersion).toBe(29);

--- a/app/lib/methods/emojis.test.ts
+++ b/app/lib/methods/emojis.test.ts
@@ -75,6 +75,16 @@ describe('addFrequentlyUsed', () => {
 		expect(existing.update).toHaveBeenCalledTimes(1);
 		expect(existing.count).toBe(4);
 	});
+
+	it('runs the existing-row lookup inside the serialized write so concurrent calls cannot both create', async () => {
+		mockWrite.mockImplementation(() => Promise.resolve());
+
+		await addFrequentlyUsed('grinning');
+
+		expect(mockWrite).toHaveBeenCalledTimes(1);
+		expect(mockQuery).not.toHaveBeenCalled();
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
 });
 
 describe('getFrequentlyUsedEmojis', () => {

--- a/app/lib/methods/emojis.ts
+++ b/app/lib/methods/emojis.ts
@@ -1,49 +1,81 @@
-import { sanitizedRaw } from '@nozbe/watermelondb/RawRecord';
 import { Q } from '@nozbe/watermelondb';
 
 import database from '../database';
-import { type IEmoji, type TFrequentlyUsedEmojiModel } from '../../definitions';
+import { type ICustomEmoji, type IEmoji, type TFrequentlyUsedEmojiModel } from '../../definitions';
 import log from './helpers/log';
 import { sanitizeLikeString } from '../database/utils';
-import { emojis } from '../constants/emojis';
+import { DEFAULT_EMOJIS, emojis } from '../constants/emojis';
+
+const FREQUENTLY_USED_TABLE = 'frequently_used_emojis';
+
+// A frequently-used emoji is uniquely identified by its content + whether it is custom.
+// We deliberately do NOT use the emoji content / custom-emoji name as the WatermelonDB
+// record id: that content can be non-ASCII (CJK, ZWJ sequences, ...) and non-ASCII record
+// ids do not round-trip across the native SQLite/JSI bridge. A mangled id desyncs the
+// adapter's cached-id set from the JS RecordCache, making the entire .fetch() throw
+// "Record ID ... was sent over the bridge, but it's not cached" and crashing every emoji
+// surface (NATIVE-1192). Querying by the content field instead keeps content as a plain
+// column value (which round-trips fine) and lets WatermelonDB own a safe, ASCII record id.
+const getEmojiContent = (emoji: IEmoji) => (typeof emoji === 'string' ? emoji : emoji.name);
 
 export const addFrequentlyUsed = async (emoji: IEmoji) => {
 	const db = database.active;
-	const freqEmojiCollection = db.get('frequently_used_emojis');
-	let freqEmojiRecord: TFrequentlyUsedEmojiModel;
+	const freqEmojiCollection = db.get(FREQUENTLY_USED_TABLE);
+	const content = getEmojiContent(emoji);
+	const isCustom = typeof emoji !== 'string';
 	try {
-		if (typeof emoji === 'string') {
-			freqEmojiRecord = await freqEmojiCollection.find(emoji);
-		} else {
-			freqEmojiRecord = await freqEmojiCollection.find(emoji.name);
-		}
-	} catch (error) {
-		// Do nothing
-	}
-
-	try {
+		const [existing] = (await freqEmojiCollection
+			.query(Q.where('content', content), Q.where('is_custom', isCustom))
+			.fetch()) as TFrequentlyUsedEmojiModel[];
 		await db.write(async () => {
-			if (freqEmojiRecord) {
-				await freqEmojiRecord.update(f => {
+			if (existing) {
+				await existing.update(f => {
 					if (f.count) {
 						f.count += 1;
 					}
 				});
 			} else {
 				await freqEmojiCollection.create(f => {
-					if (typeof emoji === 'string') {
-						f._raw = sanitizedRaw({ id: emoji }, freqEmojiCollection.schema);
-						Object.assign(f, { content: emoji, isCustom: false });
-					} else {
-						f._raw = sanitizedRaw({ id: emoji.name }, freqEmojiCollection.schema);
-						Object.assign(f, { content: emoji.name, extension: emoji.extension, isCustom: true });
+					const record = f as TFrequentlyUsedEmojiModel;
+					// No record.id assignment: WatermelonDB generates a safe ASCII id.
+					record.content = content;
+					record.isCustom = isCustom;
+					if (isCustom) {
+						record.extension = (emoji as ICustomEmoji).extension;
 					}
-					f.count = 1;
+					record.count = 1;
 				});
 			}
 		});
 	} catch (e) {
 		log(e);
+	}
+};
+
+export const getFrequentlyUsedEmojis = async (withDefaultEmojis = false): Promise<IEmoji[]> => {
+	const db = database.active;
+	try {
+		const records = (await db.get(FREQUENTLY_USED_TABLE).query(Q.sortBy('count', Q.desc)).fetch()) as TFrequentlyUsedEmojiModel[];
+		let frequentlyUsedEmojis: IEmoji[] = records.map(item => {
+			if (item.isCustom) {
+				return { name: item.content, extension: item.extension! }; // if isCustom is true, extension is not null
+			}
+			return item.content;
+		});
+
+		if (withDefaultEmojis && frequentlyUsedEmojis.length < DEFAULT_EMOJIS.length) {
+			frequentlyUsedEmojis = frequentlyUsedEmojis
+				.concat(DEFAULT_EMOJIS.filter(de => !frequentlyUsedEmojis.find(fue => typeof fue === 'string' && fue === de)))
+				.slice(0, DEFAULT_EMOJIS.length);
+		}
+
+		return frequentlyUsedEmojis;
+	} catch (e) {
+		// A legacy non-ASCII record id can still desync the native bridge and reject the
+		// whole fetch. Frequently-used emojis are a non-critical convenience cache, so we
+		// log and degrade gracefully instead of crashing every emoji surface (NATIVE-1192).
+		log(e);
+		return withDefaultEmojis ? [...DEFAULT_EMOJIS] : [];
 	}
 };
 

--- a/app/lib/methods/emojis.ts
+++ b/app/lib/methods/emojis.ts
@@ -8,14 +8,8 @@ import { DEFAULT_EMOJIS, emojis } from '../constants/emojis';
 
 const FREQUENTLY_USED_TABLE = 'frequently_used_emojis';
 
-// A frequently-used emoji is uniquely identified by its content + whether it is custom.
-// We deliberately do NOT use the emoji content / custom-emoji name as the WatermelonDB
-// record id: that content can be non-ASCII (CJK, ZWJ sequences, ...) and non-ASCII record
-// ids do not round-trip across the native SQLite/JSI bridge. A mangled id desyncs the
-// adapter's cached-id set from the JS RecordCache, making the entire .fetch() throw
-// "Record ID ... was sent over the bridge, but it's not cached" and crashing every emoji
-// surface (NATIVE-1192). Querying by the content field instead keeps content as a plain
-// column value (which round-trips fine) and lets WatermelonDB own a safe, ASCII record id.
+// Looked up by content, never used as the record id: emoji content / custom names can be
+// non-ASCII and corrupt across the native SQLite bridge when used as WatermelonDB ids.
 const getEmojiContent = (emoji: IEmoji) => (typeof emoji === 'string' ? emoji : emoji.name);
 
 export const addFrequentlyUsed = async (emoji: IEmoji) => {
@@ -37,7 +31,6 @@ export const addFrequentlyUsed = async (emoji: IEmoji) => {
 			} else {
 				await freqEmojiCollection.create(f => {
 					const record = f as TFrequentlyUsedEmojiModel;
-					// No record.id assignment: WatermelonDB generates a safe ASCII id.
 					record.content = content;
 					record.isCustom = isCustom;
 					if (isCustom) {
@@ -71,9 +64,7 @@ export const getFrequentlyUsedEmojis = async (withDefaultEmojis = false): Promis
 
 		return frequentlyUsedEmojis;
 	} catch (e) {
-		// A legacy non-ASCII record id can still desync the native bridge and reject the
-		// whole fetch. Frequently-used emojis are a non-critical convenience cache, so we
-		// log and degrade gracefully instead of crashing every emoji surface (NATIVE-1192).
+		// A legacy non-ASCII id can still reject the fetch; degrade rather than crash the emoji UI.
 		log(e);
 		return withDefaultEmojis ? [...DEFAULT_EMOJIS] : [];
 	}

--- a/app/lib/methods/emojis.ts
+++ b/app/lib/methods/emojis.ts
@@ -18,10 +18,10 @@ export const addFrequentlyUsed = async (emoji: IEmoji) => {
 	const content = getEmojiContent(emoji);
 	const isCustom = typeof emoji !== 'string';
 	try {
-		const [existing] = (await freqEmojiCollection
-			.query(Q.where('content', content), Q.where('is_custom', isCustom))
-			.fetch()) as TFrequentlyUsedEmojiModel[];
 		await db.write(async () => {
+			const [existing] = (await freqEmojiCollection
+				.query(Q.where('content', content), Q.where('is_custom', isCustom))
+				.fetch()) as TFrequentlyUsedEmojiModel[];
 			if (existing) {
 				await existing.update(f => {
 					if (f.count) {


### PR DESCRIPTION
## Proposed changes

`addFrequentlyUsed` used the emoji content / custom-emoji name as the WatermelonDB record id. Custom emoji names are server-controlled and can be non-ASCII (CJK, ZWJ sequences). Non-ASCII ids do not round-trip across the native SQLite/JSI bridge: the adapter's cached-id set desyncs from the JS `RecordCache`, so the entire `frequently_used_emojis` `.fetch()` rejects with `Record ID ... was sent over the bridge, but it's not cached` and crashes every emoji surface (picker, composer search, reaction bar). Because results map synchronously, a single bad row takes down the whole fetch.

This PR:

- Lets WatermelonDB own a safe ASCII record id and dedups frequently-used emoji by the `content` + `is_custom` fields instead of `find`-by-id (content stays a plain column value, which round-trips fine).
- Runs that dedupe lookup inside `db.write()` so the find-or-create is serialized — two concurrent `addFrequentlyUsed` calls can no longer both miss the row and insert a duplicate.
- Centralizes the read in a resilient `getFrequentlyUsedEmojis` that logs and degrades to defaults on a bridge error instead of crashing the UI.
- Adds a v29 migration that purges only legacy rows whose id contains a non-printable-ASCII character (`id GLOB '*[^ -~]*'`), so ASCII shortname ids such as `heart_eyes` are preserved.
- Adds unit tests (mocked `database.active`, the repo's existing DB-test pattern) for the method and the `useFrequentlyUsedEmoji` hook.

For contrast, `getCustomEmojis` was never affected — it correctly keys `custom_emojis` by the server `_id` (ASCII-safe).

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1192

## How to test or reproduce

This crash only manifests with the native SQLite/JSI adapter — it cannot be reproduced in pure JS (non-ASCII ids round-trip fine there), so it needs a device/emulator build.

**About the trigger:** the crash requires a custom emoji whose **name is non-ASCII** (CJK, Cyrillic, emoji glyphs, etc.). Modern Rocket.Chat servers slugify custom emoji names to ASCII on create (`大丈夫` → `da4_zhang4_fu1`), so you cannot create a triggering emoji through Admin → Emoji there. To reproduce, use a server that stores non-ASCII names verbatim — an older Rocket.Chat, or any workspace that already carries such an emoji as legacy data.

### Reproduce the crash (pre-fix build, non-slugifying server)

1. On a server that has a custom emoji with a non-ASCII name (e.g. `大丈夫`), open any channel.
2. Open the emoji picker (or long-press a message → reaction bar) and tap that custom emoji — this writes it to `frequently_used_emojis`.
3. Reopen any emoji surface (picker / composer emoji search / message reaction bar). Before the fix, the fetch rejects with `Record ID frequently_used_emojis#大丈夫 was sent over the bridge, but it's not cached` and every emoji surface fails to load.

### Verify the fix (this branch, same server)

1. React with / pick the non-ASCII custom emoji. ✅ No crash; the reaction is added.
2. Reopen the picker, composer emoji search, and reaction bar. ✅ "Frequently used" shows the emoji and renders it; no crash.
3. React with it again on another message. ✅ A single frequently-used entry — the count increments, no duplicate row.
4. ✅ It renders correctly in the message body (`:name:`), the reaction badge, the picker grid, and the frequently-used row.

### Verify the upgrade heals existing installs

1. On the **previous** (pre-fix) build, react with the non-ASCII custom emoji to write the corrupt row.
2. Update to this build and open the app.
3. ✅ App opens normally, the emoji surfaces work, and the corrupted entry is gone — the v29 migration purges only non-printable-ASCII ids (ASCII shortnames such as `heart_eyes` are kept).

### Regression check (any server)

1. React with / pick a few standard emoji (e.g. 😀) and an ASCII-named custom emoji.
2. ✅ Both appear in Frequently used, dedupe and increment count on repeat, and survive an app restart.

### Automated coverage

`TZ=UTC pnpm test --testPathPattern='app/lib/(methods/emojis|hooks/useFrequentlyUsedEmoji).test'`

- `addFrequentlyUsed` creates via a content + is_custom query, never sets the emoji as the id, increments count on repeat, and runs its lookup inside the serialized write (no read-before-write race).
- `getFrequentlyUsedEmojis` maps row shapes and returns `[]` / defaults instead of throwing when a bridge desync is simulated.
- `useFrequentlyUsedEmoji` exposes the fetched emojis and flips `loaded`, and refetches when `withDefaultEmojis` changes.
- v29 migration deletes only non-printable-ASCII ids.

## Screenshots

N/A — crash fix, no visual change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The migration heals existing broken installs once at upgrade; the safe-id change prevents new bad rows; the resilient read is belt-and-suspenders so any unforeseen desync can never crash the emoji UI again.

Out of scope (flagged for follow-up): the same content-as-id anti-pattern exists, lower-risk, in `getSlashCommands` (`command.command`) and `sendFileMessage` (`uploadPath`, can contain non-ASCII filename chars). Every other `sanitizedRaw({ id })` site uses a server `_id` / `rid`, which is ASCII-safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved frequently-used emoji handling: normalized lookup, correct counting, deduplication, and optional default fallbacks via a new retrieval API.

* **Bug Fixes**
  * Migration cleans up legacy/corrupted emoji records.
  * More robust error handling when emoji data is unavailable.

* **Tests**
  * Added tests for emoji management, hook behavior, and the migration cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->