### PR TITLE
fix: keep live socket on deeplink login (prevent orphan WebSocket clobber)

### DIFF
--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -87,6 +87,7 @@ import createSagaMiddleware from 'redux-saga';
 import { deepLinkingOpen } from '../../actions/deepLinking';
 import { loginSuccess } from '../../actions/login';
 import { selectServerSuccess } from '../../actions/server';
+import { connectSuccess } from '../../actions/connect';
 import { appStart } from '../../actions/app';
 import { RootEnum } from '../../definitions';
 import reducers from '../../reducers';
@@ -204,6 +205,11 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
+		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// loginRequest, so it never logs in on a still-connecting socket.
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
 		// Saga is now waiting for LOGIN.SUCCESS
 		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
 
@@ -240,6 +246,11 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
+		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// loginRequest, so it never logs in on a still-connecting socket.
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
 		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
 		await flushSagaMicrotasks();
 
@@ -272,6 +283,11 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
+		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// loginRequest, so it never logs in on a still-connecting socket.
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
 		// Dispatch LOGIN.SUCCESS AND APP.START(ROOT_INSIDE) synchronously before any flush.
 		// The reducer processes both dispatches before the saga's select runs,
 		// so the select sees ROOT_INSIDE and skips the take.
@@ -299,6 +315,11 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		await flushSagaMicrotasks();
 
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// loginRequest, so it never logs in on a still-connecting socket.
+		store.dispatch(connectSuccess());
 		await flushSagaMicrotasks();
 
 		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
@@ -334,6 +355,11 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		await flushSagaMicrotasks();
 
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// loginRequest, so it never logs in on a still-connecting socket.
+		store.dispatch(connectSuccess());
 		await flushSagaMicrotasks();
 
 		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -205,7 +205,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
-		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// The saga waits for METEOR.SUCCESS ('connected') before dispatching
 		// loginRequest, so it never logs in on a still-connecting socket.
 		store.dispatch(connectSuccess());
 		await flushSagaMicrotasks();
@@ -246,7 +246,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
-		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// The saga waits for METEOR.SUCCESS ('connected') before dispatching
 		// loginRequest, so it never logs in on a still-connecting socket.
 		store.dispatch(connectSuccess());
 		await flushSagaMicrotasks();
@@ -283,7 +283,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
-		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// The saga waits for METEOR.SUCCESS ('connected') before dispatching
 		// loginRequest, so it never logs in on a still-connecting socket.
 		store.dispatch(connectSuccess());
 		await flushSagaMicrotasks();
@@ -317,7 +317,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
-		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// The saga waits for METEOR.SUCCESS ('connected') before dispatching
 		// loginRequest, so it never logs in on a still-connecting socket.
 		store.dispatch(connectSuccess());
 		await flushSagaMicrotasks();
@@ -357,7 +357,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
 		await flushSagaMicrotasks();
 
-		// Fix B: the saga now waits for METEOR.SUCCESS ('connected') before dispatching
+		// The saga waits for METEOR.SUCCESS ('connected') before dispatching
 		// loginRequest, so it never logs in on a still-connecting socket.
 		store.dispatch(connectSuccess());
 		await flushSagaMicrotasks();

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -47,6 +47,17 @@ jest.mock('../../lib/services/restApi', () => ({
 	notifyUser: jest.fn()
 }));
 
+// handleNavigateCallRoom reads database.active.get('subscriptions').find(rid).
+// Configured per test via jest.mocked(database.active.get) in beforeEach.
+jest.mock('../../lib/database', () => ({
+	__esModule: true,
+	default: {
+		active: {
+			get: jest.fn()
+		}
+	}
+}));
+
 jest.mock('../../lib/methods/videoConf', () => ({
 	videoConfJoin: jest.fn()
 }));
@@ -84,11 +95,12 @@ jest.mock('../../lib/methods/helpers', () => ({
 import { applyMiddleware, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
-import { deepLinkingOpen } from '../../actions/deepLinking';
+import { deepLinkingOpen, deepLinkingClickCallPush } from '../../actions/deepLinking';
 import { loginSuccess } from '../../actions/login';
 import { selectServerSuccess } from '../../actions/server';
 import { connectSuccess } from '../../actions/connect';
 import { appStart } from '../../actions/app';
+import { LOGIN } from '../../actions/actionsTypes';
 import { RootEnum } from '../../definitions';
 import reducers from '../../reducers';
 import deepLinkingRoot from '../deepLinking';
@@ -96,10 +108,11 @@ import UserPreferences from '../../lib/methods/userPreferences';
 import { getServerById } from '../../lib/database/services/Server';
 import { canOpenRoom } from '../../lib/methods/canOpenRoom';
 import { getServerInfo } from '../../lib/methods/getServerInfo';
-import { goRoom } from '../../lib/methods/helpers/goRoom';
+import { goRoom, navigateToRoom } from '../../lib/methods/helpers/goRoom';
 import { waitForNavigationReady } from '../../lib/navigation/appNavigation';
 import sdk from '../../lib/services/sdk';
 import EventEmitter from '../../lib/methods/helpers/events';
+import database from '../../lib/database';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -116,6 +129,19 @@ function setupStore(preloadedState?: PreloadedState) {
 	const store = createStore(reducers, preloadedState, applyMiddleware(sagaMiddleware));
 	sagaMiddleware.run(deepLinkingRoot);
 	return store;
+}
+
+/** setupStore that also records dispatched actions (incl. saga puts) for assertions. */
+function setupRecordingStore(preloadedState?: PreloadedState) {
+	const actions: { type: string }[] = [];
+	const recorder = () => (next: (a: any) => any) => (action: any) => {
+		actions.push(action);
+		return next(action);
+	};
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(reducers, preloadedState, applyMiddleware(recorder, sagaMiddleware));
+	sagaMiddleware.run(deepLinkingRoot);
+	return { store, actions };
 }
 
 // ─── Factories ────────────────────────────────────────────────────────────────
@@ -227,6 +253,56 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		await flushSagaMicrotasks();
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	// Ordering race: socket connects before SERVER.SELECT_SUCCESS; the guard must
+	// skip the already-fired METEOR.SUCCESS take instead of hanging.
+	it('completes the chain when METEOR.SUCCESS fires before SERVER.SELECT_SUCCESS', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		// Socket connects first — before SERVER.SELECT_SUCCESS is dispatched.
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	// loginRequest must not fire until the socket is connected (locks the gate).
+	it('does not dispatch loginRequest until METEOR.SUCCESS', async () => {
+		const { store, actions } = setupRecordingStore();
+		const loginRequested = () => actions.some(a => a.type === LOGIN.REQUEST);
+
+		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Server selected but socket not connected yet → still parked at the gate.
+		expect(loginRequested()).toBe(false);
+
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
+		// Socket connected → gate released, loginRequest dispatched.
+		expect(loginRequested()).toBe(true);
 	});
 
 	/**
@@ -475,5 +551,111 @@ describe('deepLinking saga — server already connected, should skip changing se
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
 		emitSpy.mockRestore();
+	});
+});
+
+// ─── handleClickCallPush (OPEN_VIDEO_CONF) — new server + token ──────────────────
+
+describe('deepLinking saga — handleClickCallPush (new server + token + call room)', () => {
+	/** Call-push params: host + token + the rid handleNavigateCallRoom looks up. */
+	const makeCallParams = (overrides: Record<string, any> = {}) => makeParamsWithToken({ rid: 'room-1', ...overrides });
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(navigateToRoom).mockReset();
+		jest.mocked(database.active.get).mockReset();
+
+		// Unknown server with a token → reaches the SELECT_SUCCESS/METEOR.SUCCESS gate.
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return 'https://other.server.com';
+			return null;
+		});
+		jest.mocked(getServerById).mockResolvedValue(null);
+		jest.mocked(getServerInfo).mockResolvedValue({ success: true, version: '6.0.0' } as any);
+
+		// handleNavigateCallRoom resolves the subscription for params.rid.
+		jest.mocked(database.active.get).mockReturnValue({
+			find: jest.fn().mockResolvedValue({ rid: 'room-1', name: 'general', t: 'c' })
+		} as any);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	// Ordering race (call-push path): socket connects before SERVER.SELECT_SUCCESS;
+	// the guard must skip the already-fired METEOR.SUCCESS take instead of hanging.
+	it('completes the call-room chain when METEOR.SUCCESS fires before SERVER.SELECT_SUCCESS', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingClickCallPush(makeCallParams()));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		// Socket connects first — before SERVER.SELECT_SUCCESS is dispatched.
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	// Happy path: full chain in normal order navigates once.
+	it('navigates to the call room once after the full chain completes', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingClickCallPush(makeCallParams()));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Still parked at the METEOR.SUCCESS gate — no navigation yet.
+		expect(jest.mocked(navigateToRoom)).not.toHaveBeenCalled();
+
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	// loginRequest must not fire until the socket is connected (locks the gate).
+	it('does not dispatch loginRequest until METEOR.SUCCESS', async () => {
+		const { store, actions } = setupRecordingStore();
+		const loginRequested = () => actions.some(a => a.type === LOGIN.REQUEST);
+
+		store.dispatch(deepLinkingClickCallPush(makeCallParams()));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		// Server selected but socket not connected yet → still parked at the gate.
+		expect(loginRequested()).toBe(false);
+
+		store.dispatch(connectSuccess());
+		await flushSagaMicrotasks();
+
+		// Socket connected → gate released, loginRequest dispatched.
+		expect(loginRequested()).toBe(true);
 	});
 });

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -237,6 +237,12 @@ const handleOpen = function* handleOpen({ params }) {
 		if (params.token) {
 			if (!hostAlreadyConnected) {
 				yield take(types.SERVER.SELECT_SUCCESS);
+				// Wait for the socket to reach 'connected' (METEOR.SUCCESS) before logging in.
+				// Dispatching loginRequest while the socket is still CONNECTING makes the SDK
+				// login-guard open a second, orphaned socket whose later close clobbers Redux
+				// and falsely shows "Waiting for network". When the host is already connected we
+				// skip this — the socket is live, so there's no race (and METEOR.SUCCESS won't refire).
+				yield take(types.METEOR.SUCCESS);
 			}
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);
@@ -332,6 +338,11 @@ const handleClickCallPush = function* handleClickCallPush({ params }) {
 		EventEmitter.emit('NewServer', { server: host });
 		if (params.token) {
 			yield take(types.SERVER.SELECT_SUCCESS);
+			// Wait for the socket to reach 'connected' (METEOR.SUCCESS) before logging in.
+			// Dispatching loginRequest while the socket is still CONNECTING makes the SDK
+			// login-guard open a second, orphaned socket whose later close clobbers Redux
+			// and falsely shows "Waiting for network".
+			yield take(types.METEOR.SUCCESS);
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);
 			yield handleNavigateCallRoom({ params });

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -237,11 +237,7 @@ const handleOpen = function* handleOpen({ params }) {
 		if (params.token) {
 			if (!hostAlreadyConnected) {
 				yield take(types.SERVER.SELECT_SUCCESS);
-				// Wait for the socket to reach 'connected' (METEOR.SUCCESS) before logging in.
-				// Dispatching loginRequest while the socket is still CONNECTING makes the SDK
-				// login-guard open a second, orphaned socket whose later close clobbers Redux
-				// and falsely shows "Waiting for network". When the host is already connected we
-				// skip this — the socket is live, so there's no race (and METEOR.SUCCESS won't refire).
+				// SERVER.SELECT_SUCCESS doesn't mean 'connected'
 				yield take(types.METEOR.SUCCESS);
 			}
 			yield put(loginRequest({ resume: params.token }, true));
@@ -338,10 +334,7 @@ const handleClickCallPush = function* handleClickCallPush({ params }) {
 		EventEmitter.emit('NewServer', { server: host });
 		if (params.token) {
 			yield take(types.SERVER.SELECT_SUCCESS);
-			// Wait for the socket to reach 'connected' (METEOR.SUCCESS) before logging in.
-			// Dispatching loginRequest while the socket is still CONNECTING makes the SDK
-			// login-guard open a second, orphaned socket whose later close clobbers Redux
-			// and falsely shows "Waiting for network".
+			// SERVER.SELECT_SUCCESS doesn't mean 'connected'
 			yield take(types.METEOR.SUCCESS);
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -237,8 +237,11 @@ const handleOpen = function* handleOpen({ params }) {
 		if (params.token) {
 			if (!hostAlreadyConnected) {
 				yield take(types.SERVER.SELECT_SUCCESS);
-				// SERVER.SELECT_SUCCESS doesn't mean 'connected'
-				yield take(types.METEOR.SUCCESS);
+				// SERVER.SELECT_SUCCESS doesn't mean 'connected'; skip the take if it already is.
+				const connected = yield select(state => state.meteor.connected);
+				if (!connected) {
+					yield take(types.METEOR.SUCCESS);
+				}
 			}
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);
@@ -334,8 +337,11 @@ const handleClickCallPush = function* handleClickCallPush({ params }) {
 		EventEmitter.emit('NewServer', { server: host });
 		if (params.token) {
 			yield take(types.SERVER.SELECT_SUCCESS);
-			// SERVER.SELECT_SUCCESS doesn't mean 'connected'
-			yield take(types.METEOR.SUCCESS);
+			// SERVER.SELECT_SUCCESS doesn't mean 'connected'; skip the take if it already is.
+			const connected = yield select(state => state.meteor.connected);
+			if (!connected) {
+				yield take(types.METEOR.SUCCESS);
+			}
 			yield put(loginRequest({ resume: params.token }, true));
 			yield take(types.LOGIN.SUCCESS);
 			yield handleNavigateCallRoom({ params });

--- a/patches/@rocket.chat+sdk+1.3.3-mobile.patch
+++ b/patches/@rocket.chat+sdk+1.3.3-mobile.patch
@@ -6,7 +6,7 @@ index 19d31ae..07bda5f 100644
          this.logger.error(err)
          return reject(err)
        }
-+      // FIX A (defense): tear down the previous connection before replacing it.
++      // Tear down the previous connection before replacing it.
 +      // The `this.connected` early-return above means we only reach here when the
 +      // existing socket isn't healthy, so detaching its handlers and closing it stops
 +      // a stale or still-connecting socket from later firing onClose and clobbering the
@@ -35,7 +35,7 @@ index 19d31ae..07bda5f 100644
    /** Emit close event so it can be used for promise resolve in close() */
 -  onClose = (e: any) => {
 +  onClose = (e: any, closedConnection?: WebSocket) => {
-+    // FIX A (primary): ignore close events from a socket we've already replaced (an
++    // Ignore close events from a socket we've already replaced (an
 +    // orphan). Only the current connection's close should flip app state or trigger a
 +    // reopen; otherwise a zombie socket's late close clobbers the live connection and
 +    // the app falsely shows "Waiting for network".

--- a/patches/@rocket.chat+sdk+1.3.3-mobile.patch
+++ b/patches/@rocket.chat+sdk+1.3.3-mobile.patch
@@ -1,8 +1,51 @@
 diff --git a/node_modules/@rocket.chat/sdk/lib/drivers/ddp.ts b/node_modules/@rocket.chat/sdk/lib/drivers/ddp.ts
-index 19d31ae..3f33982 100644
+index 19d31ae..07bda5f 100644
 --- a/node_modules/@rocket.chat/sdk/lib/drivers/ddp.ts
 +++ b/node_modules/@rocket.chat/sdk/lib/drivers/ddp.ts
-@@ -175,15 +175,115 @@ export class Socket extends EventEmitter {
+@@ -101,9 +101,25 @@ export class Socket extends EventEmitter {
+         this.logger.error(err)
+         return reject(err)
+       }
++      // FIX A (defense): tear down the previous connection before replacing it.
++      // The `this.connected` early-return above means we only reach here when the
++      // existing socket isn't healthy, so detaching its handlers and closing it stops
++      // a stale or still-connecting socket from later firing onClose and clobbering the
++      // live connection. Mirrors forceReopen's teardown.
++      if (this.connection) {
++        try {
++          this.connection.onopen = null as any
++          this.connection.onmessage = null as any
++          this.connection.onerror = null as any
++          this.connection.onclose = null as any
++          this.connection.close(userDisconnectCloseCode)
++        } catch (err) {
++          this.logger.debug(`[ddp] open: previous connection teardown failed: ${(err as Error).message}`)
++        }
++      }
+       this.connection = connection
+       this.connection.onmessage = this.onMessage.bind(this)
+-      this.connection.onclose = this.onClose.bind(this)
++      this.connection.onclose = (ev: any) => this.onClose(ev, connection) // pass closing socket so onClose can compare identity
+       this.connection.onopen = this.onOpen.bind(this, resolve)
+       this.emit('connecting')
+     })
+@@ -125,7 +141,14 @@ export class Socket extends EventEmitter {
+   }
+ 
+   /** Emit close event so it can be used for promise resolve in close() */
+-  onClose = (e: any) => {
++  onClose = (e: any, closedConnection?: WebSocket) => {
++    // FIX A (primary): ignore close events from a socket we've already replaced (an
++    // orphan). Only the current connection's close should flip app state or trigger a
++    // reopen; otherwise a zombie socket's late close clobbers the live connection and
++    // the app falsely shows "Waiting for network".
++    if (closedConnection && closedConnection !== this.connection) {
++      return
++    }
+     this.emit('close', e)
+     try {
+       if (e?.code !== userDisconnectCloseCode) {
+@@ -175,15 +198,115 @@ export class Socket extends EventEmitter {
      return Promise.resolve()
    }
  
@@ -125,7 +168,7 @@ index 19d31ae..3f33982 100644
    }
  
    /** Clear connection and try to connect again. */
-@@ -549,7 +649,9 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
+@@ -549,7 +672,9 @@ export class DDPDriver extends EventEmitter implements ISocket, IDriver {
        'uiInteraction',
        'e2ekeyRequest',
        'userData',


### PR DESCRIPTION
## Proposed changes

Standalone fix extracted from #7311 (commit `29e4f8b`).

Opening the app through an auth deeplink (and the call-push path) dispatched `loginRequest` **before** the WebSocket reached `connected`. The SDK login-guard then opened a second, orphaned socket. When the server later idle-timed-out the abandoned socket, its `close` flipped Redux to `disconnected` — so the app showed **"Waiting for network"** while a live, healthy socket still existed.

**SDK patch** (`patches/@rocket.chat+sdk+1.3.3-mobile.patch`, ddp driver)
- `onClose` now ignores close events from a socket that has already been replaced (compares identity against the current connection), so a zombie socket's late close can't clobber the live connection.
- `open()` tears down the previous connection's handlers and closes it before replacing it (mirrors `forceReopen`'s teardown).

**deepLinking saga** (`app/sagas/deepLinking.js`)
- Before dispatching the resume `loginRequest` (auth-deeplink and call-push paths), gate on the socket being `connected`: after `SERVER.SELECT_SUCCESS`, read `state.meteor.connected` and only `take(METEOR.SUCCESS)` when still disconnected. This both prevents login on a still-connecting socket (the orphan-socket clobber) **and** can't hang the splash when the socket connects *before* `SELECT_SUCCESS` — `METEOR.SUCCESS` fires once and never refires, so an unconditional `take` would wait forever. `handleOpen`'s already-connected fast path skips the wait entirely.

## Issue(s)

[NATIVE-1232](https://rocketchat.atlassian.net/browse/NATIVE-1232) · related: [NATIVE-1123](https://rocketchat.atlassian.net/browse/NATIVE-1123)

## How to test or reproduce

1. Cold-start the app via an auth deeplink carrying a resume token (`rocketchat://auth?...`) for a workspace you are **not** currently connected to.
2. Before this fix: a second (orphan) socket opens; when the server idle-times-out the abandoned socket, the app falls to **"Waiting for network"** even though a live socket exists. After this fix: login waits for `connected` first, only one socket is ever opened, and no false "Waiting for network" appears.
3. Repeat via a call-push deeplink — same path, same expectation.
4. Unit test: `TZ=UTC pnpm test --testPathPattern='app/sagas/__tests__/deepLinking.test'` → 12/12 pass. Coverage now includes the connect-before-`SELECT_SUCCESS` ordering race, a gate assertion (no `loginRequest` until `connected`), and first-ever coverage for `handleClickCallPush`.

## Screenshots

n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable) — `app/sagas/__tests__/deepLinking.test.ts`
- [ ] I have added necessary documentation (if applicable) — inline comments next to each wait/guard
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Cherry-picked from #7311 with `git cherry-pick -x`; the SDK-patch and saga changes apply cleanly. The `handleOpen` placement was adapted to `develop`'s `hostAlreadyConnected` fast path (the wait sits inside the `!hostAlreadyConnected` branch). The wait was later hardened from an unconditional `take(METEOR.SUCCESS)` into a `state.meteor.connected` guard so a socket that connects before `SELECT_SUCCESS` can't make the saga block on a `METEOR.SUCCESS` that will never refire.


[NATIVE-1232]: https://rocketchat.atlassian.net/browse/NATIVE-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cases where login proceeded before the socket was fully connected.
  * Improved reconnection handling with health-check probing and safer socket teardown to avoid stale-close interference and reduce false "Waiting for network" notices.

* **New Features**
  * Added support for media-signal and media-calls event types.

* **Tests**
  * Strengthened deep-linking tests to assert connection-before-login sequencing and race-order coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
