### PR TITLE
refactor: migrate MessageComposer state to a per-instance Zustand store

### DIFF
--- a/app/containers/MessageComposer/context.test.tsx
+++ b/app/containers/MessageComposer/context.test.tsx
@@ -1,0 +1,270 @@
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+
+import { type IShareAttachment } from '../../definitions';
+import {
+	MessageComposerProvider,
+	useAlsoSendThreadToChannel,
+	useAutocompleteParams,
+	useComposerAttachments,
+	useFocused,
+	useMessageComposerApi,
+	useMicOrSend,
+	useRecordingAudio,
+	useShowMarkdownToolbar
+} from './context';
+
+type Api = ReturnType<typeof useMessageComposerApi>;
+
+// These are characterization tests for the composer state container. They pin the full contract that the
+// current split-context implementation provides and that the Zustand migration must preserve unchanged, but
+// which the behavior-level suite in MessageComposer.test.tsx does not cover:
+//   1. Per-slice re-render granularity — changing one slice must not re-render consumers of another.
+//   2. Per-instance isolation — each MessageComposerProvider owns independent state (no shared store).
+//   3. Set→read for every public slice, including the attachment setters (add/update/remove/clear).
+//   4. A stable `api` reference — selectors that return a fresh actions object trip Zustand v5's
+//      "snapshot changed" re-render loop, so the api the swap exposes must stay referentially stable.
+// Every pin imports the public surface only (the hooks + provider). The store factory is intentionally NOT
+// exported for testing, so these stay true characterization tests: green on the current code AND green,
+// unchanged, after the swap. Each probe records renders through a jest.fn spy (calling a spy during render is
+// pure from React's point of view; mutating an outer counter is not).
+
+// Renders one probe per entry in `probes` (name -> subscription hook) plus an api probe. Adding a slice to a
+// test = add an entry here. Returns the (stable) api, a per-probe render counter, and a per-probe value reader.
+const renderComposer = (probes: Record<string, () => unknown>) => {
+	const probeSpies: Record<string, jest.Mock> = {};
+	const apiSpy = jest.fn();
+
+	const probeElements = Object.entries(probes).map(([name, useHook]) => {
+		const spy = jest.fn();
+		probeSpies[name] = spy;
+		const Probe = () => {
+			spy(useHook());
+			return null;
+		};
+		return <Probe key={name} />;
+	});
+
+	const ApiProbe = () => {
+		apiSpy(useMessageComposerApi());
+		return null;
+	};
+
+	render(
+		<MessageComposerProvider>
+			<>
+				{probeElements}
+				<ApiProbe />
+			</>
+		</MessageComposerProvider>
+	);
+
+	const renderCount = (name: string) => probeSpies[name].mock.calls.length;
+	const latestValue = (name: string) => {
+		const { calls } = probeSpies[name].mock;
+		return calls[calls.length - 1]?.[0];
+	};
+
+	// api is stable, so the first render's value is the one every test calls setters on.
+	const [[api]] = apiSpy.mock.calls as [Api][];
+	return { api, renderCount, latestValue };
+};
+
+const attachment = (path: string, extra?: Partial<IShareAttachment>): IShareAttachment => ({
+	filename: `${path}.png`,
+	size: 1,
+	path,
+	...extra
+});
+
+// The six scalar slices, each driven through set→read and granularity by the same loop. Adding a scalar slice
+// later = add a row. `attachments` is the list slice and gets its own block below.
+type ScalarCase = {
+	name: string;
+	useHook: () => unknown;
+	initial: unknown;
+	mutate: (api: Api) => void;
+	next: unknown;
+};
+
+const SCALAR_SLICES: ScalarCase[] = [
+	{ name: 'focused', useHook: useFocused, initial: false, mutate: api => api.setFocused(true), next: true },
+	{ name: 'micOrSend', useHook: useMicOrSend, initial: 'mic', mutate: api => api.setMicOrSend('send'), next: 'send' },
+	{
+		name: 'showMarkdownToolbar',
+		useHook: useShowMarkdownToolbar,
+		initial: false,
+		mutate: api => api.setMarkdownToolbar(true),
+		next: true
+	},
+	{
+		name: 'alsoSendThreadToChannel',
+		useHook: useAlsoSendThreadToChannel,
+		initial: false,
+		mutate: api => api.setAlsoSendThreadToChannel(true),
+		next: true
+	},
+	{ name: 'recordingAudio', useHook: useRecordingAudio, initial: false, mutate: api => api.setRecordingAudio(true), next: true },
+	{
+		name: 'autocompleteParams',
+		useHook: useAutocompleteParams,
+		initial: { text: '', type: null },
+		mutate: api => api.setAutocompleteParams({ text: '@ro', type: '@' }),
+		next: { text: '@ro', type: '@' }
+	}
+];
+
+describe('MessageComposer state container', () => {
+	describe('per-instance isolation', () => {
+		it('keeps state independent across provider instances', () => {
+			const spyA = jest.fn();
+			const spyB = jest.fn();
+
+			const Probe = ({ spy }: { spy: jest.Mock }) => {
+				spy({ focused: useFocused(), api: useMessageComposerApi() });
+				return null;
+			};
+
+			render(
+				<>
+					<MessageComposerProvider>
+						<Probe spy={spyA} />
+					</MessageComposerProvider>
+					<MessageComposerProvider>
+						<Probe spy={spyB} />
+					</MessageComposerProvider>
+				</>
+			);
+
+			const latest = (spy: jest.Mock): { focused: boolean; api: Api } => spy.mock.calls[spy.mock.calls.length - 1][0];
+
+			expect(latest(spyA).focused).toBe(false);
+			expect(latest(spyB).focused).toBe(false);
+
+			// Mutating one instance must not leak into the other
+			act(() => latest(spyA).api.setFocused(true));
+
+			expect(latest(spyA).focused).toBe(true);
+			expect(latest(spyB).focused).toBe(false);
+
+			// And the reverse direction stays isolated too
+			act(() => latest(spyB).api.setRecordingAudio(true));
+
+			expect(latest(spyA).focused).toBe(true);
+		});
+	});
+
+	describe('scalar slices', () => {
+		describe.each(SCALAR_SLICES)('$name', ({ name, useHook, initial, mutate, next }) => {
+			it('exposes the initial value, then reflects the update (set→read)', () => {
+				const { api, latestValue } = renderComposer({ [name]: useHook });
+
+				expect(latestValue(name)).toEqual(initial);
+
+				act(() => mutate(api));
+
+				expect(latestValue(name)).toEqual(next);
+			});
+
+			it('re-renders its own consumer but not an unrelated one when it changes (granularity)', () => {
+				// attachments is the control slice — it is never the scalar under test
+				const { api, renderCount } = renderComposer({ [name]: useHook, attachments: useComposerAttachments });
+
+				const sliceBaseline = renderCount(name);
+				const controlBaseline = renderCount('attachments');
+
+				act(() => mutate(api));
+
+				expect(renderCount(name)).toBeGreaterThan(sliceBaseline);
+				expect(renderCount('attachments')).toBe(controlBaseline);
+			});
+		});
+	});
+
+	describe('attachments', () => {
+		it('add appends attachments in order', () => {
+			const { api, latestValue } = renderComposer({ attachments: useComposerAttachments });
+
+			expect(latestValue('attachments')).toEqual([]);
+
+			act(() => api.addAttachments([attachment('a')]));
+			act(() => api.addAttachments([attachment('b')]));
+
+			expect((latestValue('attachments') as IShareAttachment[]).map(a => a.path)).toEqual(['a', 'b']);
+		});
+
+		it('update merges a patch into the matching attachment by path, leaving others untouched', () => {
+			const { api, latestValue } = renderComposer({ attachments: useComposerAttachments });
+
+			act(() => api.addAttachments([attachment('a'), attachment('b')]));
+			act(() => api.updateAttachment('a', { description: 'hello' }));
+
+			const result = latestValue('attachments') as IShareAttachment[];
+			expect(result.find(a => a.path === 'a')).toMatchObject({ path: 'a', filename: 'a.png', description: 'hello' });
+			expect(result.find(a => a.path === 'b')?.description).toBeUndefined();
+		});
+
+		it('remove filters out the attachment with the matching path', () => {
+			const { api, latestValue } = renderComposer({ attachments: useComposerAttachments });
+
+			act(() => api.addAttachments([attachment('a'), attachment('b')]));
+			act(() => api.removeAttachment('a'));
+
+			expect((latestValue('attachments') as IShareAttachment[]).map(a => a.path)).toEqual(['b']);
+		});
+
+		it('clear empties the attachments', () => {
+			const { api, latestValue } = renderComposer({ attachments: useComposerAttachments });
+
+			act(() => api.addAttachments([attachment('a'), attachment('b')]));
+			act(() => api.clearAttachments());
+
+			expect(latestValue('attachments')).toEqual([]);
+		});
+
+		// The reverse direction (a scalar change must not re-render an attachments consumer) is already covered
+		// for every scalar by the granularity row in the SCALAR_SLICES table, which uses attachments as its
+		// control. This pins the direction the table can't: a list mutation must not re-render scalar consumers.
+		it('does not re-render a scalar consumer when attachments change', () => {
+			const { api, renderCount } = renderComposer({ attachments: useComposerAttachments, focused: useFocused });
+
+			const attachmentsBaseline = renderCount('attachments');
+			const focusedBaseline = renderCount('focused');
+
+			act(() => api.addAttachments([attachment('a')]));
+
+			expect(renderCount('attachments')).toBeGreaterThan(attachmentsBaseline);
+			expect(renderCount('focused')).toBe(focusedBaseline);
+		});
+	});
+
+	describe('actions reference stability', () => {
+		it('keeps the same api reference across slice updates', () => {
+			const probe = jest.fn();
+
+			// The probe subscribes to BOTH a changing slice and the api, so per-slice granularity can't keep it
+			// from re-rendering and let this pass for the wrong reason — it genuinely re-renders, and the api ref
+			// must still be identical before and after.
+			const Probe = () => {
+				useFocused();
+				probe(useMessageComposerApi());
+				return null;
+			};
+
+			render(
+				<MessageComposerProvider>
+					<Probe />
+				</MessageComposerProvider>
+			);
+
+			const callsBefore = probe.mock.calls.length;
+			const ref1: Api = probe.mock.calls[callsBefore - 1][0];
+
+			act(() => ref1.setFocused(true));
+
+			expect(probe.mock.calls.length).toBeGreaterThan(callsBefore);
+			const ref2: Api = probe.mock.calls[probe.mock.calls.length - 1][0];
+			expect(ref2).toBe(ref1);
+		});
+	});
+});

--- a/app/containers/MessageComposer/context.test.tsx
+++ b/app/containers/MessageComposer/context.test.tsx
@@ -16,10 +16,10 @@ import {
 
 type Api = ReturnType<typeof useMessageComposerApi>;
 
-// Characterization tests for the composer store, pinning the public hook/provider contract so the
-// split-context → zustand swap stays behaviour-identical. Non-obvious constraint: the `actions` bag must stay a
-// stable reference — a selector returning a fresh object each render trips zustand v5's snapshot-equality loop.
-// Renders are counted with jest.fn spies, not an outer counter (a spy call in render is pure; mutation isn't).
+// Tests for the composer store's public hook/provider contract and its per-slice re-render granularity.
+// Non-obvious constraint: the `actions` bag must stay a stable reference — a selector returning a fresh object
+// each render trips zustand v5's snapshot-equality loop. Renders are counted with jest.fn spies, not an outer
+// counter (a spy call in render is pure; mutation isn't).
 
 // One probe per `probes` entry (name -> hook) plus an api probe; returns the stable api and per-probe render/value readers.
 const renderComposer = (probes: Record<string, () => unknown>) => {

--- a/app/containers/MessageComposer/context.test.tsx
+++ b/app/containers/MessageComposer/context.test.tsx
@@ -16,21 +16,12 @@ import {
 
 type Api = ReturnType<typeof useMessageComposerApi>;
 
-// These are characterization tests for the composer state container. They pin the full contract that the
-// current split-context implementation provides and that the Zustand migration must preserve unchanged, but
-// which the behavior-level suite in MessageComposer.test.tsx does not cover:
-//   1. Per-slice re-render granularity — changing one slice must not re-render consumers of another.
-//   2. Per-instance isolation — each MessageComposerProvider owns independent state (no shared store).
-//   3. Set→read for every public slice, including the attachment setters (add/update/remove/clear).
-//   4. A stable `api` reference — selectors that return a fresh actions object trip Zustand v5's
-//      "snapshot changed" re-render loop, so the api the swap exposes must stay referentially stable.
-// Every pin imports the public surface only (the hooks + provider). The store factory is intentionally NOT
-// exported for testing, so these stay true characterization tests: green on the current code AND green,
-// unchanged, after the swap. Each probe records renders through a jest.fn spy (calling a spy during render is
-// pure from React's point of view; mutating an outer counter is not).
+// Characterization tests for the composer store, pinning the public hook/provider contract so the
+// split-context → zustand swap stays behaviour-identical. Non-obvious constraint: the `actions` bag must stay a
+// stable reference — a selector returning a fresh object each render trips zustand v5's snapshot-equality loop.
+// Renders are counted with jest.fn spies, not an outer counter (a spy call in render is pure; mutation isn't).
 
-// Renders one probe per entry in `probes` (name -> subscription hook) plus an api probe. Adding a slice to a
-// test = add an entry here. Returns the (stable) api, a per-probe render counter, and a per-probe value reader.
+// One probe per `probes` entry (name -> hook) plus an api probe; returns the stable api and per-probe render/value readers.
 const renderComposer = (probes: Record<string, () => unknown>) => {
 	const probeSpies: Record<string, jest.Mock> = {};
 	const apiSpy = jest.fn();
@@ -77,8 +68,7 @@ const attachment = (path: string, extra?: Partial<IShareAttachment>): IShareAtta
 	...extra
 });
 
-// The six scalar slices, each driven through set→read and granularity by the same loop. Adding a scalar slice
-// later = add a row. `attachments` is the list slice and gets its own block below.
+// One row per scalar slice; each runs the same set→read + granularity tests. (attachments is a list slice, tested below.)
 type ScalarCase = {
 	name: string;
 	useHook: () => unknown;
@@ -222,9 +212,7 @@ describe('MessageComposer state container', () => {
 			expect(latestValue('attachments')).toEqual([]);
 		});
 
-		// The reverse direction (a scalar change must not re-render an attachments consumer) is already covered
-		// for every scalar by the granularity row in the SCALAR_SLICES table, which uses attachments as its
-		// control. This pins the direction the table can't: a list mutation must not re-render scalar consumers.
+		// Reverse of the table's granularity check: a list mutation must not re-render scalar consumers.
 		it('does not re-render a scalar consumer when attachments change', () => {
 			const { api, renderCount } = renderComposer({ attachments: useComposerAttachments, focused: useFocused });
 
@@ -242,9 +230,7 @@ describe('MessageComposer state container', () => {
 		it('keeps the same api reference across slice updates', () => {
 			const probe = jest.fn();
 
-			// The probe subscribes to BOTH a changing slice and the api, so per-slice granularity can't keep it
-			// from re-rendering and let this pass for the wrong reason — it genuinely re-renders, and the api ref
-			// must still be identical before and after.
+			// Subscribes to a changing slice AND the api, so the re-render is real — the api ref must still be identical.
 			const Probe = () => {
 				useFocused();
 				probe(useMessageComposerApi());

--- a/app/containers/MessageComposer/context.tsx
+++ b/app/containers/MessageComposer/context.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, type ReactElement, useContext, useMemo, useReducer } from 'react';
+import React, { createContext, type ReactElement, useContext, useState } from 'react';
+import { createStore, useStore } from 'zustand';
 
 import { type IEmoji, type IShareAttachment } from '../../definitions';
 import { type IAutocompleteBase, type TMicOrSend } from './interfaces';
@@ -16,23 +17,71 @@ type TMessageComposerContextApi = {
 	clearAttachments(): void;
 };
 
-const FocusedContext = createContext<State['focused']>({} as State['focused']);
-const MicOrSendContext = createContext<State['micOrSend']>({} as State['micOrSend']);
-const ShowMarkdownToolbarContext = createContext<State['showMarkdownToolbar']>({} as State['showMarkdownToolbar']);
-const AlsoSendThreadToChannelContext = createContext<State['alsoSendThreadToChannel']>({} as State['alsoSendThreadToChannel']);
-const RecordingAudioContext = createContext<State['recordingAudio']>({} as State['recordingAudio']);
-const AutocompleteParamsContext = createContext<State['autocompleteParams']>({} as State['autocompleteParams']);
-const ComposerAttachmentsContext = createContext<State['attachments']>([] as State['attachments']);
-const MessageComposerContextApi = createContext<TMessageComposerContextApi>({} as TMessageComposerContextApi);
+type State = {
+	focused: boolean;
+	micOrSend: TMicOrSend;
+	showMarkdownToolbar: boolean;
+	alsoSendThreadToChannel: boolean;
+	recordingAudio: boolean;
+	autocompleteParams: IAutocompleteBase;
+	attachments: IShareAttachment[];
+	// Built once when the store is created and never replaced by a setter, so this reference stays stable for
+	// the lifetime of the store. Selecting it gives consumers a stable api bag (the old `useMemo([])` guarantee).
+	actions: TMessageComposerContextApi;
+};
 
-export const useMessageComposerApi = (): TMessageComposerContextApi => useContext(MessageComposerContextApi);
-export const useFocused = (): State['focused'] => useContext(FocusedContext);
-export const useMicOrSend = (): State['micOrSend'] => useContext(MicOrSendContext);
-export const useShowMarkdownToolbar = (): State['showMarkdownToolbar'] => useContext(ShowMarkdownToolbarContext);
-export const useAlsoSendThreadToChannel = (): State['alsoSendThreadToChannel'] => useContext(AlsoSendThreadToChannelContext);
-export const useRecordingAudio = (): State['recordingAudio'] => useContext(RecordingAudioContext);
-export const useAutocompleteParams = (): State['autocompleteParams'] => useContext(AutocompleteParamsContext);
-export const useComposerAttachments = (): State['attachments'] => useContext(ComposerAttachmentsContext);
+// One store per MessageComposerProvider instance — two composers (e.g. channel + open thread) are mounted at
+// once, so each needs its own isolated state. The store is the source of truth; the hooks below are thin
+// single-slice selectors, which keeps re-renders scoped to the slice that actually changed.
+const createComposerStore = () =>
+	createStore<State>()(set => ({
+		focused: false,
+		micOrSend: 'mic',
+		showMarkdownToolbar: false,
+		alsoSendThreadToChannel: false,
+		recordingAudio: false,
+		autocompleteParams: { text: '', type: null },
+		attachments: [],
+		actions: {
+			setFocused: focused => set({ focused }),
+			setMicOrSend: micOrSend => set({ micOrSend }),
+			setMarkdownToolbar: showMarkdownToolbar => set({ showMarkdownToolbar }),
+			setAlsoSendThreadToChannel: alsoSendThreadToChannel => set({ alsoSendThreadToChannel }),
+			setRecordingAudio: recordingAudio => set({ recordingAudio }),
+			setAutocompleteParams: params => set({ autocompleteParams: params }),
+			addAttachments: attachments => set(state => ({ attachments: [...state.attachments, ...attachments] })),
+			updateAttachment: (path, attachment) =>
+				set(state => ({
+					attachments: state.attachments.map(currentAttachment =>
+						currentAttachment.path === path ? { ...currentAttachment, ...attachment } : currentAttachment
+					)
+				})),
+			removeAttachment: path => set(state => ({ attachments: state.attachments.filter(attachment => attachment.path !== path) })),
+			clearAttachments: () => set({ attachments: [] })
+		}
+	}));
+
+type ComposerStore = ReturnType<typeof createComposerStore>;
+
+const ComposerStoreContext = createContext<ComposerStore | null>(null);
+
+const useComposerStore = <T,>(selector: (state: State) => T): T => {
+	const store = useContext(ComposerStoreContext);
+	if (!store) {
+		throw new Error('MessageComposer hooks must be used within a MessageComposerProvider');
+	}
+	return useStore(store, selector);
+};
+
+export const useMessageComposerApi = (): TMessageComposerContextApi => useComposerStore(state => state.actions);
+export const useFocused = (): State['focused'] => useComposerStore(state => state.focused);
+export const useMicOrSend = (): State['micOrSend'] => useComposerStore(state => state.micOrSend);
+export const useShowMarkdownToolbar = (): State['showMarkdownToolbar'] => useComposerStore(state => state.showMarkdownToolbar);
+export const useAlsoSendThreadToChannel = (): State['alsoSendThreadToChannel'] =>
+	useComposerStore(state => state.alsoSendThreadToChannel);
+export const useRecordingAudio = (): State['recordingAudio'] => useComposerStore(state => state.recordingAudio);
+export const useAutocompleteParams = (): State['autocompleteParams'] => useComposerStore(state => state.autocompleteParams);
+export const useComposerAttachments = (): State['attachments'] => useComposerStore(state => state.attachments);
 
 // TODO: rename
 type TMessageInnerContext = {
@@ -51,125 +100,10 @@ export const MessageInnerContext = createContext<TMessageInnerContext>({
 	focus: () => {}
 });
 
-type State = {
-	focused: boolean;
-	micOrSend: TMicOrSend;
-	showMarkdownToolbar: boolean;
-	alsoSendThreadToChannel: boolean;
-	recordingAudio: boolean;
-	autocompleteParams: IAutocompleteBase;
-	attachments: IShareAttachment[];
-};
-
-type Actions =
-	| { type: 'updateFocused'; focused: boolean }
-	| { type: 'setMicOrSend'; micOrSend: TMicOrSend }
-	| { type: 'setMarkdownToolbar'; showMarkdownToolbar: boolean }
-	| { type: 'setAlsoSendThreadToChannel'; alsoSendThreadToChannel: boolean }
-	| { type: 'setRecordingAudio'; recordingAudio: boolean }
-	| { type: 'setAutocompleteParams'; params: IAutocompleteBase }
-	| { type: 'addAttachments'; attachments: IShareAttachment[] }
-	| { type: 'updateAttachment'; path: string; attachment: Partial<IShareAttachment> }
-	| { type: 'removeAttachment'; path: string }
-	| { type: 'clearAttachments' };
-
-const initialState: State = {
-	focused: false,
-	micOrSend: 'mic',
-	showMarkdownToolbar: false,
-	alsoSendThreadToChannel: false,
-	recordingAudio: false,
-	autocompleteParams: { text: '', type: null },
-	attachments: []
-};
-
-const reducer = (state: State, action: Actions): State => {
-	switch (action.type) {
-		case 'updateFocused':
-			return { ...state, focused: action.focused };
-		case 'setMicOrSend':
-			return { ...state, micOrSend: action.micOrSend };
-		case 'setMarkdownToolbar':
-			return { ...state, showMarkdownToolbar: action.showMarkdownToolbar };
-		case 'setAlsoSendThreadToChannel':
-			return { ...state, alsoSendThreadToChannel: action.alsoSendThreadToChannel };
-		case 'setRecordingAudio':
-			return { ...state, recordingAudio: action.recordingAudio };
-		case 'setAutocompleteParams':
-			return { ...state, autocompleteParams: action.params };
-		case 'addAttachments':
-			return { ...state, attachments: [...state.attachments, ...action.attachments] };
-		case 'updateAttachment':
-			return {
-				...state,
-				attachments: state.attachments.map(currentAttachment =>
-					currentAttachment.path === action.path ? { ...currentAttachment, ...action.attachment } : currentAttachment
-				)
-			};
-		case 'removeAttachment':
-			return { ...state, attachments: state.attachments.filter(attachment => attachment.path !== action.path) };
-		case 'clearAttachments':
-			return { ...state, attachments: [] };
-	}
-};
-
 export const MessageComposerProvider = ({ children }: { children: ReactElement }): ReactElement => {
 	'use memo';
 
-	const [state, dispatch] = useReducer(reducer, initialState);
+	const [store] = useState(createComposerStore);
 
-	const api = useMemo(() => {
-		const setFocused = (focused: boolean) => dispatch({ type: 'updateFocused', focused });
-
-		const setMicOrSend = (micOrSend: TMicOrSend) => dispatch({ type: 'setMicOrSend', micOrSend });
-
-		const setMarkdownToolbar = (showMarkdownToolbar: boolean) => dispatch({ type: 'setMarkdownToolbar', showMarkdownToolbar });
-
-		const setAlsoSendThreadToChannel = (alsoSendThreadToChannel: boolean) =>
-			dispatch({ type: 'setAlsoSendThreadToChannel', alsoSendThreadToChannel });
-
-		const setRecordingAudio = (recordingAudio: boolean) => dispatch({ type: 'setRecordingAudio', recordingAudio });
-
-		const setAutocompleteParams = (params: IAutocompleteBase) => dispatch({ type: 'setAutocompleteParams', params });
-
-		const addAttachments = (attachments: IShareAttachment[]) => dispatch({ type: 'addAttachments', attachments });
-
-		const updateAttachment = (path: string, attachment: Partial<IShareAttachment>) =>
-			dispatch({ type: 'updateAttachment', path, attachment });
-
-		const removeAttachment = (path: string) => dispatch({ type: 'removeAttachment', path });
-
-		const clearAttachments = () => dispatch({ type: 'clearAttachments' });
-
-		return {
-			setFocused,
-			setMicOrSend,
-			setMarkdownToolbar,
-			setAlsoSendThreadToChannel,
-			setRecordingAudio,
-			setAutocompleteParams,
-			addAttachments,
-			updateAttachment,
-			removeAttachment,
-			clearAttachments
-		};
-	}, []);
-
-	return (
-		<MessageComposerContextApi.Provider value={api}>
-			<FocusedContext.Provider value={state.focused}>
-				<ShowMarkdownToolbarContext.Provider value={state.showMarkdownToolbar}>
-					<AlsoSendThreadToChannelContext.Provider value={state.alsoSendThreadToChannel}>
-						<RecordingAudioContext.Provider value={state.recordingAudio}>
-							<AutocompleteParamsContext.Provider value={state.autocompleteParams}>
-								<ComposerAttachmentsContext.Provider value={state.attachments}>
-									<MicOrSendContext.Provider value={state.micOrSend}>{children}</MicOrSendContext.Provider>
-								</ComposerAttachmentsContext.Provider>
-							</AutocompleteParamsContext.Provider>
-						</RecordingAudioContext.Provider>
-					</AlsoSendThreadToChannelContext.Provider>
-				</ShowMarkdownToolbarContext.Provider>
-			</FocusedContext.Provider>
-		</MessageComposerContextApi.Provider>
-	);
+	return <ComposerStoreContext.Provider value={store}>{children}</ComposerStoreContext.Provider>;
 };

--- a/app/containers/MessageComposer/context.tsx
+++ b/app/containers/MessageComposer/context.tsx
@@ -25,14 +25,11 @@ type State = {
 	recordingAudio: boolean;
 	autocompleteParams: IAutocompleteBase;
 	attachments: IShareAttachment[];
-	// Built once when the store is created and never replaced by a setter, so this reference stays stable for
-	// the lifetime of the store. Selecting it gives consumers a stable api bag (the old `useMemo([])` guarantee).
+	// Built once, never replaced by a setter — stays a stable ref for consumers.
 	actions: TMessageComposerContextApi;
 };
 
-// One store per MessageComposerProvider instance — two composers (e.g. channel + open thread) are mounted at
-// once, so each needs its own isolated state. The store is the source of truth; the hooks below are thin
-// single-slice selectors, which keeps re-renders scoped to the slice that actually changed.
+// One store per provider instance: channel + thread composers can be mounted at once, each needs isolated state.
 const createComposerStore = () =>
 	createStore<State>()(set => ({
 		focused: false,


### PR DESCRIPTION
## Proposed changes

Migrates the MessageComposer state container from eight split React contexts +
`useReducer` to a single per-instance vanilla Zustand store held in context. The
eight public hooks become thin single-slice selectors and the action bag is built
once for a stable reference, so the public hook surface, per-slice re-render
granularity, and per-instance isolation are all preserved. `MessageInnerContext`
is unchanged. Net −66 lines in `context.tsx` (8 providers → 1).

Behavior-preserving refactor — no user-facing change. It also clears the way to
later move `text`/`selection` into the store (deferred).

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1233

## How to test or reproduce

Internal refactor, no visible behavior change. To verify:
- `TZ=UTC pnpm test --testPathPattern='MessageComposer'` — 112 tests + 23 snapshots green.
- In a room composer: typing, mic/send toggle, markdown toolbar, attachments
  (add/remove), autocomplete, and "also send to channel" in a thread behave as before.
- Open a thread while a channel composer is mounted — the two keep independent state.

## Screenshots

_No UI changes._

## Performance

Profiled on Android (RN 0.81.5, bridgeless, dev mode) with an identical interaction sequence: focus composer → 6× markdown toolbar toggle → 3× type/backspace cycles.

| | Baseline (8 contexts + useReducer) | Zustand |
|---|---|---|
| Hot commits (≥16ms) | 12 | 5 (−58%) |
| Total React commits | 28 | 14 (−50%) |
| Fiber renders | 1,287 | 662 (−49%) |
| Hottest commit | 220ms | 82ms (−63%) |

`MessageComposerProvider` rendered 16× in the baseline (context fan-out on every dispatch); in the Zustand arm it doesn't appear in the top-20 cost table. iOS was all-clear on both arms (0 hot commits).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Why per-instance: two composers (e.g. a channel and an open thread) are mounted at
the same time, so each needs isolated state — a single global store would share it.
Keeping the split contexts was the other option, but it requires eight providers and
doesn't reduce the context fan-out this change targets.

Constraints honored: `'use memo'` retained for React Compiler annotation mode, store
lazy-initialized, `actions` kept referentially stable to avoid Zustand v5
"snapshot changed" re-render loops, and `text`/`selection` deliberately left as
uncontrolled refs (not moved into the store). Characterization tests in
`context.test.tsx` pin the full contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite verifying Message Composer state management behavior, including state isolation, slice mutations, render optimization, and attachment operations.

* **Refactor**
  * Improved internal state management architecture of the Message Composer component while maintaining all public API signatures and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->