### PR TITLE
fix(ios): restore RocketChat Watch scheme for Official target

### DIFF
--- a/ios/RocketChatRN.xcodeproj/xcshareddata/xcschemes/RocketChat Watch.xcscheme
+++ b/ios/RocketChatRN.xcodeproj/xcshareddata/xcschemes/RocketChat Watch.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1ED0388D2B507B4B00C007D4"
+               BuildableName = "Rocket.Chat Watch.app"
+               BlueprintName = "Rocket.Chat.Watch"
+               ReferencedContainer = "container:RocketChatRN.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7AAB3E0D257E6A6E00707CF6"
+               BuildableName = "Rocket.Chat.app"
+               BlueprintName = "Rocket.Chat"
+               ReferencedContainer = "container:RocketChatRN.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1ED0388D2B507B4B00C007D4"
+            BuildableName = "Rocket.Chat Watch.app"
+            BlueprintName = "Rocket.Chat.Watch"
+            ReferencedContainer = "container:RocketChatRN.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1ED0388D2B507B4B00C007D4"
+            BuildableName = "Rocket.Chat Watch.app"
+            BlueprintName = "Rocket.Chat.Watch"
+            ReferencedContainer = "container:RocketChatRN.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Proposed changes

Restores `RocketChat Watch.xcscheme` which was removed in #7322 because it referenced the now-deleted Experimental main app target.

The Watch target (`Rocket.Chat.Watch`) and its full source tree (`RocketChat Watch App/`) were never removed — only the scheme was lost. Without it, the Watch app cannot be targeted directly in Xcode — developers cannot select it from the scheme picker or run it standalone on a Watch simulator during development.

The new scheme is identical to the deleted one except the Experimental build entry (`Rocket.Chat Experimental.app`, `RocketChatRN`) is replaced with the Official main app (`Rocket.Chat.app`, `Rocket.Chat`, `7AAB3E0D257E6A6E00707CF6`).

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1250

## How to test or reproduce

1. Open `ios/RocketChatRN.xcodeproj` in Xcode
2. Select the `RocketChat Watch` scheme from the scheme picker
3. Choose a paired iPhone + Apple Watch simulator
4. Build and run — the Watch app should launch on the watch simulator

## Screenshots

N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules