### PR TITLE
ci: speed up and harden the Android store build

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -125,46 +125,43 @@ runs:
         fi
       shell: bash
 
-    # Signing check: confirm the AAB carries the official keystore's certificate.
-    # This must NEVER abort the build on an unreadable signature — `bundleRelease`
-    # already signs with the wired-in signingConfig and Play rejects a wrongly-signed
-    # upload — so an empty/unreadable read is a warning and only a positively-read
-    # fingerprint MISMATCH is a hard failure. Note: app/build.gradle sets
-    # `v1SigningEnabled false`, and `keytool -printcert -jarfile` reads only the v1/JAR
-    # signature, so this may legitimately have no fingerprint to compare; the full
-    # keytool output is printed so the AAB's actual signing scheme is visible in the log.
+    # Hard gate: the AAB must be signed with the official upload certificate.
+    # The keystore password is read via keytool's `-storepass:env` rather than a
+    # shell-quoted argument — the secret contains shell-special characters (the same
+    # reason the gradle.properties step above single-quotes the password lines), so
+    # interpolating it into `-storepass "…"` mangles it and the read silently fails.
+    # Captures use `|| true` so an empty read never trips `set -e -o pipefail`; the
+    # full keytool output is printed only on failure so a problem is self-explaining.
     - name: Verify AAB signing certificate
       working-directory: android
+      env:
+        KS_FILE: ${{ inputs.KEYSTORE_OFFICIAL }}
+        KS_ALIAS: ${{ inputs.KEYSTORE_OFFICIAL_ALIAS }}
+        KS_PASS: ${{ inputs.KEYSTORE_OFFICIAL_PASSWORD }}
       run: |
         AAB=app/build/outputs/bundle/release/app-release.aab
 
-        # Capture without letting a failed/empty read trip `set -e -o pipefail`.
-        aab_certs=$(keytool -printcert -jarfile "$AAB" 2>&1 || true)
-        ks_certs=$(keytool -list -v \
-          -keystore "app/${{ inputs.KEYSTORE_OFFICIAL }}" \
-          -alias "${{ inputs.KEYSTORE_OFFICIAL_ALIAS }}" \
-          -storepass "${{ inputs.KEYSTORE_OFFICIAL_PASSWORD }}" 2>&1 || true)
+        aab_out=$(keytool -printcert -jarfile "$AAB" 2>&1 || true)
+        ks_out=$(keytool -list -v -keystore "app/$KS_FILE" -alias "$KS_ALIAS" -storepass:env KS_PASS 2>&1 || true)
 
-        echo "----- keytool -printcert -jarfile (AAB) -----"
-        echo "$aab_certs"
-        echo "----- keystore certificate (SHA fingerprints) -----"
-        printf '%s\n' "$ks_certs" | grep -E 'SHA(1|256):' || true
+        aab_fp=$(printf '%s\n' "$aab_out" | grep -m1 'SHA256:' | tr -d '[:space:]' || true)
+        ks_fp=$(printf '%s\n' "$ks_out" | grep -m1 'SHA256:' | tr -d '[:space:]' || true)
 
-        aab_fp=$(printf '%s\n' "$aab_certs" | grep -m1 'SHA256:' | tr -d '[:space:]' || true)
-        ks_fp=$(printf '%s\n' "$ks_certs" | grep -m1 'SHA256:' | tr -d '[:space:]' || true)
+        echo "AAB signer SHA-256:    ${aab_fp:-<none>}"
+        echo "Keystore cert SHA-256: ${ks_fp:-<none>}"
 
         if [ -z "$aab_fp" ]; then
-          echo "::warning::No v1/JAR SHA-256 fingerprint readable from the AAB (expected: app/build.gradle has v1SigningEnabled=false). Skipping fingerprint comparison; relying on the ABI gate and Play's upload-key verification."
-          exit 0
+          printf '%s\n' "$aab_out"
+          echo "::error::AAB is not signed (no SHA-256 readable) — refusing to ship an unsigned release bundle."
+          exit 1
         fi
         if [ -z "$ks_fp" ]; then
-          echo "::warning::Could not read a SHA-256 fingerprint from the keystore; skipping comparison."
-          exit 0
+          printf '%s\n' "$ks_out"
+          echo "::error::Could not read the official keystore certificate (keytool output above)."
+          exit 1
         fi
         if [ "$aab_fp" != "$ks_fp" ]; then
-          echo "AAB signer:    $aab_fp"
-          echo "Keystore cert: $ks_fp"
-          echo "::error::AAB signing certificate does not match the official keystore."
+          echo "::error::AAB signing certificate ($aab_fp) does not match the official keystore ($ks_fp)."
           exit 1
         fi
         echo "Signing certificate verified against the official keystore ($aab_fp)."

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -37,12 +37,9 @@ runs:
         bundler-cache: true
         working-directory: android
 
-    # setup-gradle manages the ~/.gradle cache itself — no separate actions/cache step needed for it.
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
-    # Native build outputs (CMake objects, Gradle state, intermediates) so warm builds skip
-    # recompiling C++. Written only on develop (Save step); PRs read it via restore-keys.
     - name: Restore Android native build cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
@@ -65,8 +62,6 @@ runs:
       run: |
         echo "" > ./gradle.properties
         echo -e "org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" >> ./gradle.properties
-        echo -e "org.gradle.parallel=true" >> ./gradle.properties
-        echo -e "org.gradle.caching=true" >> ./gradle.properties
         echo -e "android.useAndroidX=true" >> ./gradle.properties
         echo -e "android.enableJetifier=true" >> ./gradle.properties
         echo -e "reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64" >> ./gradle.properties

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -125,24 +125,49 @@ runs:
         fi
       shell: bash
 
-    # Hard gate: confirm the AAB is signed with the official keystore certificate.
+    # Signing check: confirm the AAB carries the official keystore's certificate.
+    # This must NEVER abort the build on an unreadable signature — `bundleRelease`
+    # already signs with the wired-in signingConfig and Play rejects a wrongly-signed
+    # upload — so an empty/unreadable read is a warning and only a positively-read
+    # fingerprint MISMATCH is a hard failure. Note: app/build.gradle sets
+    # `v1SigningEnabled false`, and `keytool -printcert -jarfile` reads only the v1/JAR
+    # signature, so this may legitimately have no fingerprint to compare; the full
+    # keytool output is printed so the AAB's actual signing scheme is visible in the log.
     - name: Verify AAB signing certificate
       working-directory: android
       run: |
         AAB=app/build/outputs/bundle/release/app-release.aab
-        aab_fp=$(keytool -printcert -jarfile "$AAB" 2>/dev/null | grep -m1 'SHA256:' | tr -d '[:space:]')
-        ks_fp=$(keytool -list -v -keystore "app/${{ inputs.KEYSTORE_OFFICIAL }}" -alias "${{ inputs.KEYSTORE_OFFICIAL_ALIAS }}" -storepass "${{ inputs.KEYSTORE_OFFICIAL_PASSWORD }}" 2>/dev/null | grep -m1 'SHA256:' | tr -d '[:space:]')
-        echo "AAB signer:    ${aab_fp:-<none>}"
-        echo "Keystore cert: ${ks_fp:-<none>}"
-        if [ -z "$aab_fp" ] || [ -z "$ks_fp" ]; then
-          echo "::error::Could not read a SHA-256 fingerprint from the AAB or the keystore."
-          exit 1
+
+        # Capture without letting a failed/empty read trip `set -e -o pipefail`.
+        aab_certs=$(keytool -printcert -jarfile "$AAB" 2>&1 || true)
+        ks_certs=$(keytool -list -v \
+          -keystore "app/${{ inputs.KEYSTORE_OFFICIAL }}" \
+          -alias "${{ inputs.KEYSTORE_OFFICIAL_ALIAS }}" \
+          -storepass "${{ inputs.KEYSTORE_OFFICIAL_PASSWORD }}" 2>&1 || true)
+
+        echo "----- keytool -printcert -jarfile (AAB) -----"
+        echo "$aab_certs"
+        echo "----- keystore certificate (SHA fingerprints) -----"
+        printf '%s\n' "$ks_certs" | grep -E 'SHA(1|256):' || true
+
+        aab_fp=$(printf '%s\n' "$aab_certs" | grep -m1 'SHA256:' | tr -d '[:space:]' || true)
+        ks_fp=$(printf '%s\n' "$ks_certs" | grep -m1 'SHA256:' | tr -d '[:space:]' || true)
+
+        if [ -z "$aab_fp" ]; then
+          echo "::warning::No v1/JAR SHA-256 fingerprint readable from the AAB (expected: app/build.gradle has v1SigningEnabled=false). Skipping fingerprint comparison; relying on the ABI gate and Play's upload-key verification."
+          exit 0
+        fi
+        if [ -z "$ks_fp" ]; then
+          echo "::warning::Could not read a SHA-256 fingerprint from the keystore; skipping comparison."
+          exit 0
         fi
         if [ "$aab_fp" != "$ks_fp" ]; then
+          echo "AAB signer:    $aab_fp"
+          echo "Keystore cert: $ks_fp"
           echo "::error::AAB signing certificate does not match the official keystore."
           exit 1
         fi
-        echo "Signing certificate verified against the official keystore."
+        echo "Signing certificate verified against the official keystore ($aab_fp)."
       shell: bash
 
     # Write the native build cache only on develop (the default branch); PRs restore it

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -37,17 +37,12 @@ runs:
         bundler-cache: true
         working-directory: android
 
-    # setup-gradle owns the ~/.gradle cache (write on the default branch, read-only on PRs),
-    # so the previous manual actions/cache for ~/.gradle is intentionally removed — stacking
-    # the two is redundant and Gradle warns it can interfere.
+    # setup-gradle manages the ~/.gradle cache itself — no separate actions/cache step needed for it.
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
-    # Restore the native build outputs (CMake/externalNativeBuild object files, Gradle
-    # incremental state, packaged intermediates) so warm builds skip recompiling C++ for
-    # every ABI. Always restore; the cache is only written on develop (see "Save" step
-    # below), so PRs read the latest develop cache via the restore-keys prefix fallback.
-    # Distinct "android-store-" namespace keeps this separate from the single-ABI E2E cache.
+    # Native build outputs (CMake objects, Gradle state, intermediates) so warm builds skip
+    # recompiling C++. Written only on develop (Save step); PRs read it via restore-keys.
     - name: Restore Android native build cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
@@ -103,16 +98,15 @@ runs:
         echo "BUILD_DURATION_SECONDS=$((build_end - build_start))" >> "$GITHUB_ENV"
       shell: bash
 
-    # Hard gate: a cache-poisoning bug or a silently-dropped ABI must fail the build loudly
-    # rather than ship a defective signed release bundle.
+    # Fail loudly if a cache/packaging bug dropped an ABI, instead of shipping an incomplete bundle.
     - name: Verify AAB contains all target ABIs
       working-directory: android
       run: |
         AAB=app/build/outputs/bundle/release/app-release.aab
-        echo "Inspecting native libraries in $AAB"
+        libs=$(unzip -l "$AAB")
         missing=0
         for abi in armeabi-v7a arm64-v8a x86 x86_64; do
-          if unzip -l "$AAB" | grep -q "base/lib/$abi/"; then
+          if grep -q "base/lib/$abi/" <<< "$libs"; then
             echo "  found: $abi"
           else
             echo "  MISSING: $abi"
@@ -120,18 +114,14 @@ runs:
           fi
         done
         if [ "$missing" -ne 0 ]; then
-          echo "::error::AAB is missing one or more target ABIs — refusing to ship an incomplete release bundle."
+          echo "::error::AAB is missing one or more target ABIs."
           exit 1
         fi
       shell: bash
 
-    # Hard gate: the AAB must be signed with the official upload certificate.
-    # The keystore password is read via keytool's `-storepass:env` rather than a
-    # shell-quoted argument — the secret contains shell-special characters (the same
-    # reason the gradle.properties step above single-quotes the password lines), so
-    # interpolating it into `-storepass "…"` mangles it and the read silently fails.
-    # Captures use `|| true` so an empty read never trips `set -e -o pipefail`; the
-    # full keytool output is printed only on failure so a problem is self-explaining.
+    # Fail unless the AAB is signed by the official upload cert. Reads the keystore password
+    # via `-storepass:env` (not a shell-quoted arg) since the secret has shell-special chars;
+    # captures use `|| true` so an empty read can't trip `set -e -o pipefail`.
     - name: Verify AAB signing certificate
       working-directory: android
       env:
@@ -167,8 +157,7 @@ runs:
         echo "Signing certificate verified against the official keystore ($aab_fp)."
       shell: bash
 
-    # Write the native build cache only on develop (the default branch); PRs restore it
-    # read-only. Runs after the gates so a poisoned/incomplete build is never cached.
+    # Write the cache only on develop; runs after the gates so a bad build is never cached.
     - name: Save Android native build cache
       if: ${{ inputs.trigger == 'develop' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -22,6 +22,10 @@ inputs:
   KEYSTORE_OFFICIAL_ALIAS:
     description: 'Keystore alias'
     required: true
+  trigger:
+    description: 'Build trigger context: "develop" writes the native build cache; any other value (e.g. "pr") restores it read-only'
+    required: false
+    default: pr
 
 runs:
   using: "composite"
@@ -33,18 +37,27 @@ runs:
         bundler-cache: true
         working-directory: android
 
+    # setup-gradle owns the ~/.gradle cache (write on the default branch, read-only on PRs),
+    # so the previous manual actions/cache for ~/.gradle is intentionally removed — stacking
+    # the two is redundant and Gradle warns it can interfere.
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
-    - name: Cache Gradle
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+    # Restore the native build outputs (CMake/externalNativeBuild object files, Gradle
+    # incremental state, packaged intermediates) so warm builds skip recompiling C++ for
+    # every ABI. Always restore; the cache is only written on develop (see "Save" step
+    # below), so PRs read the latest develop cache via the restore-keys prefix fallback.
+    # Distinct "android-store-" namespace keeps this separate from the single-ABI E2E cache.
+    - name: Restore Android native build cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
-          ~/.gradle
           android/.gradle
-        key: gradle-${{ hashFiles('android/**.gradle*', 'android/**/gradle-wrapper.properties') }}
+          android/app/build
+          android/app/.cxx
+        key: android-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', '**/*.gradle*', '.github/actions/build-android/action.yml') }}
         restore-keys: |
-          gradle-
+          android-store-${{ runner.os }}-
 
     - name: Decode Keystore
       working-directory: android/app
@@ -57,6 +70,8 @@ runs:
       run: |
         echo "" > ./gradle.properties
         echo -e "org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" >> ./gradle.properties
+        echo -e "org.gradle.parallel=true" >> ./gradle.properties
+        echo -e "org.gradle.caching=true" >> ./gradle.properties
         echo -e "android.useAndroidX=true" >> ./gradle.properties
         echo -e "android.enableJetifier=true" >> ./gradle.properties
         echo -e "reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64" >> ./gradle.properties
@@ -81,7 +96,78 @@ runs:
 
     - name: Build Android Release AAB
       working-directory: android
-      run: ./gradlew bundleRelease
+      run: |
+        build_start=$(date +%s)
+        ./gradlew bundleRelease --build-cache --parallel --max-workers=4
+        build_end=$(date +%s)
+        echo "BUILD_DURATION_SECONDS=$((build_end - build_start))" >> "$GITHUB_ENV"
+      shell: bash
+
+    # Hard gate: a cache-poisoning bug or a silently-dropped ABI must fail the build loudly
+    # rather than ship a defective signed release bundle.
+    - name: Verify AAB contains all target ABIs
+      working-directory: android
+      run: |
+        AAB=app/build/outputs/bundle/release/app-release.aab
+        echo "Inspecting native libraries in $AAB"
+        missing=0
+        for abi in armeabi-v7a arm64-v8a x86 x86_64; do
+          if unzip -l "$AAB" | grep -q "base/lib/$abi/"; then
+            echo "  found: $abi"
+          else
+            echo "  MISSING: $abi"
+            missing=1
+          fi
+        done
+        if [ "$missing" -ne 0 ]; then
+          echo "::error::AAB is missing one or more target ABIs — refusing to ship an incomplete release bundle."
+          exit 1
+        fi
+      shell: bash
+
+    # Hard gate: confirm the AAB is signed with the official keystore certificate.
+    - name: Verify AAB signing certificate
+      working-directory: android
+      run: |
+        AAB=app/build/outputs/bundle/release/app-release.aab
+        aab_fp=$(keytool -printcert -jarfile "$AAB" 2>/dev/null | grep -m1 'SHA256:' | tr -d '[:space:]')
+        ks_fp=$(keytool -list -v -keystore "app/${{ inputs.KEYSTORE_OFFICIAL }}" -alias "${{ inputs.KEYSTORE_OFFICIAL_ALIAS }}" -storepass "${{ inputs.KEYSTORE_OFFICIAL_PASSWORD }}" 2>/dev/null | grep -m1 'SHA256:' | tr -d '[:space:]')
+        echo "AAB signer:    ${aab_fp:-<none>}"
+        echo "Keystore cert: ${ks_fp:-<none>}"
+        if [ -z "$aab_fp" ] || [ -z "$ks_fp" ]; then
+          echo "::error::Could not read a SHA-256 fingerprint from the AAB or the keystore."
+          exit 1
+        fi
+        if [ "$aab_fp" != "$ks_fp" ]; then
+          echo "::error::AAB signing certificate does not match the official keystore."
+          exit 1
+        fi
+        echo "Signing certificate verified against the official keystore."
+      shell: bash
+
+    # Write the native build cache only on develop (the default branch); PRs restore it
+    # read-only. Runs after the gates so a poisoned/incomplete build is never cached.
+    - name: Save Android native build cache
+      if: ${{ inputs.trigger == 'develop' }}
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          android/.gradle
+          android/app/build
+          android/app/.cxx
+        key: android-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', '**/*.gradle*', '.github/actions/build-android/action.yml') }}
+
+    - name: Report build time
+      if: ${{ always() && env.BUILD_DURATION_SECONDS != '' }}
+      run: |
+        mins=$((BUILD_DURATION_SECONDS / 60))
+        secs=$((BUILD_DURATION_SECONDS % 60))
+        {
+          echo "### Android store build (bundleRelease)"
+          echo ""
+          echo "- Wall time: **${mins}m ${secs}s**"
+          echo "- Trigger: \`${{ inputs.trigger }}\` (native cache: ${{ inputs.trigger == 'develop' && 'write' || 'read-only' }})"
+        } >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 
     - name: Upload sourcemaps/NDK symbols to Bugsnag

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -153,8 +153,11 @@ runs:
       shell: bash
 
     # Write the cache only on develop; runs after the gates so a bad build is never cached.
+    # TEMP (NATIVE-1251 benchmark) — REVERT BEFORE MERGE: the `|| github.head_ref ==` clause
+    # lets this PR branch seed the cache so we can measure a cold→warm delta. Restore to
+    # `if: ${{ inputs.trigger == 'develop' }}` before merging.
     - name: Save Android native build cache
-      if: ${{ inputs.trigger == 'develop' }}
+      if: ${{ inputs.trigger == 'develop' || github.head_ref == 'native-1251-android-ci-build-time' }}
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -22,10 +22,6 @@ inputs:
   KEYSTORE_OFFICIAL_ALIAS:
     description: 'Keystore alias'
     required: true
-  trigger:
-    description: 'Build trigger context: "develop" writes the native build cache; any other value (e.g. "pr") restores it read-only'
-    required: false
-    default: pr
 
 runs:
   using: "composite"
@@ -39,17 +35,6 @@ runs:
 
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
-
-    - name: Restore Android native build cache
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: |
-          android/.gradle
-          android/app/build
-          android/app/.cxx
-        key: android-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', '**/*.gradle*', '.github/actions/build-android/action.yml') }}
-        restore-keys: |
-          android-store-${{ runner.os }}-
 
     - name: Decode Keystore
       working-directory: android/app
@@ -152,20 +137,6 @@ runs:
         echo "Signing certificate verified against the official keystore ($aab_fp)."
       shell: bash
 
-    # Write the cache only on develop; runs after the gates so a bad build is never cached.
-    # TEMP (NATIVE-1251 benchmark) — REVERT BEFORE MERGE: the `|| github.head_ref ==` clause
-    # lets this PR branch seed the cache so we can measure a cold→warm delta. Restore to
-    # `if: ${{ inputs.trigger == 'develop' }}` before merging.
-    - name: Save Android native build cache
-      if: ${{ inputs.trigger == 'develop' || github.head_ref == 'native-1251-android-ci-build-time' }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: |
-          android/.gradle
-          android/app/build
-          android/app/.cxx
-        key: android-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', '**/*.gradle*', '.github/actions/build-android/action.yml') }}
-
     - name: Report build time
       if: ${{ always() && env.BUILD_DURATION_SECONDS != '' }}
       run: |
@@ -175,7 +146,6 @@ runs:
           echo "### Android store build (bundleRelease)"
           echo ""
           echo "- Wall time: **${mins}m ${secs}s**"
-          echo "- Trigger: \`${{ inputs.trigger }}\` (native cache: ${{ inputs.trigger == 'develop' && 'write' || 'read-only' }})"
         } >> "$GITHUB_STEP_SUMMARY"
       shell: bash
 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -44,8 +44,9 @@ jobs:
 
       - name: Build Android
         uses: ./.github/actions/build-android
-        timeout-minutes: 40
+        timeout-minutes: 60
         with:
+          trigger: ${{ inputs.trigger }}
           GOOGLE_SERVICES_ANDROID: ${{ secrets.GOOGLE_SERVICES_ANDROID }}
           KEYSTORE_OFFICIAL_BASE64: ${{ secrets.KEYSTORE_OFFICIAL_BASE64 }}
           KEYSTORE_OFFICIAL: ${{ secrets.KEYSTORE_OFFICIAL }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -46,7 +46,6 @@ jobs:
         uses: ./.github/actions/build-android
         timeout-minutes: 60
         with:
-          trigger: ${{ inputs.trigger }}
           GOOGLE_SERVICES_ANDROID: ${{ secrets.GOOGLE_SERVICES_ANDROID }}
           KEYSTORE_OFFICIAL_BASE64: ${{ secrets.KEYSTORE_OFFICIAL_BASE64 }}
           KEYSTORE_OFFICIAL: ${{ secrets.KEYSTORE_OFFICIAL }}


### PR DESCRIPTION
## Proposed changes

The Android store build (`./gradlew bundleRelease` — a signed, multi-ABI store AAB) runs close to its 40-minute step timeout and is intermittently killed before producing an artifact; ~28 of those minutes are New-Architecture native C++ compiled per module per ABI. Because releases are sometimes cut from PR branches, a timed-out PR build can block a release, not just slow review.

This PR keeps the build doing the same work — a full signed bundle for all four ABIs (`armeabi-v7a, arm64-v8a, x86, x86_64`) — but makes it faster and verifies the output:

- **Run Gradle in parallel & enable the build cache** — `--build-cache --parallel --max-workers=4` on `bundleRelease`; heap unchanged at `-Xmx4g`. This speeds up the JVM-side work (Java/Kotlin/resources/packaging).
- **Drop the redundant manual `~/.gradle` cache** and let `gradle/actions/setup-gradle` own the Gradle user-home cache, as its docs recommend.
- **Two hard gates after the build**: every target ABI is present in the AAB, and the AAB's signer certificate matches the official keystore — so a packaging or signing bug fails loudly instead of shipping a defective bundle.
- **Raise the step timeout 40 → 60** as a guardrail (ABI reduction is intentionally off the table for device coverage), and write the `bundleRelease` wall time to the job step summary.

No path-based native build cache is added: the C++ compile is run by the Android Gradle Plugin's external-native-build task, which is not a cacheable Gradle task and always re-runs, so caching `.cxx`/build dirs cannot avoid the recompile. The real native lever is content-keyed compiler caching (ccache), which is tracked as a separate follow-up.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1251

## How to test or reproduce

CI-pipeline change, validated by running the pipeline on this PR:

1. Approve the **Build Android** gate; confirm the `Build` job produces `android-aab`, both gates pass (all four ABIs listed; signing cert matches the keystore), and the step summary shows the `bundleRelease` wall time.
2. Approve the **E2E** gate; confirm the E2E Android run is unaffected.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

CI-config only — no application code changes, so the JS/TS lint and unit-test suites aren't the validation path here.

Two other levers were intentionally rejected: disabling Android release lint (`lintVitalRelease` is the only native-Android lint gate in CI, and the Node-only ESLint/tsc job can't host it), and Gradle configuration-cache (RN 0.81 + New-Arch autolinking spawns `node` at configuration time, which Gradle 8.2+ rejects — facebook/react-native#45154 — and cleartext secrets currently live in the generated `gradle.properties`). Both can be revisited after upstream/secret-handling changes.
