### PR TITLE
ci(maestro): rebalance iOS shards and isolate driver warmup from test timing

### DIFF
--- a/.github/workflows/maestro-ios.yml
+++ b/.github/workflows/maestro-ios.yml
@@ -40,13 +40,6 @@ jobs:
           path: ~/.maestro
           key: maestro-${{ runner.os }}-${{ env.MAESTRO_VERSION }}
 
-      - name: Install Maestro + idb
-        run: |
-          brew tap facebook/fb
-          brew install facebook/fb/idb-companion
-          curl -fsSL "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-
       - name: Configure Simulator
         run: |
           defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
@@ -58,18 +51,32 @@ jobs:
           defaults write com.apple.iphonesimulator ShowChrome -bool false
           defaults write com.apple.iphonesimulator DeviceFramebufferOnly -bool true
 
-      - name: Boot Simulator
-        timeout-minutes: 15
+      # Kick off the cold boot asynchronously so the iOS runtime boots in the
+      # background while Maestro + idb install. We block on it afterwards in
+      # "Wait for Simulator Ready".
+      - name: Start Simulator Boot
         run: |
           if [ "${{ inputs.shard }}" = "14" ]; then
             SIM_NAME="iPhone SE (3rd generation)"
           else
             SIM_NAME="iPhone 16 Pro"
           fi
+          echo "SIM_NAME=$SIM_NAME" >> "$GITHUB_ENV"
 
-          echo "Booting simulator: $SIM_NAME"
-
+          echo "Starting boot for simulator: $SIM_NAME"
           xcrun simctl boot "$SIM_NAME" || true
+
+      - name: Install Maestro + idb
+        run: |
+          brew tap facebook/fb
+          brew install facebook/fb/idb-companion
+          curl -fsSL "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Wait for Simulator Ready
+        timeout-minutes: 15
+        run: |
+          echo "Waiting for simulator to finish booting: $SIM_NAME"
           xcrun simctl bootstatus "$SIM_NAME" -b
 
           echo "Disabling animations"
@@ -77,7 +84,7 @@ jobs:
 
           echo "Warming SpringBoard"
           xcrun simctl launch booted com.apple.springboard
-          sleep 15
+          sleep 5
 
           echo "Booted devices:"
           xcrun simctl list devices | grep Booted
@@ -96,13 +103,21 @@ jobs:
       - name: Make Maestro Script Executable
         run: chmod +x .github/scripts/run-maestro.sh
 
+      # Installs Maestro's XCTest driver onto the booted simulator (~3min on a
+      # cold sim) so the timed step below measures test execution only.
+      - name: Warm Up Maestro Driver
+        timeout-minutes: 6
+        run: |
+          cat > /tmp/maestro-warmup.yaml <<'EOF'
+          appId: com.apple.Preferences
+          ---
+          - launchApp
+          EOF
+          maestro test /tmp/maestro-warmup.yaml || true
+
       - name: Run Maestro Tests
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
-        with:
-          timeout_minutes: 30
-          max_attempts: 2
-          retry_on: timeout
-          command: ./.github/scripts/run-maestro.sh ios ${{ inputs.shard }}
+        timeout-minutes: 30
+        run: ./.github/scripts/run-maestro.sh ios ${{ inputs.shard }}
 
       - name: Upload Maestro Logs
         if: always()

--- a/.maestro/tests/assorted/delete-server.yaml
+++ b/.maestro/tests/assorted/delete-server.yaml
@@ -5,7 +5,7 @@ onFlowStart:
 onFlowComplete:
   - evalScript: ${output.utils.deleteCreatedUsers()}
 tags:
-  - test-6
+  - test-7
 
 ---
 - evalScript: ${output.user = output.utils.createUser()}

--- a/.maestro/tests/assorted/display-perf.yaml
+++ b/.maestro/tests/assorted/display-perf.yaml
@@ -5,7 +5,7 @@ onFlowStart:
 onFlowComplete:
   - evalScript: ${output.utils.deleteCreatedUsers()}
 tags:
-  - test-6
+  - test-8
 
 ---
 - evalScript: ${output.user = output.utils.createUser()}

--- a/.maestro/tests/e2ee/e2e-encryption.yaml
+++ b/.maestro/tests/e2ee/e2e-encryption.yaml
@@ -5,7 +5,7 @@ onFlowStart:
 onFlowComplete:
   - evalScript: ${output.utils.deleteCreatedUsers()}
 tags:
-  - test-9
+  - test-3
 ---
 - evalScript: ${output.room = 'encrypted' + output.random()}
 - evalScript: ${output.userA = output.utils.createUser()}

--- a/.maestro/tests/onboarding/server-history.yaml
+++ b/.maestro/tests/onboarding/server-history.yaml
@@ -5,7 +5,7 @@ onFlowStart:
 onFlowEnd:
   - evalScript: ${output.utils.deleteCreatedUsers()}
 tags:
-  - test-3
+  - test-1
 
 ---
 - evalScript: ${output.user = output.utils.createUser()}

--- a/.maestro/tests/onboarding/workspace/invalid-workspace.yaml
+++ b/.maestro/tests/onboarding/workspace/invalid-workspace.yaml
@@ -1,7 +1,7 @@
 appId: ${APP_ID}
 name: Invalid Workspace
 tags:
-  - test-3
+  - test-2
 
 ---
 - runFlow: ../../../helpers/launch-app.yaml

--- a/.maestro/tests/onboarding/workspace/valid-workspace.yaml
+++ b/.maestro/tests/onboarding/workspace/valid-workspace.yaml
@@ -3,7 +3,7 @@ name: Valid Workspace
 onFlowStart:
   - runFlow: '../../../helpers/setup.yaml'
 tags:
-  - test-3
+  - test-2
 
 ---
 - runFlow: ../../../helpers/launch-app.yaml

--- a/.maestro/tests/room/message-markdown-click.yaml
+++ b/.maestro/tests/room/message-markdown-click.yaml
@@ -6,7 +6,7 @@ onFlowStart:
 onFlowComplete:
   - evalScript: ${output.utils.deleteCreatedUsers()}
 tags:
-  - test-12
+  - test-9
 
 ---
 - evalScript: ${output.user = output.utils.createUser()}

--- a/.maestro/tests/room/room-info.yaml
+++ b/.maestro/tests/room/room-info.yaml
@@ -5,7 +5,7 @@ onFlowStart:
 onFlowComplete:
   - evalScript: ${output.utils.deleteCreatedUsers()}
 tags:
-  - test-12
+  - test-9
 
 ---
 - evalScript: ${output.user = output.utils.createUser()}

--- a/.maestro/tests/room/share-message.yaml
+++ b/.maestro/tests/room/share-message.yaml
@@ -3,7 +3,7 @@ name: Share Message
 onFlowStart:
   - runFlow: '../../helpers/setup.yaml'
 tags:
-  - test-12
+  - test-9
 
 ---
 - evalScript: ${output.user = output.utils.createUser()}

--- a/.maestro/tests/room/threads.yaml
+++ b/.maestro/tests/room/threads.yaml
@@ -5,7 +5,7 @@ onFlowStart:
 onFlowComplete:
   - evalScript: ${output.utils.deleteCreatedUsers()}
 tags:
-  - test-12
+  - test-13
 
 ---
 - evalScript: ${output.user = output.utils.createUser()}


### PR DESCRIPTION
## Proposed changes

iOS Maestro shard 12 carried ~35 minutes of flow time, exceeding the step's 30-minute timeout: the Room flow was killed mid-run and Share Message never started. This PR rebalances the shard assignments using measured per-flow durations from a full develop run and cleans up the iOS Maestro workflow:

**Shard rebalance** (heaviest iOS shard goes from ~35 min to ~15 min):
- E2E Encryption moves to shard 3 and gets it to itself — it is the heaviest single flow on both platforms (~13 min). Server History moves to shard 1; Valid/Invalid Workspace move to shard 2.
- Room Info, Message Markdown Click and Share Message move from shard 12 to shard 9; Threads moves from 12 to 13. Shard 12 keeps Room + Open room with 50+ messages.
- Delete Server moves from shard 6 to 7; Display Perf from 6 to 8.

**`maestro-ios.yml` changes:**
- Replace `nick-fields/retry` with a plain `timeout-minutes: 30` on the test step. `run-maestro.sh` already reruns flaky flows internally, so the action's only remaining effect was a second full 30-minute attempt after a timeout — doubling runner cost on oversized shards. The Android workflow already works this way.
- Add a warmup step that installs Maestro's XCTest driver onto the booted simulator (~3 min on a cold simulator) before the timed test step, so the test step's duration reflects flow execution only.
- Boot the simulator asynchronously while Maestro and idb install, then block on boot status, instead of waiting serially.

Flow-to-shard mapping was verified by replaying `run-maestro.sh`'s tag grep for all 14 shards — every flow is assigned exactly once, none dropped. Room and Share Message iOS durations are estimated (they never completed on iOS recently), so shards 9 and 12 carry the most uncertainty.

A follow-up task exists to replace these static `test-N` tags with duration-aware auto-balancing per platform: https://rocketchat.atlassian.net/browse/NATIVE-1265

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1123

## How to test or reproduce

Approve the E2E hold on this PR and check the Maestro iOS/Android matrix: all 14 shards should pass, no shard's "Run Maestro Tests" step should approach the 30-minute timeout, and the new "Warm Up Maestro Driver" step should absorb the ~3-minute driver install on iOS.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced iOS test automation workflow by optimizing simulator startup sequence with asynchronous boot and parallel dependency installation, reducing CI/CD pipeline duration.
  * Reorganized test categorization and updated test tags across Maestro test suites for improved test management and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->