### PR TITLE
fix: case-sensitive search for Cyrillic characters in share extension

### DIFF
--- a/app/lib/database/utils.test.ts
+++ b/app/lib/database/utils.test.ts
@@ -1,4 +1,10 @@
+import type { Q } from '@nozbe/watermelondb';
+
 import * as utils from './utils';
+
+// Extracts every `LIKE` value (e.g. '%moy%') present in a serialized Q.or clause
+const getLikeValues = (clause: Q.Or): string[] =>
+	(clause as any).conditions.map((condition: any) => condition.comparison.right.value);
 
 describe('sanitizeLikeStringTester', () => {
 	// example chars that shouldn't return
@@ -18,6 +24,48 @@ describe('sanitizeLikeStringTester', () => {
 		['japanese', 'テスト123']
 	])('render test (%s)', (_, str) => {
 		expect(utils.sanitizeLikeString(`${str}${disallowedChars}`)).toBe(`${str}${'_'.repeat(disallowedChars.length)}`);
+	});
+});
+
+describe('getSubscriptionSearchClause', () => {
+	const columnsOf = (clause: Q.Or): string[] => (clause as any).conditions.map((condition: any) => condition.left);
+
+	test('queries the slugified and sanitized name/fname columns', () => {
+		const clause = utils.getSubscriptionSearchClause('test');
+		expect((clause as any).type).toBe('or');
+		expect(columnsOf(clause)).toEqual(['sanitized_fname', 'name', 'name', 'fname']);
+		expect(getLikeValues(clause)).toEqual(['%test%', '%test%', '%test%', '%test%']);
+	});
+
+	// The actual bug: SQLite LIKE is case-sensitive for Cyrillic, so the search must rely on the
+	// slugified (lower latin) value. Upper and lower case input must produce the same slugified clause.
+	test('produces the same slugified clause regardless of Cyrillic case', () => {
+		const upper = getLikeValues(utils.getSubscriptionSearchClause('М'));
+		const lower = getLikeValues(utils.getSubscriptionSearchClause('м'));
+		// the slugified clauses (sanitized_fname + name) match case-insensitively
+		expect(upper[0]).toBe('%m%');
+		expect(lower[0]).toBe('%m%');
+		expect(upper[0]).toBe(lower[0]);
+		expect(upper[1]).toBe(lower[1]);
+	});
+
+	test('slugifies a multi-word Cyrillic name so a lowercase query matches an uppercase channel', () => {
+		// channel named 'Мой Канал' would be stored slugified as 'moy-kanal'
+		const clause = utils.getSubscriptionSearchClause('Мой');
+		const [slugifiedFname] = getLikeValues(clause);
+		expect(slugifiedFname).toBe('%moy%');
+		expect('moy-kanal').toContain(slugifiedFname.replace(/%/g, ''));
+	});
+
+	test('keeps the sanitized (non-slugified) fallback for the original characters', () => {
+		const clause = utils.getSubscriptionSearchClause('тест');
+		const values = getLikeValues(clause);
+		// slugified clauses transliterate to latin...
+		expect(values[0]).toBe('%test%');
+		expect(values[1]).toBe('%test%');
+		// ...while the fallback clauses keep the original Cyrillic for not-yet-slugified rows
+		expect(values[2]).toBe('%тест%');
+		expect(values[3]).toBe('%тест%');
 	});
 });
 

--- a/app/lib/database/utils.ts
+++ b/app/lib/database/utils.ts
@@ -1,3 +1,4 @@
+import { Q } from '@nozbe/watermelondb';
 import XRegExp from 'xregexp';
 import { slugify } from 'transliteration';
 
@@ -14,6 +15,23 @@ export const slugifyLikeString = (str?: string) => {
 	str?.replace(likeStringRegex, '_');
 	const slugified = slugify(str);
 	return slugified;
+};
+
+// Builds the WHERE clause used to search subscriptions by name/fname.
+// Querying the slugified `sanitized_fname`/`name` columns makes the search case-insensitive
+// for non-latin alphabets (e.g. Cyrillic), where SQLite's LIKE is case-sensitive.
+export const getSubscriptionSearchClause = (searchText: string): Q.Or => {
+	const likeString = sanitizeLikeString(searchText);
+	const slugifiedString = slugifyLikeString(searchText);
+	return Q.or(
+		// `sanitized_fname` is an optional column, so it's going to start null and it's going to get filled over time
+		Q.where('sanitized_fname', Q.like(`%${slugifiedString}%`)),
+		// the param 'name' is slugified by the server when the slugify setting is enabled, just for channels and teams
+		Q.where('name', Q.like(`%${slugifiedString}%`)),
+		// Still need the conditionals below because at the first moment the sanitized_fname won't be filled
+		Q.where('name', Q.like(`%${likeString}%`)),
+		Q.where('fname', Q.like(`%${likeString}%`))
+	);
 };
 
 export const sanitizer = (r: object): object => r;

--- a/app/lib/methods/search.ts
+++ b/app/lib/methods/search.ts
@@ -1,6 +1,6 @@
 import { Q } from '@nozbe/watermelondb';
 
-import { sanitizeLikeString, slugifyLikeString } from '../database/utils';
+import { getSubscriptionSearchClause, sanitizeLikeString } from '../database/utils';
 import database from '../database/index';
 import { store as reduxStore } from '../store/auxStore';
 import { spotlight } from '../services/restApi';
@@ -20,23 +20,9 @@ export const localSearchSubscription = async ({
 }): Promise<ISearchLocal[]> => {
 	const searchText = text.trim();
 	const db = database.active;
-	const likeString = sanitizeLikeString(searchText);
-	const slugifiedString = slugifyLikeString(searchText);
 	let subscriptions = await db
 		.get('subscriptions')
-		.query(
-			Q.or(
-				// `sanitized_fname` is an optional column, so it's going to start null and it's going to get filled over time
-				Q.where('sanitized_fname', Q.like(`%${slugifiedString}%`)),
-				// TODO: Remove the conditionals below at some point. It is merged at 4.39
-				// the param 'name' is slugified by the server when the slugify setting is enable, just for channels and teams
-				Q.where('name', Q.like(`%${slugifiedString}%`)),
-				// Still need the below conditionals because at the first moment the the sanitized_fname won't be filled
-				Q.where('name', Q.like(`%${likeString}%`)),
-				Q.where('fname', Q.like(`%${likeString}%`))
-			),
-			Q.sortBy('room_updated_at', Q.desc)
-		)
+		.query(getSubscriptionSearchClause(searchText), Q.sortBy('room_updated_at', Q.desc))
 		.fetch();
 
 	if (filterUsers && !filterRooms) {

--- a/app/views/ShareListView/index.tsx
+++ b/app/views/ShareListView/index.tsx
@@ -19,7 +19,7 @@ import SearchHeader from '../../containers/SearchHeader';
 import { themes } from '../../lib/constants/colors';
 import { type TSupportedThemes, withTheme } from '../../theme';
 import SafeAreaView from '../../containers/SafeAreaView';
-import { sanitizeLikeString } from '../../lib/database/utils';
+import { getSubscriptionSearchClause } from '../../lib/database/utils';
 import styles from './styles';
 import { type IApplicationState, RootEnum, type TServerModel, type TSubscriptionModel } from '../../definitions';
 import { type ShareInsideStackParamList } from '../../definitions/navigationTypes';
@@ -227,8 +227,7 @@ class ShareListView extends Component<IShareListViewProps, IState> {
 			Q.sortBy('room_updated_at', Q.desc)
 		] as (Q.WhereDescription | Q.Skip | Q.Take | Q.SortBy | Q.Or)[];
 		if (text) {
-			const likeString = sanitizeLikeString(text);
-			defaultWhereClause.push(Q.or(Q.where('name', Q.like(`%${likeString}%`)), Q.where('fname', Q.like(`%${likeString}%`))));
+			defaultWhereClause.push(getSubscriptionSearchClause(text));
 		}
 		const data = (await db
 			.get('subscriptions')


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Search in the share extension (Send to) was case-sensitive for non-Latin alphabets such as Cyrillic, because SQLite's LIKE is only case-insensitive for ASCII. Searching м would not find a channel named Мой Канал, and vice versa.

This PR makes the share extension search case-insensitive by matching against the slugified (lower-Latin) sanitized_fname column — the same approach already used by the in-app search (localSearchSubscription).

- Extracted the shared search-clause logic into a pure getSubscriptionSearchClause helper in
app/lib/database/utils.ts.
- Wired both ShareListView.query (share extension) and localSearchSubscription to use it, removing the
duplicated query block.
- Added unit tests covering the Cyrillic case-insensitivity and the non-slugified fallback.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/SUP-1058


## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
### Server: mobile.qa.rocket.chat

### Setup
1. Log into the app on mobile.qa.rocket.chat.
2. Create a channel with an uppercase Cyrillic name → e.g. Мой Канал.
3. Create a second channel with a lowercase Cyrillic name → e.g. привет.
4. Open both channels once so they sync into the local DB.

### Steps
1. Go to the device's gallery/photos, pick any image → Share → select Rocket.Chat.
2. On the "Send to" screen, tap the search icon.
3. Type lowercase м → expect Мой Канал (uppercase) to appear.
4. Clear, type uppercase М → expect Мой Канал to still appear.
5. Clear, type uppercase П → expect привет (lowercase) to appear.
6. Clear, type a Latin query like gen → expect Latin channels (e.g. general) to appear (no regression).
7. Select the found Cyrillic channel and complete the share → file lands in the correct room.

## Screenshots
| before | after |
| ----- | ----- |
| | |

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for subscription search including Cyrillic character handling, case sensitivity, and multi-word query support

* **Refactor**
  * Centralized subscription search logic with enhanced pattern matching across multiple text fields to improve result accuracy for diverse character sets and input variations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->