### PR TITLE
chore: adopt @rocket.chat/mobile-crypto 0.3.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -248,7 +248,7 @@ PODS:
   - MMKV (2.2.4):
     - MMKVCore (~> 2.2.4)
   - MMKVCore (2.2.4)
-  - MobileCrypto (0.2.2):
+  - MobileCrypto (0.3.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4023,7 +4023,7 @@ SPEC CHECKSUMS:
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   MMKV: 1a8e7dbce7f9cad02c52e1b1091d07bd843aefaf
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
-  MobileCrypto: 41cd66d5588e979cf95d1ff6ae2eec88eb284ef1
+  MobileCrypto: 382f541e04405f45c323b11a404d3cc4546d0669
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroMmkv: 4a2d747ce97a4ae740b3cb3a3853366813faf831
   NitroModules: 18e41c298d86fc753fc754969fa9f84044e70711

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@react-navigation/native-stack": "^7.17.5",
 		"@rocket.chat/media-signaling": "1.0.0-rc.1",
 		"@rocket.chat/message-parser": "0.31.31",
-		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#13c76b6095e29deba12fd1e0f139b0634c811699",
+		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#main",
 		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#mobile",
 		"@rocket.chat/ui-kit": "^0.39.0",
 		"axios": "0.30.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@react-navigation/native-stack": "^7.17.5",
 		"@rocket.chat/media-signaling": "1.0.0-rc.1",
 		"@rocket.chat/message-parser": "0.31.31",
-		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto",
+		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#13c76b6095e29deba12fd1e0f139b0634c811699",
 		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#mobile",
 		"@rocket.chat/ui-kit": "^0.39.0",
 		"axios": "0.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: 0.31.31
         version: 0.31.31
       '@rocket.chat/mobile-crypto':
-        specifier: RocketChat/rocket.chat-mobile-crypto
-        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/a6b848345a33be3a1bcfadecde1fb0f516abc498(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: RocketChat/rocket.chat-mobile-crypto#13c76b6095e29deba12fd1e0f139b0634c811699
+        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@rocket.chat/sdk':
         specifier: RocketChat/Rocket.Chat.js.SDK#mobile
         version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/b6d2b3f25b0ff8283dd71faf6dae720c47fecd8f
@@ -2447,9 +2447,9 @@ packages:
   '@rocket.chat/message-parser@0.31.31':
     resolution: {integrity: sha512-YWHdin2ejndwgQJXlHIzAmQB+xvZLeEOqOkPq8RxdyTjAaGo1DbBCrc0aU7u0LOUnGN+jm3H4grnYdI9SPwitA==}
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/a6b848345a33be3a1bcfadecde1fb0f516abc498':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/a6b848345a33be3a1bcfadecde1fb0f516abc498}
-    version: 0.2.2
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699':
+    resolution: {gitHosted: true, integrity: sha512-9o3LxsQydrmPEQ/cp1MIBdcRmDCEcfYjt1vUrDEFdtEqPN76IiHKJc9/vE6cBUmgO5lR1MxJ5+eu9NcYK1BAKw==, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699}
+    version: 0.3.0
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -10462,7 +10462,7 @@ snapshots:
     dependencies:
       tldts: 5.7.112
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/a6b848345a33be3a1bcfadecde1fb0f516abc498(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: 0.31.31
         version: 0.31.31
       '@rocket.chat/mobile-crypto':
-        specifier: RocketChat/rocket.chat-mobile-crypto#13c76b6095e29deba12fd1e0f139b0634c811699
-        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: RocketChat/rocket.chat-mobile-crypto#main
+        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@rocket.chat/sdk':
         specifier: RocketChat/Rocket.Chat.js.SDK#mobile
         version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/b6d2b3f25b0ff8283dd71faf6dae720c47fecd8f
@@ -2447,8 +2447,8 @@ packages:
   '@rocket.chat/message-parser@0.31.31':
     resolution: {integrity: sha512-YWHdin2ejndwgQJXlHIzAmQB+xvZLeEOqOkPq8RxdyTjAaGo1DbBCrc0aU7u0LOUnGN+jm3H4grnYdI9SPwitA==}
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699':
-    resolution: {gitHosted: true, integrity: sha512-9o3LxsQydrmPEQ/cp1MIBdcRmDCEcfYjt1vUrDEFdtEqPN76IiHKJc9/vE6cBUmgO5lR1MxJ5+eu9NcYK1BAKw==, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699}
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0':
+    resolution: {gitHosted: true, integrity: sha512-gk3YAmpBh34zGwDH+j5gjFFvHyvkXCm3jdTUe1EdLfyjzhi9sU6xUYH8JjgVlJ6NnGxxCO5hmsdn6QRkB3vL7g==, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0}
     version: 0.3.0
     peerDependencies:
       react: '*'
@@ -10462,7 +10462,7 @@ snapshots:
     dependencies:
       tldts: 5.7.112
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/13c76b6095e29deba12fd1e0f139b0634c811699(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0)


### PR DESCRIPTION
## Proposed changes

Point the app at `@rocket.chat/mobile-crypto` v0.3.0, rebuilt against React Native 0.83 as a New Architecture TurboModule. The dependency pin moves from the library's default branch to the rebuilt commit `13c76b6`.

Notable changes pulled in:
- iOS import is now linkage-agnostic (`__has_include` guard), so it builds under both static libraries and `use_frameworks!`.
- Android `rsaVerify` / `rsaVerifyBase64` now accept PKCS#1 public keys, which were previously rejected (SPKI still works). This is the path that decrypts E2E keys already stored on a device.
- Android toolchain defaults moved to Java 17 / Kotlin 2.1.20 / SDK 36. These are read from this app's existing `rootProject.ext`, so nothing changes on the app side.

Files touched: `package.json` (git pin), `pnpm-lock.yaml`, `ios/Podfile.lock` (MobileCrypto 0.3.0).

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1235
Depends on https://github.com/RocketChat/rocket.chat-mobile-crypto/pull/14

## How to test or reproduce

1. `pnpm install && pnpm pod-install`
2. Build and run on iOS and Android.
3. Open an end-to-end encrypted room and confirm encrypted messages send and receive correctly across sessions.
4. Confirm decryption of E2E keys already stored on the device from before the upgrade (exercises the Android PKCS#1 verify fix).

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The pin targets a library commit that is not yet on the library's default branch; that change needs to land (and ideally be published) before this PR merges. The rebuild was validated against RN 0.83; this app is on RN 0.81, where the library is expected to work (it reads SDK/Kotlin versions from the host app and its `react-native` peer range is unconstrained), but it should be confirmed on device before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the mobile cryptography dependency to a pinned reference for more consistent builds and improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->