### PR TITLE
fix: mount the emoji searchbar only when it's visible

### DIFF
--- a/app/containers/MessageComposer/MessageComposer.tsx
+++ b/app/containers/MessageComposer/MessageComposer.tsx
@@ -246,6 +246,7 @@ export const MessageComposer = ({
 			<MessageComposerContent
 				recordingAudio={recordingAudio}
 				action={action}
+				showEmojiSearchbar={showEmojiSearchbar}
 				composerInputComponentRef={composerInputComponentRef}
 				composerInputRef={composerInputRef}
 				onLayout={handleLayout}>

--- a/app/containers/MessageComposer/components/EmojiSearchbar.tsx
+++ b/app/containers/MessageComposer/components/EmojiSearchbar.tsx
@@ -18,12 +18,12 @@ import { useEmojiKeyboard } from '../hooks/useEmojiKeyboard';
 
 const BUTTON_HIT_SLOP = { top: 4, right: 4, bottom: 4, left: 4 };
 
-export const EmojiSearchbar = (): ReactElement | null => {
+export const EmojiSearchbar = (): ReactElement => {
 	'use memo';
 
 	const { colors } = useTheme();
 	const [searchText, setSearchText] = useState<string>('');
-	const { showEmojiSearchbar, closeEmojiSearchbar } = useEmojiKeyboard();
+	const { closeEmojiSearchbar } = useEmojiKeyboard();
 	const { onEmojiSelected } = useContext(MessageInnerContext);
 	const { frequentlyUsed } = useFrequentlyUsedEmoji(true);
 	const [emojis, setEmojis] = useState<IEmoji[]>([]);
@@ -40,10 +40,6 @@ export const EmojiSearchbar = (): ReactElement | null => {
 	};
 
 	const renderItem = ({ item }: { item: IEmoji }) => <PressableEmoji emoji={item} onPress={handleEmojiSelected} />;
-
-	if (!showEmojiSearchbar) {
-		return null;
-	}
 
 	return (
 		<View style={{ backgroundColor: colors.surfaceLight }}>

--- a/app/containers/MessageComposer/components/MessageComposerContent.tsx
+++ b/app/containers/MessageComposer/components/MessageComposerContent.tsx
@@ -17,6 +17,7 @@ import { MESSAGE_COMPOSER_EXIT_FOCUS_NATIVE_ID } from '../../../lib/constants/ac
 interface MessageComposerContentProps {
 	recordingAudio: boolean;
 	action: TMessageAction | undefined;
+	showEmojiSearchbar: boolean;
 	composerInputComponentRef: RefObject<IComposerInput>;
 	composerInputRef: RefObject<any>;
 	children?: ReactElement | null;
@@ -24,7 +25,7 @@ interface MessageComposerContentProps {
 }
 
 export const MessageComposerContent = memo<MessageComposerContentProps>(
-	({ recordingAudio, action, composerInputComponentRef, composerInputRef, children, onLayout }) => {
+	({ recordingAudio, action, showEmojiSearchbar, composerInputComponentRef, composerInputRef, children, onLayout }) => {
 		'use memo';
 
 		const { colors } = useTheme();
@@ -47,7 +48,7 @@ export const MessageComposerContent = memo<MessageComposerContentProps>(
 				</View>
 				<Quotes />
 				<Toolbar />
-				<EmojiSearchbar />
+				{showEmojiSearchbar ? <EmojiSearchbar /> : null}
 				<SendThreadToChannel />
 				{children}
 			</View>


### PR DESCRIPTION
## Proposed changes

EmojiSearchbar was always mounted inside the message composer and hid itself with an internal early `return null`. So on every room open it mounted, ran its hooks, and triggered a frequently-used-emoji database read — despite being hidden until the user opens emoji search.

This gates the mount on `showEmojiSearchbar`, threads the flag from MessageComposer through MessageComposerContent, and removes the now-dead internal null guard. The searchbar now mounts only when it becomes visible, avoiding a render and an async DB read on every room open.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1292

## How to test or reproduce

1. Open a room: the emoji searchbar is not present (no visible behavior change).
2. Tap the emoji button → "search" to open the emoji searchbar: it appears, shows frequently-used emoji, search works, and the back chevron closes it.
3. Pick an emoji from the searchbar: it inserts as before and the "frequently used" list updates.

## Screenshots

N/A — no visual change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the message composer so emoji searchbar visibility is driven by the composer’s current emoji-search state.
  * The emoji searchbar UI is now rendered consistently by the composer content, and the visibility logic is handled via a dedicated prop rather than internal conditional rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->