### PR TITLE
[IMPROVEMENT] Migrate deprecated keep-awake methods in JitsiMeetView and AudioPlayer

### DIFF
--- a/app/containers/AudioPlayer/index.tsx
+++ b/app/containers/AudioPlayer/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { InteractionManager, View } from 'react-native';
 import { type AVPlaybackStatus } from 'expo-av';
-import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { useSharedValue } from 'react-native-reanimated';
 import { useNavigation } from '@react-navigation/native';
 
@@ -131,11 +131,18 @@ const AudioPlayer = ({
 	}, [fileUri, isDownloaded]);
 
 	useEffect(() => {
-		if (paused) {
-			deactivateKeepAwake();
-		} else {
-			activateKeepAwake();
-		}
+		const handleAwakeState = async () => {
+			try {
+				if (paused) {
+					deactivateKeepAwake();
+				} else {
+					await activateKeepAwakeAsync();
+				}
+			} catch (e) {
+				// Do nothing
+			}
+		};
+		handleAwakeState();
 	}, [paused]);
 
 	useEffect(() => {

--- a/app/views/JitsiMeetView/index.tsx
+++ b/app/views/JitsiMeetView/index.tsx
@@ -1,6 +1,6 @@
 import CookieManager from '@react-native-cookies/cookies';
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { activateKeepAwake, deactivateKeepAwake } from 'expo-keep-awake';
+import { useKeepAwake } from 'expo-keep-awake';
 import { useCallback, useEffect, useState, type ReactElement } from 'react';
 import { ActivityIndicator, Linking, SafeAreaView, StyleSheet, View } from 'react-native';
 import WebView, { type WebViewNavigation } from 'react-native-webview';
@@ -25,6 +25,8 @@ const JitsiMeetView = (): ReactElement => {
 
 	const [authModal, setAuthModal] = useState(false);
 	const [cookiesSet, setCookiesSet] = useState(false);
+
+	useKeepAwake();
 
 	const setCookies = async () => {
 		const date = new Date();
@@ -88,12 +90,10 @@ const JitsiMeetView = (): ReactElement => {
 	useEffect(() => {
 		handleJitsiApp();
 		onConferenceJoined();
-		activateKeepAwake();
 
 		return () => {
 			logEvent(videoConf ? events.LIVECHAT_VIDEOCONF_TERMINATE : events.JM_CONFERENCE_TERMINATE);
 			if (!videoConf) endVideoConfTimer();
-			deactivateKeepAwake();
 		};
 	}, [handleJitsiApp, onConferenceJoined, videoConf]);
 


### PR DESCRIPTION
This PR is a code quality improvement that addresses deprecations in the expo-keep-awake library across two components: JitsiMeetView and AudioPlayer.

Improvements included:

JitsiMeetView: Replaced the deprecated activateKeepAwake and deactivateKeepAwake calls inside the useEffect lifecycle with the recommended useKeepAwake hook, properly placing it at the top level of the component to conform to React's rules of hooks.


AudioPlayer: Replaced the deprecated activateKeepAwake method with the asynchronous activateKeepAwakeAsync() method within the useEffect conditionally tracking the audio paused state. This correctly keeps the screen active only while audio is playing.


How Has This Been Tested?
Tested locally on simulator/device to ensure the screen continues to properly stay awake when navigating to the Jitsi meeting view or playing an audio message, and that pnpm lint and pnpm test successfully pass without rules-of-hooks errors.

Checklist
 I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
 I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
 Lint and unit tests pass locally with my changes
 I have added tests that prove my fix is effective or that my feature works (if applicable)
 I have added necessary documentation (if applicable)
 Any dependent changes have been merged and published in downstream modules


Further comments
This is a straightforward deprecation migration to keep the codebase up to date with modern expo-keep-awake API standards and ensure strict compliance with React's Rules of Hooks in the case of JitsiMeetView.