### PR TITLE
chore: stop redux action console flood in dev

### DIFF
--- a/app/lib/store/actionBuffer.test.ts
+++ b/app/lib/store/actionBuffer.test.ts
@@ -1,0 +1,52 @@
+import { applyMiddleware, createStore } from 'redux';
+
+import { actionBuffer } from './actionBuffer';
+
+const trivialReducer = (state = {}, _action: any) => state;
+
+const makeStore = () => createStore(trivialReducer, applyMiddleware(actionBuffer()));
+
+beforeEach(() => {
+	(global as any).__reduxActions = undefined;
+});
+
+describe('actionBuffer middleware', () => {
+	it('records the dispatched action type in global.__reduxActions', () => {
+		const store = makeStore();
+		store.dispatch({ type: 'TEST_ACTION' });
+		const buf: any[] = (global as any).__reduxActions;
+		expect(buf).toBeDefined();
+		expect(buf[buf.length - 1].type).toBe('TEST_ACTION');
+	});
+
+	it('caps the buffer at 100 and drops the oldest entry (FIFO)', () => {
+		const store = makeStore();
+		for (let i = 0; i < 110; i++) {
+			store.dispatch({ type: `ACTION_${i}` });
+		}
+		const buf: any[] = (global as any).__reduxActions;
+		expect(buf.length).toBe(100);
+		expect(buf[0].type).toBe('ACTION_10');
+		expect(buf[99].type).toBe('ACTION_109');
+	});
+
+	it('writes nothing to the console', () => {
+		const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+		const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+		const groupSpy = jest.spyOn(console, 'group').mockImplementation(() => {});
+		const groupEndSpy = jest.spyOn(console, 'groupEnd').mockImplementation(() => {});
+
+		const store = makeStore();
+		store.dispatch({ type: 'SILENT_ACTION' });
+
+		expect(logSpy).not.toHaveBeenCalled();
+		expect(infoSpy).not.toHaveBeenCalled();
+		expect(groupSpy).not.toHaveBeenCalled();
+		expect(groupEndSpy).not.toHaveBeenCalled();
+
+		logSpy.mockRestore();
+		infoSpy.mockRestore();
+		groupSpy.mockRestore();
+		groupEndSpy.mockRestore();
+	});
+});

--- a/app/lib/store/actionBuffer.ts
+++ b/app/lib/store/actionBuffer.ts
@@ -1,0 +1,9 @@
+const CAP = 100;
+
+export const actionBuffer = () => (_store: any) => (next: any) => (action: any) => {
+	(global as any).__reduxActions ??= [];
+	const buf = (global as any).__reduxActions;
+	buf.push({ type: action.type, t: Date.now() });
+	if (buf.length > CAP) buf.shift();
+	return next(action);
+};

--- a/app/lib/store/index.ts
+++ b/app/lib/store/index.ts
@@ -5,13 +5,16 @@ import reducers from '../../reducers';
 import sagas from '../../sagas';
 import applyAppStateMiddleware from './appStateMiddleware';
 import applyInternetStateMiddleware from './internetStateMiddleware';
-import { logger } from './reduxLogger';
 
 let sagaMiddleware;
 let enhancers;
 
 if (__DEV__) {
 	const reduxImmutableStateInvariant = require('redux-immutable-state-invariant').default();
+	const { actionBuffer } = require('./actionBuffer');
+	// Uncomment the next line (and the applyMiddleware(logger) line below) to print every action + next state to Metro.
+	// const { logger } = require('./reduxLogger');
+
 	sagaMiddleware = createSagaMiddleware();
 
 	enhancers = compose(
@@ -19,7 +22,8 @@ if (__DEV__) {
 		applyInternetStateMiddleware(),
 		applyMiddleware(reduxImmutableStateInvariant),
 		applyMiddleware(sagaMiddleware),
-		applyMiddleware(logger)
+		applyMiddleware(actionBuffer())
+		// applyMiddleware(logger)
 	);
 } else {
 	sagaMiddleware = createSagaMiddleware();
@@ -28,5 +32,9 @@ if (__DEV__) {
 
 const store = createStore(reducers, enhancers);
 sagaMiddleware.run(sagas);
+
+if (__DEV__) {
+	(global as any).reduxStore = store;
+}
 
 export default store;


### PR DESCRIPTION
## Proposed changes

In dev builds, `reduxLogger` logged every dispatched action and the full store state to Metro on each dispatch (`console.group`/`info`/`log`/`groupEnd`), flooding the console and slowing the dev loop.

This removes the logger from the store wiring and replaces it with inspection surfaces that stay quiet:

- A silent, dev-only action ring buffer on `global.__reduxActions` (records each action `type` + timestamp, capped at 100, oldest dropped). Writes nothing to the console.
- The store exposed on `global.reduxStore` (dev only) so current state is readable at runtime by agents.
- The verbose logger kept available but commented in the store config, so a developer can re-enable it on demand.

Both surfaces live inside the `if (__DEV__)` branch, so release builds strip them and the production store config is unchanged.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1298

## How to test or reproduce

1. Run the app in dev (Metro). The Metro console no longer shows per-action `dispatching` / `next state` lines.
2. With the JS debugger attached, read state: `globalThis.reduxStore.getState().login.isAuthenticated`.
3. Read recent actions: `globalThis.__reduxActions.slice(-10)`.
4. Confirm an action fired: `globalThis.__reduxActions.some(a => a.type === 'LOGIN_SUCCESS')`.
5. To get the old verbose logging back: in `app/lib/store/index.ts`, uncomment the `logger` require and the `applyMiddleware(logger)` line (add a comma after `applyMiddleware(actionBuffer())`).

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a development-only action tracking middleware that records Redux actions (type + timestamp) into a fixed-size buffer (100 entries) with automatic FIFO overflow handling.
  * When running in development mode, the Redux store is now exposed globally for easier debugging.

* **Tests**
  * Added a Jest test suite covering action recording, buffer capacity limits, FIFO removal behavior, and ensuring no console output is produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->