### PR TITLE
refactor: migrate ShareExtensionStack to React Navigation static config

### DIFF
--- a/app/definitions/navigationTypes.ts
+++ b/app/definitions/navigationTypes.ts
@@ -1,11 +1,11 @@
 import { type NavigatorScreenParams } from '@react-navigation/core';
 import { type NativeStackNavigationOptions } from '@react-navigation/native-stack';
 
-import { type TSubscriptionModel } from './ISubscription';
-import { type TServerModel } from './IServer';
-import { type IAttachment } from './IAttachment';
 import { type MasterDetailInsideStackParamList } from '../stacks/MasterDetailStack/types';
 import { type OutsideParamList, type InsideStackParamList } from '../stacks/types';
+import { type ShareInsideStackParamList } from '../stacks/ShareExtensionStack';
+
+export type { ShareInsideStackParamList };
 
 interface INavigationProps {
 	route?: any;
@@ -30,18 +30,4 @@ export type StackParamList = {
 	MasterDetailStack: NavigatorScreenParams<MasterDetailInsideStackParamList>;
 	SetUsernameStack: NavigatorScreenParams<SetUsernameStackParamList>;
 	ShareExtensionStack: NavigatorScreenParams<ShareInsideStackParamList>;
-};
-
-export type ShareInsideStackParamList = {
-	ShareListView: undefined;
-	ShareView: {
-		attachments: IAttachment[];
-		isShareView?: boolean;
-		isShareExtension: boolean;
-		serverInfo: TServerModel;
-		text: string;
-		room: TSubscriptionModel;
-		thread?: any; // TODO: Change
-	};
-	SelectServerView: undefined;
 };

--- a/app/lib/navigation/withNavigation.tsx
+++ b/app/lib/navigation/withNavigation.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import { type ComponentType } from 'react';
 
+// Screen-registration-only HOC: injects navigation via hook; does not forward refs (React Navigation static API renders screens without refs).
 function withNavigation<P extends { navigation: any }>(WrappedComponent: ComponentType<P>): ComponentType<Omit<P, 'navigation'>> {
 	const WithNavigation = (props: Omit<P, 'navigation'>) => {
 		const navigation = useNavigation();

--- a/app/lib/navigation/withNavigation.tsx
+++ b/app/lib/navigation/withNavigation.tsx
@@ -1,8 +1,8 @@
 import { useNavigation } from '@react-navigation/native';
 import { type ComponentType } from 'react';
 
-// Screen-registration-only HOC: injects navigation via hook; does not forward refs (React Navigation static API renders screens without refs).
 function withNavigation<P extends { navigation: any }>(WrappedComponent: ComponentType<P>): ComponentType<Omit<P, 'navigation'>> {
+	// Screen-registration-only bridge: static API passes only { route } to screens, so no ref forwarding needed.
 	const WithNavigation = (props: Omit<P, 'navigation'>) => {
 		const navigation = useNavigation();
 		return <WrappedComponent {...(props as P)} navigation={navigation} />;

--- a/app/lib/navigation/withNavigation.tsx
+++ b/app/lib/navigation/withNavigation.tsx
@@ -1,0 +1,13 @@
+import { useNavigation } from '@react-navigation/native';
+import { type ComponentType } from 'react';
+
+function withNavigation<P extends { navigation: any }>(WrappedComponent: ComponentType<P>): ComponentType<Omit<P, 'navigation'>> {
+	const WithNavigation = (props: Omit<P, 'navigation'>) => {
+		const navigation = useNavigation();
+		return <WrappedComponent {...(props as P)} navigation={navigation} />;
+	};
+	WithNavigation.displayName = `WithNavigation(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+	return WithNavigation;
+}
+
+export default withNavigation;

--- a/app/stacks/ShareExtensionStack.tsx
+++ b/app/stacks/ShareExtensionStack.tsx
@@ -9,10 +9,9 @@ import ShareListView from '../views/ShareListView';
 import ShareView from '../views/ShareView';
 import withNavigation from '../lib/navigation/withNavigation';
 import { type InsideStackParamList } from './types';
+import { type Optional } from '../definitions/utils';
 
-// Extension-only subset: InsideStack's ShareView params with callback fields made optional.
-type ShareViewParams = Omit<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'> &
-	Partial<Pick<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'>>;
+type ShareViewParams = Optional<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'>;
 
 // withNavigation(x as any) returns ComponentType<{}> — not assignable to ComponentType<StaticScreenProps<T>> — due to the
 // type cycle: these components reference ShareInsideStackParamList ← StaticParamList<typeof ShareExtension> ← these components.

--- a/app/stacks/ShareExtensionStack.tsx
+++ b/app/stacks/ShareExtensionStack.tsx
@@ -8,20 +8,13 @@ import SelectServerView from '../views/SelectServerView';
 import ShareListView from '../views/ShareListView';
 import ShareView from '../views/ShareView';
 import withNavigation from '../lib/navigation/withNavigation';
-import { type IAttachment, type TServerModel, type TSubscriptionModel } from '../definitions';
+import { type InsideStackParamList } from './types';
 
-type ShareViewParams = {
-	attachments: IAttachment[];
-	isShareView?: boolean;
-	isShareExtension: boolean;
-	serverInfo: TServerModel;
-	text: string;
-	room: TSubscriptionModel;
-	thread?: any;
-};
+// Extension-only subset: omits InsideStack callbacks/params the share extension never provides.
+type ShareViewParams = Omit<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'>;
 
-// Cast through `any` to break the type cycle that would arise from ShareListView/ShareView
-// referencing ShareInsideStackParamList ← StaticParamList<typeof ShareExtension> ← these components.
+// withNavigation(x as any) returns ComponentType<{}> — not assignable to ComponentType<StaticScreenProps<T>> — due to the
+// type cycle: these components reference ShareInsideStackParamList ← StaticParamList<typeof ShareExtension> ← these components.
 const ShareListViewScreen: ComponentType<StaticScreenProps<undefined>> = withNavigation(ShareListView as any) as any;
 const ShareViewScreen: ComponentType<StaticScreenProps<ShareViewParams>> = withNavigation(ShareView as any) as any;
 

--- a/app/stacks/ShareExtensionStack.tsx
+++ b/app/stacks/ShareExtensionStack.tsx
@@ -1,27 +1,46 @@
-import { useContext } from 'react';
+import { useContext, type ComponentType } from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { type StaticParamList, type StaticScreenProps } from '@react-navigation/native';
 
 import { ThemeContext } from '../theme';
 import { defaultHeader, themedHeader } from '../lib/methods/helpers/navigation';
 import SelectServerView from '../views/SelectServerView';
 import ShareListView from '../views/ShareListView';
 import ShareView from '../views/ShareView';
+import withNavigation from '../lib/navigation/withNavigation';
+import { type IAttachment, type TServerModel, type TSubscriptionModel } from '../definitions';
 
-const ShareExtension = createNativeStackNavigator<any>();
-const ShareExtensionStack = () => {
+type ShareViewParams = {
+	attachments: IAttachment[];
+	isShareView?: boolean;
+	isShareExtension: boolean;
+	serverInfo: TServerModel;
+	text: string;
+	room: TSubscriptionModel;
+	thread?: any;
+};
+
+// Cast through `any` to break the type cycle that would arise from ShareListView/ShareView
+// referencing ShareInsideStackParamList ← StaticParamList<typeof ShareExtension> ← these components.
+const ShareListViewScreen: ComponentType<StaticScreenProps<undefined>> = withNavigation(ShareListView as any) as any;
+const ShareViewScreen: ComponentType<StaticScreenProps<ShareViewParams>> = withNavigation(ShareView as any) as any;
+
+const ShareExtension = createNativeStackNavigator({
+	screenOptions: defaultHeader,
+	screens: {
+		ShareListView: ShareListViewScreen,
+		ShareView: ShareViewScreen,
+		SelectServerView
+	}
+}).with(({ Navigator }) => {
 	'use memo';
 
 	const { theme } = useContext(ThemeContext);
+	return <Navigator screenOptions={themedHeader(theme)} />;
+});
 
-	return (
-		<ShareExtension.Navigator screenOptions={{ ...defaultHeader, ...themedHeader(theme) }}>
-			{/* @ts-ignore */}
-			<ShareExtension.Screen name='ShareListView' component={ShareListView} />
-			{/* @ts-ignore */}
-			<ShareExtension.Screen name='ShareView' component={ShareView} />
-			<ShareExtension.Screen name='SelectServerView' component={SelectServerView} />
-		</ShareExtension.Navigator>
-	);
-};
+export type ShareInsideStackParamList = StaticParamList<typeof ShareExtension>;
+
+const ShareExtensionStack = ShareExtension.getComponent();
 
 export default ShareExtensionStack;

--- a/app/stacks/ShareExtensionStack.tsx
+++ b/app/stacks/ShareExtensionStack.tsx
@@ -13,8 +13,7 @@ import { type Optional } from '../definitions/utils';
 
 type ShareViewParams = Optional<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'>;
 
-// withNavigation(x as any) returns ComponentType<{}> — not assignable to ComponentType<StaticScreenProps<T>> — due to the
-// type cycle: these components reference ShareInsideStackParamList ← StaticParamList<typeof ShareExtension> ← these components.
+// Cast through `any` to break the navigation-prop type cycle; removing it reintroduces a real TS circular ref.
 const ShareListViewScreen: ComponentType<StaticScreenProps<undefined>> = withNavigation(ShareListView as any) as any;
 const ShareViewScreen: ComponentType<StaticScreenProps<ShareViewParams>> = withNavigation(ShareView as any) as any;
 

--- a/app/stacks/ShareExtensionStack.tsx
+++ b/app/stacks/ShareExtensionStack.tsx
@@ -10,8 +10,13 @@ import ShareView from '../views/ShareView';
 import withNavigation from '../lib/navigation/withNavigation';
 import { type InsideStackParamList } from './types';
 
-// Extension-only subset: omits InsideStack callbacks/params the share extension never provides.
-type ShareViewParams = Omit<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'>;
+// Extension-only subset: derived from InsideStackParamList['ShareView'] with share-extension-only fields made optional.
+type ShareViewParams = Omit<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'> & {
+	thread?: InsideStackParamList['ShareView']['thread'];
+	action?: InsideStackParamList['ShareView']['action'];
+	finishShareView?: InsideStackParamList['ShareView']['finishShareView'];
+	startShareView?: InsideStackParamList['ShareView']['startShareView'];
+};
 
 // withNavigation(x as any) returns ComponentType<{}> — not assignable to ComponentType<StaticScreenProps<T>> — due to the
 // type cycle: these components reference ShareInsideStackParamList ← StaticParamList<typeof ShareExtension> ← these components.

--- a/app/stacks/ShareExtensionStack.tsx
+++ b/app/stacks/ShareExtensionStack.tsx
@@ -10,13 +10,9 @@ import ShareView from '../views/ShareView';
 import withNavigation from '../lib/navigation/withNavigation';
 import { type InsideStackParamList } from './types';
 
-// Extension-only subset: derived from InsideStackParamList['ShareView'] with share-extension-only fields made optional.
-type ShareViewParams = Omit<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'> & {
-	thread?: InsideStackParamList['ShareView']['thread'];
-	action?: InsideStackParamList['ShareView']['action'];
-	finishShareView?: InsideStackParamList['ShareView']['finishShareView'];
-	startShareView?: InsideStackParamList['ShareView']['startShareView'];
-};
+// Extension-only subset: InsideStack's ShareView params with callback fields made optional.
+type ShareViewParams = Omit<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'> &
+	Partial<Pick<InsideStackParamList['ShareView'], 'thread' | 'action' | 'finishShareView' | 'startShareView'>>;
 
 // withNavigation(x as any) returns ComponentType<{}> — not assignable to ComponentType<StaticScreenProps<T>> — due to the
 // type cycle: these components reference ShareInsideStackParamList ← StaticParamList<typeof ShareExtension> ← these components.


### PR DESCRIPTION
## Proposed changes

Converts `ShareExtensionStack` from the dynamic JSX navigator API to React Navigation's static config API (`createNativeStackNavigator` with a `screens` object). Adds a shared `withNavigation` HOC in `app/lib/navigation/` that injects `navigation={useNavigation()}` at the screen registration site, allowing class components (`ShareListView`, `ShareView`) to keep using `this.props.navigation` without internal edits.

**What changed:**
- `ShareExtensionStack.tsx` — static config with `.with()` theme wrapper; `ShareListView` and `ShareView` wrapped via `withNavigation()` at registration; `SelectServerView` registered directly (already uses `useNavigation()` internally); default export is `ShareExtension.getComponent()` so `AppContainer` is untouched.
- `app/lib/navigation/withNavigation.tsx` — new generic HOC: `withNavigation(Component)` returns a component with `navigation` injected via `useNavigation()`, all other props forwarded.
- `app/definitions/navigationTypes.ts` — hand-written `ShareInsideStackParamList` replaced with a re-export of `StaticParamList<typeof ShareExtension>` from `ShareExtensionStack`; unused `IAttachment`/`TServerModel`/`TSubscriptionModel` imports removed.

**Type cycle note:** `ShareListView` and `ShareView` reference `ShareInsideStackParamList` in their navigation prop types, which would create a circular `StaticParamList` reference. Both are cast through `any` at registration with explicit `ComponentType<StaticScreenProps<...>>` annotations so TypeScript can resolve the param list without tracing back through the component props.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1302

## How to test or reproduce

Share-extension smoke flow (on-device, separate gate):
1. Open the OS share sheet from any app (photo, URL, text).
2. Choose Rocket.Chat as the share target.
3. The share extension opens on `ShareListView` — confirm the room list loads and the server switcher button navigates to `SelectServerView`.
4. Select a server on `SelectServerView` — confirm it navigates back.
5. Select a room — confirm navigation to `ShareView`.
6. Add a message and tap Send — confirm the share completes and the extension closes.

## Screenshots

N/A — no visual changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is slice 2 of the React Navigation static config migration (slice 1 = OutsideStack, PR #7410). `AppContainer` still uses the dynamic root stack; the `.getComponent()` bridge is scaffolding that will be removed when the root slice ships.

https://claude.ai/code/session_01Qh9P8Bbp6V7PFpCY2X5on3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Share Extension navigation parameter types by sharing and re-exporting stack types to keep routing consistent.
  * Updated the Share Extension navigator to a config-driven setup for cleaner screen registration.
  * Improved navigation prop injection for Share Extension screens using a reusable wrapper, while ensuring headers reflect the active theme.
  * Adjusted Share view parameters so selected fields are now optional when used within the Share flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->