### PR TITLE
ci: run Build PR pipeline for PRs based on feature branches

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Proposed changes

GitHub matches `on.pull_request.branches` against the **base ref**, and the `'*'` glob does not match refs containing a slash. Any PR whose base is a feature branch (e.g. a stacked PR targeting `feat/...`) never triggered the Build PR pipeline (ESLint/Test, Android build, iOS build, E2E) — only PRs based directly on `develop` built.

Changed the filter to `'**'`, which matches across slashes, so stacked PRs run the pipeline.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1306

## How to test or reproduce

Open a PR whose base is a slashed feature branch and confirm the Build PR workflow runs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

https://claude.ai/code/session_01SVjvyuH3Ku5wZDxKSCfHY7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains infrastructure updates with no user-facing changes.

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->