### PR TITLE
feat: open browser login providers in a system auth session for WebAuthn support

### DIFF
--- a/app/containers/LoginServices/interfaces.ts
+++ b/app/containers/LoginServices/interfaces.ts
@@ -6,10 +6,10 @@ import { type TIconsName } from '../CustomIcon';
 type TAuthType = 'oauth' | 'oauth_custom' | 'saml' | 'cas' | 'apple';
 
 type TServiceName = 'facebook' | 'github' | 'gitlab' | 'google' | 'linkedin' | 'meteor-developer' | 'twitter' | 'wordpress';
-export interface IOpenOAuth {
+export interface IOpenSSOWebView {
 	url: string;
-	ssoToken?: string;
-	authType?: TAuthType;
+	ssoToken: string;
+	authType: 'saml' | 'cas';
 }
 
 export interface IItemService {

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -1,16 +1,15 @@
 import * as AppleAuthentication from 'expo-apple-authentication';
 import * as WebBrowser from 'expo-web-browser';
-import { Linking } from 'react-native';
 import { Base64 } from 'js-base64';
 
-import Navigation from '../../lib/navigation/appNavigation';
-import { type IItemService, type IOpenOAuth, type IServiceLogin } from './interfaces';
+import { type IItemService, type IServiceLogin } from './interfaces';
 import { random } from '../../lib/methods/helpers';
 import { loginOAuthOrSso } from '../../lib/services/connect';
 import log, { events, logEvent } from '../../lib/methods/helpers/log';
 import { store } from '../../lib/store/auxStore';
 import { deepLinkingOpen } from '../../actions/deepLinking';
 import parseDeepLinking from '../../lib/methods/helpers/parseDeepLinking';
+import { parseSamlOrCasRedirect } from '../../lib/methods/helpers/parseSamlOrCasRedirect';
 
 type TLoginStyle = 'popup' | 'redirect';
 
@@ -20,9 +19,9 @@ export const onPressFacebook = ({ service, server }: IServiceLogin) => {
 	const endpoint = 'https://m.facebook.com/v2.9/dialog/oauth';
 	const redirect_uri = `${server}/_oauth/facebook?close`;
 	const scope = 'email';
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}&display=touch`;
-	openOAuth({ url: `${endpoint}${params}` });
+	openOAuthSession(`${endpoint}${params}`);
 };
 
 export const onPressGithub = ({ service, server }: IServiceLogin) => {
@@ -31,9 +30,9 @@ export const onPressGithub = ({ service, server }: IServiceLogin) => {
 	const endpoint = `https://github.com/login?client_id=${clientId}&return_to=${encodeURIComponent('/login/oauth/authorize')}`;
 	const redirect_uri = `${server}/_oauth/github?close`;
 	const scope = 'user:email';
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}`;
-	openOAuth({ url: `${endpoint}${encodeURIComponent(params)}` });
+	openOAuthSession(`${endpoint}${encodeURIComponent(params)}`);
 };
 
 export const onPressGitlab = ({ service, server, urlOption }: IServiceLogin) => {
@@ -43,9 +42,9 @@ export const onPressGitlab = ({ service, server, urlOption }: IServiceLogin) => 
 	const endpoint = `${baseURL}/oauth/authorize`;
 	const redirect_uri = `${server}/_oauth/gitlab?close`;
 	const scope = 'read_user';
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}&response_type=code`;
-	openOAuth({ url: `${endpoint}${params}` });
+	openOAuthSession(`${endpoint}${params}`);
 };
 
 export const onPressGoogle = ({ service, server }: IServiceLogin) => {
@@ -56,7 +55,7 @@ export const onPressGoogle = ({ service, server }: IServiceLogin) => {
 	const scope = encodeURIComponent('profile email');
 	const state = getOAuthState('redirect');
 	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}&response_type=code`;
-	Linking.openURL(`${endpoint}${params}`);
+	openOAuthSession(`${endpoint}${params}`);
 };
 
 export const onPressLinkedin = ({ service, server }: IServiceLogin) => {
@@ -65,9 +64,9 @@ export const onPressLinkedin = ({ service, server }: IServiceLogin) => {
 	const endpoint = 'https://www.linkedin.com/oauth/v2/authorization';
 	const redirect_uri = `${server}/_oauth/linkedin?close`;
 	const scope = 'r_liteprofile,r_emailaddress';
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}&response_type=code`;
-	openOAuth({ url: `${endpoint}${params}` });
+	openOAuthSession(`${endpoint}${params}`);
 };
 
 export const onPressMeteor = ({ service, server }: IServiceLogin) => {
@@ -75,16 +74,16 @@ export const onPressMeteor = ({ service, server }: IServiceLogin) => {
 	const { clientId } = service;
 	const endpoint = 'https://www.meteor.com/oauth2/authorize';
 	const redirect_uri = `${server}/_oauth/meteor-developer`;
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&state=${state}&response_type=code`;
-	openOAuth({ url: `${endpoint}${params}` });
+	openOAuthSession(`${endpoint}${params}`);
 };
 
 export const onPressTwitter = ({ server }: IServiceLogin) => {
 	logEvent(events.ENTER_WITH_TWITTER);
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const url = `${server}/_oauth/twitter/?requestTokenAndRedirect=true&state=${state}`;
-	openOAuth({ url });
+	openOAuthSession(url);
 };
 
 export const onPressWordpress = ({ service, server }: IServiceLogin) => {
@@ -93,9 +92,9 @@ export const onPressWordpress = ({ service, server }: IServiceLogin) => {
 	const endpoint = `${serverURL}/oauth/authorize`;
 	const redirect_uri = `${server}/_oauth/wordpress?close`;
 	const scope = 'openid';
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}&response_type=code`;
-	openOAuth({ url: `${endpoint}${params}` });
+	openOAuthSession(`${endpoint}${params}`);
 };
 
 export const onPressCustomOAuth = ({ loginService, server }: { loginService: IItemService; server: string }) => {
@@ -119,14 +118,14 @@ export const onPressSaml = ({ loginService, server }: { loginService: IItemServi
 	const { provider } = clientConfig;
 	const ssoToken = random(17);
 	const url = `${server}/_saml/authorize/${provider}/${ssoToken}`;
-	openOAuth({ url, ssoToken, authType: 'saml' });
+	openSSOSession(url, 'saml', ssoToken);
 };
 
 export const onPressCas = ({ casLoginUrl, server }: { casLoginUrl: string; server: string }) => {
 	logEvent(events.ENTER_WITH_CAS);
 	const ssoToken = random(17);
 	const url = `${casLoginUrl}?service=${server}/_cas/${ssoToken}`;
-	openOAuth({ url, ssoToken, authType: 'cas' });
+	openSSOSession(url, 'cas', ssoToken);
 };
 
 export const onPressAppleLogin = async () => {
@@ -177,6 +176,16 @@ const getOAuthState = (loginStyle: TLoginStyle = 'popup') => {
 	return Base64.encodeURI(JSON.stringify(obj));
 };
 
-const openOAuth = ({ url, ssoToken, authType = 'oauth' }: IOpenOAuth) => {
-	Navigation.navigate('AuthenticationWebView', { url, authType, ssoToken });
+const openSSOSession = async (url: string, authType: 'saml' | 'cas', ssoToken: string) => {
+	try {
+		const result = await WebBrowser.openAuthSessionAsync(url, OAUTH_REDIRECT_URL);
+		if (result.type === 'success' && 'url' in result && result.url) {
+			const parsed = parseSamlOrCasRedirect(result.url, authType, ssoToken);
+			if (parsed) {
+				await loginOAuthOrSso(parsed.payload);
+			}
+		}
+	} catch (e) {
+		log(e);
+	}
 };

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -1,4 +1,5 @@
 import * as AppleAuthentication from 'expo-apple-authentication';
+import * as WebBrowser from 'expo-web-browser';
 import { Linking } from 'react-native';
 import { Base64 } from 'js-base64';
 
@@ -6,7 +7,10 @@ import Navigation from '../../lib/navigation/appNavigation';
 import { type IItemService, type IOpenOAuth, type IServiceLogin } from './interfaces';
 import { random } from '../../lib/methods/helpers';
 import { loginOAuthOrSso } from '../../lib/services/connect';
-import { events, logEvent } from '../../lib/methods/helpers/log';
+import log, { events, logEvent } from '../../lib/methods/helpers/log';
+import { store } from '../../lib/store/auxStore';
+import { deepLinkingOpen } from '../../actions/deepLinking';
+import parseDeepLinking from '../../lib/methods/helpers/parseDeepLinking';
 
 type TLoginStyle = 'popup' | 'redirect';
 
@@ -98,7 +102,7 @@ export const onPressCustomOAuth = ({ loginService, server }: { loginService: IIt
 	logEvent(events.ENTER_WITH_CUSTOM_OAUTH);
 	const { serverURL, authorizePath, clientId, scope, service } = loginService;
 	const redirectUri = `${server}/_oauth/${service}`;
-	const state = getOAuthState();
+	const state = getOAuthState('redirect');
 	const separator = authorizePath.indexOf('?') !== -1 ? '&' : '?';
 	const params = `${separator}client_id=${clientId}&redirect_uri=${encodeURIComponent(
 		redirectUri
@@ -106,7 +110,7 @@ export const onPressCustomOAuth = ({ loginService, server }: { loginService: IIt
 	const domain = `${serverURL}`;
 	const absolutePath = `${authorizePath}${params}`;
 	const url = absolutePath.includes(domain) ? absolutePath : domain + absolutePath;
-	openOAuth({ url });
+	openOAuthSession(url);
 };
 
 export const onPressSaml = ({ loginService, server }: { loginService: IItemService; server: string }) => {
@@ -137,6 +141,22 @@ export const onPressAppleLogin = async () => {
 		await loginOAuthOrSso({ fullName, email, identityToken });
 	} catch {
 		logEvent(events.ENTER_WITH_APPLE_F);
+	}
+};
+
+const OAUTH_REDIRECT_URL = 'rocketchat://auth';
+
+const openOAuthSession = async (url: string) => {
+	try {
+		const result = await WebBrowser.openAuthSessionAsync(url, OAUTH_REDIRECT_URL);
+		if (result.type === 'success' && 'url' in result && result.url) {
+			const parsed = parseDeepLinking(result.url);
+			if (parsed) {
+				store.dispatch(deepLinkingOpen(parsed));
+			}
+		}
+	} catch (e) {
+		log(e);
 	}
 };
 

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -2,14 +2,14 @@ import * as AppleAuthentication from 'expo-apple-authentication';
 import * as WebBrowser from 'expo-web-browser';
 import { Base64 } from 'js-base64';
 
-import { type IItemService, type IServiceLogin } from './interfaces';
+import Navigation from '../../lib/navigation/appNavigation';
+import { type IItemService, type IOpenOAuth, type IServiceLogin } from './interfaces';
 import { random } from '../../lib/methods/helpers';
 import { loginOAuthOrSso } from '../../lib/services/connect';
 import log, { events, logEvent } from '../../lib/methods/helpers/log';
 import { store } from '../../lib/store/auxStore';
 import { deepLinkingOpen } from '../../actions/deepLinking';
 import parseDeepLinking from '../../lib/methods/helpers/parseDeepLinking';
-import { parseSamlOrCasRedirect } from '../../lib/methods/helpers/parseSamlOrCasRedirect';
 
 type TLoginStyle = 'popup' | 'redirect';
 
@@ -118,14 +118,14 @@ export const onPressSaml = ({ loginService, server }: { loginService: IItemServi
 	const { provider } = clientConfig;
 	const ssoToken = random(17);
 	const url = `${server}/_saml/authorize/${provider}/${ssoToken}`;
-	openSSOSession(url, 'saml', ssoToken);
+	openOAuth({ url, ssoToken, authType: 'saml' });
 };
 
 export const onPressCas = ({ casLoginUrl, server }: { casLoginUrl: string; server: string }) => {
 	logEvent(events.ENTER_WITH_CAS);
 	const ssoToken = random(17);
 	const url = `${casLoginUrl}?service=${server}/_cas/${ssoToken}`;
-	openSSOSession(url, 'cas', ssoToken);
+	openOAuth({ url, ssoToken, authType: 'cas' });
 };
 
 export const onPressAppleLogin = async () => {
@@ -176,16 +176,6 @@ const getOAuthState = (loginStyle: TLoginStyle = 'popup') => {
 	return Base64.encodeURI(JSON.stringify(obj));
 };
 
-const openSSOSession = async (url: string, authType: 'saml' | 'cas', ssoToken: string) => {
-	try {
-		const result = await WebBrowser.openAuthSessionAsync(url, OAUTH_REDIRECT_URL);
-		if (result.type === 'success' && 'url' in result && result.url) {
-			const parsed = parseSamlOrCasRedirect(result.url, authType, ssoToken);
-			if (parsed) {
-				await loginOAuthOrSso(parsed.payload);
-			}
-		}
-	} catch (e) {
-		log(e);
-	}
+const openOAuth = ({ url, ssoToken, authType = 'oauth' }: IOpenOAuth) => {
+	Navigation.navigate('AuthenticationWebView', { url, authType, ssoToken });
 };

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -3,7 +3,7 @@ import * as WebBrowser from 'expo-web-browser';
 import { Base64 } from 'js-base64';
 
 import Navigation from '../../lib/navigation/appNavigation';
-import { type IItemService, type IOpenOAuth, type IServiceLogin } from './interfaces';
+import { type IItemService, type IOpenSSOWebView, type IServiceLogin } from './interfaces';
 import { random } from '../../lib/methods/helpers';
 import { loginOAuthOrSso } from '../../lib/services/connect';
 import log, { events, logEvent } from '../../lib/methods/helpers/log';
@@ -118,14 +118,14 @@ export const onPressSaml = ({ loginService, server }: { loginService: IItemServi
 	const { provider } = clientConfig;
 	const ssoToken = random(17);
 	const url = `${server}/_saml/authorize/${provider}/${ssoToken}`;
-	openOAuth({ url, ssoToken, authType: 'saml' });
+	openSSOWebView({ url, ssoToken, authType: 'saml' });
 };
 
 export const onPressCas = ({ casLoginUrl, server }: { casLoginUrl: string; server: string }) => {
 	logEvent(events.ENTER_WITH_CAS);
 	const ssoToken = random(17);
 	const url = `${casLoginUrl}?service=${server}/_cas/${ssoToken}`;
-	openOAuth({ url, ssoToken, authType: 'cas' });
+	openSSOWebView({ url, ssoToken, authType: 'cas' });
 };
 
 export const onPressAppleLogin = async () => {
@@ -176,6 +176,6 @@ const getOAuthState = (loginStyle: TLoginStyle = 'popup') => {
 	return Base64.encodeURI(JSON.stringify(obj));
 };
 
-const openOAuth = ({ url, ssoToken, authType = 'oauth' }: IOpenOAuth) => {
+const openSSOWebView = ({ url, ssoToken, authType }: IOpenSSOWebView) => {
 	Navigation.navigate('AuthenticationWebView', { url, authType, ssoToken });
 };

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -51,7 +51,6 @@ interface IState {
 	themePreferences: IThemePreference;
 }
 
-
 export default class Root extends Component<{}, IState> {
 	private listenerTimeout!: any;
 	private videoConfActionCleanup?: () => void;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -21,7 +21,7 @@ import { type IThemePreference } from './definitions/ITheme';
 import { themes } from './lib/constants/colors';
 import { getAllowAnalyticsEvents, getAllowCrashReport } from './lib/methods/crashReport';
 import { toggleAnalyticsEventsReport, toggleCrashErrorsReport } from './lib/methods/helpers/log';
-import parseQuery from './lib/methods/helpers/parseQuery';
+import parseDeepLinking from './lib/methods/helpers/parseDeepLinking';
 import {
 	getTheme,
 	initialTheme,
@@ -51,28 +51,6 @@ interface IState {
 	themePreferences: IThemePreference;
 }
 
-const parseDeepLinking = (url: string) => {
-	if (url) {
-		url = url.replace(/rocketchat:\/\/|https:\/\/go.rocket.chat\//, '');
-		const regex = /^(room|auth|invite|shareextension)\?/;
-		const match = url.match(regex);
-		if (match) {
-			const matchedPattern = match[1];
-			const query = url.replace(regex, '').trim();
-
-			if (query) {
-				const parsedQuery = parseQuery(query);
-				return {
-					...parsedQuery,
-					type: matchedPattern === 'shareextension' ? matchedPattern : parsedQuery?.type
-				};
-			}
-		}
-	}
-
-	// Return null if the URL doesn't match or is not valid
-	return null;
-};
 
 export default class Root extends Component<{}, IState> {
 	private listenerTimeout!: any;

--- a/app/lib/methods/helpers/__tests__/parseDeepLinking.test.ts
+++ b/app/lib/methods/helpers/__tests__/parseDeepLinking.test.ts
@@ -1,0 +1,38 @@
+import parseDeepLinking from '../parseDeepLinking';
+
+describe('parseDeepLinking', () => {
+	it('parses an OAuth redirect URL', () => {
+		const result = parseDeepLinking(
+			'rocketchat://auth?host=https://open.rocket.chat&type=oauth&credentialToken=abc&credentialSecret=def'
+		);
+		expect(result).toMatchObject({
+			type: 'oauth',
+			host: 'https://open.rocket.chat',
+			credentialToken: 'abc',
+			credentialSecret: 'def'
+		});
+	});
+
+	it('parses a room URL', () => {
+		const result = parseDeepLinking('rocketchat://room?host=open.rocket.chat&rid=GENERAL&path=channel/general');
+		expect(result).toMatchObject({ host: 'open.rocket.chat', rid: 'GENERAL' });
+	});
+
+	it('parses an invite URL', () => {
+		const result = parseDeepLinking('rocketchat://invite?host=open.rocket.chat&path=invite/token123');
+		expect(result).toMatchObject({ host: 'open.rocket.chat', path: 'invite/token123' });
+	});
+
+	it('parses a shareextension URL and sets type to shareextension', () => {
+		const result = parseDeepLinking('rocketchat://shareextension?text=hello');
+		expect(result).toMatchObject({ type: 'shareextension' });
+	});
+
+	it('returns null for a non-matching URL', () => {
+		expect(parseDeepLinking('https://example.com/some/path')).toBeNull();
+	});
+
+	it('returns null for an empty string', () => {
+		expect(parseDeepLinking('')).toBeNull();
+	});
+});

--- a/app/lib/methods/helpers/parseDeepLinking.ts
+++ b/app/lib/methods/helpers/parseDeepLinking.ts
@@ -1,0 +1,25 @@
+import parseQuery from './parseQuery';
+
+const parseDeepLinking = (url: string) => {
+	if (url) {
+		url = url.replace(/rocketchat:\/\/|https:\/\/go.rocket.chat\//, '');
+		const regex = /^(room|auth|invite|shareextension)\?/;
+		const match = url.match(regex);
+		if (match) {
+			const matchedPattern = match[1];
+			const query = url.replace(regex, '').trim();
+
+			if (query) {
+				const parsedQuery = parseQuery(query);
+				return {
+					...parsedQuery,
+					type: matchedPattern === 'shareextension' ? matchedPattern : parsedQuery?.type
+				};
+			}
+		}
+	}
+
+	return null;
+};
+
+export default parseDeepLinking;

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -110,6 +110,7 @@ import { canOpenRoom } from '../../lib/methods/canOpenRoom';
 import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { goRoom, navigateToRoom } from '../../lib/methods/helpers/goRoom';
 import { waitForNavigationReady } from '../../lib/navigation/appNavigation';
+import { loginOAuthOrSso } from '../../lib/services/connect';
 import sdk from '../../lib/services/sdk';
 import EventEmitter from '../../lib/methods/helpers/events';
 import database from '../../lib/database';
@@ -657,5 +658,62 @@ describe('deepLinking saga — handleClickCallPush (new server + token + call ro
 
 		// Socket connected → gate released, loginRequest dispatched.
 		expect(loginRequested()).toBe(true);
+	});
+});
+
+// ─── handleOAuth — single-use credentialToken dedup guard ────────────────────
+
+describe('deepLinking saga — handleOAuth dedup guard', () => {
+	// handleOAuth tracks the consumed credentialToken in module scope and it is never reset between
+	// tests, so every oauth case here must use a globally-unique token or the guard silently suppresses it.
+	beforeEach(() => {
+		jest.mocked(loginOAuthOrSso).mockReset();
+		jest.mocked(loginOAuthOrSso).mockResolvedValue(undefined as any);
+	});
+
+	it('calls loginOAuthOrSso with the oauth credentials on a fresh token', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-fresh-A', credentialSecret: 'secret-A' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledTimes(1);
+		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledWith({
+			oauth: { credentialToken: 'token-fresh-A', credentialSecret: 'secret-A' }
+		});
+	});
+
+	it('does not call loginOAuthOrSso a second time for the same credentialToken', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-dup-B', credentialSecret: 'secret-B' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// Second dispatch with the identical token — guard must suppress it.
+		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-dup-B', credentialSecret: 'secret-B' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls loginOAuthOrSso again for a different credentialToken after a previous one was consumed', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-first-C', credentialSecret: 'secret-C' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		// A distinct token must not be blocked by the guard.
+		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-second-C', credentialSecret: 'secret-C2' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledTimes(2);
+		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenNthCalledWith(2, {
+			oauth: { credentialToken: 'token-second-C', credentialSecret: 'secret-C2' }
+		});
 	});
 });

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -684,6 +684,16 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 		});
 	});
 
+	it('does not call loginOAuthOrSso when the credentialSecret is missing', async () => {
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-no-secret-D' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(loginOAuthOrSso)).not.toHaveBeenCalled();
+	});
+
 	it('does not call loginOAuthOrSso a second time for the same credentialToken', async () => {
 		const store = setupStore();
 

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -132,7 +132,7 @@ let consumedOAuthToken;
 
 const handleOAuth = function* handleOAuth({ params }) {
 	const { credentialToken, credentialSecret } = params;
-	if (!credentialToken || credentialToken === consumedOAuthToken) {
+	if (!credentialToken || !credentialSecret || credentialToken === consumedOAuthToken) {
 		return;
 	}
 	consumedOAuthToken = credentialToken;

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -128,10 +128,16 @@ const fallbackNavigation = function* fallbackNavigation() {
 	yield put(appInit());
 };
 
+let consumedOAuthToken;
+
 const handleOAuth = function* handleOAuth({ params }) {
 	const { credentialToken, credentialSecret } = params;
+	if (!credentialToken || credentialToken === consumedOAuthToken) {
+		return;
+	}
+	consumedOAuthToken = credentialToken;
 	try {
-		yield loginOAuthOrSso({ oauth: { credentialToken, credentialSecret } }, false);
+		yield loginOAuthOrSso({ oauth: { credentialToken, credentialSecret } });
 	} catch (e) {
 		log(e);
 	}


### PR DESCRIPTION
## Proposed changes

Browser-based login currently opens inside an in-app WebView. WebViews cannot run the browser WebAuthn/FIDO2 API, so providers that require passkeys (Custom OAuth with Keycloak, Authentik, AWS Cognito, etc.) cannot complete login on mobile.

This switches every browser-based login to a real system auth session via `WebBrowser.openAuthSessionAsync` (ASWebAuthenticationSession on iOS, Chrome Custom Tabs on Android), both of which support WebAuthn. It follows the path Custom OAuth and Google login already used: the provider opens in the auth session, and the app completes login when the browser redirects back.

Changes:
- `serviceLogin.ts` — Facebook, Github, Gitlab, Google, Linkedin, Meteor, Twitter and Wordpress request the server's `redirect` login style and open in the auth session. The server redirects to `rocketchat://auth?…&type=oauth&credentialToken=…&credentialSecret=…`, and login completes through the existing deep-link pipeline (`parseDeepLinking` → `deepLinkingOpen` → `handleOAuth`). SAML and CAS open in the auth session and complete by parsing the redirect result directly with `parseSamlOrCasRedirect`. The now-unused WebView navigation helper is removed.
- `parseDeepLinking.ts` (new) — the deep-link parser is extracted from `app/index.tsx` into a shared helper so both the OS deep-link listener and the new auth-session handler can use it. Behavior is unchanged.
- `deepLinking.js` — `handleOAuth` is guarded against re-using a single-use `credentialToken`. On Android the redirect is delivered on two channels (the auth-session result and the OS deep-link listener, since the `rocketchat` scheme is registered `BROWSABLE`), which would otherwise consume the token twice and fail the login.

The in-app WebView is retained for iframe authentication.

## Issue(s)

- Closes https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/5681
- https://rocketchat.atlassian.net/browse/NATIVE-1312
- [ ] Add Co-Author on merge

## How to test or reproduce

OAuth (incl. WebAuthn/passkey):

1. Configure a Custom OAuth provider that enforces WebAuthn/passkey authentication (e.g. Keycloak with a passkey policy).
2. On the login screen, tap the provider button. A system auth session opens (not a WebView). Complete the passkey challenge.
3. The browser redirects back to the app and login completes. Before this change, the WebView could not invoke the WebAuthn API, so this failed.
4. Verify Google, Facebook, Github, Gitlab, Linkedin, Meteor, Twitter and Wordpress still log in normally through the auth session.

SAML and CAS (dedicated QA step — please test explicitly):

5. Configure a SAML provider and log in by tapping the SAML button. The auth session opens, you complete the IdP login, and the app logs you in.
6. Configure a CAS provider and log in by tapping the CAS button. The auth session opens, you complete the CAS login, and the app logs you in.

These two now complete by parsing the auth-session redirect result rather than inspecting WebView navigation, so they need explicit verification on both iOS and Android.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The server has supported redirect-style OAuth for all providers since 3.15.0, so no server change is required. A single deep-link parser is shared between the OS listener and the auth-session handler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved OAuth sign-in flow by using an external browser auth session with redirect/deep-link handling, including SAML/CAS.
* **Bug Fixes**
  * Prevented duplicate OAuth logins by ignoring repeated credential tokens during deep-link processing.
* **Tests**
  * Added Jest coverage for deep-link URL parsing and OAuth dedup behavior in the deep-link saga.
* **Refactor**
  * Centralized deep-link parsing into a shared helper and updated routing/handlers to use it across auth providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->