### PR TITLE
fix: prevent crash when rendering Section blocks with fields

### DIFF
--- a/app/containers/UIKit/Section.tsx
+++ b/app/containers/UIKit/Section.tsx
@@ -1,9 +1,7 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { BlockContext } from '@rocket.chat/ui-kit';
 
-import { themes } from '../../lib/constants/colors';
 import { type IAccessoryComponent, type IFields, type ISection } from './interfaces';
-import { useTheme } from '../../theme';
 
 const styles = StyleSheet.create({
 	content: {
@@ -26,14 +24,12 @@ const styles = StyleSheet.create({
 
 const Accessory = ({ element, parser }: IAccessoryComponent) => parser.renderAccessories({ ...element }, BlockContext.SECTION);
 
-const Fields = ({ fields, parser, theme }: IFields) => (
+const Fields = ({ fields, parser }: IFields) => (
 	<>
 		{fields.map((field, index) => (
-			<Text
-				key={`${(field as any).type || 'field'}-${index}`}
-				style={[styles.text, styles.field, { color: themes[theme].fontDefault }]}>
+			<View key={`${(field as any).type || 'field'}-${index}`} style={[styles.text, styles.field]}>
 				{parser.text(field)}
-			</Text>
+			</View>
 		))}
 	</>
 );
@@ -41,12 +37,10 @@ const Fields = ({ fields, parser, theme }: IFields) => (
 const accessoriesRight = ['image', 'overflow'];
 
 export const Section = ({ blockId, appId, text, fields, accessory, parser }: ISection) => {
-	const { theme } = useTheme();
-
 	return (
 		<View style={[styles.content, accessory && accessoriesRight.includes(accessory.type) ? styles.row : styles.column]}>
 			{text ? <View style={styles.text}>{parser.text(text)}</View> : null}
-			{fields ? <Fields fields={fields} theme={theme} parser={parser} /> : null}
+			{fields ? <Fields fields={fields} parser={parser} /> : null}
 			{accessory ? <Accessory element={{ blockId, appId, ...accessory }} parser={parser} /> : null}
 		</View>
 	);

--- a/app/containers/UIKit/Section.tsx
+++ b/app/containers/UIKit/Section.tsx
@@ -27,7 +27,7 @@ const Accessory = ({ element, parser }: IAccessoryComponent) => parser.renderAcc
 const Fields = ({ fields, parser }: IFields) => (
 	<>
 		{fields.map((field, index) => (
-			<View key={`${(field as any).type || 'field'}-${index}`} style={[styles.text, styles.field]}>
+			<View key={`${field.type || 'field'}-${index}`} style={[styles.text, styles.field]}>
 				{parser.text(field)}
 			</View>
 		))}

--- a/app/containers/UIKit/__snapshots__/UiKitMessage.test.tsx.snap
+++ b/app/containers/UIKit/__snapshots__/UiKitMessage.test.tsx.snap
@@ -730,7 +730,7 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
     ]
   }
 >
-  <Text
+  <View
     style={
       [
         {
@@ -739,9 +739,6 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
         },
         {
           "marginVertical": 6,
-        },
-        {
-          "color": "#2F343D",
         },
       ]
     }
@@ -766,8 +763,8 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
     >
       *this is plain_text text*
     </Text>
-  </Text>
-  <Text
+  </View>
+  <View
     style={
       [
         {
@@ -776,9 +773,6 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
         },
         {
           "marginVertical": 6,
-        },
-        {
-          "color": "#2F343D",
         },
       ]
     }
@@ -803,8 +797,8 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
     >
       *this is plain_text text*
     </Text>
-  </Text>
-  <Text
+  </View>
+  <View
     style={
       [
         {
@@ -813,9 +807,6 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
         },
         {
           "marginVertical": 6,
-        },
-        {
-          "color": "#2F343D",
         },
       ]
     }
@@ -840,8 +831,8 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
     >
       *this is plain_text text*
     </Text>
-  </Text>
-  <Text
+  </View>
+  <View
     style={
       [
         {
@@ -850,9 +841,6 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
         },
         {
           "marginVertical": 6,
-        },
-        {
-          "color": "#2F343D",
         },
       ]
     }
@@ -877,8 +865,8 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
     >
       *this is plain_text text*
     </Text>
-  </Text>
-  <Text
+  </View>
+  <View
     style={
       [
         {
@@ -887,9 +875,6 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
         },
         {
           "marginVertical": 6,
-        },
-        {
-          "color": "#2F343D",
         },
       ]
     }
@@ -914,7 +899,7 @@ exports[`Story Snapshots: Fields should match snapshot 1`] = `
     >
       *this is plain_text text*
     </Text>
-  </Text>
+  </View>
 </View>
 `;
 

--- a/app/containers/UIKit/__snapshots__/UiKitModal.test.tsx.snap
+++ b/app/containers/UIKit/__snapshots__/UiKitModal.test.tsx.snap
@@ -5668,7 +5668,7 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
       ]
     }
   >
-    <Text
+    <View
       style={
         [
           {
@@ -5677,9 +5677,6 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           },
           {
             "marginVertical": 6,
-          },
-          {
-            "color": "#2F343D",
           },
         ]
       }
@@ -5803,8 +5800,8 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           </Text>
         </Text>
       </View>
-    </Text>
-    <Text
+    </View>
+    <View
       style={
         [
           {
@@ -5813,9 +5810,6 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           },
           {
             "marginVertical": 6,
-          },
-          {
-            "color": "#2F343D",
           },
         ]
       }
@@ -5939,7 +5933,7 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           </Text>
         </Text>
       </View>
-    </Text>
+    </View>
   </View>,
   <View
     style={
@@ -5953,7 +5947,7 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
       ]
     }
   >
-    <Text
+    <View
       style={
         [
           {
@@ -5962,9 +5956,6 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           },
           {
             "marginVertical": 6,
-          },
-          {
-            "color": "#2F343D",
           },
         ]
       }
@@ -6088,8 +6079,8 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           </Text>
         </Text>
       </View>
-    </Text>
-    <Text
+    </View>
+    <View
       style={
         [
           {
@@ -6098,9 +6089,6 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           },
           {
             "marginVertical": 6,
-          },
-          {
-            "color": "#2F343D",
           },
         ]
       }
@@ -6224,7 +6212,7 @@ exports[`Story Snapshots: ModalSectionSelects should match snapshot 1`] = `
           </Text>
         </Text>
       </View>
-    </Text>
+    </View>
   </View>,
 ]
 `;

--- a/app/containers/UIKit/interfaces.ts
+++ b/app/containers/UIKit/interfaces.ts
@@ -265,7 +265,6 @@ export interface ISection extends Block {
 
 export interface IFields {
 	parser: IParser;
-	theme: TSupportedThemes;
 	fields: readonly IText[];
 }
 


### PR DESCRIPTION
## Proposed changes

Opening a modal or message that contains a **Section block with `fields`** (e.g. the `ModalSectionSelects` view) crashed the app.

Root cause: in `app/containers/UIKit/Section.tsx`, the `Fields` sub-component wrapped each field in a React Native `<Text>`:

```tsx
<Text style={[styles.text, styles.field, { color: themes[theme].fontDefault }]}>
  {parser.text(field)}
</Text>
```

`parser.text()` returns a non-`<Text>` node (a block/markdown element) for section/select fields, and React Native throws when a non-`<Text>` child is nested inside a `<Text>`. The section's main `text` is already rendered correctly inside a `<View>` (line 48); the `Fields` path simply didn't follow the same pattern.

This wraps each field in a `<View>` instead, matching the existing `text` rendering. The redundant text-color override — and the now-unused `theme`/`themes`/`useTheme` plumbing (including the `theme` prop on the `IFields` interface) — are removed, since `parser.text()` renders its own styled text.

## Issue(s)

Closes #6951

## How to test or reproduce

1. Open a UiKit modal/message that contains a `section` block with a `fields` array (the `ModalSectionSelects` story reproduces it).
2. Before this change the screen crashes; after it, the fields render normally.

Automated: `TZ=UTC pnpm test --testPathPattern='UiKit'` — all UiKit suites pass (46 tests). The `UiKitModal`/`UiKitMessage` Section snapshots were regenerated to reflect the `<Text>` → `<View>` wrapper change (the inner text node rendered by `parser.text()` is unchanged). `pnpm lint` (ESLint + `tsc`) passes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the Contributing Guide
- [x] Lint and unit tests pass locally with my changes
- [x] I have added/updated tests (regenerated the affected Section snapshots)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how section fields are rendered by removing theme-based default color handling.
  * Simplified the field rendering flow so field definitions are no longer tied to theme information.
  * Adjusted the exported fields interface to drop the theme property, keeping parser and field data only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->