### PR TITLE
fix: insert multiline code block as a fenced block on its own lines

### DIFF
--- a/app/containers/MessageComposer/MessageComposer.test.tsx
+++ b/app/containers/MessageComposer/MessageComposer.test.tsx
@@ -403,7 +403,7 @@ describe('MessageComposer', () => {
 				await user.press(screen.getByTestId('message-composer-code-block'));
 				await user.press(screen.getByTestId('message-composer-send'));
 				expect(onSendMessage).toHaveBeenCalledTimes(1);
-				expect(onSendMessage).toHaveBeenCalledWith('``````', false);
+				expect(onSendMessage).toHaveBeenCalledWith('```\n\n```', false);
 				expect(screen.toJSON()).toMatchSnapshot();
 			});
 
@@ -422,7 +422,7 @@ describe('MessageComposer', () => {
 				await user.press(screen.getByTestId('message-composer-code-block'));
 				await user.press(screen.getByTestId('message-composer-send'));
 				expect(onSendMessage).toHaveBeenCalledTimes(1);
-				expect(onSendMessage).toHaveBeenCalledWith('```test```', false);
+				expect(onSendMessage).toHaveBeenCalledWith('```\ntest\n```', false);
 				expect(screen.toJSON()).toMatchSnapshot();
 			});
 		});

--- a/app/containers/MessageComposer/components/ComposerInput.tsx
+++ b/app/containers/MessageComposer/components/ComposerInput.tsx
@@ -14,7 +14,7 @@ import {
 	type TSetInput
 } from '../interfaces';
 import { useAutocompleteParams, useFocused, useMessageComposerApi, useMicOrSend } from '../context';
-import { fetchIsAllOrHere, getMentionRegexp } from '../helpers';
+import { fetchIsAllOrHere, getMentionRegexp, wrapCodeBlock } from '../helpers';
 import { useAutoSaveDraft } from '../hooks';
 import sharedStyles from '../../../views/Styles';
 import { useTheme } from '../../../theme';
@@ -131,6 +131,11 @@ export const ComposerInput = memo(
 					emitter.on('addMarkdown', ({ style }) => {
 						const { start, end } = selectionRef.current;
 						const text = textRef.current;
+						if (style === 'code-block') {
+							const { updatedText, selection } = wrapCodeBlock(text, start, end);
+							setInput(updatedText, selection);
+							return;
+						}
 						const markdown = MARKDOWN_STYLES[style];
 						const newText = `${text.substr(0, start)}${markdown}${text.substr(start, end - start)}${markdown}${text.substr(end)}`;
 						setInput(newText, {

--- a/app/containers/MessageComposer/helpers/index.ts
+++ b/app/containers/MessageComposer/helpers/index.ts
@@ -3,3 +3,4 @@ export * from './forceJpgExtension';
 export * from './getMentionRegexp';
 export * from './prepareQuoteMessage';
 export * from './insertEmojiAtCursor';
+export * from './wrapCodeBlock';

--- a/app/containers/MessageComposer/helpers/wrapCodeBlock.test.ts
+++ b/app/containers/MessageComposer/helpers/wrapCodeBlock.test.ts
@@ -1,0 +1,38 @@
+import { wrapCodeBlock } from './wrapCodeBlock';
+
+describe('wrapCodeBlock', () => {
+	it('inserts an empty fenced block with the cursor on the middle line', () => {
+		expect(wrapCodeBlock('', 0, 0)).toEqual({
+			updatedText: '```\n\n```',
+			selection: { start: 4, end: 4 }
+		});
+	});
+
+	it('adds a leading newline when the cursor is not at the start of a line', () => {
+		expect(wrapCodeBlock('comment', 7, 7)).toEqual({
+			updatedText: 'comment\n```\n\n```',
+			selection: { start: 12, end: 12 }
+		});
+	});
+
+	it('does not add a leading newline when already at the start of a line', () => {
+		expect(wrapCodeBlock('comment\n', 8, 8)).toEqual({
+			updatedText: 'comment\n```\n\n```',
+			selection: { start: 12, end: 12 }
+		});
+	});
+
+	it('wraps the selected text inside the block and keeps it selected', () => {
+		expect(wrapCodeBlock('comment\nfoo', 8, 11)).toEqual({
+			updatedText: 'comment\n```\nfoo\n```',
+			selection: { start: 12, end: 15 }
+		});
+	});
+
+	it('adds a trailing newline so the closing fence stays on its own line', () => {
+		expect(wrapCodeBlock('abc', 0, 0)).toEqual({
+			updatedText: '```\n\n```\nabc',
+			selection: { start: 4, end: 4 }
+		});
+	});
+});

--- a/app/containers/MessageComposer/helpers/wrapCodeBlock.ts
+++ b/app/containers/MessageComposer/helpers/wrapCodeBlock.ts
@@ -1,0 +1,25 @@
+// Wraps the current selection (or the cursor when nothing is selected) in a fenced code block.
+// Fenced code blocks are only parsed when the ``` markers sit alone on their own line, so the
+// opening and closing fences are placed on dedicated lines and separated from the surrounding
+// text. The cursor is left on the (possibly empty) content line between the fences.
+// See https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/7099
+export const wrapCodeBlock = (
+	text: string,
+	start: number,
+	end: number
+): { updatedText: string; selection: { start: number; end: number } } => {
+	const before = text.substring(0, start);
+	const selected = text.substring(start, end);
+	const after = text.substring(end);
+
+	const prefix = before.length > 0 && !before.endsWith('\n') ? '\n```\n' : '```\n';
+	const suffix = after.length > 0 && !after.startsWith('\n') ? '\n```\n' : '\n```';
+
+	const updatedText = `${before}${prefix}${selected}${suffix}${after}`;
+	const cursor = before.length + prefix.length;
+
+	return {
+		updatedText,
+		selection: { start: cursor, end: cursor + selected.length }
+	};
+};

--- a/app/containers/MessageComposer/helpers/wrapCodeBlock.ts
+++ b/app/containers/MessageComposer/helpers/wrapCodeBlock.ts
@@ -3,11 +3,17 @@
 // opening and closing fences are placed on dedicated lines and separated from the surrounding
 // text. The cursor is left on the (possibly empty) content line between the fences.
 // See https://github.com/RocketChat/Rocket.Chat.ReactNative/issues/7099
-export const wrapCodeBlock = (
-	text: string,
-	start: number,
-	end: number
-): { updatedText: string; selection: { start: number; end: number } } => {
+interface ISelectionRange {
+	start: number;
+	end: number;
+}
+
+interface IWrapCodeBlockResult {
+	updatedText: string;
+	selection: ISelectionRange;
+}
+
+export const wrapCodeBlock = (text: string, start: number, end: number): IWrapCodeBlockResult => {
 	const before = text.substring(0, start);
 	const selected = text.substring(start, end);
 	const after = text.substring(end);


### PR DESCRIPTION
## Proposed changes

Tapping the **multiline code-block** formatting button produced a broken result: it wrapped the selection inline, e.g. typing nothing and tapping the button inserted six backticks with the cursor stuck in the middle of them on a single line (`` ```|``` ``). Fenced code blocks are only parsed by the renderer when the ` ``` ` markers sit **alone on their own line**, so this never actually rendered as a code block and forced users to manually add line breaks.

This makes the code-block button insert a proper fenced block:

- the opening and closing ` ``` ` fences are placed on their own lines;
- a leading newline is added when the cursor isn't already at the start of a line (so the opening fence isn't glued to preceding text), and a trailing newline when needed so the closing fence stays alone on its line;
- the cursor is left on the (possibly empty) content line between the fences, ready to type/paste code;
- any selected text is wrapped inside the block.

So tapping the button now yields:

```
​```
|
​```
```

(with the cursor `|` on the middle line), matching the behaviour requested in the issue. The other formatting buttons (bold, italic, strike, inline code) are unchanged.

The insertion logic is extracted into a pure `wrapCodeBlock` helper (mirroring the existing `insertEmojiAtCursor` helper) so it can be unit-tested directly.

## Issue(s)

Closes #7099

## How to test or reproduce

1. Open the message composer, optionally type some text and/or select text.
2. Open the formatting toolbar and tap the **code block** button.
3. The selection (or an empty line) is now wrapped in a ` ``` ` fenced block on its own lines, with the cursor on the content line — instead of six backticks on a single line.

Automated: `TZ=UTC pnpm test --testPathPattern='wrapCodeBlock|MessageComposer/MessageComposer.test'` (new `wrapCodeBlock` unit tests + updated MessageComposer toolbar tests, 39 tests pass). `pnpm lint` (ESLint + `tsc`) passes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the Contributing Guide
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code-block formatting in the message composer so fenced markdown uses newline-separated triple-backtick delimiters.
  * Enhanced insertion behavior to better handle cursor/selection placement when adding code blocks, including empty blocks and existing-line newline edge cases.
* **Tests**
  * Added coverage for code-block wrapping across common cursor and selection scenarios, and updated related expectations to match the new serialization format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->