### PR TITLE
fix(android): add User-Agent interceptor to shared OkHttpClient

### DIFF
--- a/android/app/src/main/java/chat/rocket/reactnative/networking/SSLPinningTurboModule.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/networking/SSLPinningTurboModule.java
@@ -46,17 +46,24 @@ public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyCh
     private static ReactApplicationContext reactContext;
     private static OkHttpClient sharedClient;
 
-    private static Interceptor userAgentInterceptor() {
-        return chain -> {
-            Request original = chain.request();
-            if (original.header("User-Agent") != null) {
-                return chain.proceed(original);
-            }
-            Request request = original.newBuilder()
-                    .header("User-Agent", NotificationHelper.getUserAgent())
-                    .build();
-            return chain.proceed(request);
-        };
+    private static final Interceptor USER_AGENT_INTERCEPTOR = chain -> {
+        Request original = chain.request();
+        if (original.header("User-Agent") != null) {
+            return chain.proceed(original);
+        }
+        Request request = original.newBuilder()
+                .header("User-Agent", NotificationHelper.getUserAgent())
+                .build();
+        return chain.proceed(request);
+    };
+
+    public static OkHttpClient.Builder getOkHttpClientBuilder() {
+        return new OkHttpClient.Builder()
+                .addInterceptor(USER_AGENT_INTERCEPTOR)
+                .connectTimeout(0, TimeUnit.MILLISECONDS)
+                .readTimeout(0, TimeUnit.MILLISECONDS)
+                .writeTimeout(0, TimeUnit.MILLISECONDS)
+                .cookieJar(new ReactCookieJarContainer());
     }
 
     public static OkHttpClient getSharedOkHttpClient() {
@@ -64,12 +71,7 @@ public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyCh
             return sharedClient;
         }
         if (alias != null) {
-            OkHttpClient.Builder builder = new OkHttpClient.Builder()
-                    .addInterceptor(userAgentInterceptor())
-                    .connectTimeout(0, TimeUnit.MILLISECONDS)
-                    .readTimeout(0, TimeUnit.MILLISECONDS)
-                    .writeTimeout(0, TimeUnit.MILLISECONDS)
-                    .cookieJar(new ReactCookieJarContainer());
+            OkHttpClient.Builder builder = getOkHttpClientBuilder();
 
             SSLSocketFactory sslSocketFactory = getSSLFactory(alias);
             X509TrustManager trustManager = getTrustManagerFactory();
@@ -106,12 +108,7 @@ public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyCh
         if (shared != null) {
             return shared;
         }
-        OkHttpClient.Builder builder = new OkHttpClient.Builder()
-                .addInterceptor(userAgentInterceptor())
-                .connectTimeout(0, TimeUnit.MILLISECONDS)
-                .readTimeout(0, TimeUnit.MILLISECONDS)
-                .writeTimeout(0, TimeUnit.MILLISECONDS)
-                .cookieJar(new ReactCookieJarContainer());
+        OkHttpClient.Builder builder = getOkHttpClientBuilder();
 
         if (alias != null) {
             SSLSocketFactory sslSocketFactory = getSSLFactory(alias);

--- a/android/app/src/main/java/chat/rocket/reactnative/networking/SSLPinningTurboModule.java
+++ b/android/app/src/main/java/chat/rocket/reactnative/networking/SSLPinningTurboModule.java
@@ -24,6 +24,8 @@ import javax.net.ssl.X509TrustManager;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Interceptor;
 import android.app.Activity;
 import javax.net.ssl.KeyManager;
 import android.security.KeyChain;
@@ -35,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import com.reactnativecommunity.webview.RNCWebViewManager;
 import expo.modules.filesystem.legacy.FileSystemLegacyModule;
 import chat.rocket.reactnative.networking.ExpoImageClient;
+import chat.rocket.reactnative.notification.NotificationHelper;
 
 public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyChainAliasCallback {
 
@@ -43,12 +46,26 @@ public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyCh
     private static ReactApplicationContext reactContext;
     private static OkHttpClient sharedClient;
 
+    private static Interceptor userAgentInterceptor() {
+        return chain -> {
+            Request original = chain.request();
+            if (original.header("User-Agent") != null) {
+                return chain.proceed(original);
+            }
+            Request request = original.newBuilder()
+                    .header("User-Agent", NotificationHelper.getUserAgent())
+                    .build();
+            return chain.proceed(request);
+        };
+    }
+
     public static OkHttpClient getSharedOkHttpClient() {
         if (sharedClient != null) {
             return sharedClient;
         }
         if (alias != null) {
             OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                    .addInterceptor(userAgentInterceptor())
                     .connectTimeout(0, TimeUnit.MILLISECONDS)
                     .readTimeout(0, TimeUnit.MILLISECONDS)
                     .writeTimeout(0, TimeUnit.MILLISECONDS)
@@ -90,6 +107,7 @@ public class SSLPinningTurboModule extends NativeSSLPinningSpec implements KeyCh
             return shared;
         }
         OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .addInterceptor(userAgentInterceptor())
                 .connectTimeout(0, TimeUnit.MILLISECONDS)
                 .readTimeout(0, TimeUnit.MILLISECONDS)
                 .writeTimeout(0, TimeUnit.MILLISECONDS)

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/DDPClient.kt
@@ -20,7 +20,7 @@ class DDPClient {
     companion object {
         private const val TAG = "RocketChat.DDPClient"
         private val sharedClient: OkHttpClient by lazy {
-            SSLPinningTurboModule.getSharedOkHttpClient() ?: OkHttpClient.Builder()
+            SSLPinningTurboModule.getSharedOkHttpClient() ?: SSLPinningTurboModule.getOkHttpClientBuilder()
                 .pingInterval(30, TimeUnit.SECONDS)
                 .build()
         }

--- a/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
+++ b/android/app/src/main/java/chat/rocket/reactnative/voip/MediaCallsAnswerRequest.kt
@@ -43,7 +43,7 @@ class MediaCallsAnswerRequest(
         private const val TAG = "RocketChat.MediaCallsAnswerRequest"
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
         private val httpClient: OkHttpClient by lazy {
-            val base = SSLPinningTurboModule.getSharedOkHttpClient() ?: OkHttpClient()
+            val base = SSLPinningTurboModule.getSharedOkHttpClient() ?: SSLPinningTurboModule.getOkHttpClientBuilder().build()
             base.newBuilder()
                 .callTimeout(10, TimeUnit.SECONDS)
                 .connectTimeout(5, TimeUnit.SECONDS)


### PR DESCRIPTION
## Problem

Native HTTP calls on Android were leaking the default `Dalvik/...` User-Agent on call sites that didn't explicitly set one. This caused WAF rules and server logs to see `okhttp/...` instead of `RC Mobile`.

Confirmed sites missing the `RC Mobile` UA:
- `SSLPinningTurboModule.getSharedOkHttpClient()` (used by ExpoImageClient, etc.)
- `MediaCallsAnswerRequest.kt` (VoIP accept/decline) — inherited via shared client

## Solution

Add a centralized `userAgentInterceptor()` to both `getSharedOkHttpClient()` and `getOkHttpClient()`. The interceptor:

1. Checks if the request already has an explicit `User-Agent` header → passes through unchanged
2. Otherwise adds `RC Mobile; android {version}; v{appVersion} ({build})`

Uses the existing `NotificationHelper.getUserAgent()` so the format stays consistent with the manual headers already set in `LoadNotification.java`, `ReplyBroadcast.java`, and `NotificationHelper`.

Fixes #7342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request handling so a default `User-Agent` is always included when a request doesn’t already set one.
  * Ensured VoIP networking uses the same header/request customization across both shared and fallback HTTP clients, preventing inconsistent request metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->