### PR TITLE
feat: add pre-migration analytics probe for device and DB-size distribution

### DIFF
--- a/app/lib/methods/dbMigrationProbe.test.ts
+++ b/app/lib/methods/dbMigrationProbe.test.ts
@@ -1,6 +1,13 @@
 import { Platform } from 'react-native';
 
-import { dbFileUri, serverUrlToDbName, statFileBytes, collectDbSizes, runDbMigrationProbe } from './dbMigrationProbe';
+import {
+	dbFileUri,
+	serverUrlToDbName,
+	statFileBytes,
+	statDbWithSidecars,
+	collectDbSizes,
+	runDbMigrationProbe
+} from './dbMigrationProbe';
 
 // ── mocks ────────────────────────────────────────────────────────────────────
 
@@ -107,30 +114,66 @@ describe('statFileBytes', () => {
 	});
 });
 
+// ── statDbWithSidecars ────────────────────────────────────────────────────────
+
+describe('statDbWithSidecars', () => {
+	it('sums main + wal + shm when all exist', async () => {
+		mockGetInfoAsync
+			.mockResolvedValueOnce({ exists: true, size: 500 }) // main
+			.mockResolvedValueOnce({ exists: true, size: 200 }) // -wal
+			.mockResolvedValueOnce({ exists: true, size: 50 }); // -shm
+		expect(await statDbWithSidecars('file:///foo.db')).toBe(750);
+	});
+
+	it('treats a missing -wal as 0 bytes', async () => {
+		mockGetInfoAsync
+			.mockResolvedValueOnce({ exists: true, size: 500 }) // main
+			.mockResolvedValueOnce({ exists: false }) // -wal missing
+			.mockResolvedValueOnce({ exists: true, size: 50 }); // -shm
+		expect(await statDbWithSidecars('file:///foo.db')).toBe(550);
+	});
+
+	it('treats a missing -shm as 0 bytes', async () => {
+		mockGetInfoAsync
+			.mockResolvedValueOnce({ exists: true, size: 500 }) // main
+			.mockResolvedValueOnce({ exists: true, size: 200 }) // -wal
+			.mockResolvedValueOnce({ exists: false }); // -shm missing
+		expect(await statDbWithSidecars('file:///foo.db')).toBe(700);
+	});
+
+	it('returns null when main file is absent', async () => {
+		mockGetInfoAsync.mockResolvedValue({ exists: false });
+		expect(await statDbWithSidecars('file:///foo.db')).toBeNull();
+	});
+});
+
 // ── collectDbSizes ────────────────────────────────────────────────────────────
 
 describe('collectDbSizes', () => {
-	it('sums serversDb + all server DBs when all stats succeed', async () => {
+	it('sums main+wal+shm for each DB when all stats succeed', async () => {
+		// Every stat call returns 1000; each db = 1000*3 = 3000.
 		mockGetInfoAsync.mockResolvedValue({ exists: true, size: 1000 });
 		mockServersGet.mockReturnValue(makeServerCollection(['https://a.com', 'https://b.com']));
 
 		const result = await collectDbSizes();
 
-		// serversDb (1000) + a.com (1000) + b.com (1000)
-		expect(result.serversDbBytes).toBe(1000);
-		expect(result.totalBytes).toBe(3000);
+		expect(result.serversDbBytes).toBe(3000);
+		expect(result.totalBytes).toBe(9000); // serversDb(3000) + a.com(3000) + b.com(3000)
 	});
 
-	it('sets totalBytes to null when any server DB stat fails', async () => {
-		mockGetInfoAsync
-			.mockResolvedValueOnce({ exists: true, size: 500 }) // serversDb
-			.mockResolvedValueOnce({ exists: true, size: 200 }) // first server
-			.mockResolvedValueOnce({ exists: false }); // second server missing
+	it('sets totalBytes to null when any server main DB file is missing', async () => {
+		mockGetInfoAsync.mockImplementation((uri: string) => {
+			// b.com main file missing; all other files (including sidecars) exist
+			if (uri.includes('b.com') && !uri.endsWith('-wal') && !uri.endsWith('-shm')) {
+				return Promise.resolve({ exists: false });
+			}
+			return Promise.resolve({ exists: true, size: 1000 });
+		});
 		mockServersGet.mockReturnValue(makeServerCollection(['https://a.com', 'https://b.com']));
 
 		const result = await collectDbSizes();
 
-		expect(result.serversDbBytes).toBe(500);
+		expect(result.serversDbBytes).toBe(3000);
 		expect(result.totalBytes).toBeNull();
 	});
 
@@ -142,11 +185,11 @@ describe('collectDbSizes', () => {
 
 		const result = await collectDbSizes();
 
-		expect(result.serversDbBytes).toBe(800);
+		expect(result.serversDbBytes).toBe(2400); // 800 * 3
 		expect(result.totalBytes).toBeNull();
 	});
 
-	it('reports serversDbBytes even when it is null', async () => {
+	it('reports serversDbBytes as null when the main file is absent', async () => {
 		mockGetInfoAsync.mockResolvedValue({ exists: false });
 		mockServersGet.mockReturnValue(makeServerCollection([]));
 
@@ -161,13 +204,16 @@ describe('collectDbSizes', () => {
 
 describe('runDbMigrationProbe', () => {
 	beforeEach(() => {
-		mockGetInfoAsync.mockResolvedValue({ exists: true, size: 2048 });
+		// WAL/SHM absent so byte values stay simple (main only).
+		mockGetInfoAsync.mockImplementation((uri: string) =>
+			uri.endsWith('-wal') || uri.endsWith('-shm')
+				? Promise.resolve({ exists: false })
+				: Promise.resolve({ exists: true, size: 2048 })
+		);
 		mockServersGet.mockReturnValue(makeServerCollection(['https://open.rocket.chat']));
 	});
 
 	it('fires the analytics event with correct payload on first run', async () => {
-		mockGetBool.mockReturnValue(null);
-
 		await runDbMigrationProbe();
 
 		expect(mockLogEvent).toHaveBeenCalledWith('db_migration_probe', {
@@ -176,7 +222,7 @@ describe('runDbMigrationProbe', () => {
 			os_version: '14',
 			free_disk_mb: 10 * 1024, // 10 GB → 10240 MB
 			servers_db_bytes: 2048,
-			total_db_bytes: 4096 // serversDb + one server DB
+			total_db_bytes: 4096 // serversDb(2048) + open.rocket.chat(2048)
 		});
 		expect(mockSetBool).toHaveBeenCalledWith('db_migration_probe_v1', true);
 	});
@@ -191,12 +237,19 @@ describe('runDbMigrationProbe', () => {
 	});
 
 	it('does not throw or set the flag when logEvent throws', async () => {
-		mockGetBool.mockReturnValue(null);
 		mockLogEvent.mockImplementation(() => {
 			throw new Error('analytics unavailable');
 		});
 
 		await expect(runDbMigrationProbe()).resolves.toBeUndefined();
 		expect(mockSetBool).not.toHaveBeenCalled();
+	});
+
+	it('does not throw when getBool throws', async () => {
+		mockGetBool.mockImplementation(() => {
+			throw new Error('mmkv unavailable');
+		});
+
+		await expect(runDbMigrationProbe()).resolves.toBeUndefined();
 	});
 });

--- a/app/lib/methods/dbMigrationProbe.test.ts
+++ b/app/lib/methods/dbMigrationProbe.test.ts
@@ -1,0 +1,202 @@
+import { Platform } from 'react-native';
+
+import { dbFileUri, serverUrlToDbName, statFileBytes, collectDbSizes, runDbMigrationProbe } from './dbMigrationProbe';
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('react-native', () => ({ Platform: { OS: 'android' } }));
+
+const mockGetInfoAsync = jest.fn();
+jest.mock('expo-file-system/legacy', () => ({
+	getInfoAsync: (...args: unknown[]) => mockGetInfoAsync(...args),
+	documentDirectory: 'file:///data/user/0/chat.rocket.android/files/'
+}));
+
+const mockLogEvent = jest.fn();
+jest.mock('./helpers/log', () => ({
+	logEvent: (...args: unknown[]) => mockLogEvent(...args),
+	events: { DB_MIGRATION_PROBE: 'db_migration_probe' }
+}));
+
+jest.mock('./appGroup', () => ({ appGroupPath: '' }));
+
+const mockGetBool = jest.fn();
+const mockSetBool = jest.fn();
+jest.mock('./userPreferences', () => ({
+	__esModule: true,
+	default: { getBool: (...args: unknown[]) => mockGetBool(...args), setBool: (...args: unknown[]) => mockSetBool(...args) }
+}));
+
+const mockServersGet = jest.fn();
+jest.mock('../database', () => ({
+	__esModule: true,
+	default: { servers: { get: (...args: unknown[]) => mockServersGet(...args) } }
+}));
+
+const mockGetModel = jest.fn(() => 'Pixel 7');
+const mockGetSystemName = jest.fn(() => 'Android');
+const mockGetSystemVersion = jest.fn(() => '14');
+const mockGetFreeDiskStorage = jest.fn(() => Promise.resolve(10 * 1024 * 1024 * 1024)); // 10 GB
+jest.mock('react-native-device-info', () => ({
+	__esModule: true,
+	default: {
+		getModel: () => mockGetModel(),
+		getSystemName: () => mockGetSystemName(),
+		getSystemVersion: () => mockGetSystemVersion(),
+		getFreeDiskStorage: () => mockGetFreeDiskStorage()
+	}
+}));
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeServerCollection(ids: string[]) {
+	const records = ids.map(id => ({ id }));
+	return { query: () => ({ fetch: () => Promise.resolve(records) }) };
+}
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	(Platform as any).OS = 'android';
+	mockGetBool.mockReturnValue(null);
+});
+
+// ── dbFileUri ─────────────────────────────────────────────────────────────────
+
+describe('dbFileUri', () => {
+	it('constructs android URI with double .db suffix', () => {
+		(Platform as any).OS = 'android';
+		expect(dbFileUri('default.db')).toBe('file:///data/user/0/chat.rocket.android/default.db.db');
+	});
+
+	it('constructs ios URI from absolute appGroupPath', () => {
+		(Platform as any).OS = 'ios';
+		expect(dbFileUri('/private/var/mobile/Containers/Shared/AppGroup/ABC/default.db')).toBe(
+			'file:///private/var/mobile/Containers/Shared/AppGroup/ABC/default.db'
+		);
+	});
+});
+
+// ── serverUrlToDbName ─────────────────────────────────────────────────────────
+
+describe('serverUrlToDbName', () => {
+	it('strips protocol and replaces slashes', () => {
+		expect(serverUrlToDbName('https://open.rocket.chat')).toBe('open.rocket.chat.db');
+	});
+
+	it('handles URLs with a path segment', () => {
+		expect(serverUrlToDbName('https://example.com/sub')).toBe('example.com.sub.db');
+	});
+});
+
+// ── statFileBytes ─────────────────────────────────────────────────────────────
+
+describe('statFileBytes', () => {
+	it('returns size when file exists', async () => {
+		mockGetInfoAsync.mockResolvedValue({ exists: true, size: 4096 });
+		expect(await statFileBytes('file:///foo.db')).toBe(4096);
+	});
+
+	it('returns null when file does not exist', async () => {
+		mockGetInfoAsync.mockResolvedValue({ exists: false });
+		expect(await statFileBytes('file:///missing.db')).toBeNull();
+	});
+
+	it('returns null when getInfoAsync throws', async () => {
+		mockGetInfoAsync.mockRejectedValue(new Error('permission denied'));
+		expect(await statFileBytes('file:///bad.db')).toBeNull();
+	});
+});
+
+// ── collectDbSizes ────────────────────────────────────────────────────────────
+
+describe('collectDbSizes', () => {
+	it('sums serversDb + all server DBs when all stats succeed', async () => {
+		mockGetInfoAsync.mockResolvedValue({ exists: true, size: 1000 });
+		mockServersGet.mockReturnValue(makeServerCollection(['https://a.com', 'https://b.com']));
+
+		const result = await collectDbSizes();
+
+		// serversDb (1000) + a.com (1000) + b.com (1000)
+		expect(result.serversDbBytes).toBe(1000);
+		expect(result.totalBytes).toBe(3000);
+	});
+
+	it('sets totalBytes to null when any server DB stat fails', async () => {
+		mockGetInfoAsync
+			.mockResolvedValueOnce({ exists: true, size: 500 }) // serversDb
+			.mockResolvedValueOnce({ exists: true, size: 200 }) // first server
+			.mockResolvedValueOnce({ exists: false }); // second server missing
+		mockServersGet.mockReturnValue(makeServerCollection(['https://a.com', 'https://b.com']));
+
+		const result = await collectDbSizes();
+
+		expect(result.serversDbBytes).toBe(500);
+		expect(result.totalBytes).toBeNull();
+	});
+
+	it('sets totalBytes to null when server query throws', async () => {
+		mockGetInfoAsync.mockResolvedValue({ exists: true, size: 800 });
+		mockServersGet.mockReturnValue({
+			query: () => ({ fetch: () => Promise.reject(new Error('db error')) })
+		});
+
+		const result = await collectDbSizes();
+
+		expect(result.serversDbBytes).toBe(800);
+		expect(result.totalBytes).toBeNull();
+	});
+
+	it('reports serversDbBytes even when it is null', async () => {
+		mockGetInfoAsync.mockResolvedValue({ exists: false });
+		mockServersGet.mockReturnValue(makeServerCollection([]));
+
+		const result = await collectDbSizes();
+
+		expect(result.serversDbBytes).toBeNull();
+		expect(result.totalBytes).toBe(0); // 0 servers, serversDb null treated as 0
+	});
+});
+
+// ── runDbMigrationProbe ───────────────────────────────────────────────────────
+
+describe('runDbMigrationProbe', () => {
+	beforeEach(() => {
+		mockGetInfoAsync.mockResolvedValue({ exists: true, size: 2048 });
+		mockServersGet.mockReturnValue(makeServerCollection(['https://open.rocket.chat']));
+	});
+
+	it('fires the analytics event with correct payload on first run', async () => {
+		mockGetBool.mockReturnValue(null);
+
+		await runDbMigrationProbe();
+
+		expect(mockLogEvent).toHaveBeenCalledWith('db_migration_probe', {
+			device_model: 'Pixel 7',
+			os_name: 'Android',
+			os_version: '14',
+			free_disk_mb: 10 * 1024, // 10 GB → 10240 MB
+			servers_db_bytes: 2048,
+			total_db_bytes: 4096 // serversDb + one server DB
+		});
+		expect(mockSetBool).toHaveBeenCalledWith('db_migration_probe_v1', true);
+	});
+
+	it('does not fire when guard flag is already set', async () => {
+		mockGetBool.mockReturnValue(true);
+
+		await runDbMigrationProbe();
+
+		expect(mockLogEvent).not.toHaveBeenCalled();
+		expect(mockSetBool).not.toHaveBeenCalled();
+	});
+
+	it('does not throw or set the flag when logEvent throws', async () => {
+		mockGetBool.mockReturnValue(null);
+		mockLogEvent.mockImplementation(() => {
+			throw new Error('analytics unavailable');
+		});
+
+		await expect(runDbMigrationProbe()).resolves.toBeUndefined();
+		expect(mockSetBool).not.toHaveBeenCalled();
+	});
+});

--- a/app/lib/methods/dbMigrationProbe.ts
+++ b/app/lib/methods/dbMigrationProbe.ts
@@ -1,0 +1,82 @@
+import { Platform } from 'react-native';
+import { getInfoAsync, documentDirectory } from 'expo-file-system/legacy';
+import DeviceInfo from 'react-native-device-info';
+
+import database from '../database';
+import { appGroupPath } from './appGroup';
+import { logEvent, events } from './helpers/log';
+import userPreferences from './userPreferences';
+
+const PROBE_FIRED_KEY = 'db_migration_probe_v1';
+
+// The WatermelonDB JSI bridge on Android resolves a relative dbName via
+// getDatabasePath(dbName + '.db').replace('/databases', ''), so a name like
+// 'foo.db' lands at <appDataRoot>/foo.db.db. iOS paths are absolute (from the
+// App Group container) and are passed through unchanged.
+export function dbFileUri(dbName: string): string {
+	if (Platform.OS === 'ios') {
+		return `file://${dbName}`;
+	}
+	// documentDirectory = 'file:///data/user/0/<pkg>/files/'
+	const appDataRoot = (documentDirectory ?? '').replace('files/', '');
+	return `${appDataRoot}${dbName}.db`;
+}
+
+// Mirrors the getDatabasePath + getDatabase transforms in app/lib/database/index.ts.
+export function serverUrlToDbName(serverUrl: string): string {
+	const path = serverUrl.replace(/(^\w+:|^)\/\//, '').replace(/\//g, '.');
+	return `${appGroupPath}${path}.db`;
+}
+
+export async function statFileBytes(uri: string): Promise<number | null> {
+	try {
+		const info = await getInfoAsync(uri);
+		return info.exists ? info.size ?? null : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function collectDbSizes(): Promise<{ serversDbBytes: number | null; totalBytes: number | null }> {
+	const serversDbUri = dbFileUri(`${appGroupPath}default.db`);
+	const serversDbBytes = await statFileBytes(serversDbUri);
+
+	try {
+		const servers = await database.servers.get('servers').query().fetch();
+		const sizes = await Promise.all(servers.map(s => statFileBytes(dbFileUri(serverUrlToDbName(s.id)))));
+		const anyMissing = sizes.some(sz => sz === null);
+		const serverDbTotal = sizes.reduce<number>((acc, sz) => acc + (sz ?? 0), 0);
+		return {
+			serversDbBytes,
+			totalBytes: anyMissing ? null : (serversDbBytes ?? 0) + serverDbTotal
+		};
+	} catch {
+		return { serversDbBytes, totalBytes: null };
+	}
+}
+
+export async function runDbMigrationProbe(): Promise<void> {
+	if (userPreferences.getBool(PROBE_FIRED_KEY)) {
+		return;
+	}
+
+	try {
+		const [freeDiskBytes, { serversDbBytes, totalBytes }] = await Promise.all([
+			DeviceInfo.getFreeDiskStorage(),
+			collectDbSizes()
+		]);
+
+		logEvent(events.DB_MIGRATION_PROBE, {
+			device_model: DeviceInfo.getModel(),
+			os_name: DeviceInfo.getSystemName(),
+			os_version: DeviceInfo.getSystemVersion(),
+			free_disk_mb: Math.round(freeDiskBytes / 1024 / 1024),
+			servers_db_bytes: serversDbBytes ?? -1,
+			total_db_bytes: totalBytes ?? -1
+		});
+
+		userPreferences.setBool(PROBE_FIRED_KEY, true);
+	} catch {
+		// Probe is best-effort; never crash the app.
+	}
+}

--- a/app/lib/methods/dbMigrationProbe.ts
+++ b/app/lib/methods/dbMigrationProbe.ts
@@ -17,7 +17,6 @@ export function dbFileUri(dbName: string): string {
 	if (Platform.OS === 'ios') {
 		return `file://${dbName}`;
 	}
-	// documentDirectory = 'file:///data/user/0/<pkg>/files/'
 	const appDataRoot = (documentDirectory ?? '').replace('files/', '');
 	return `${appDataRoot}${dbName}.db`;
 }
@@ -37,13 +36,24 @@ export async function statFileBytes(uri: string): Promise<number | null> {
 	}
 }
 
+// WAL mode keeps -wal and -shm alongside the main file; include them so the
+// reported size reflects actual on-disk footprint. Missing sidecars contribute 0
+// (normal when no uncommitted writes are pending). Returns null only when the
+// main file itself is absent.
+export async function statDbWithSidecars(uri: string): Promise<number | null> {
+	const main = await statFileBytes(uri);
+	if (main === null) return null;
+	const [wal, shm] = await Promise.all([statFileBytes(`${uri}-wal`), statFileBytes(`${uri}-shm`)]);
+	return main + (wal ?? 0) + (shm ?? 0);
+}
+
 export async function collectDbSizes(): Promise<{ serversDbBytes: number | null; totalBytes: number | null }> {
 	const serversDbUri = dbFileUri(`${appGroupPath}default.db`);
-	const serversDbBytes = await statFileBytes(serversDbUri);
+	const serversDbBytes = await statDbWithSidecars(serversDbUri);
 
 	try {
 		const servers = await database.servers.get('servers').query().fetch();
-		const sizes = await Promise.all(servers.map(s => statFileBytes(dbFileUri(serverUrlToDbName(s.id)))));
+		const sizes = await Promise.all(servers.map(s => statDbWithSidecars(dbFileUri(serverUrlToDbName(s.id)))));
 		const anyMissing = sizes.some(sz => sz === null);
 		const serverDbTotal = sizes.reduce<number>((acc, sz) => acc + (sz ?? 0), 0);
 		return {
@@ -56,11 +66,11 @@ export async function collectDbSizes(): Promise<{ serversDbBytes: number | null;
 }
 
 export async function runDbMigrationProbe(): Promise<void> {
-	if (userPreferences.getBool(PROBE_FIRED_KEY)) {
-		return;
-	}
-
 	try {
+		if (userPreferences.getBool(PROBE_FIRED_KEY)) {
+			return;
+		}
+
 		const [freeDiskBytes, { serversDbBytes, totalBytes }] = await Promise.all([
 			DeviceInfo.getFreeDiskStorage(),
 			collectDbSizes()

--- a/app/lib/methods/helpers/log/events.ts
+++ b/app/lib/methods/helpers/log/events.ts
@@ -370,6 +370,6 @@ export default {
 	DELETE_OWN_ACCOUNT_F: 'delete_own_account_f',
 
 	// PRE-MIGRATION PROBE — fires once per install to capture device + DB-size distribution
-	// before the SQLCipher migration ships. Remove after migration stabilises.
+	// before the SQLCipher migration ships.
 	DB_MIGRATION_PROBE: 'db_migration_probe'
 };

--- a/app/lib/methods/helpers/log/events.ts
+++ b/app/lib/methods/helpers/log/events.ts
@@ -367,5 +367,9 @@ export default {
 
 	// DELETE OWN ACCOUNT ACCOUNT
 	DELETE_OWN_ACCOUNT: 'delete_own_account',
-	DELETE_OWN_ACCOUNT_F: 'delete_own_account_f'
+	DELETE_OWN_ACCOUNT_F: 'delete_own_account_f',
+
+	// PRE-MIGRATION PROBE — fires once per install to capture device + DB-size distribution
+	// before the SQLCipher migration ships. Remove after migration stabilises.
+	DB_MIGRATION_PROBE: 'db_migration_probe'
 };

--- a/app/sagas/selectServer.ts
+++ b/app/sagas/selectServer.ts
@@ -43,6 +43,7 @@ import { appSelector } from '../lib/hooks/useAppSelector';
 import { getServerById } from '../lib/database/services/Server';
 import { getLoggedUserById } from '../lib/database/services/LoggedUser';
 import SSLPinning from '../lib/methods/helpers/sslPinning';
+import { runDbMigrationProbe } from '../lib/methods/dbMigrationProbe';
 
 const getServerVersion = function (version: string | null) {
 	let validVersion = valid(version);
@@ -216,6 +217,7 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 		// we'll set serverVersion as metadata for bugsnag
 		logServerVersion(serverVersion);
 		yield put(selectServerSuccess({ server, version: serverVersion, name: serverInfo?.name || 'Rocket.Chat' }));
+		runDbMigrationProbe();
 	} catch (e) {
 		yield put(selectServerFailure());
 		log(e);


### PR DESCRIPTION
## Proposed changes

Fire-once probe that collects device model, OS version, free disk space, and total WatermelonDB on-disk size via the existing Firebase Analytics / Bugsnag event pipeline (`db_migration_probe`). Guards with an MMKV boolean flag so it fires at most once per install, triggered on first server select after login.

The team needs this data to size the upcoming SQLCipher migration: real-world DB sizes and device OS distribution before migration code ships.

No new native modules — uses `react-native-device-info` (already installed) for device/disk info and `expo-file-system/legacy` (already installed) for file stats. No PII, no auth tokens, no message content — byte counts and device facts only.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1280

## How to test or reproduce

Wipe MMKV storage (or use a fresh install), log in to any server. The event `db_migration_probe` should appear in Firebase DebugView with fields: `device_model`, `os_name`, `os_version`, `free_disk_mb`, `servers_db_bytes`, `total_db_bytes`. Logging in again should not re-fire the event.

## Screenshots

N/A — analytics-only change, no UI.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

https://claude.ai/code/session_01TE9VsFTeXsXc8ssqeR8MJ7