### PR TITLE
fix(watermelon): prevent room list query flicker on connection status change

### DIFF
--- a/app/views/RoomsListView/hooks/useSubscriptions.ts
+++ b/app/views/RoomsListView/hooks/useSubscriptions.ts
@@ -39,7 +39,7 @@ export const useSubscriptions = () => {
 	'use memo';
 
 	const useRealName = useAppSelector(state => state.settings.UI_Use_Real_Name);
-	const server = useAppSelector(state => state.server);
+	const server = useAppSelector(state => state.server.server);
 	const subscriptionRef = useRef<Subscription>(null);
 	const [subscriptions, setSubscriptions] = useState<TSubscriptionModel[]>([]);
 	const [loading, setLoading] = useState(true);


### PR DESCRIPTION
### Problem
In `useSubscriptions.ts`, the `server` state was retrieved using `const server = useAppSelector(state => state.server);`.
Since the `state.server` object contains several properties including the connection status (`loading`, `connecting`, etc.), any transition in connection state (e.g., from `connecting` to `connected`) triggers a state update. This state update causes `useSubscriptions` to re-evaluate, triggering a complete re-query of WatermelonDB for the list of rooms, which results in a highly visible and disruptive UX flicker.

### Solution
We restrict the selector dependency to only track `state.server.server` (the actual server URL). This ensures that simple connection status transitions (which do not change the active server URL) do not trigger unnecessary WatermelonDB queries or UI flickers.

Closes #7093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription updates so they refresh when the server connection changes, helping keep live data in sync more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->