### PR TITLE
docs: add CI trigger map for GitHub Actions workflows

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,93 @@
+# CI workflows
+
+Maps which event triggers which workflow and how they call each other.
+
+## Entrypoints
+
+| Workflow | Trigger | What runs |
+|---|---|---|
+| [build-pr.yml](workflows/build-pr.yml) | `pull_request` (all branches) | ESLint + tests, PR changelog, Android + iOS store builds (gated), E2E build + Maestro shards on both platforms (gated) |
+| [build-develop.yml](workflows/build-develop.yml) | `push: develop` | ESLint + tests, release changelog, Android + iOS store builds, seeds Android AVD + SDK caches for E2E shards |
+| [prettier.yml](workflows/prettier.yml) | `push: * except master, develop, single-server` (main repo) | Auto-formats with Prettier + ESLint and commits any fixes back to the branch |
+| [organize_translations.yml](workflows/organize_translations.yml) | `push` touching `app/i18n/locales/**.json` | Sorts JSON keys and commits the result |
+
+## Call graph
+
+```mermaid
+flowchart TD
+    classDef entry fill:#d4e6f1,stroke:#2980b9
+    classDef reusable fill:#d5f5e3,stroke:#27ae60
+    classDef action fill:#fef9e7,stroke:#f39c12
+
+    PR([build-pr.yml]):::entry
+    DEV([build-develop.yml]):::entry
+    PRET([prettier.yml]):::entry
+    TRANS([organize_translations.yml]):::entry
+
+    ESLINT[eslint.yml]:::reusable
+    CHANGELOG[generate-changelog.yml]:::reusable
+    BUILDAND[build-android.yml]:::reusable
+    BUILDIOS[build-ios.yml]:::reusable
+    E2EAND[e2e-build-android.yml]:::reusable
+    E2EIOS[e2e-build-ios.yml]:::reusable
+    MASTAND[maestro-android.yml]:::reusable
+    MASIOS[maestro-ios.yml]:::reusable
+
+    SN[setup-node]:::action
+    FSV[fetch-supported-versions]:::action
+    GBV[generate-build-version]:::action
+    AACT[build-android action]:::action
+    IACT[build-ios action]:::action
+    UAND[upload-android]:::action
+    UIAND[upload-internal-android]:::action
+    UIOS[upload-ios]:::action
+    PREAND[preinstall-android-sdk]:::action
+    E2EACC[e2e-account]:::action
+
+    PR --> ESLINT
+    PR --> BUILDAND
+    PR --> BUILDIOS
+    PR --> E2EAND
+    PR --> E2EIOS
+    PR --> MASTAND
+    PR --> MASIOS
+
+    DEV --> ESLINT
+    DEV --> CHANGELOG
+    DEV --> BUILDAND
+    DEV --> BUILDIOS
+
+    PRET --> SN
+
+    ESLINT --> SN
+
+    BUILDAND --> SN
+    BUILDAND --> FSV
+    BUILDAND --> GBV
+    BUILDAND --> AACT
+    BUILDAND --> UAND
+    BUILDAND --> UIAND
+
+    BUILDIOS --> SN
+    BUILDIOS --> FSV
+    BUILDIOS --> GBV
+    BUILDIOS --> IACT
+    BUILDIOS --> UIOS
+
+    E2EAND --> SN
+    E2EIOS --> SN
+
+    MASTAND --> PREAND
+    MASTAND --> E2EACC
+
+    MASIOS --> E2EACC
+```
+
+## Manual gates
+
+| Environment | Workflow / job | Fires when |
+|---|---|---|
+| `android_build` | [build-android.yml](workflows/build-android.yml) — `build-hold` | Called with `trigger == pr` (i.e. from `build-pr.yml`) |
+| `upload_android` | [build-android.yml](workflows/build-android.yml) — `upload-hold` | Called with `trigger == pr`, after the Android build completes |
+| `ios_build` | [build-ios.yml](workflows/build-ios.yml) — `build-hold` | Called with `trigger == pr` (i.e. from `build-pr.yml`) |
+| `approve_e2e_testing` | [build-pr.yml](workflows/build-pr.yml) — `e2e-hold` | Every `pull_request` run |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,7 @@ pnpm storybook-generate    # Generate story snapshots
 - `index.js` — registers app, conditionally loads Storybook
 - `app/index.tsx` — Redux provider, theme, navigation, notifications setup
 - `app/AppContainer.tsx` — root navigation container
+
+## Continuous Integration
+
+CI triggers, call graph, and manual gates: see `.github/README.md`.


### PR DESCRIPTION
## Proposed changes

Adds a single source of truth for CI visibility. Until now there was no document mapping GitHub Actions triggers to workflows — answering "what runs on a PR?" or "what runs on a push to develop?" meant opening and cross-referencing several of the 12 workflow files, plus the GitHub UI for the approval gates.

This PR adds `.github/README.md` with three sections:

- **Entrypoints** — the 4 event-triggered workflows, their trigger event, and a one-line summary of what each runs.
- **Call graph** — a Mermaid diagram of entrypoint workflows → reusable workflows → composite actions.
- **Manual gates** — the 4 GitHub `environment` approval gates and the condition under which each fires (these previously lived only in the GitHub UI).

It also adds a short **Continuous Integration** section to `CLAUDE.md` pointing to the map.

Scope is deliberately limited to cross-file facts that are not present in any single workflow file (the call graph, the gates, the entrypoint overview), so the document stays low-drift. Per-workflow `on:`/branch/path details remain in the YAML as the source of truth. No workflow or action YAML is modified, so check contexts and branch protection are unaffected.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1343

## How to test or reproduce

- Open `.github/README.md` on GitHub and confirm the Mermaid call graph renders and the workflow links resolve.
- Confirm the entrypoints, call graph, and gates match the current workflow files under `.github/workflows/`.

## Screenshots

N/A — documentation only.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The document intentionally covers only facts that span multiple files. If it begins to drift from the workflows, a natural follow-up is to generate it from the workflow YAML and fail CI when the checked-in copy is stale.

https://claude.ai/code/session_013Ai5iqwADTryxoiJRNdhCa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CI overview page explaining how major GitHub events map to workflows, including a visual call graph and manual gate conditions.
  * Updated the main project guidance with a new “Continuous Integration” section that directs readers to the CI overview for trigger, call graph, and gate details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->