### PR TITLE
refactor: migrate TeamChannelsView to hooks and extract list/permission logic

### DIFF
--- a/app/lib/hooks/usePermissions.test.tsx
+++ b/app/lib/hooks/usePermissions.test.tsx
@@ -1,0 +1,80 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePermissions } from './usePermissions';
+import { getSubscriptionByRoomId } from '../database/services/Subscription';
+
+const mockGetSubscriptionByRoomId = getSubscriptionByRoomId as jest.Mock;
+
+// Drive Redux-derived values (user roles + permission roles) deterministically.
+const mockState = {
+	login: { user: { roles: ['user'] } },
+	permissions: {
+		'create-c': ['admin'],
+		'edit-room': ['room-role']
+	}
+};
+
+jest.mock('./useAppSelector', () => ({
+	useAppSelector: (selector: (state: any) => any) => selector(mockState)
+}));
+
+jest.mock('../database/services/Subscription', () => ({
+	getSubscriptionByRoomId: jest.fn()
+}));
+
+// A subscription stub whose observe() emits the given roles synchronously.
+const makeSub = (roles: string[]) => ({
+	observe: () => ({
+		subscribe: (cb: (s: any) => void) => {
+			cb({ roles });
+			return { unsubscribe: jest.fn() };
+		}
+	})
+});
+
+describe('usePermissions — useSubscriptionRoles rid dependency', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('does not query a subscription while rid is undefined', () => {
+		renderHook(() => usePermissions(['create-c'], undefined));
+		expect(mockGetSubscriptionByRoomId).not.toHaveBeenCalled();
+	});
+
+	it('re-subscribes when rid changes from undefined to a real rid', async () => {
+		mockGetSubscriptionByRoomId.mockResolvedValue(makeSub([]));
+
+		const { rerender } = renderHook(({ rid }: { rid?: string }) => usePermissions(['create-c'], rid), {
+			initialProps: { rid: undefined as string | undefined }
+		});
+
+		expect(mockGetSubscriptionByRoomId).not.toHaveBeenCalled();
+
+		await act(async () => {
+			rerender({ rid: 'room-late' });
+			await Promise.resolve();
+		});
+
+		await waitFor(() => expect(mockGetSubscriptionByRoomId).toHaveBeenCalledWith('room-late'));
+	});
+
+	it('grants permission when a room role from the late-arriving rid matches', async () => {
+		// 'edit-room' is granted to role 'room-role', which the user only has via the room subscription.
+		mockGetSubscriptionByRoomId.mockResolvedValue(makeSub(['room-role']));
+
+		const { result, rerender } = renderHook(({ rid }: { rid?: string }) => usePermissions(['edit-room'], rid), {
+			initialProps: { rid: undefined as string | undefined }
+		});
+
+		// No rid yet => user roles only => not granted.
+		expect(result.current).toEqual([false]);
+
+		await act(async () => {
+			rerender({ rid: 'room-late' });
+			await Promise.resolve();
+		});
+
+		await waitFor(() => expect(result.current).toEqual([true]));
+	});
+});

--- a/app/lib/hooks/usePermissions.ts
+++ b/app/lib/hooks/usePermissions.ts
@@ -16,9 +16,11 @@ export const getPermissionsSelector = createSelector(
 	(permissions, permissionsArray) => permissionsArray.map(p => permissions[p])
 );
 
+const EMPTY_ROLES: TSubscriptionModel['roles'] = [];
+
 const useSubscriptionRoles = (rid?: string): TSubscriptionModel['roles'] => {
-	const [subscriptionRoles, setSubscriptionRoles] = useState<TSubscriptionModel['roles']>([]);
-	const subscriptionRoleRef = useRef<TSubscriptionModel['roles']>([]);
+	const [rolesByRid, setRolesByRid] = useState<{ rid?: string; roles: TSubscriptionModel['roles'] }>({ roles: EMPTY_ROLES });
+	const rolesByRidRef = useRef(rolesByRid);
 
 	useEffect(() => {
 		if (!rid) {
@@ -32,9 +34,9 @@ const useSubscriptionRoles = (rid?: string): TSubscriptionModel['roles'] => {
 			const observable = sub.observe();
 			subSubscription = observable.subscribe(s => {
 				const newRoles = orderBy(s.roles);
-				if (!dequal(subscriptionRoleRef.current, newRoles)) {
-					subscriptionRoleRef.current = newRoles;
-					setSubscriptionRoles(newRoles);
+				if (rolesByRidRef.current.rid !== rid || !dequal(rolesByRidRef.current.roles, newRoles)) {
+					rolesByRidRef.current = { rid, roles: newRoles };
+					setRolesByRid(rolesByRidRef.current);
 				}
 			});
 		});
@@ -44,9 +46,10 @@ const useSubscriptionRoles = (rid?: string): TSubscriptionModel['roles'] => {
 				subSubscription.unsubscribe();
 			}
 		};
-	}, []);
+	}, [rid]);
 
-	return subscriptionRoles;
+	// Ignore roles captured for a previous rid so stale roles never leak after rid changes.
+	return rolesByRid.rid === rid ? rolesByRid.roles : EMPTY_ROLES;
 };
 
 export function usePermissions(permissions: TSupportedPermissions[], rid?: string): boolean[] {

--- a/app/lib/hooks/useTeamChannelPermissions.test.ts
+++ b/app/lib/hooks/useTeamChannelPermissions.test.ts
@@ -1,0 +1,139 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useCreateNewPermission, useAddExistingPermission, useCanCreateTeamChannel } from './useTeamChannelPermissions';
+
+const mockUsePermissions = jest.fn();
+let mockServerVersion: string | undefined;
+
+jest.mock('./usePermissions', () => ({
+	usePermissions: (permissions: string[], rid?: string) => mockUsePermissions(permissions, rid)
+}));
+
+jest.mock('react-redux', () => ({
+	...jest.requireActual('react-redux'),
+	useSelector: (selector: (state: any) => any) => selector({ server: { version: mockServerVersion } })
+}));
+
+// Resolve the granted result by which permissions were requested, so a single
+// mock can serve both hooks regardless of call order.
+const grant = (granted: string[]) => (permissions: string[]) => permissions.map(p => granted.includes(p));
+
+const RID = 'room-1';
+
+describe('useTeamChannelPermissions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockServerVersion = '7.0.0';
+	});
+
+	describe('useCreateNewPermission', () => {
+		it('v7+ t=c requests create-c and create-team-channel', () => {
+			mockUsePermissions.mockImplementation(grant([]));
+			renderHook(() => useCreateNewPermission(RID, 'c'));
+			expect(mockUsePermissions).toHaveBeenCalledWith(['create-c', 'create-team-channel'], RID);
+		});
+
+		it('v7+ t=p requests create-p and create-team-group', () => {
+			mockUsePermissions.mockImplementation(grant([]));
+			renderHook(() => useCreateNewPermission(RID, 'p'));
+			expect(mockUsePermissions).toHaveBeenCalledWith(['create-p', 'create-team-group'], RID);
+		});
+
+		it('pre-v7 t=c requests only create-c', () => {
+			mockServerVersion = '6.0.0';
+			mockUsePermissions.mockImplementation(grant([]));
+			renderHook(() => useCreateNewPermission(RID, 'c'));
+			expect(mockUsePermissions).toHaveBeenCalledWith(['create-c'], RID);
+		});
+
+		it('pre-v7 t=p requests only create-p', () => {
+			mockServerVersion = '6.0.0';
+			mockUsePermissions.mockImplementation(grant([]));
+			renderHook(() => useCreateNewPermission(RID, 'p'));
+			expect(mockUsePermissions).toHaveBeenCalledWith(['create-p'], RID);
+		});
+
+		it('returns true when any requested permission is granted', () => {
+			mockUsePermissions.mockImplementation(grant(['create-team-channel']));
+			const { result } = renderHook(() => useCreateNewPermission(RID, 'c'));
+			expect(result.current).toBe(true);
+		});
+
+		it('returns false when no requested permission is granted', () => {
+			mockUsePermissions.mockImplementation(grant([]));
+			const { result } = renderHook(() => useCreateNewPermission(RID, 'c'));
+			expect(result.current).toBe(false);
+		});
+	});
+
+	describe('useAddExistingPermission', () => {
+		it('v7+ requests move-room-to-team', () => {
+			mockUsePermissions.mockImplementation(grant([]));
+			renderHook(() => useAddExistingPermission(RID));
+			expect(mockUsePermissions).toHaveBeenCalledWith(['move-room-to-team'], RID);
+		});
+
+		it('pre-v7 requests add-team-channel', () => {
+			mockServerVersion = '6.0.0';
+			mockUsePermissions.mockImplementation(grant([]));
+			renderHook(() => useAddExistingPermission(RID));
+			expect(mockUsePermissions).toHaveBeenCalledWith(['add-team-channel'], RID);
+		});
+
+		it('returns the first (and only) permission result', () => {
+			mockUsePermissions.mockImplementation(grant(['move-room-to-team']));
+			const { result } = renderHook(() => useAddExistingPermission(RID));
+			expect(result.current).toBe(true);
+		});
+	});
+
+	describe('useCanCreateTeamChannel — equivalence with the old async logic', () => {
+		// Old v7+: t=c => moveRoomToTeam || createC || createTeamChannel ; t=p => moveRoomToTeam || createP || createTeamGroup
+		// Old pre-v7: t=c => addTeamChannel || createC ; t=p => addTeamChannel || createP
+
+		it('v7+ t=c true when only moveRoomToTeam granted', () => {
+			mockUsePermissions.mockImplementation(grant(['move-room-to-team']));
+			const { result } = renderHook(() => useCanCreateTeamChannel(RID, 'c'));
+			expect(result.current).toBe(true);
+		});
+
+		it('v7+ t=c true when only create-team-channel granted', () => {
+			mockUsePermissions.mockImplementation(grant(['create-team-channel']));
+			const { result } = renderHook(() => useCanCreateTeamChannel(RID, 'c'));
+			expect(result.current).toBe(true);
+		});
+
+		it('v7+ t=p true when only create-team-group granted', () => {
+			mockUsePermissions.mockImplementation(grant(['create-team-group']));
+			const { result } = renderHook(() => useCanCreateTeamChannel(RID, 'p'));
+			expect(result.current).toBe(true);
+		});
+
+		it('v7+ t=c false when none of move-room-to-team/create-c/create-team-channel granted', () => {
+			mockUsePermissions.mockImplementation(grant(['add-team-channel', 'create-p']));
+			const { result } = renderHook(() => useCanCreateTeamChannel(RID, 'c'));
+			expect(result.current).toBe(false);
+		});
+
+		it('pre-v7 t=c true when only addTeamChannel granted', () => {
+			mockServerVersion = '6.0.0';
+			mockUsePermissions.mockImplementation(grant(['add-team-channel']));
+			const { result } = renderHook(() => useCanCreateTeamChannel(RID, 'c'));
+			expect(result.current).toBe(true);
+		});
+
+		it('pre-v7 t=p true when only create-p granted', () => {
+			mockServerVersion = '6.0.0';
+			mockUsePermissions.mockImplementation(grant(['create-p']));
+			const { result } = renderHook(() => useCanCreateTeamChannel(RID, 'p'));
+			expect(result.current).toBe(true);
+		});
+
+		it('pre-v7 t=c false when only v7 perms granted', () => {
+			mockServerVersion = '6.0.0';
+			mockUsePermissions.mockImplementation(grant(['move-room-to-team', 'create-team-channel']));
+			const { result } = renderHook(() => useCanCreateTeamChannel(RID, 'c'));
+			expect(result.current).toBe(false);
+		});
+	});
+});

--- a/app/lib/hooks/useTeamChannelPermissions.ts
+++ b/app/lib/hooks/useTeamChannelPermissions.ts
@@ -1,0 +1,36 @@
+import { useSelector } from 'react-redux';
+
+import { type IApplicationState } from '../../definitions';
+import { usePermissions } from './usePermissions';
+import { compareServerVersion } from '../methods/helpers';
+import { type TSupportedPermissions } from '../../reducers/permissions';
+
+export const useCreateNewPermission = (rid: string, t: 'c' | 'p') => {
+	const permissions: TSupportedPermissions[] = t === 'c' ? ['create-c'] : ['create-p'];
+
+	const serverVersion = useSelector((state: IApplicationState) => state.server.version);
+	if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
+		permissions.push(t === 'c' ? 'create-team-channel' : 'create-team-group');
+	}
+
+	const result = usePermissions(permissions, rid);
+	return result.some(Boolean);
+};
+
+export const useAddExistingPermission = (rid: string) => {
+	let permissions: TSupportedPermissions[] = ['add-team-channel'];
+
+	const serverVersion = useSelector((state: IApplicationState) => state.server.version);
+	if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
+		permissions = ['move-room-to-team'];
+	}
+
+	const result = usePermissions(permissions, rid);
+	return result[0];
+};
+
+export const useCanCreateTeamChannel = (rid: string, t: 'c' | 'p') => {
+	const canCreateNew = useCreateNewPermission(rid, t);
+	const canAddExisting = useAddExistingPermission(rid);
+	return canCreateNew || canAddExisting;
+};

--- a/app/views/AddChannelTeamView.tsx
+++ b/app/views/AddChannelTeamView.tsx
@@ -1,18 +1,14 @@
 import { useLayoutEffect } from 'react';
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { type CompositeNavigationProp } from '@react-navigation/core';
 
 import * as List from '../containers/List';
 import SafeAreaView from '../containers/SafeAreaView';
 import I18n from '../i18n';
 import { type ChatsStackParamList, type DrawerParamList, type NewMessageStackParamList } from '../stacks/types';
-import { type IApplicationState } from '../definitions';
-import { usePermissions } from '../lib/hooks/usePermissions';
+import { useCreateNewPermission, useAddExistingPermission } from '../lib/hooks/useTeamChannelPermissions';
 import { useMasterDetail } from '../lib/hooks/useMasterDetail';
-import { compareServerVersion } from '../lib/methods/helpers';
-import { type TSupportedPermissions } from '../reducers/permissions';
 
 type TRoute = RouteProp<ChatsStackParamList, 'AddChannelTeamView'>;
 
@@ -20,30 +16,6 @@ type TNavigation = CompositeNavigationProp<
 	NativeStackNavigationProp<ChatsStackParamList, 'AddChannelTeamView'>,
 	CompositeNavigationProp<NativeStackNavigationProp<NewMessageStackParamList>, NativeStackNavigationProp<DrawerParamList>>
 >;
-
-const useCreateNewPermission = (rid: string, t: 'c' | 'p') => {
-	const permissions: TSupportedPermissions[] = t === 'c' ? ['create-c'] : ['create-p'];
-
-	const serverVersion = useSelector((state: IApplicationState) => state.server.version);
-	if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
-		permissions.push(t === 'c' ? 'create-team-channel' : 'create-team-group');
-	}
-
-	const result = usePermissions(permissions, rid);
-	return result.some(Boolean);
-};
-
-const useAddExistingPermission = (rid: string) => {
-	let permissions: TSupportedPermissions[] = ['add-team-channel'];
-
-	const serverVersion = useSelector((state: IApplicationState) => state.server.version);
-	if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
-		permissions = ['move-room-to-team'];
-	}
-
-	const result = usePermissions(permissions, rid);
-	return result[0];
-};
 
 const AddChannelTeamView = () => {
 	const navigation = useNavigation<TNavigation>();

--- a/app/views/TeamChannelsView.test.tsx
+++ b/app/views/TeamChannelsView.test.tsx
@@ -45,31 +45,32 @@ jest.mock('../theme', () => ({
 	})
 }));
 
+const mockReduxState = {
+	server: { version: '7.0.0' },
+	settings: {
+		UI_Use_Real_Name: false,
+		Store_Last_Message: false
+	},
+	permissions: {
+		'add-team-channel': ['add-team-channel-role'],
+		'move-room-to-team': ['move-room-to-team-role'],
+		'edit-team-channel': ['edit-team-channel-role'],
+		'remove-team-channel': ['remove-team-channel-role'],
+		'delete-c': ['delete-c-role'],
+		'create-c': ['create-c-role'],
+		'create-team-channel': ['create-team-channel-role'],
+		'create-p': ['create-p-role'],
+		'create-team-group': ['create-team-group-role'],
+		'delete-p': ['delete-p-role']
+	},
+	sortPreferences: {
+		showAvatar: false,
+		displayMode: 'expanded'
+	}
+};
+
 jest.mock('../lib/hooks/useAppSelector', () => ({
-	useAppSelector: (selector: (state: any) => unknown) =>
-		selector({
-			server: { version: '7.0.0' },
-			settings: {
-				UI_Use_Real_Name: false,
-				Store_Last_Message: false
-			},
-			permissions: {
-				'add-team-channel': ['add-team-channel-role'],
-				'move-room-to-team': ['move-room-to-team-role'],
-				'edit-team-channel': ['edit-team-channel-role'],
-				'remove-team-channel': ['remove-team-channel-role'],
-				'delete-c': ['delete-c-role'],
-				'create-c': ['create-c-role'],
-				'create-team-channel': ['create-team-channel-role'],
-				'create-p': ['create-p-role'],
-				'create-team-group': ['create-team-group-role'],
-				'delete-p': ['delete-p-role']
-			},
-			sortPreferences: {
-				showAvatar: false,
-				displayMode: 'expanded'
-			}
-		})
+	useAppSelector: (selector: (state: any) => unknown) => selector(mockReduxState)
 }));
 
 jest.mock('../lib/hooks/useMasterDetail', () => ({

--- a/app/views/TeamChannelsView.test.tsx
+++ b/app/views/TeamChannelsView.test.tsx
@@ -1,0 +1,519 @@
+import { Alert } from 'react-native';
+import { BorderlessButton } from 'react-native-gesture-handler';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import TeamChannelsView, { type IItem } from './TeamChannelsView';
+
+const mockShowActionSheet = jest.fn();
+const mockPop = jest.fn();
+const mockSetOptions = jest.fn();
+const mockNavigate = jest.fn();
+
+const mockNavigation = {
+	addListener: jest.fn(() => jest.fn()),
+	setOptions: mockSetOptions,
+	pop: mockPop,
+	navigate: mockNavigate
+};
+
+const defaultRouteParams = {
+	teamId: 'team-123',
+	joined: true
+};
+
+jest.mock('../lib/hooks/navigation', () => ({
+	useAppNavigation: () => mockNavigation,
+	useAppRoute: () => ({
+		params: defaultRouteParams
+	})
+}));
+
+jest.mock('../containers/ActionSheet', () => ({
+	useActionSheet: () => ({
+		showActionSheet: mockShowActionSheet
+	})
+}));
+
+jest.mock('../theme', () => ({
+	useTheme: () => ({
+		colors: {
+			surfaceRoom: 'white',
+			fontDefault: '#111',
+			fontHint: '#999',
+			fontTitlesLabels: '#222'
+		}
+	})
+}));
+
+jest.mock('../lib/hooks/useAppSelector', () => ({
+	useAppSelector: (selector: (state: any) => unknown) =>
+		selector({
+			server: { version: '7.0.0' },
+			settings: {
+				UI_Use_Real_Name: false,
+				Store_Last_Message: false
+			},
+			permissions: {
+				'add-team-channel': ['add-team-channel-role'],
+				'move-room-to-team': ['move-room-to-team-role'],
+				'edit-team-channel': ['edit-team-channel-role'],
+				'remove-team-channel': ['remove-team-channel-role'],
+				'delete-c': ['delete-c-role'],
+				'create-c': ['create-c-role'],
+				'create-team-channel': ['create-team-channel-role'],
+				'create-p': ['create-p-role'],
+				'create-team-group': ['create-team-group-role'],
+				'delete-p': ['delete-p-role']
+			},
+			sortPreferences: {
+				showAvatar: false,
+				displayMode: 'expanded'
+			}
+		})
+}));
+
+jest.mock('../lib/hooks/useMasterDetail', () => ({
+	useMasterDetail: () => false
+}));
+
+const mockTeamSubscription = {
+	_id: 'sub-main',
+	rid: 'room-main',
+	teamId: 'team-123',
+	teamMain: true,
+	t: 'c',
+	name: 'team-channel',
+	fname: 'Team Channel',
+	topic: 'A team topic',
+	observe: jest.fn(() => ({ subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })) }))
+};
+
+const mockChildSubscription = {
+	_id: 'sub-child',
+	rid: 'room-child',
+	teamId: 'team-123',
+	teamMain: false,
+	t: 'c',
+	name: 'child-channel',
+	fname: 'Child Channel',
+	observe: jest.fn()
+};
+
+const mockFetch = jest.fn();
+const mockFind = jest.fn();
+const mockQuery = jest.fn(() => ({ fetch: mockFetch }));
+const mockGet = jest.fn(() => ({ query: mockQuery, find: mockFind }));
+
+jest.mock('../lib/database', () => ({
+	__esModule: true,
+	default: {
+		get active() {
+			return { get: mockGet };
+		}
+	}
+}));
+
+const mockGetTeamListRoom = jest.fn();
+const mockGetRoomInfo = jest.fn();
+const mockUpdateTeamRoom = jest.fn();
+const mockRemoveTeamRoom = jest.fn();
+const mockHasPermission = jest.fn();
+
+jest.mock('../lib/services/restApi', () => ({
+	getTeamListRoom: (...args: any[]) => mockGetTeamListRoom(...args),
+	getRoomInfo: (...args: any[]) => mockGetRoomInfo(...args),
+	updateTeamRoom: (...args: any[]) => mockUpdateTeamRoom(...args),
+	removeTeamRoom: (...args: any[]) => mockRemoveTeamRoom(...args)
+}));
+
+jest.mock('../lib/methods/helpers', () => ({
+	...jest.requireActual('../lib/methods/helpers'),
+	hasPermission: (...args: any[]) => mockHasPermission(...args),
+	getRoomTitle: (room: any) => room.fname || room.name,
+	getRoomAvatar: () => '',
+	isIOS: false,
+	compareServerVersion: jest.requireActual('../lib/methods/helpers').compareServerVersion
+}));
+
+jest.mock('../lib/methods/helpers/goRoom', () => ({
+	goRoom: jest.fn()
+}));
+
+jest.mock('../lib/methods/helpers/info', () => ({
+	showErrorAlert: jest.fn()
+}));
+
+jest.mock('../lib/methods/helpers/log', () => ({
+	__esModule: true,
+	default: jest.fn(),
+	logEvent: jest.fn(),
+	events: {
+		TC_SEARCH: 'TC_SEARCH',
+		TC_CANCEL_SEARCH: 'TC_CANCEL_SEARCH',
+		TC_GO_ACTIONS: 'TC_GO_ACTIONS',
+		TC_GO_ROOM: 'TC_GO_ROOM',
+		TC_TOGGLE_AUTOJOIN: 'TC_TOGGLE_AUTOJOIN',
+		TC_TOGGLE_AUTOJOIN_F: 'TC_TOGGLE_AUTOJOIN_F',
+		TC_DELETE_ROOM: 'TC_DELETE_ROOM',
+		TC_DELETE_ROOM_F: 'TC_DELETE_ROOM_F',
+		ROOM_SHOW_BOX_ACTIONS: 'ROOM_SHOW_BOX_ACTIONS'
+	}
+}));
+
+jest.mock('../actions/room', () => ({
+	deleteRoom: jest.fn(() => ({ type: 'DELETE_ROOM' }))
+}));
+
+jest.mock('react-redux', () => ({
+	...jest.requireActual('react-redux'),
+	useDispatch: () => jest.fn()
+}));
+
+jest.mock('../containers/RoomItem', () => {
+	const { TouchableOpacity, Text } = require('react-native');
+	return ({ item, onPress, onLongPress }: any) => (
+		<TouchableOpacity testID={`room-item-${item._id}`} onPress={() => onPress(item)} onLongPress={() => onLongPress(item)}>
+			<Text>{item.fname}</Text>
+		</TouchableOpacity>
+	);
+});
+
+jest.mock('../containers/RoomHeader', () => () => null);
+
+jest.mock('../containers/BackgroundContainer', () => {
+	const { View, Text } = require('react-native');
+	return ({ loading, text }: any) => (
+		<View testID='background-container'>
+			{loading && <Text testID='loading-indicator'>loading</Text>}
+			{text !== undefined && <Text testID='background-text'>{text}</Text>}
+		</View>
+	);
+});
+
+jest.mock('../containers/ActivityIndicator', () => () => null);
+
+jest.mock('../containers/SafeAreaView', () => {
+	const { View } = require('react-native');
+	return ({ children, testID }: any) => <View testID={testID}>{children}</View>;
+});
+
+jest.mock('../containers/SearchHeader', () => {
+	const { TextInput } = require('react-native');
+	return ({ onSearchChangeText, testID }: any) => <TextInput testID={testID} onChangeText={onSearchChangeText} />;
+});
+
+const makeRoom = (overrides: Partial<IItem> = {}): IItem => ({
+	_id: 'room-1' as any,
+	fname: 'Room One',
+	name: 'room-one',
+	customFields: {},
+	broadcast: false,
+	encrypted: false,
+	t: 'c',
+	msgs: 0,
+	usersCount: 0,
+	u: { _id: 'u1', name: 'User' },
+	ts: '',
+	ro: false,
+	teamId: 'team-123',
+	default: false,
+	sysMes: false,
+	_updatedAt: '',
+	teamDefault: false,
+	...overrides
+});
+
+const setupSuccessfulLoad = (rooms: IItem[] = [makeRoom()]) => {
+	mockFetch.mockResolvedValue([mockTeamSubscription, mockChildSubscription]);
+	mockHasPermission.mockResolvedValue([true, true, true]);
+	mockGetTeamListRoom.mockResolvedValue({ success: true, rooms });
+};
+
+// The most recent navigation options applied by the reactive header effect.
+const lastSetOptions = () => mockSetOptions.mock.calls[mockSetOptions.mock.calls.length - 1][0];
+
+// Render a header slot (headerLeft/headerTitle/headerRight) so its real buttons/inputs are queryable.
+const renderHeaderSlot = (slot: () => any) => render(slot());
+
+describe('TeamChannelsView', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('1. Renders team-channels-view; shows loading while loading', () => {
+		it('renders SafeAreaView with testID team-channels-view', () => {
+			mockFetch.mockResolvedValue([mockTeamSubscription]);
+			mockHasPermission.mockResolvedValue([false]);
+			mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [] });
+
+			const { getByTestId } = render(<TeamChannelsView />);
+			expect(getByTestId('team-channels-view')).toBeTruthy();
+		});
+
+		it('shows loading background container while loading=true', async () => {
+			mockFetch.mockResolvedValue([mockTeamSubscription]);
+			mockHasPermission.mockResolvedValue([false]);
+			// Never resolves during this test phase
+			mockGetTeamListRoom.mockReturnValue(new Promise(() => {}));
+
+			const { getByTestId } = render(<TeamChannelsView />);
+			await waitFor(() => expect(getByTestId('loading-indicator')).toBeTruthy());
+		});
+	});
+
+	describe('2. loadTeam — team from DB; not-found → pop + alert', () => {
+		it('pops and shows error when team subscription is not found', async () => {
+			const { showErrorAlert } = require('../lib/methods/helpers/info');
+			mockFetch.mockResolvedValue([mockChildSubscription]);
+			mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [] });
+
+			render(<TeamChannelsView />);
+
+			await waitFor(() => expect(mockPop).toHaveBeenCalledTimes(1));
+			expect(showErrorAlert).toHaveBeenCalledWith('Team not found');
+		});
+
+		it('pops and shows error when DB query throws', async () => {
+			const { showErrorAlert } = require('../lib/methods/helpers/info');
+			mockFetch.mockRejectedValue(new Error('DB error'));
+			mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [] });
+
+			render(<TeamChannelsView />);
+
+			await waitFor(() => expect(mockPop).toHaveBeenCalledTimes(1));
+			expect(showErrorAlert).toHaveBeenCalledWith('Team not found');
+		});
+	});
+
+	describe('3. Initial load fetches channels; end set when result < API_FETCH_COUNT', () => {
+		it('renders room items after loading', async () => {
+			const rooms = [makeRoom({ _id: 'r1' as any, fname: 'Room One' })];
+			setupSuccessfulLoad(rooms);
+
+			const { findByTestId } = render(<TeamChannelsView />);
+
+			await findByTestId('room-item-r1');
+			expect(mockGetTeamListRoom).toHaveBeenCalledWith(expect.objectContaining({ teamId: 'team-123', offset: 0, count: 25 }));
+		});
+
+		it('sets end=true when result count < API_FETCH_COUNT (25)', async () => {
+			const rooms = [makeRoom({ _id: 'r1' as any })];
+			setupSuccessfulLoad(rooms);
+
+			mockGetTeamListRoom.mockResolvedValueOnce({ success: true, rooms });
+
+			const { findByTestId } = render(<TeamChannelsView />);
+			await findByTestId('room-item-r1');
+
+			// Second load attempt should not fire (end=true, only 1 item < 25)
+			const callCount = mockGetTeamListRoom.mock.calls.length;
+			expect(callCount).toBe(1);
+		});
+	});
+
+	describe('4. onEndReached triggers pagination', () => {
+		it('appends more data on end reached', async () => {
+			const page1 = Array.from({ length: 25 }, (_, i) => makeRoom({ _id: `r${i}` as any, fname: `Room ${i}` }));
+			const page2 = [makeRoom({ _id: 'r-extra' as any, fname: 'Extra Room' })];
+
+			mockFetch.mockResolvedValue([mockTeamSubscription, mockChildSubscription]);
+			mockHasPermission.mockResolvedValue([true, true, true]);
+			mockGetTeamListRoom
+				.mockResolvedValueOnce({ success: true, rooms: page1 })
+				.mockResolvedValueOnce({ success: true, rooms: page2 });
+
+			const { UNSAFE_getByType, findByTestId } = render(<TeamChannelsView />);
+
+			await findByTestId('room-item-r0');
+
+			const { FlatList } = require('react-native');
+			const flatList = UNSAFE_getByType(FlatList);
+
+			await act(() => {
+				flatList.props.onEndReached?.();
+			});
+
+			await waitFor(() => expect(mockGetTeamListRoom).toHaveBeenCalledTimes(2));
+		});
+	});
+
+	describe('5. Search: header switches; typing filters; cancel restores', () => {
+		it('setOptions is called on mount (normal header)', async () => {
+			setupSuccessfulLoad([]);
+			mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [] });
+
+			render(<TeamChannelsView />);
+
+			await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+		});
+
+		it('pressing search then typing fetches with offset 0 and the typed filter', async () => {
+			setupSuccessfulLoad([makeRoom({ _id: 'r1' as any })]);
+
+			const { findByTestId } = render(<TeamChannelsView />);
+			await findByTestId('room-item-r1');
+
+			// Press the search button rendered in the normal header (drives onSearchPress).
+			const normalHeader = lastSetOptions();
+			const searchButton = await renderHeaderSlot(normalHeader.headerRight).findByTestId('team-channels-view-search');
+			await act(() => {
+				fireEvent.press(searchButton);
+			});
+
+			// The reactive header effect re-applies options with the SearchHeader title.
+			await waitFor(() => expect(lastSetOptions().headerTitle).toBeDefined());
+			mockGetTeamListRoom.mockClear();
+
+			const searchHeader = lastSetOptions();
+			const searchInput = renderHeaderSlot(searchHeader.headerTitle).getByTestId('team-channels-view-search-header');
+			await act(() => {
+				fireEvent.changeText(searchInput, 'design');
+			});
+
+			await waitFor(
+				() => expect(mockGetTeamListRoom).toHaveBeenCalledWith(expect.objectContaining({ offset: 0, filter: 'design' })),
+				{ timeout: 2000 }
+			);
+		});
+
+		it('pressing the close button in search mode restores the normal header', async () => {
+			setupSuccessfulLoad([makeRoom({ _id: 'r1' as any })]);
+
+			const { findByTestId } = render(<TeamChannelsView />);
+			await findByTestId('room-item-r1');
+
+			// Enter search mode.
+			const searchButton = await renderHeaderSlot(lastSetOptions().headerRight).findByTestId('team-channels-view-search');
+			await act(() => {
+				fireEvent.press(searchButton);
+			});
+
+			// Confirm the search header is now active.
+			await waitFor(() =>
+				expect(renderHeaderSlot(lastSetOptions().headerTitle).getByTestId('team-channels-view-search-header')).toBeTruthy()
+			);
+
+			// Press the close button in the search headerLeft slot.
+			const closeButton = renderHeaderSlot(lastSetOptions().headerLeft).UNSAFE_getAllByType(BorderlessButton)[0];
+			await act(() => {
+				fireEvent.press(closeButton);
+			});
+
+			// Normal header is restored: search button is back, search header is gone.
+			await waitFor(() =>
+				expect(renderHeaderSlot(lastSetOptions().headerRight).getByTestId('team-channels-view-search')).toBeTruthy()
+			);
+			expect(lastSetOptions().headerTitle).toBeDefined();
+			expect(renderHeaderSlot(lastSetOptions().headerTitle).queryByTestId('team-channels-view-search-header')).toBeNull();
+		});
+	});
+
+	describe('6. toggleAutoJoin and removeRoom', () => {
+		it('toggleAutoJoin flips teamDefault on item', async () => {
+			const room = makeRoom({ _id: 'r1' as any, teamDefault: false });
+			setupSuccessfulLoad([room]);
+			mockHasPermission.mockResolvedValue([true, true, true]);
+			mockUpdateTeamRoom.mockResolvedValue({ success: true });
+
+			mockShowActionSheet.mockImplementation(({ options }: any) => {
+				const autoJoinOption = options.find((o: any) => o.testID === 'action-sheet-auto-join');
+				autoJoinOption?.onPress();
+			});
+
+			const { findByTestId } = render(<TeamChannelsView />);
+			const item = await findByTestId('room-item-r1');
+
+			await act(() => {
+				fireEvent(item, 'longPress');
+			});
+
+			await waitFor(() => expect(mockUpdateTeamRoom).toHaveBeenCalledWith({ roomId: 'r1', isDefault: true }));
+		});
+
+		it('removeRoom filters item out of data after success', async () => {
+			const room = makeRoom({ _id: 'r1' as any });
+			setupSuccessfulLoad([room]);
+			mockRemoveTeamRoom.mockResolvedValue({ success: true, room: { _id: 'r1' } });
+
+			// Action sheet: press the "remove from team" option.
+			mockShowActionSheet.mockImplementation(({ options }: any) => {
+				options.find((o: any) => o.testID === 'action-sheet-remove-from-team')?.onPress();
+			});
+			// Confirmation alert: press the destructive button.
+			const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_title, _message, buttons) => {
+				buttons?.find(b => b.style === 'destructive')?.onPress?.();
+			});
+
+			const { findByTestId, queryByTestId } = render(<TeamChannelsView />);
+			const item = await findByTestId('room-item-r1');
+
+			await act(() => {
+				fireEvent(item, 'longPress');
+			});
+
+			await waitFor(() => expect(mockRemoveTeamRoom).toHaveBeenCalledWith({ roomId: 'r1', teamId: 'team-123' }));
+			await waitFor(() => expect(queryByTestId('room-item-r1')).toBeNull());
+
+			alertSpy.mockRestore();
+		});
+	});
+
+	describe('7. Action sheet options gated by permissions', () => {
+		it('shows auto-join option when edit-team-channel permission is granted', async () => {
+			const room = makeRoom({ _id: 'r1' as any });
+			setupSuccessfulLoad([room]);
+
+			mockHasPermission.mockImplementation((perms: any[]) => Promise.resolve(perms.map(() => true)));
+
+			const { findByTestId } = render(<TeamChannelsView />);
+			const item = await findByTestId('room-item-r1');
+
+			await act(() => {
+				fireEvent(item, 'longPress');
+			});
+
+			await waitFor(() => expect(mockShowActionSheet).toHaveBeenCalled());
+			const { options } = mockShowActionSheet.mock.calls[0][0];
+			const hasAutoJoin = options?.some((o: any) => o.testID === 'action-sheet-auto-join');
+			expect(hasAutoJoin).toBe(true);
+		});
+
+		it('does not call showActionSheet when no permissions', async () => {
+			const room = makeRoom({ _id: 'r1' as any });
+			setupSuccessfulLoad([room]);
+
+			mockHasPermission.mockResolvedValue([false, false, false]);
+
+			const { findByTestId } = render(<TeamChannelsView />);
+			const item = await findByTestId('room-item-r1');
+
+			await act(() => {
+				fireEvent(item, 'longPress');
+			});
+
+			await waitFor(() => {
+				expect(mockShowActionSheet).not.toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('8. Create button shown only when showCreate', () => {
+		it('calls setOptions when hasCreatePermission is true', async () => {
+			setupSuccessfulLoad([]);
+			mockHasPermission.mockResolvedValue([true, true, true]);
+
+			render(<TeamChannelsView />);
+
+			await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+		});
+
+		it('calls setOptions when hasCreatePermission is false', async () => {
+			setupSuccessfulLoad([]);
+			mockHasPermission.mockResolvedValue([false, false, false]);
+
+			render(<TeamChannelsView />);
+
+			await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+		});
+	});
+});

--- a/app/views/TeamChannelsView.tsx
+++ b/app/views/TeamChannelsView.tsx
@@ -2,7 +2,7 @@ import { Q } from '@nozbe/watermelondb';
 import { type NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import { Alert, FlatList, Keyboard, PixelRatio, useWindowDimensions } from 'react-native';
 import { shallowEqual, useDispatch } from 'react-redux';
-import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { useEffect, useReducer } from 'react';
 
 import { deleteRoom } from '../actions/room';
 import { type DisplayMode } from '../lib/constants/constantDisplayMode';
@@ -32,6 +32,8 @@ import { getRoomAvatar, getRoomTitle, hasPermission, useDebounce, isIOS, compare
 import { getRoomInfo, getTeamListRoom, updateTeamRoom, removeTeamRoom } from '../lib/services/restApi';
 
 const API_FETCH_COUNT = 25;
+
+const EMPTY_PERMISSION: string[] = [];
 
 const getItemLayout = (data: ArrayLike<IItem> | null | undefined, index: number) => {
 	const rowHeight = 75 * PixelRatio.getFontScale();
@@ -105,12 +107,18 @@ const initialState: ITeamChannelsViewState = {
 	team: null
 };
 
-const stateReducer = (state: ITeamChannelsViewState, partial: Partial<ITeamChannelsViewState>): ITeamChannelsViewState => ({
+type TeamChannelsStateUpdate =
+	| Partial<ITeamChannelsViewState>
+	| ((state: ITeamChannelsViewState) => Partial<ITeamChannelsViewState>);
+
+const stateReducer = (state: ITeamChannelsViewState, update: TeamChannelsStateUpdate): ITeamChannelsViewState => ({
 	...state,
-	...partial
+	...(typeof update === 'function' ? update(state) : update)
 });
 
 const TeamChannelsView = () => {
+	'use memo';
+
 	const navigation = useAppNavigation<ChatsStackParamList, 'TeamChannelsView'>();
 	const {
 		params: { teamId, joined }
@@ -143,16 +151,16 @@ const TeamChannelsView = () => {
 			serverVersion: state.server.version as string,
 			useRealName: state.settings.UI_Use_Real_Name as boolean,
 			StoreLastMessage: state.settings.Store_Last_Message as boolean,
-			addTeamChannelPermission: state.permissions['add-team-channel'] ?? [],
-			moveRoomToTeamPermission: state.permissions['move-room-to-team'] ?? [],
-			editTeamChannelPermission: state.permissions['edit-team-channel'] ?? [],
-			removeTeamChannelPermission: state.permissions['remove-team-channel'] ?? [],
-			createCPermission: state.permissions['create-c'] ?? [],
-			createTeamChannelPermission: state.permissions['create-team-channel'] ?? [],
-			createPPermission: state.permissions['create-p'] ?? [],
-			createTeamGroupPermission: state.permissions['create-team-group'] ?? [],
-			deleteCPermission: state.permissions['delete-c'] ?? [],
-			deletePPermission: state.permissions['delete-p'] ?? [],
+			addTeamChannelPermission: state.permissions['add-team-channel'] ?? EMPTY_PERMISSION,
+			moveRoomToTeamPermission: state.permissions['move-room-to-team'] ?? EMPTY_PERMISSION,
+			editTeamChannelPermission: state.permissions['edit-team-channel'] ?? EMPTY_PERMISSION,
+			removeTeamChannelPermission: state.permissions['remove-team-channel'] ?? EMPTY_PERMISSION,
+			createCPermission: state.permissions['create-c'] ?? EMPTY_PERMISSION,
+			createTeamChannelPermission: state.permissions['create-team-channel'] ?? EMPTY_PERMISSION,
+			createPPermission: state.permissions['create-p'] ?? EMPTY_PERMISSION,
+			createTeamGroupPermission: state.permissions['create-team-group'] ?? EMPTY_PERMISSION,
+			deleteCPermission: state.permissions['delete-c'] ?? EMPTY_PERMISSION,
+			deletePPermission: state.permissions['delete-p'] ?? EMPTY_PERMISSION,
 			showAvatar: state.sortPreferences.showAvatar,
 			displayMode: state.sortPreferences.displayMode
 		}),
@@ -162,11 +170,8 @@ const TeamChannelsView = () => {
 	const [state, updateState] = useReducer(stateReducer, initialState);
 	const { loading, loadingMore, data, isSearching, searchText, search, showCreate, team } = state;
 
-	const stateRef = useRef(state);
-	stateRef.current = state;
-
 	const load = useDebounce(async () => {
-		const { loadingMore, data, search, isSearching, searchText, end } = stateRef.current;
+		const { loadingMore, data, search, isSearching, searchText, end } = state;
 		const length = isSearching ? search.length : data.length;
 		if (loadingMore || end) {
 			return;
@@ -205,26 +210,6 @@ const TeamChannelsView = () => {
 		}
 	}, 300);
 
-	const onSearchPress = useCallback(() => {
-		logEvent(events.TC_SEARCH);
-		updateState({ isSearching: true });
-	}, []);
-
-	const onCancelSearchPress = useCallback(() => {
-		logEvent(events.TC_CANCEL_SEARCH);
-		if (!stateRef.current.isSearching) {
-			return;
-		}
-		Keyboard.dismiss();
-		updateState({
-			searchText: null,
-			isSearching: false,
-			search: [],
-			loadingMore: false,
-			end: false
-		});
-	}, []);
-
 	const onSearchChangeText = useDebounce((text: string) => {
 		updateState({
 			searchText: text,
@@ -238,13 +223,33 @@ const TeamChannelsView = () => {
 		}
 	}, textInputDebounceTime);
 
-	const goRoomActionsView = useCallback(
-		(screen?: string) => {
-			logEvent(events.TC_GO_ACTIONS);
-			const { team } = stateRef.current;
-			if (!team) {
+	useEffect(() => {
+		if (!team) {
+			return;
+		}
+
+		const onSearchPress = () => {
+			logEvent(events.TC_SEARCH);
+			updateState({ isSearching: true });
+		};
+
+		const onCancelSearchPress = () => {
+			logEvent(events.TC_CANCEL_SEARCH);
+			if (!isSearching) {
 				return;
 			}
+			Keyboard.dismiss();
+			updateState({
+				searchText: null,
+				isSearching: false,
+				search: [],
+				loadingMore: false,
+				end: false
+			});
+		};
+
+		const goRoomActionsView = (screen?: string) => {
+			logEvent(events.TC_GO_ACTIONS);
 			if (isMasterDetail && screen) {
 				navigation.navigate('ModalStackNavigator', {
 					screen: 'RoomActionsView',
@@ -263,14 +268,7 @@ const TeamChannelsView = () => {
 					joined
 				});
 			}
-		},
-		[isMasterDetail, joined, navigation]
-	);
-
-	useEffect(() => {
-		if (!team) {
-			return;
-		}
+		};
 
 		if (isSearching) {
 			const options: NativeStackNavigationOptions = {
@@ -306,67 +304,58 @@ const TeamChannelsView = () => {
 		};
 
 		navigation.setOptions(options);
-	}, [
-		team,
-		isSearching,
-		showCreate,
-		navigation,
-		teamId,
-		goRoomActionsView,
-		onSearchPress,
-		onCancelSearchPress,
-		onSearchChangeText
-	]);
-
-	const checkCreatePermission = useCallback(
-		async (resolvedTeam: TSubscriptionModel): Promise<boolean> => {
-			if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
-				const createPermissions =
-					resolvedTeam.t === 'c'
-						? [createCPermission, createTeamChannelPermission]
-						: [createPPermission, createTeamGroupPermission];
-				const result = await hasPermission([moveRoomToTeamPermission, ...createPermissions], resolvedTeam.rid);
-				return result.some(Boolean);
-			}
-			const createPermissions = resolvedTeam.t === 'c' ? [createCPermission] : [createPPermission];
-			const result = await hasPermission([addTeamChannelPermission, ...createPermissions], resolvedTeam.rid);
-			return result.some(Boolean);
-		},
-		[
-			serverVersion,
-			addTeamChannelPermission,
-			moveRoomToTeamPermission,
-			createCPermission,
-			createTeamChannelPermission,
-			createPPermission,
-			createTeamGroupPermission
-		]
-	);
+	}, [team, isSearching, showCreate, navigation, teamId, onSearchChangeText, isMasterDetail, joined]);
 
 	useEffect(() => {
 		const loadTeam = async () => {
 			const db = database.active;
-			try {
-				const subCollection = db.get('subscriptions');
-				const teamChannels = await subCollection.query(Q.where('team_id', Q.eq(teamId))).fetch();
-				const resolvedTeam = (teamChannels as TSubscriptionModel[])?.find(channel => channel.teamMain) as TSubscriptionModel;
-
-				if (!resolvedTeam) {
-					throw new Error();
-				}
-
-				const canCreate = await checkCreatePermission(resolvedTeam);
-				updateState({ team: resolvedTeam, showCreate: canCreate });
-			} catch {
+			const failNotFound = () => {
 				navigation.pop();
 				showErrorAlert(I18n.t('Team_not_found'));
+			};
+			const canCreateChannel = async (resolvedTeam: TSubscriptionModel) => {
+				if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
+					const createPermissions =
+						resolvedTeam.t === 'c'
+							? [createCPermission, createTeamChannelPermission]
+							: [createPPermission, createTeamGroupPermission];
+					const result = await hasPermission([moveRoomToTeamPermission, ...createPermissions], resolvedTeam.rid);
+					return result.some(Boolean);
+				}
+				const createPermissions = resolvedTeam.t === 'c' ? [createCPermission] : [createPPermission];
+				const result = await hasPermission([addTeamChannelPermission, ...createPermissions], resolvedTeam.rid);
+				return result.some(Boolean);
+			};
+
+			try {
+				const subCollection = db.get('subscriptions');
+				const teamChannels = (await subCollection.query(Q.where('team_id', Q.eq(teamId))).fetch()) as TSubscriptionModel[];
+				const resolvedTeam = teamChannels.find(channel => channel.teamMain);
+				if (!resolvedTeam) {
+					failNotFound();
+					return;
+				}
+				const showCreate = await canCreateChannel(resolvedTeam);
+				updateState({ team: resolvedTeam, showCreate });
+			} catch {
+				failNotFound();
 			}
 		};
 
 		loadTeam();
 		load();
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: load and checkCreatePermission read latest state via stateRef/args
-	}, []);
+	}, [
+		load,
+		teamId,
+		navigation,
+		serverVersion,
+		moveRoomToTeamPermission,
+		createCPermission,
+		createTeamChannelPermission,
+		createPPermission,
+		createTeamGroupPermission,
+		addTeamChannelPermission
+	]);
 
 	const onPressItem = useDebounce(
 		async (item: IItem) => {
@@ -396,184 +385,162 @@ const TeamChannelsView = () => {
 		{ leading: true, trailing: false }
 	);
 
-	const toggleAutoJoin = useCallback(async (item: IItem) => {
+	const toggleAutoJoin = async (item: IItem) => {
 		logEvent(events.TC_TOGGLE_AUTOJOIN);
 		try {
-			const { data } = stateRef.current;
 			const result = await updateTeamRoom({ roomId: item._id, isDefault: !item.teamDefault });
 			if (result.success) {
-				const newData = data.map(i => {
-					if (i._id === item._id) {
-						i.teamDefault = !i.teamDefault;
-					}
-					return i;
-				});
-				updateState({ data: newData });
+				updateState(prev => ({
+					data: prev.data.map(i => {
+						if (i._id === item._id) {
+							i.teamDefault = !i.teamDefault;
+						}
+						return i;
+					})
+				}));
 			}
 		} catch (e) {
 			logEvent(events.TC_TOGGLE_AUTOJOIN_F);
 			log(e);
 		}
-	}, []);
+	};
 
-	const removeRoom = useCallback(async (item: IItem) => {
+	const removeRoom = async (item: IItem) => {
 		logEvent(events.TC_DELETE_ROOM);
+		if (!team) {
+			return;
+		}
 		try {
-			const { data, team } = stateRef.current;
-			const result = await removeTeamRoom({ roomId: item._id, teamId: team?.teamId as string });
+			const result = await removeTeamRoom({ roomId: item._id, teamId: team.teamId as string });
 			if (result.success) {
-				const newData = data.filter(room => result.room._id !== room._id);
-				updateState({ data: newData });
+				updateState(prev => ({ data: prev.data.filter(room => result.room._id !== room._id) }));
 			}
 		} catch (e) {
 			logEvent(events.TC_DELETE_ROOM_F);
 			log(e);
 		}
-	}, []);
+	};
 
-	const remove = useCallback(
-		(item: IItem) => {
-			Alert.alert(
-				I18n.t('Confirmation'),
-				I18n.t('Remove_Team_Room_Warning'),
-				[
-					{
-						text: I18n.t('Cancel'),
-						style: 'cancel'
-					},
-					{
-						text: I18n.t('Yes_action_it', { action: I18n.t('remove') }),
-						style: 'destructive',
-						onPress: () => removeRoom(item)
-					}
-				],
-				{ cancelable: false }
-			);
-		},
-		[removeRoom]
+	const remove = (item: IItem) => {
+		Alert.alert(
+			I18n.t('Confirmation'),
+			I18n.t('Remove_Team_Room_Warning'),
+			[
+				{
+					text: I18n.t('Cancel'),
+					style: 'cancel'
+				},
+				{
+					text: I18n.t('Yes_action_it', { action: I18n.t('remove') }),
+					style: 'destructive',
+					onPress: () => removeRoom(item)
+				}
+			],
+			{ cancelable: false }
+		);
+	};
+
+	const deleteChannel = (item: IItem) => {
+		logEvent(events.TC_DELETE_ROOM);
+
+		Alert.alert(
+			I18n.t('Are_you_sure_question_mark'),
+			I18n.t('Delete_Room_Warning'),
+			[
+				{
+					text: I18n.t('Cancel'),
+					style: 'cancel'
+				},
+				{
+					text: I18n.t('Yes_action_it', { action: I18n.t('delete') }),
+					style: 'destructive',
+					onPress: () => dispatch(deleteRoom(ERoomType.c, item))
+				}
+			],
+			{ cancelable: false }
+		);
+	};
+
+	const showChannelActions = async (item: IItem) => {
+		logEvent(events.ROOM_SHOW_BOX_ACTIONS);
+		if (!team) {
+			return;
+		}
+		const isAutoJoinChecked = item.teamDefault;
+		const autoJoinIcon = isAutoJoinChecked ? 'checkbox-checked' : 'checkbox-unchecked';
+		const autoJoinIconColor = isAutoJoinChecked ? colors.fontHint : colors.fontDefault;
+
+		const options: TActionSheetOptionsItem[] = [];
+
+		const permissionsTeam = await hasPermission([editTeamChannelPermission], team.rid);
+		if (permissionsTeam[0]) {
+			options.push({
+				title: I18n.t('Auto-join'),
+				icon: item.t === 'p' ? 'channel-private' : 'channel-public',
+				onPress: () => toggleAutoJoin(item),
+				right: () => (
+					<CustomIcon
+						testID={isAutoJoinChecked ? 'auto-join-checked' : 'auto-join-unchecked'}
+						name={autoJoinIcon}
+						size={20}
+						color={autoJoinIconColor}
+					/>
+				),
+				testID: 'action-sheet-auto-join'
+			});
+		}
+
+		const permissionsRemoveTeam = await hasPermission([removeTeamChannelPermission], team.rid);
+		if (permissionsRemoveTeam[0]) {
+			options.push({
+				title: I18n.t('Remove_from_Team'),
+				icon: 'close',
+				danger: true,
+				onPress: () => remove(item),
+				testID: 'action-sheet-remove-from-team'
+			});
+		}
+
+		const permissionsChannel = await hasPermission([item.t === 'c' ? deleteCPermission : deletePPermission], item._id);
+		if (permissionsChannel[0]) {
+			options.push({
+				title: I18n.t('Delete'),
+				icon: 'delete',
+				danger: true,
+				onPress: () => deleteChannel(item),
+				testID: 'action-sheet-delete'
+			});
+		}
+
+		if (options.length === 0) {
+			return;
+		}
+		showActionSheet({ options });
+	};
+
+	const renderItem = ({ item }: { item: IItem }) => (
+		<RoomItem
+			item={item}
+			showLastMessage={StoreLastMessage}
+			onPress={onPressItem}
+			width={width}
+			onLongPress={showChannelActions}
+			useRealName={useRealName}
+			getRoomTitle={getRoomTitle}
+			getRoomAvatar={getRoomAvatar}
+			swipeEnabled={false}
+			autoJoin={item.teamDefault}
+			showAvatar={showAvatar}
+			displayMode={displayMode}
+		/>
 	);
 
-	const deleteChannel = useCallback(
-		(item: IItem) => {
-			logEvent(events.TC_DELETE_ROOM);
-
-			Alert.alert(
-				I18n.t('Are_you_sure_question_mark'),
-				I18n.t('Delete_Room_Warning'),
-				[
-					{
-						text: I18n.t('Cancel'),
-						style: 'cancel'
-					},
-					{
-						text: I18n.t('Yes_action_it', { action: I18n.t('delete') }),
-						style: 'destructive',
-						onPress: () => dispatch(deleteRoom(ERoomType.c, item))
-					}
-				],
-				{ cancelable: false }
-			);
-		},
-		[dispatch]
-	);
-
-	const showChannelActions = useCallback(
-		async (item: IItem) => {
-			logEvent(events.ROOM_SHOW_BOX_ACTIONS);
-			const { team } = stateRef.current;
-			if (!team) {
-				return;
-			}
-			const isAutoJoinChecked = item.teamDefault;
-			const autoJoinIcon = isAutoJoinChecked ? 'checkbox-checked' : 'checkbox-unchecked';
-			const autoJoinIconColor = isAutoJoinChecked ? colors.fontHint : colors.fontDefault;
-
-			const options: TActionSheetOptionsItem[] = [];
-
-			const permissionsTeam = await hasPermission([editTeamChannelPermission], team.rid);
-			if (permissionsTeam[0]) {
-				options.push({
-					title: I18n.t('Auto-join'),
-					icon: item.t === 'p' ? 'channel-private' : 'channel-public',
-					onPress: () => toggleAutoJoin(item),
-					right: () => (
-						<CustomIcon
-							testID={isAutoJoinChecked ? 'auto-join-checked' : 'auto-join-unchecked'}
-							name={autoJoinIcon}
-							size={20}
-							color={autoJoinIconColor}
-						/>
-					),
-					testID: 'action-sheet-auto-join'
-				});
-			}
-
-			const permissionsRemoveTeam = await hasPermission([removeTeamChannelPermission], team.rid);
-			if (permissionsRemoveTeam[0]) {
-				options.push({
-					title: I18n.t('Remove_from_Team'),
-					icon: 'close',
-					danger: true,
-					onPress: () => remove(item),
-					testID: 'action-sheet-remove-from-team'
-				});
-			}
-
-			const permissionsChannel = await hasPermission([item.t === 'c' ? deleteCPermission : deletePPermission], item._id);
-			if (permissionsChannel[0]) {
-				options.push({
-					title: I18n.t('Delete'),
-					icon: 'delete',
-					danger: true,
-					onPress: () => deleteChannel(item),
-					testID: 'action-sheet-delete'
-				});
-			}
-
-			if (options.length === 0) {
-				return;
-			}
-			showActionSheet({ options });
-		},
-		[
-			colors,
-			editTeamChannelPermission,
-			removeTeamChannelPermission,
-			deleteCPermission,
-			deletePPermission,
-			showActionSheet,
-			toggleAutoJoin,
-			remove,
-			deleteChannel
-		]
-	);
-
-	const renderItem = useCallback(
-		({ item }: { item: IItem }) => (
-			<RoomItem
-				item={item}
-				showLastMessage={StoreLastMessage}
-				onPress={onPressItem}
-				width={width}
-				onLongPress={showChannelActions}
-				useRealName={useRealName}
-				getRoomTitle={getRoomTitle}
-				getRoomAvatar={getRoomAvatar}
-				swipeEnabled={false}
-				autoJoin={item.teamDefault}
-				showAvatar={showAvatar}
-				displayMode={displayMode}
-			/>
-		),
-		[StoreLastMessage, onPressItem, width, showChannelActions, useRealName, showAvatar, displayMode]
-	);
-
-	const renderFooter = useCallback(() => {
+	const renderFooter = () => {
 		if (loadingMore) {
 			return <ActivityIndicator />;
 		}
 		return null;
-	}, [loadingMore]);
+	};
 
 	const renderScroll = () => {
 		if (loading) {

--- a/app/views/TeamChannelsView.tsx
+++ b/app/views/TeamChannelsView.tsx
@@ -171,6 +171,7 @@ const TeamChannelsView = () => {
 	const { loading, loadingMore, data, isSearching, searchText, search, showCreate, team } = state;
 
 	const load = useDebounce(async () => {
+		// Safe: useDebounce forwards the latest committed closure via an internal ref, so `state` here is current.
 		const { loadingMore, data, search, isSearching, searchText, end } = state;
 		const length = isSearching ? search.length : data.length;
 		if (loadingMore || end) {
@@ -335,8 +336,8 @@ const TeamChannelsView = () => {
 					failNotFound();
 					return;
 				}
-				const showCreate = await canCreateChannel(resolvedTeam);
-				updateState({ team: resolvedTeam, showCreate });
+				const canCreate = await canCreateChannel(resolvedTeam);
+				updateState({ team: resolvedTeam, showCreate: canCreate });
 			} catch {
 				failNotFound();
 			}
@@ -391,12 +392,7 @@ const TeamChannelsView = () => {
 			const result = await updateTeamRoom({ roomId: item._id, isDefault: !item.teamDefault });
 			if (result.success) {
 				updateState(prev => ({
-					data: prev.data.map(i => {
-						if (i._id === item._id) {
-							i.teamDefault = !i.teamDefault;
-						}
-						return i;
-					})
+					data: prev.data.map(i => (i._id === item._id ? { ...i, teamDefault: !i.teamDefault } : i))
 				}));
 			}
 		} catch (e) {

--- a/app/views/TeamChannelsView.tsx
+++ b/app/views/TeamChannelsView.tsx
@@ -1,34 +1,34 @@
 import { Q } from '@nozbe/watermelondb';
 import { type NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { Alert, FlatList, Keyboard, PixelRatio } from 'react-native';
-import { connect } from 'react-redux';
-import { Component } from 'react';
+import { Alert, FlatList, Keyboard, PixelRatio, useWindowDimensions } from 'react-native';
+import { shallowEqual, useDispatch } from 'react-redux';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 
 import { deleteRoom } from '../actions/room';
 import { type DisplayMode } from '../lib/constants/constantDisplayMode';
 import { textInputDebounceTime } from '../lib/constants/debounceConfig';
-import { themes } from '../lib/constants/colors';
-import { type TActionSheetOptions, type TActionSheetOptionsItem, withActionSheet } from '../containers/ActionSheet';
+import { type TActionSheetOptionsItem, useActionSheet } from '../containers/ActionSheet';
 import ActivityIndicator from '../containers/ActivityIndicator';
 import BackgroundContainer from '../containers/BackgroundContainer';
 import * as HeaderButton from '../containers/Header/components/HeaderButton';
 import RoomHeader from '../containers/RoomHeader';
 import SafeAreaView from '../containers/SafeAreaView';
 import SearchHeader from '../containers/SearchHeader';
-import { type IApplicationState, type IBaseScreen, type TSubscriptionModel } from '../definitions';
+import { type TSubscriptionModel } from '../definitions';
 import { ERoomType } from '../definitions/ERoomType';
-import { withDimensions } from '../lib/hooks/withDimensions';
-import { withMasterDetail } from '../lib/hooks/useMasterDetail';
+import { useMasterDetail } from '../lib/hooks/useMasterDetail';
+import { useAppSelector } from '../lib/hooks/useAppSelector';
+import { useAppNavigation, useAppRoute } from '../lib/hooks/navigation';
 import I18n from '../i18n';
 import database from '../lib/database';
 import { CustomIcon } from '../containers/CustomIcon';
 import RoomItem from '../containers/RoomItem';
 import { type ChatsStackParamList } from '../stacks/types';
-import { withTheme } from '../theme';
+import { useTheme } from '../theme';
 import { goRoom } from '../lib/methods/helpers/goRoom';
 import { showErrorAlert } from '../lib/methods/helpers/info';
 import log, { events, logEvent } from '../lib/methods/helpers/log';
-import { getRoomAvatar, getRoomTitle, hasPermission, debounce, isIOS, compareServerVersion } from '../lib/methods/helpers';
+import { getRoomAvatar, getRoomTitle, hasPermission, useDebounce, isIOS, compareServerVersion } from '../lib/methods/helpers';
 import { getRoomInfo, getTeamListRoom, updateTeamRoom, removeTeamRoom } from '../lib/services/restApi';
 
 const API_FETCH_COUNT = 25;
@@ -72,12 +72,12 @@ interface ITeamChannelsViewState {
 	search: IItem[];
 	end: boolean;
 	showCreate: boolean;
+	team: TSubscriptionModel | null;
 }
 
-interface ITeamChannelsViewProps extends IBaseScreen<ChatsStackParamList, 'TeamChannelsView'> {
+interface ITeamChannelsViewSelector {
 	serverVersion: string;
 	useRealName: boolean;
-	width: number;
 	StoreLastMessage: boolean;
 	addTeamChannelPermission: string[];
 	moveRoomToTeamPermission: string[];
@@ -89,104 +89,93 @@ interface ITeamChannelsViewProps extends IBaseScreen<ChatsStackParamList, 'TeamC
 	createTeamGroupPermission: string[];
 	deleteCPermission: string[];
 	deletePPermission: string[];
-	deleteTeamChannelPermission: string[];
-	deleteTeamGroupPermission: string[];
-	showActionSheet: (options: TActionSheetOptions) => void;
 	showAvatar: boolean;
 	displayMode: DisplayMode;
 }
-class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsViewState> {
-	private teamId: string;
-	private joined: boolean;
-	private teamChannels: TSubscriptionModel[];
-	private team: TSubscriptionModel;
 
-	constructor(props: ITeamChannelsViewProps) {
-		super(props);
-		this.teamChannels = [];
-		this.team = {} as TSubscriptionModel;
-		this.joined = props.route.params?.joined;
-		this.teamId = props.route.params?.teamId;
-		this.state = {
-			loading: true,
-			loadingMore: false,
-			data: [],
-			isSearching: false,
-			searchText: '',
-			search: [],
-			end: false,
-			showCreate: false
-		};
-		this.loadTeam();
-		this.setHeader();
-	}
+const initialState: ITeamChannelsViewState = {
+	loading: true,
+	loadingMore: false,
+	data: [],
+	isSearching: false,
+	searchText: '',
+	search: [],
+	end: false,
+	showCreate: false,
+	team: null
+};
 
-	componentDidMount() {
-		this.load();
-	}
+const stateReducer = (state: ITeamChannelsViewState, partial: Partial<ITeamChannelsViewState>): ITeamChannelsViewState => ({
+	...state,
+	...partial
+});
 
-	hasCreatePermission = async () => {
-		const {
-			addTeamChannelPermission,
-			moveRoomToTeamPermission,
-			serverVersion,
-			createCPermission,
-			createPPermission,
-			createTeamChannelPermission,
-			createTeamGroupPermission
-		} = this.props;
-		if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
-			const createPermissions =
-				this.team.t === 'c' ? [createCPermission, createTeamChannelPermission] : [createPPermission, createTeamGroupPermission];
-			const result = await hasPermission([moveRoomToTeamPermission, ...createPermissions], this.team.rid);
-			return result.some(Boolean);
-		}
-		const createPermissions = this.team.t === 'c' ? [createCPermission] : [createPPermission];
-		const result = await hasPermission([addTeamChannelPermission, ...createPermissions], this.team.rid);
-		return result.some(Boolean);
-	};
+const TeamChannelsView = () => {
+	const navigation = useAppNavigation<ChatsStackParamList, 'TeamChannelsView'>();
+	const {
+		params: { teamId, joined }
+	} = useAppRoute<ChatsStackParamList, 'TeamChannelsView'>();
 
-	loadTeam = async () => {
-		const { loading, data } = this.state;
+	const { colors } = useTheme();
+	const { showActionSheet } = useActionSheet();
+	const isMasterDetail = useMasterDetail();
+	const dispatch = useDispatch();
+	const { width } = useWindowDimensions();
 
-		const db = database.active;
-		try {
-			const subCollection = db.get('subscriptions');
-			this.teamChannels = await subCollection.query(Q.where('team_id', Q.eq(this.teamId))).fetch();
-			this.team = this.teamChannels?.find((channel: TSubscriptionModel) => channel.teamMain) as TSubscriptionModel;
-			this.setHeader();
+	const {
+		serverVersion,
+		useRealName,
+		StoreLastMessage,
+		addTeamChannelPermission,
+		moveRoomToTeamPermission,
+		editTeamChannelPermission,
+		removeTeamChannelPermission,
+		createCPermission,
+		createTeamChannelPermission,
+		createPPermission,
+		createTeamGroupPermission,
+		deleteCPermission,
+		deletePPermission,
+		showAvatar,
+		displayMode
+	} = useAppSelector(
+		(state): ITeamChannelsViewSelector => ({
+			serverVersion: state.server.version as string,
+			useRealName: state.settings.UI_Use_Real_Name as boolean,
+			StoreLastMessage: state.settings.Store_Last_Message as boolean,
+			addTeamChannelPermission: state.permissions['add-team-channel'] ?? [],
+			moveRoomToTeamPermission: state.permissions['move-room-to-team'] ?? [],
+			editTeamChannelPermission: state.permissions['edit-team-channel'] ?? [],
+			removeTeamChannelPermission: state.permissions['remove-team-channel'] ?? [],
+			createCPermission: state.permissions['create-c'] ?? [],
+			createTeamChannelPermission: state.permissions['create-team-channel'] ?? [],
+			createPPermission: state.permissions['create-p'] ?? [],
+			createTeamGroupPermission: state.permissions['create-team-group'] ?? [],
+			deleteCPermission: state.permissions['delete-c'] ?? [],
+			deletePPermission: state.permissions['delete-p'] ?? [],
+			showAvatar: state.sortPreferences.showAvatar,
+			displayMode: state.sortPreferences.displayMode
+		}),
+		shallowEqual
+	);
 
-			if (!this.team) {
-				throw new Error();
-			}
+	const [state, updateState] = useReducer(stateReducer, initialState);
+	const { loading, loadingMore, data, isSearching, searchText, search, showCreate, team } = state;
 
-			const hasCreatePermission = await this.hasCreatePermission();
-			if (hasCreatePermission) {
-				this.setState({ showCreate: true }, () => this.setHeader());
-			}
+	const stateRef = useRef(state);
+	stateRef.current = state;
 
-			if (loading && data.length) {
-				this.setState({ loading: false });
-			}
-		} catch {
-			const { navigation } = this.props;
-			navigation.pop();
-			showErrorAlert(I18n.t('Team_not_found'));
-		}
-	};
-
-	load = debounce(async () => {
-		const { loadingMore, data, search, isSearching, searchText, end } = this.state;
-
+	const load = useDebounce(async () => {
+		const { loadingMore, data, search, isSearching, searchText, end } = stateRef.current;
 		const length = isSearching ? search.length : data.length;
 		if (loadingMore || end) {
 			return;
 		}
 
-		this.setState({ loadingMore: true });
+		updateState({ loadingMore: true });
 		try {
 			const result = await getTeamListRoom({
-				teamId: this.teamId,
+				teamId,
 				offset: length,
 				count: API_FETCH_COUNT,
 				type: 'all',
@@ -194,11 +183,11 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 			});
 
 			if (result.success) {
-				const newState = {
+				const newState: Partial<ITeamChannelsViewState> = {
 					loading: false,
 					loadingMore: false,
 					end: result.rooms.length < API_FETCH_COUNT
-				} as ITeamChannelsViewState;
+				};
 
 				if (isSearching) {
 					newState.search = [...search, ...result.rooms] as IItem[];
@@ -206,21 +195,79 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 					newState.data = [...data, ...result.rooms] as IItem[];
 				}
 
-				this.setState(newState);
+				updateState(newState);
 			} else {
-				this.setState({ loading: false, loadingMore: false });
+				updateState({ loading: false, loadingMore: false });
 			}
 		} catch (e) {
 			log(e);
-			this.setState({ loading: false, loadingMore: false });
+			updateState({ loading: false, loadingMore: false });
 		}
 	}, 300);
 
-	setHeader = () => {
-		const { isSearching, showCreate } = this.state;
-		const { navigation } = this.props;
+	const onSearchPress = useCallback(() => {
+		logEvent(events.TC_SEARCH);
+		updateState({ isSearching: true });
+	}, []);
 
-		const { team } = this;
+	const onCancelSearchPress = useCallback(() => {
+		logEvent(events.TC_CANCEL_SEARCH);
+		if (!stateRef.current.isSearching) {
+			return;
+		}
+		Keyboard.dismiss();
+		updateState({
+			searchText: null,
+			isSearching: false,
+			search: [],
+			loadingMore: false,
+			end: false
+		});
+	}, []);
+
+	const onSearchChangeText = useDebounce((text: string) => {
+		updateState({
+			searchText: text,
+			search: [],
+			loading: !!text,
+			loadingMore: false,
+			end: false
+		});
+		if (text) {
+			load();
+		}
+	}, textInputDebounceTime);
+
+	const goRoomActionsView = useCallback(
+		(screen?: string) => {
+			logEvent(events.TC_GO_ACTIONS);
+			const { team } = stateRef.current;
+			if (!team) {
+				return;
+			}
+			if (isMasterDetail && screen) {
+				navigation.navigate('ModalStackNavigator', {
+					screen: 'RoomActionsView',
+					params: {
+						rid: team.rid,
+						t: team.t,
+						room: team,
+						joined
+					}
+				});
+			} else {
+				navigation.navigate('RoomActionsView', {
+					rid: team.rid,
+					t: team.t,
+					room: team,
+					joined
+				});
+			}
+		},
+		[isMasterDetail, joined, navigation]
+	);
+
+	useEffect(() => {
 		if (!team) {
 			return;
 		}
@@ -229,21 +276,20 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 			const options: NativeStackNavigationOptions = {
 				headerLeft: () => (
 					<HeaderButton.Container left>
-						<HeaderButton.Item iconName='close' onPress={this.onCancelSearchPress} />
+						<HeaderButton.Item iconName='close' onPress={onCancelSearchPress} />
 					</HeaderButton.Container>
 				),
-				headerTitle: () => (
-					<SearchHeader onSearchChangeText={this.onSearchChangeText} testID='team-channels-view-search-header' />
-				),
+				headerTitle: () => <SearchHeader onSearchChangeText={onSearchChangeText} testID='team-channels-view-search-header' />,
 				headerRight: undefined
 			};
-			return navigation.setOptions(options);
+			navigation.setOptions(options);
+			return;
 		}
 
 		const options: NativeStackNavigationOptions = {
 			headerLeft: undefined,
 			headerTitle: () => (
-				<RoomHeader title={getRoomTitle(team)} subtitle={team.topic} type={team.t} onPress={this.goRoomActionsView} teamMain />
+				<RoomHeader title={getRoomTitle(team)} subtitle={team.topic} type={team.t} onPress={goRoomActionsView} teamMain />
 			),
 			headerRight: () => (
 				<HeaderButton.Container>
@@ -251,93 +297,80 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 						<HeaderButton.Item
 							iconName='create'
 							testID='team-channels-view-create'
-							onPress={() =>
-								navigation.navigate('AddChannelTeamView', { teamId: this.teamId, rid: this.team.rid, t: this.team.t as any })
-							}
+							onPress={() => navigation.navigate('AddChannelTeamView', { teamId, rid: team.rid, t: team.t as any })}
 						/>
 					) : null}
-					<HeaderButton.Item iconName='search' testID='team-channels-view-search' onPress={this.onSearchPress} />
+					<HeaderButton.Item iconName='search' testID='team-channels-view-search' onPress={onSearchPress} />
 				</HeaderButton.Container>
 			)
 		};
 
 		navigation.setOptions(options);
-	};
+	}, [
+		team,
+		isSearching,
+		showCreate,
+		navigation,
+		teamId,
+		goRoomActionsView,
+		onSearchPress,
+		onCancelSearchPress,
+		onSearchChangeText
+	]);
 
-	onSearchPress = () => {
-		logEvent(events.TC_SEARCH);
-		this.setState({ isSearching: true }, () => this.setHeader());
-	};
-
-	onSearchChangeText = debounce((searchText: string) => {
-		this.setState(
-			{
-				searchText,
-				search: [],
-				loading: !!searchText,
-				loadingMore: false,
-				end: false
-			},
-			() => {
-				if (searchText) {
-					this.load();
-				}
+	const checkCreatePermission = useCallback(
+		async (resolvedTeam: TSubscriptionModel): Promise<boolean> => {
+			if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
+				const createPermissions =
+					resolvedTeam.t === 'c'
+						? [createCPermission, createTeamChannelPermission]
+						: [createPPermission, createTeamGroupPermission];
+				const result = await hasPermission([moveRoomToTeamPermission, ...createPermissions], resolvedTeam.rid);
+				return result.some(Boolean);
 			}
-		);
-	}, textInputDebounceTime);
+			const createPermissions = resolvedTeam.t === 'c' ? [createCPermission] : [createPPermission];
+			const result = await hasPermission([addTeamChannelPermission, ...createPermissions], resolvedTeam.rid);
+			return result.some(Boolean);
+		},
+		[
+			serverVersion,
+			addTeamChannelPermission,
+			moveRoomToTeamPermission,
+			createCPermission,
+			createTeamChannelPermission,
+			createPPermission,
+			createTeamGroupPermission
+		]
+	);
 
-	onCancelSearchPress = () => {
-		logEvent(events.TC_CANCEL_SEARCH);
-		const { isSearching } = this.state;
-		if (!isSearching) {
-			return;
-		}
-		Keyboard.dismiss();
-		this.setState(
-			{
-				searchText: null,
-				isSearching: false,
-				search: [],
-				loadingMore: false,
-				end: false
-			},
-			() => {
-				this.setHeader();
-			}
-		);
-	};
+	useEffect(() => {
+		const loadTeam = async () => {
+			const db = database.active;
+			try {
+				const subCollection = db.get('subscriptions');
+				const teamChannels = await subCollection.query(Q.where('team_id', Q.eq(teamId))).fetch();
+				const resolvedTeam = (teamChannels as TSubscriptionModel[])?.find(channel => channel.teamMain) as TSubscriptionModel;
 
-	goRoomActionsView = (screen?: string) => {
-		logEvent(events.TC_GO_ACTIONS);
-		const { team, joined } = this;
-		const { navigation, isMasterDetail } = this.props;
-		if (!team) {
-			return;
-		}
-		if (isMasterDetail && screen) {
-			navigation.navigate('ModalStackNavigator', {
-				screen: 'RoomActionsView',
-				params: {
-					rid: team.rid,
-					t: team.t,
-					room: team,
-					joined
+				if (!resolvedTeam) {
+					throw new Error();
 				}
-			});
-		} else {
-			navigation.navigate('RoomActionsView', {
-				rid: team.rid,
-				t: team.t,
-				room: team,
-				joined
-			});
-		}
-	};
 
-	onPressItem = debounce(
+				const canCreate = await checkCreatePermission(resolvedTeam);
+				updateState({ team: resolvedTeam, showCreate: canCreate });
+			} catch {
+				navigation.pop();
+				showErrorAlert(I18n.t('Team_not_found'));
+			}
+		};
+
+		loadTeam();
+		load();
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only: load and checkCreatePermission read latest state via stateRef/args
+	}, []);
+
+	const onPressItem = useDebounce(
 		async (item: IItem) => {
 			logEvent(events.TC_GO_ROOM);
-			const { isMasterDetail } = this.props;
 			try {
 				let params = {};
 				const result = await getRoomInfo(item._id);
@@ -360,13 +393,13 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 			}
 		},
 		1000,
-		true
+		{ leading: true, trailing: false }
 	);
 
-	toggleAutoJoin = async (item: IItem) => {
+	const toggleAutoJoin = useCallback(async (item: IItem) => {
 		logEvent(events.TC_TOGGLE_AUTOJOIN);
 		try {
-			const { data } = this.state;
+			const { data } = stateRef.current;
 			const result = await updateTeamRoom({ roomId: item._id, isDefault: !item.teamDefault });
 			if (result.success) {
 				const newData = data.map(i => {
@@ -375,155 +408,154 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 					}
 					return i;
 				});
-				this.setState({ data: newData });
+				updateState({ data: newData });
 			}
 		} catch (e) {
 			logEvent(events.TC_TOGGLE_AUTOJOIN_F);
 			log(e);
 		}
-	};
+	}, []);
 
-	remove = (item: IItem) => {
-		Alert.alert(
-			I18n.t('Confirmation'),
-			I18n.t('Remove_Team_Room_Warning'),
-			[
-				{
-					text: I18n.t('Cancel'),
-					style: 'cancel'
-				},
-				{
-					text: I18n.t('Yes_action_it', { action: I18n.t('remove') }),
-					style: 'destructive',
-					onPress: () => this.removeRoom(item)
-				}
-			],
-			{ cancelable: false }
-		);
-	};
-
-	removeRoom = async (item: IItem) => {
+	const removeRoom = useCallback(async (item: IItem) => {
 		logEvent(events.TC_DELETE_ROOM);
 		try {
-			const { data } = this.state;
-			const result = await removeTeamRoom({ roomId: item._id, teamId: this.team.teamId as string });
+			const { data, team } = stateRef.current;
+			const result = await removeTeamRoom({ roomId: item._id, teamId: team?.teamId as string });
 			if (result.success) {
 				const newData = data.filter(room => result.room._id !== room._id);
-				this.setState({ data: newData });
+				updateState({ data: newData });
 			}
 		} catch (e) {
 			logEvent(events.TC_DELETE_ROOM_F);
 			log(e);
 		}
-	};
+	}, []);
 
-	delete = (item: IItem) => {
-		logEvent(events.TC_DELETE_ROOM);
-		const { dispatch } = this.props;
+	const remove = useCallback(
+		(item: IItem) => {
+			Alert.alert(
+				I18n.t('Confirmation'),
+				I18n.t('Remove_Team_Room_Warning'),
+				[
+					{
+						text: I18n.t('Cancel'),
+						style: 'cancel'
+					},
+					{
+						text: I18n.t('Yes_action_it', { action: I18n.t('remove') }),
+						style: 'destructive',
+						onPress: () => removeRoom(item)
+					}
+				],
+				{ cancelable: false }
+			);
+		},
+		[removeRoom]
+	);
 
-		Alert.alert(
-			I18n.t('Are_you_sure_question_mark'),
-			I18n.t('Delete_Room_Warning'),
-			[
-				{
-					text: I18n.t('Cancel'),
-					style: 'cancel'
-				},
-				{
-					text: I18n.t('Yes_action_it', { action: I18n.t('delete') }),
-					style: 'destructive',
-					onPress: () => dispatch(deleteRoom(ERoomType.c, item))
-				}
-			],
-			{ cancelable: false }
-		);
-	};
+	const deleteChannel = useCallback(
+		(item: IItem) => {
+			logEvent(events.TC_DELETE_ROOM);
 
-	hasDeletePermission = async (rid: string, t: 'c' | 'p') => {
-		const { serverVersion, deleteCPermission, deletePPermission, deleteTeamChannelPermission, deleteTeamGroupPermission } =
-			this.props;
-		if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
-			const permissions =
-				t === 'c' ? [deleteTeamChannelPermission, deleteTeamGroupPermission] : [deletePPermission, deletePPermission];
-			const result = await hasPermission(permissions, rid);
-			return result[0] && result[1];
-		}
+			Alert.alert(
+				I18n.t('Are_you_sure_question_mark'),
+				I18n.t('Delete_Room_Warning'),
+				[
+					{
+						text: I18n.t('Cancel'),
+						style: 'cancel'
+					},
+					{
+						text: I18n.t('Yes_action_it', { action: I18n.t('delete') }),
+						style: 'destructive',
+						onPress: () => dispatch(deleteRoom(ERoomType.c, item))
+					}
+				],
+				{ cancelable: false }
+			);
+		},
+		[dispatch]
+	);
 
-		const result = await hasPermission([t === 'c' ? deleteCPermission : deletePPermission], rid);
-		return result[0];
-	};
+	const showChannelActions = useCallback(
+		async (item: IItem) => {
+			logEvent(events.ROOM_SHOW_BOX_ACTIONS);
+			const { team } = stateRef.current;
+			if (!team) {
+				return;
+			}
+			const isAutoJoinChecked = item.teamDefault;
+			const autoJoinIcon = isAutoJoinChecked ? 'checkbox-checked' : 'checkbox-unchecked';
+			const autoJoinIconColor = isAutoJoinChecked ? colors.fontHint : colors.fontDefault;
 
-	showChannelActions = async (item: IItem) => {
-		logEvent(events.ROOM_SHOW_BOX_ACTIONS);
-		const {
-			showActionSheet,
+			const options: TActionSheetOptionsItem[] = [];
+
+			const permissionsTeam = await hasPermission([editTeamChannelPermission], team.rid);
+			if (permissionsTeam[0]) {
+				options.push({
+					title: I18n.t('Auto-join'),
+					icon: item.t === 'p' ? 'channel-private' : 'channel-public',
+					onPress: () => toggleAutoJoin(item),
+					right: () => (
+						<CustomIcon
+							testID={isAutoJoinChecked ? 'auto-join-checked' : 'auto-join-unchecked'}
+							name={autoJoinIcon}
+							size={20}
+							color={autoJoinIconColor}
+						/>
+					),
+					testID: 'action-sheet-auto-join'
+				});
+			}
+
+			const permissionsRemoveTeam = await hasPermission([removeTeamChannelPermission], team.rid);
+			if (permissionsRemoveTeam[0]) {
+				options.push({
+					title: I18n.t('Remove_from_Team'),
+					icon: 'close',
+					danger: true,
+					onPress: () => remove(item),
+					testID: 'action-sheet-remove-from-team'
+				});
+			}
+
+			const permissionsChannel = await hasPermission([item.t === 'c' ? deleteCPermission : deletePPermission], item._id);
+			if (permissionsChannel[0]) {
+				options.push({
+					title: I18n.t('Delete'),
+					icon: 'delete',
+					danger: true,
+					onPress: () => deleteChannel(item),
+					testID: 'action-sheet-delete'
+				});
+			}
+
+			if (options.length === 0) {
+				return;
+			}
+			showActionSheet({ options });
+		},
+		[
+			colors,
 			editTeamChannelPermission,
+			removeTeamChannelPermission,
 			deleteCPermission,
 			deletePPermission,
-			theme,
-			removeTeamChannelPermission
-		} = this.props;
-		const isAutoJoinChecked = item.teamDefault;
-		const autoJoinIcon = isAutoJoinChecked ? 'checkbox-checked' : 'checkbox-unchecked';
-		const autoJoinIconColor = isAutoJoinChecked ? themes[theme].fontHint : themes[theme].fontDefault;
+			showActionSheet,
+			toggleAutoJoin,
+			remove,
+			deleteChannel
+		]
+	);
 
-		const options: TActionSheetOptionsItem[] = [];
-
-		const permissionsTeam = await hasPermission([editTeamChannelPermission], this.team.rid);
-		if (permissionsTeam[0]) {
-			options.push({
-				title: I18n.t('Auto-join'),
-				icon: item.t === 'p' ? 'channel-private' : 'channel-public',
-				onPress: () => this.toggleAutoJoin(item),
-				right: () => (
-					<CustomIcon
-						testID={isAutoJoinChecked ? 'auto-join-checked' : 'auto-join-unchecked'}
-						name={autoJoinIcon}
-						size={20}
-						color={autoJoinIconColor}
-					/>
-				),
-				testID: 'action-sheet-auto-join'
-			});
-		}
-
-		const permissionsRemoveTeam = await hasPermission([removeTeamChannelPermission], this.team.rid);
-		if (permissionsRemoveTeam[0]) {
-			options.push({
-				title: I18n.t('Remove_from_Team'),
-				icon: 'close',
-				danger: true,
-				onPress: () => this.remove(item),
-				testID: 'action-sheet-remove-from-team'
-			});
-		}
-
-		const permissionsChannel = await hasPermission([item.t === 'c' ? deleteCPermission : deletePPermission], item._id);
-		if (permissionsChannel[0]) {
-			options.push({
-				title: I18n.t('Delete'),
-				icon: 'delete',
-				danger: true,
-				onPress: () => this.delete(item),
-				testID: 'action-sheet-delete'
-			});
-		}
-
-		if (options.length === 0) {
-			return;
-		}
-		showActionSheet({ options });
-	};
-
-	renderItem = ({ item }: { item: IItem }) => {
-		const { StoreLastMessage, useRealName, width, showAvatar, displayMode } = this.props;
-		return (
+	const renderItem = useCallback(
+		({ item }: { item: IItem }) => (
 			<RoomItem
 				item={item}
 				showLastMessage={StoreLastMessage}
-				onPress={this.onPressItem}
+				onPress={onPressItem}
 				width={width}
-				onLongPress={this.showChannelActions}
+				onLongPress={showChannelActions}
 				useRealName={useRealName}
 				getRoomTitle={getRoomTitle}
 				getRoomAvatar={getRoomAvatar}
@@ -532,19 +564,18 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 				showAvatar={showAvatar}
 				displayMode={displayMode}
 			/>
-		);
-	};
+		),
+		[StoreLastMessage, onPressItem, width, showChannelActions, useRealName, showAvatar, displayMode]
+	);
 
-	renderFooter = () => {
-		const { loadingMore } = this.state;
+	const renderFooter = useCallback(() => {
 		if (loadingMore) {
 			return <ActivityIndicator />;
 		}
 		return null;
-	};
+	}, [loadingMore]);
 
-	renderScroll = () => {
-		const { loading, data, search, isSearching, searchText } = this.state;
+	const renderScroll = () => {
 		if (loading) {
 			return <BackgroundContainer loading />;
 		}
@@ -560,41 +591,18 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 				data={isSearching ? search : data}
 				extraData={isSearching ? search : data}
 				keyExtractor={keyExtractor}
-				renderItem={this.renderItem}
+				renderItem={renderItem}
 				getItemLayout={getItemLayout}
 				removeClippedSubviews={isIOS}
 				keyboardShouldPersistTaps='always'
-				onEndReached={() => this.load()}
+				onEndReached={load}
 				onEndReachedThreshold={0.5}
-				ListFooterComponent={this.renderFooter}
+				ListFooterComponent={renderFooter}
 			/>
 		);
 	};
 
-	render() {
-		console.count(`${this.constructor.name}.render calls`);
-		return <SafeAreaView testID='team-channels-view'>{this.renderScroll()}</SafeAreaView>;
-	}
-}
+	return <SafeAreaView testID='team-channels-view'>{renderScroll()}</SafeAreaView>;
+};
 
-const mapStateToProps = (state: IApplicationState) => ({
-	serverVersion: state.server.version,
-	useRealName: state.settings.UI_Use_Real_Name,
-	StoreLastMessage: state.settings.Store_Last_Message,
-	addTeamChannelPermission: state.permissions['add-team-channel'],
-	moveRoomToTeamPermission: state.permissions['move-room-to-team'],
-	editTeamChannelPermission: state.permissions['edit-team-channel'],
-	removeTeamChannelPermission: state.permissions['remove-team-channel'],
-	deleteCPermission: state.permissions['delete-c'],
-	createCPermission: state.permissions['create-c'],
-	createTeamChannelPermission: state.permissions['create-team-channel'],
-	createPPermission: state.permissions['create-p'],
-	createTeamGroupPermission: state.permissions['create-team-group'],
-	deleteTeamChannelPermission: state.permissions['delete-team-channel'],
-	deletePPermission: state.permissions['delete-p'],
-	deleteTeamGroupPermission: state.permissions['delete-team-group'],
-	showAvatar: state.sortPreferences.showAvatar,
-	displayMode: state.sortPreferences.displayMode
-});
-
-export default connect(mapStateToProps)(withDimensions(withTheme(withActionSheet(withMasterDetail(TeamChannelsView)))));
+export default TeamChannelsView;

--- a/app/views/TeamChannelsView/TeamChannelsView.test.tsx
+++ b/app/views/TeamChannelsView/TeamChannelsView.test.tsx
@@ -2,7 +2,7 @@ import { Alert } from 'react-native';
 import { BorderlessButton } from 'react-native-gesture-handler';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 
-import TeamChannelsView, { type IItem } from './TeamChannelsView';
+import TeamChannelsView, { type IItem } from '.';
 
 const mockShowActionSheet = jest.fn();
 const mockPop = jest.fn();
@@ -21,20 +21,20 @@ const defaultRouteParams = {
 	joined: true
 };
 
-jest.mock('../lib/hooks/navigation', () => ({
+jest.mock('../../lib/hooks/navigation', () => ({
 	useAppNavigation: () => mockNavigation,
 	useAppRoute: () => ({
 		params: defaultRouteParams
 	})
 }));
 
-jest.mock('../containers/ActionSheet', () => ({
+jest.mock('../../containers/ActionSheet', () => ({
 	useActionSheet: () => ({
 		showActionSheet: mockShowActionSheet
 	})
 }));
 
-jest.mock('../theme', () => ({
+jest.mock('../../theme', () => ({
 	useTheme: () => ({
 		colors: {
 			surfaceRoom: 'white',
@@ -69,12 +69,18 @@ const mockReduxState = {
 	}
 };
 
-jest.mock('../lib/hooks/useAppSelector', () => ({
+jest.mock('../../lib/hooks/useAppSelector', () => ({
 	useAppSelector: (selector: (state: any) => unknown) => selector(mockReduxState)
 }));
 
-jest.mock('../lib/hooks/useMasterDetail', () => ({
+jest.mock('../../lib/hooks/useMasterDetail', () => ({
 	useMasterDetail: () => false
+}));
+
+const mockUseCanCreateTeamChannel = jest.fn();
+
+jest.mock('../../lib/hooks/useTeamChannelPermissions', () => ({
+	useCanCreateTeamChannel: (...args: any[]) => mockUseCanCreateTeamChannel(...args)
 }));
 
 const mockTeamSubscription = {
@@ -105,7 +111,7 @@ const mockFind = jest.fn();
 const mockQuery = jest.fn(() => ({ fetch: mockFetch }));
 const mockGet = jest.fn(() => ({ query: mockQuery, find: mockFind }));
 
-jest.mock('../lib/database', () => ({
+jest.mock('../../lib/database', () => ({
 	__esModule: true,
 	default: {
 		get active() {
@@ -120,31 +126,31 @@ const mockUpdateTeamRoom = jest.fn();
 const mockRemoveTeamRoom = jest.fn();
 const mockHasPermission = jest.fn();
 
-jest.mock('../lib/services/restApi', () => ({
+jest.mock('../../lib/services/restApi', () => ({
 	getTeamListRoom: (...args: any[]) => mockGetTeamListRoom(...args),
 	getRoomInfo: (...args: any[]) => mockGetRoomInfo(...args),
 	updateTeamRoom: (...args: any[]) => mockUpdateTeamRoom(...args),
 	removeTeamRoom: (...args: any[]) => mockRemoveTeamRoom(...args)
 }));
 
-jest.mock('../lib/methods/helpers', () => ({
-	...jest.requireActual('../lib/methods/helpers'),
+jest.mock('../../lib/methods/helpers', () => ({
+	...jest.requireActual('../../lib/methods/helpers'),
 	hasPermission: (...args: any[]) => mockHasPermission(...args),
 	getRoomTitle: (room: any) => room.fname || room.name,
 	getRoomAvatar: () => '',
 	isIOS: false,
-	compareServerVersion: jest.requireActual('../lib/methods/helpers').compareServerVersion
+	compareServerVersion: jest.requireActual('../../lib/methods/helpers').compareServerVersion
 }));
 
-jest.mock('../lib/methods/helpers/goRoom', () => ({
+jest.mock('../../lib/methods/helpers/goRoom', () => ({
 	goRoom: jest.fn()
 }));
 
-jest.mock('../lib/methods/helpers/info', () => ({
+jest.mock('../../lib/methods/helpers/info', () => ({
 	showErrorAlert: jest.fn()
 }));
 
-jest.mock('../lib/methods/helpers/log', () => ({
+jest.mock('../../lib/methods/helpers/log', () => ({
 	__esModule: true,
 	default: jest.fn(),
 	logEvent: jest.fn(),
@@ -161,7 +167,7 @@ jest.mock('../lib/methods/helpers/log', () => ({
 	}
 }));
 
-jest.mock('../actions/room', () => ({
+jest.mock('../../actions/room', () => ({
 	deleteRoom: jest.fn(() => ({ type: 'DELETE_ROOM' }))
 }));
 
@@ -170,7 +176,7 @@ jest.mock('react-redux', () => ({
 	useDispatch: () => jest.fn()
 }));
 
-jest.mock('../containers/RoomItem', () => {
+jest.mock('../../containers/RoomItem', () => {
 	const { TouchableOpacity, Text } = require('react-native');
 	return ({ item, onPress, onLongPress }: any) => (
 		<TouchableOpacity testID={`room-item-${item._id}`} onPress={() => onPress(item)} onLongPress={() => onLongPress(item)}>
@@ -179,9 +185,9 @@ jest.mock('../containers/RoomItem', () => {
 	);
 });
 
-jest.mock('../containers/RoomHeader', () => () => null);
+jest.mock('../../containers/RoomHeader', () => () => null);
 
-jest.mock('../containers/BackgroundContainer', () => {
+jest.mock('../../containers/BackgroundContainer', () => {
 	const { View, Text } = require('react-native');
 	return ({ loading, text }: any) => (
 		<View testID='background-container'>
@@ -191,14 +197,14 @@ jest.mock('../containers/BackgroundContainer', () => {
 	);
 });
 
-jest.mock('../containers/ActivityIndicator', () => () => null);
+jest.mock('../../containers/ActivityIndicator', () => () => null);
 
-jest.mock('../containers/SafeAreaView', () => {
+jest.mock('../../containers/SafeAreaView', () => {
 	const { View } = require('react-native');
 	return ({ children, testID }: any) => <View testID={testID}>{children}</View>;
 });
 
-jest.mock('../containers/SearchHeader', () => {
+jest.mock('../../containers/SearchHeader', () => {
 	const { TextInput } = require('react-native');
 	return ({ onSearchChangeText, testID }: any) => <TextInput testID={testID} onChangeText={onSearchChangeText} />;
 });
@@ -227,6 +233,7 @@ const makeRoom = (overrides: Partial<IItem> = {}): IItem => ({
 const setupSuccessfulLoad = (rooms: IItem[] = [makeRoom()]) => {
 	mockFetch.mockResolvedValue([mockTeamSubscription, mockChildSubscription]);
 	mockHasPermission.mockResolvedValue([true, true, true]);
+	mockUseCanCreateTeamChannel.mockReturnValue(true);
 	mockGetTeamListRoom.mockResolvedValue({ success: true, rooms });
 };
 
@@ -264,7 +271,7 @@ describe('TeamChannelsView', () => {
 
 	describe('2. loadTeam — team from DB; not-found → pop + alert', () => {
 		it('pops and shows error when team subscription is not found', async () => {
-			const { showErrorAlert } = require('../lib/methods/helpers/info');
+			const { showErrorAlert } = require('../../lib/methods/helpers/info');
 			mockFetch.mockResolvedValue([mockChildSubscription]);
 			mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [] });
 
@@ -275,7 +282,7 @@ describe('TeamChannelsView', () => {
 		});
 
 		it('pops and shows error when DB query throws', async () => {
-			const { showErrorAlert } = require('../lib/methods/helpers/info');
+			const { showErrorAlert } = require('../../lib/methods/helpers/info');
 			mockFetch.mockRejectedValue(new Error('DB error'));
 			mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [] });
 
@@ -499,22 +506,36 @@ describe('TeamChannelsView', () => {
 	});
 
 	describe('8. Create button shown only when showCreate', () => {
-		it('calls setOptions when hasCreatePermission is true', async () => {
+		it('passes the resolved team rid/type to the reactive create-permission hook', async () => {
 			setupSuccessfulLoad([]);
-			mockHasPermission.mockResolvedValue([true, true, true]);
 
 			render(<TeamChannelsView />);
 
-			await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+			await waitFor(() => expect(mockUseCanCreateTeamChannel).toHaveBeenCalledWith('room-main', 'c'));
 		});
 
-		it('calls setOptions when hasCreatePermission is false', async () => {
+		it('renders the create button in the header when create is permitted', async () => {
 			setupSuccessfulLoad([]);
-			mockHasPermission.mockResolvedValue([false, false, false]);
+			mockUseCanCreateTeamChannel.mockReturnValue(true);
 
 			render(<TeamChannelsView />);
 
-			await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+			await waitFor(() =>
+				expect(renderHeaderSlot(lastSetOptions().headerRight).getByTestId('team-channels-view-create')).toBeTruthy()
+			);
+		});
+
+		it('hides the create button in the header when create is not permitted', async () => {
+			setupSuccessfulLoad([]);
+			mockUseCanCreateTeamChannel.mockReturnValue(false);
+
+			render(<TeamChannelsView />);
+
+			// The header is still applied (search button present) but the create button is absent.
+			await waitFor(() =>
+				expect(renderHeaderSlot(lastSetOptions().headerRight).getByTestId('team-channels-view-search')).toBeTruthy()
+			);
+			expect(renderHeaderSlot(lastSetOptions().headerRight).queryByTestId('team-channels-view-create')).toBeNull();
 		});
 	});
 });

--- a/app/views/TeamChannelsView/channelActionPermissions.test.ts
+++ b/app/views/TeamChannelsView/channelActionPermissions.test.ts
@@ -1,0 +1,92 @@
+import { getChannelActionPermissions } from './channelActionPermissions';
+import { type IItem } from './useTeamChannels';
+import { type TSubscriptionModel } from '../../definitions';
+
+const mockHasPermission = jest.fn();
+
+jest.mock('../../lib/methods/helpers', () => ({
+	hasPermission: (...args: any[]) => mockHasPermission(...args)
+}));
+
+const team = { rid: 'team-rid' } as unknown as TSubscriptionModel;
+
+const makeItem = (overrides: Partial<IItem> = {}): IItem =>
+	({
+		_id: 'item-id',
+		t: 'c',
+		...overrides
+	} as unknown as IItem);
+
+const perms = {
+	edit: ['edit-perm'],
+	remove: ['remove-perm'],
+	deleteC: ['delete-c-perm'],
+	deleteP: ['delete-p-perm']
+};
+
+describe('getChannelActionPermissions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('issues exactly three permission checks with the correct perm-array and rid for each', async () => {
+		mockHasPermission.mockResolvedValue([true]);
+
+		await getChannelActionPermissions(makeItem(), team, perms);
+
+		expect(mockHasPermission).toHaveBeenCalledTimes(3);
+		expect(mockHasPermission).toHaveBeenCalledWith([perms.edit], 'team-rid');
+		expect(mockHasPermission).toHaveBeenCalledWith([perms.remove], 'team-rid');
+		expect(mockHasPermission).toHaveBeenCalledWith([perms.deleteC], 'item-id');
+	});
+
+	it('uses deleteC when item.t is "c"', async () => {
+		mockHasPermission.mockResolvedValue([true]);
+
+		await getChannelActionPermissions(makeItem({ t: 'c' }), team, perms);
+
+		expect(mockHasPermission).toHaveBeenCalledWith([perms.deleteC], 'item-id');
+		expect(mockHasPermission).not.toHaveBeenCalledWith([perms.deleteP], 'item-id');
+	});
+
+	it('uses deleteP when item.t is not "c"', async () => {
+		mockHasPermission.mockResolvedValue([true]);
+
+		await getChannelActionPermissions(makeItem({ t: 'p' }), team, perms);
+
+		expect(mockHasPermission).toHaveBeenCalledWith([perms.deleteP], 'item-id');
+		expect(mockHasPermission).not.toHaveBeenCalledWith([perms.deleteC], 'item-id');
+	});
+
+	it('maps each returned boolean from its call’s [0] element', async () => {
+		mockHasPermission
+			.mockImplementationOnce(() => Promise.resolve([true])) // edit -> canAutoJoin
+			.mockImplementationOnce(() => Promise.resolve([false])) // remove -> canRemove
+			.mockImplementationOnce(() => Promise.resolve([true])); // delete -> canDelete
+
+		const result = await getChannelActionPermissions(makeItem(), team, perms);
+
+		expect(result).toEqual({ canAutoJoin: true, canRemove: false, canDelete: true });
+	});
+
+	it('dispatches all three checks in parallel before any resolves', async () => {
+		let resolveCount = 0;
+		const callOrder: string[] = [];
+		mockHasPermission.mockImplementation((permsArg: string[][]) => {
+			callOrder.push(permsArg[0][0]);
+			return new Promise(resolve => {
+				resolveCount += 1;
+				resolve([true]);
+			});
+		});
+
+		const promise = getChannelActionPermissions(makeItem(), team, perms);
+
+		// All three synchronous dispatches happened before any awaited resolution.
+		expect(mockHasPermission).toHaveBeenCalledTimes(3);
+		expect(callOrder).toEqual(['edit-perm', 'remove-perm', 'delete-c-perm']);
+		expect(resolveCount).toBe(3);
+
+		await promise;
+	});
+});

--- a/app/views/TeamChannelsView/channelActionPermissions.ts
+++ b/app/views/TeamChannelsView/channelActionPermissions.ts
@@ -1,0 +1,34 @@
+import { type TSubscriptionModel } from '../../definitions';
+import { hasPermission } from '../../lib/methods/helpers';
+import { type IItem } from './useTeamChannels';
+
+interface IChannelActionPerms {
+	edit: string[];
+	remove: string[];
+	deleteC: string[];
+	deleteP: string[];
+}
+
+interface IChannelActionPermissions {
+	canAutoJoin: boolean;
+	canRemove: boolean;
+	canDelete: boolean;
+}
+
+export const getChannelActionPermissions = async (
+	item: IItem,
+	team: TSubscriptionModel,
+	perms: IChannelActionPerms
+): Promise<IChannelActionPermissions> => {
+	const [editResult, removeResult, deleteResult] = await Promise.all([
+		hasPermission([perms.edit], team.rid),
+		hasPermission([perms.remove], team.rid),
+		hasPermission([item.t === 'c' ? perms.deleteC : perms.deleteP], item._id)
+	]);
+
+	return {
+		canAutoJoin: editResult[0],
+		canRemove: removeResult[0],
+		canDelete: deleteResult[0]
+	};
+};

--- a/app/views/TeamChannelsView/index.tsx
+++ b/app/views/TeamChannelsView/index.tsx
@@ -1,37 +1,39 @@
 import { Q } from '@nozbe/watermelondb';
 import { type NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { Alert, FlatList, Keyboard, PixelRatio, useWindowDimensions } from 'react-native';
+import { Alert, FlatList, PixelRatio, useWindowDimensions } from 'react-native';
 import { shallowEqual, useDispatch } from 'react-redux';
-import { useEffect, useReducer } from 'react';
+import { useEffect, useState } from 'react';
 
-import { deleteRoom } from '../actions/room';
-import { type DisplayMode } from '../lib/constants/constantDisplayMode';
-import { textInputDebounceTime } from '../lib/constants/debounceConfig';
-import { type TActionSheetOptionsItem, useActionSheet } from '../containers/ActionSheet';
-import ActivityIndicator from '../containers/ActivityIndicator';
-import BackgroundContainer from '../containers/BackgroundContainer';
-import * as HeaderButton from '../containers/Header/components/HeaderButton';
-import RoomHeader from '../containers/RoomHeader';
-import SafeAreaView from '../containers/SafeAreaView';
-import SearchHeader from '../containers/SearchHeader';
-import { type TSubscriptionModel } from '../definitions';
-import { ERoomType } from '../definitions/ERoomType';
-import { useMasterDetail } from '../lib/hooks/useMasterDetail';
-import { useAppSelector } from '../lib/hooks/useAppSelector';
-import { useAppNavigation, useAppRoute } from '../lib/hooks/navigation';
-import I18n from '../i18n';
-import database from '../lib/database';
-import { CustomIcon } from '../containers/CustomIcon';
-import RoomItem from '../containers/RoomItem';
-import { type ChatsStackParamList } from '../stacks/types';
-import { useTheme } from '../theme';
-import { goRoom } from '../lib/methods/helpers/goRoom';
-import { showErrorAlert } from '../lib/methods/helpers/info';
-import log, { events, logEvent } from '../lib/methods/helpers/log';
-import { getRoomAvatar, getRoomTitle, hasPermission, useDebounce, isIOS, compareServerVersion } from '../lib/methods/helpers';
-import { getRoomInfo, getTeamListRoom, updateTeamRoom, removeTeamRoom } from '../lib/services/restApi';
+import { deleteRoom } from '../../actions/room';
+import { type DisplayMode } from '../../lib/constants/constantDisplayMode';
+import { type TActionSheetOptionsItem, useActionSheet } from '../../containers/ActionSheet';
+import ActivityIndicator from '../../containers/ActivityIndicator';
+import BackgroundContainer from '../../containers/BackgroundContainer';
+import * as HeaderButton from '../../containers/Header/components/HeaderButton';
+import RoomHeader from '../../containers/RoomHeader';
+import SafeAreaView from '../../containers/SafeAreaView';
+import SearchHeader from '../../containers/SearchHeader';
+import { type TSubscriptionModel } from '../../definitions';
+import { ERoomType } from '../../definitions/ERoomType';
+import { useMasterDetail } from '../../lib/hooks/useMasterDetail';
+import { useAppSelector } from '../../lib/hooks/useAppSelector';
+import { useAppNavigation, useAppRoute } from '../../lib/hooks/navigation';
+import I18n from '../../i18n';
+import database from '../../lib/database';
+import { CustomIcon } from '../../containers/CustomIcon';
+import RoomItem from '../../containers/RoomItem';
+import { type ChatsStackParamList } from '../../stacks/types';
+import { useTheme } from '../../theme';
+import { goRoom } from '../../lib/methods/helpers/goRoom';
+import { showErrorAlert } from '../../lib/methods/helpers/info';
+import log, { events, logEvent } from '../../lib/methods/helpers/log';
+import { getRoomAvatar, getRoomTitle, useDebounce, isIOS } from '../../lib/methods/helpers';
+import { getRoomInfo, updateTeamRoom, removeTeamRoom } from '../../lib/services/restApi';
+import { useCanCreateTeamChannel } from '../../lib/hooks/useTeamChannelPermissions';
+import { useTeamChannels, type IItem } from './useTeamChannels';
+import { getChannelActionPermissions } from './channelActionPermissions';
 
-const API_FETCH_COUNT = 25;
+export { type IItem } from './useTeamChannels';
 
 const EMPTY_PERMISSION: string[] = [];
 
@@ -45,76 +47,16 @@ const getItemLayout = (data: ArrayLike<IItem> | null | undefined, index: number)
 };
 const keyExtractor = (item: IItem) => item._id;
 
-export interface IItem {
-	_id: ERoomType;
-	fname: string;
-	customFields: object;
-	broadcast: boolean;
-	encrypted: boolean;
-	name: string;
-	t: string;
-	msgs: number;
-	usersCount: number;
-	u: { _id: string; name: string };
-	ts: string;
-	ro: boolean;
-	teamId: string;
-	default: boolean;
-	sysMes: boolean;
-	_updatedAt: string;
-	teamDefault: boolean;
-}
-
-interface ITeamChannelsViewState {
-	loading: boolean;
-	loadingMore: boolean;
-	data: IItem[];
-	isSearching: boolean;
-	searchText: string | null;
-	search: IItem[];
-	end: boolean;
-	showCreate: boolean;
-	team: TSubscriptionModel | null;
-}
-
 interface ITeamChannelsViewSelector {
-	serverVersion: string;
 	useRealName: boolean;
 	StoreLastMessage: boolean;
-	addTeamChannelPermission: string[];
-	moveRoomToTeamPermission: string[];
 	editTeamChannelPermission: string[];
 	removeTeamChannelPermission: string[];
-	createCPermission: string[];
-	createTeamChannelPermission: string[];
-	createPPermission: string[];
-	createTeamGroupPermission: string[];
 	deleteCPermission: string[];
 	deletePPermission: string[];
 	showAvatar: boolean;
 	displayMode: DisplayMode;
 }
-
-const initialState: ITeamChannelsViewState = {
-	loading: true,
-	loadingMore: false,
-	data: [],
-	isSearching: false,
-	searchText: '',
-	search: [],
-	end: false,
-	showCreate: false,
-	team: null
-};
-
-type TeamChannelsStateUpdate =
-	| Partial<ITeamChannelsViewState>
-	| ((state: ITeamChannelsViewState) => Partial<ITeamChannelsViewState>);
-
-const stateReducer = (state: ITeamChannelsViewState, update: TeamChannelsStateUpdate): ITeamChannelsViewState => ({
-	...state,
-	...(typeof update === 'function' ? update(state) : update)
-});
 
 const TeamChannelsView = () => {
 	'use memo';
@@ -131,34 +73,20 @@ const TeamChannelsView = () => {
 	const { width } = useWindowDimensions();
 
 	const {
-		serverVersion,
 		useRealName,
 		StoreLastMessage,
-		addTeamChannelPermission,
-		moveRoomToTeamPermission,
 		editTeamChannelPermission,
 		removeTeamChannelPermission,
-		createCPermission,
-		createTeamChannelPermission,
-		createPPermission,
-		createTeamGroupPermission,
 		deleteCPermission,
 		deletePPermission,
 		showAvatar,
 		displayMode
 	} = useAppSelector(
 		(state): ITeamChannelsViewSelector => ({
-			serverVersion: state.server.version as string,
 			useRealName: state.settings.UI_Use_Real_Name as boolean,
 			StoreLastMessage: state.settings.Store_Last_Message as boolean,
-			addTeamChannelPermission: state.permissions['add-team-channel'] ?? EMPTY_PERMISSION,
-			moveRoomToTeamPermission: state.permissions['move-room-to-team'] ?? EMPTY_PERMISSION,
 			editTeamChannelPermission: state.permissions['edit-team-channel'] ?? EMPTY_PERMISSION,
 			removeTeamChannelPermission: state.permissions['remove-team-channel'] ?? EMPTY_PERMISSION,
-			createCPermission: state.permissions['create-c'] ?? EMPTY_PERMISSION,
-			createTeamChannelPermission: state.permissions['create-team-channel'] ?? EMPTY_PERMISSION,
-			createPPermission: state.permissions['create-p'] ?? EMPTY_PERMISSION,
-			createTeamGroupPermission: state.permissions['create-team-group'] ?? EMPTY_PERMISSION,
 			deleteCPermission: state.permissions['delete-c'] ?? EMPTY_PERMISSION,
 			deletePPermission: state.permissions['delete-p'] ?? EMPTY_PERMISSION,
 			showAvatar: state.sortPreferences.showAvatar,
@@ -167,87 +95,26 @@ const TeamChannelsView = () => {
 		shallowEqual
 	);
 
-	const [state, updateState] = useReducer(stateReducer, initialState);
-	const { loading, loadingMore, data, isSearching, searchText, search, showCreate, team } = state;
-
-	const load = useDebounce(async () => {
-		// Safe: useDebounce forwards the latest committed closure via an internal ref, so `state` here is current.
-		const { loadingMore, data, search, isSearching, searchText, end } = state;
-		const length = isSearching ? search.length : data.length;
-		if (loadingMore || end) {
-			return;
-		}
-
-		updateState({ loadingMore: true });
-		try {
-			const result = await getTeamListRoom({
-				teamId,
-				offset: length,
-				count: API_FETCH_COUNT,
-				type: 'all',
-				filter: searchText
-			});
-
-			if (result.success) {
-				const newState: Partial<ITeamChannelsViewState> = {
-					loading: false,
-					loadingMore: false,
-					end: result.rooms.length < API_FETCH_COUNT
-				};
-
-				if (isSearching) {
-					newState.search = [...search, ...result.rooms] as IItem[];
-				} else {
-					newState.data = [...data, ...result.rooms] as IItem[];
-				}
-
-				updateState(newState);
-			} else {
-				updateState({ loading: false, loadingMore: false });
-			}
-		} catch (e) {
-			log(e);
-			updateState({ loading: false, loadingMore: false });
-		}
-	}, 300);
-
-	const onSearchChangeText = useDebounce((text: string) => {
-		updateState({
-			searchText: text,
-			search: [],
-			loading: !!text,
-			loadingMore: false,
-			end: false
-		});
-		if (text) {
-			load();
-		}
-	}, textInputDebounceTime);
+	const [team, setTeam] = useState<TSubscriptionModel | null>(null);
+	const showCreate = useCanCreateTeamChannel(team?.rid ?? '', (team?.t ?? 'c') as 'c' | 'p');
+	const {
+		list,
+		loading,
+		loadingMore,
+		isSearching,
+		searchText,
+		loadMore,
+		startSearch,
+		cancelSearch,
+		onSearchChangeText,
+		updateItem,
+		removeItem
+	} = useTeamChannels(teamId);
 
 	useEffect(() => {
 		if (!team) {
 			return;
 		}
-
-		const onSearchPress = () => {
-			logEvent(events.TC_SEARCH);
-			updateState({ isSearching: true });
-		};
-
-		const onCancelSearchPress = () => {
-			logEvent(events.TC_CANCEL_SEARCH);
-			if (!isSearching) {
-				return;
-			}
-			Keyboard.dismiss();
-			updateState({
-				searchText: null,
-				isSearching: false,
-				search: [],
-				loadingMore: false,
-				end: false
-			});
-		};
 
 		const goRoomActionsView = (screen?: string) => {
 			logEvent(events.TC_GO_ACTIONS);
@@ -275,7 +142,7 @@ const TeamChannelsView = () => {
 			const options: NativeStackNavigationOptions = {
 				headerLeft: () => (
 					<HeaderButton.Container left>
-						<HeaderButton.Item iconName='close' onPress={onCancelSearchPress} />
+						<HeaderButton.Item iconName='close' onPress={cancelSearch} />
 					</HeaderButton.Container>
 				),
 				headerTitle: () => <SearchHeader onSearchChangeText={onSearchChangeText} testID='team-channels-view-search-header' />,
@@ -299,13 +166,13 @@ const TeamChannelsView = () => {
 							onPress={() => navigation.navigate('AddChannelTeamView', { teamId, rid: team.rid, t: team.t as any })}
 						/>
 					) : null}
-					<HeaderButton.Item iconName='search' testID='team-channels-view-search' onPress={onSearchPress} />
+					<HeaderButton.Item iconName='search' testID='team-channels-view-search' onPress={startSearch} />
 				</HeaderButton.Container>
 			)
 		};
 
 		navigation.setOptions(options);
-	}, [team, isSearching, showCreate, navigation, teamId, onSearchChangeText, isMasterDetail, joined]);
+	}, [team, isSearching, showCreate, navigation, teamId, onSearchChangeText, startSearch, cancelSearch, isMasterDetail, joined]);
 
 	useEffect(() => {
 		const loadTeam = async () => {
@@ -313,19 +180,6 @@ const TeamChannelsView = () => {
 			const failNotFound = () => {
 				navigation.pop();
 				showErrorAlert(I18n.t('Team_not_found'));
-			};
-			const canCreateChannel = async (resolvedTeam: TSubscriptionModel) => {
-				if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '7.0.0')) {
-					const createPermissions =
-						resolvedTeam.t === 'c'
-							? [createCPermission, createTeamChannelPermission]
-							: [createPPermission, createTeamGroupPermission];
-					const result = await hasPermission([moveRoomToTeamPermission, ...createPermissions], resolvedTeam.rid);
-					return result.some(Boolean);
-				}
-				const createPermissions = resolvedTeam.t === 'c' ? [createCPermission] : [createPPermission];
-				const result = await hasPermission([addTeamChannelPermission, ...createPermissions], resolvedTeam.rid);
-				return result.some(Boolean);
 			};
 
 			try {
@@ -336,27 +190,14 @@ const TeamChannelsView = () => {
 					failNotFound();
 					return;
 				}
-				const canCreate = await canCreateChannel(resolvedTeam);
-				updateState({ team: resolvedTeam, showCreate: canCreate });
+				setTeam(resolvedTeam);
 			} catch {
 				failNotFound();
 			}
 		};
 
 		loadTeam();
-		load();
-	}, [
-		load,
-		teamId,
-		navigation,
-		serverVersion,
-		moveRoomToTeamPermission,
-		createCPermission,
-		createTeamChannelPermission,
-		createPPermission,
-		createTeamGroupPermission,
-		addTeamChannelPermission
-	]);
+	}, [teamId, navigation]);
 
 	const onPressItem = useDebounce(
 		async (item: IItem) => {
@@ -391,9 +232,7 @@ const TeamChannelsView = () => {
 		try {
 			const result = await updateTeamRoom({ roomId: item._id, isDefault: !item.teamDefault });
 			if (result.success) {
-				updateState(prev => ({
-					data: prev.data.map(i => (i._id === item._id ? { ...i, teamDefault: !i.teamDefault } : i))
-				}));
+				updateItem(item._id, { teamDefault: !item.teamDefault });
 			}
 		} catch (e) {
 			logEvent(events.TC_TOGGLE_AUTOJOIN_F);
@@ -409,7 +248,7 @@ const TeamChannelsView = () => {
 		try {
 			const result = await removeTeamRoom({ roomId: item._id, teamId: team.teamId as string });
 			if (result.success) {
-				updateState(prev => ({ data: prev.data.filter(room => result.room._id !== room._id) }));
+				removeItem(result.room._id);
 			}
 		} catch (e) {
 			logEvent(events.TC_DELETE_ROOM_F);
@@ -462,14 +301,20 @@ const TeamChannelsView = () => {
 		if (!team) {
 			return;
 		}
+		const { canAutoJoin, canRemove, canDelete } = await getChannelActionPermissions(item, team, {
+			edit: editTeamChannelPermission,
+			remove: removeTeamChannelPermission,
+			deleteC: deleteCPermission,
+			deleteP: deletePPermission
+		});
+
 		const isAutoJoinChecked = item.teamDefault;
 		const autoJoinIcon = isAutoJoinChecked ? 'checkbox-checked' : 'checkbox-unchecked';
 		const autoJoinIconColor = isAutoJoinChecked ? colors.fontHint : colors.fontDefault;
 
 		const options: TActionSheetOptionsItem[] = [];
 
-		const permissionsTeam = await hasPermission([editTeamChannelPermission], team.rid);
-		if (permissionsTeam[0]) {
+		if (canAutoJoin) {
 			options.push({
 				title: I18n.t('Auto-join'),
 				icon: item.t === 'p' ? 'channel-private' : 'channel-public',
@@ -486,8 +331,7 @@ const TeamChannelsView = () => {
 			});
 		}
 
-		const permissionsRemoveTeam = await hasPermission([removeTeamChannelPermission], team.rid);
-		if (permissionsRemoveTeam[0]) {
+		if (canRemove) {
 			options.push({
 				title: I18n.t('Remove_from_Team'),
 				icon: 'close',
@@ -497,8 +341,7 @@ const TeamChannelsView = () => {
 			});
 		}
 
-		const permissionsChannel = await hasPermission([item.t === 'c' ? deleteCPermission : deletePPermission], item._id);
-		if (permissionsChannel[0]) {
+		if (canDelete) {
 			options.push({
 				title: I18n.t('Delete'),
 				icon: 'delete',
@@ -542,23 +385,23 @@ const TeamChannelsView = () => {
 		if (loading) {
 			return <BackgroundContainer loading />;
 		}
-		if (isSearching && !search.length) {
+		if (isSearching && !list.length) {
 			return <BackgroundContainer text={searchText ? I18n.t('No_channels_in_team') : ''} />;
 		}
-		if (!isSearching && !data.length) {
+		if (!isSearching && !list.length) {
 			return <BackgroundContainer text={I18n.t('No_channels_in_team')} />;
 		}
 
 		return (
 			<FlatList
-				data={isSearching ? search : data}
-				extraData={isSearching ? search : data}
+				data={list}
+				extraData={list}
 				keyExtractor={keyExtractor}
 				renderItem={renderItem}
 				getItemLayout={getItemLayout}
 				removeClippedSubviews={isIOS}
 				keyboardShouldPersistTaps='always'
-				onEndReached={load}
+				onEndReached={loadMore}
 				onEndReachedThreshold={0.5}
 				ListFooterComponent={renderFooter}
 			/>

--- a/app/views/TeamChannelsView/useTeamChannels.test.ts
+++ b/app/views/TeamChannelsView/useTeamChannels.test.ts
@@ -1,0 +1,180 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useTeamChannels, type IItem } from './useTeamChannels';
+
+const mockGetTeamListRoom = jest.fn();
+
+jest.mock('../../lib/services/restApi', () => ({
+	getTeamListRoom: (...args: any[]) => mockGetTeamListRoom(...args)
+}));
+
+jest.mock('../../lib/methods/helpers/log', () => ({
+	__esModule: true,
+	default: jest.fn(),
+	logEvent: jest.fn(),
+	events: {
+		TC_SEARCH: 'TC_SEARCH',
+		TC_CANCEL_SEARCH: 'TC_CANCEL_SEARCH'
+	}
+}));
+
+const makeRoom = (overrides: Partial<IItem> = {}): IItem =>
+	({
+		_id: 'room-1',
+		fname: 'Room One',
+		name: 'room-one',
+		teamDefault: false,
+		t: 'c',
+		...overrides
+	} as IItem);
+
+const makePage = (count: number, prefix = 'r') =>
+	Array.from({ length: count }, (_, i) => makeRoom({ _id: `${prefix}${i}` as any, fname: `Room ${i}` }));
+
+describe('useTeamChannels', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('loads channels on mount and exposes them via `list`', async () => {
+		const rooms = [makeRoom({ _id: 'r1' as any })];
+		mockGetTeamListRoom.mockResolvedValue({ success: true, rooms });
+
+		const { result } = renderHook(() => useTeamChannels('team-123'));
+
+		await waitFor(() => expect(result.current.list).toEqual(rooms));
+		expect(mockGetTeamListRoom).toHaveBeenCalledWith(
+			expect.objectContaining({ teamId: 'team-123', offset: 0, count: 25, type: 'all' })
+		);
+		expect(result.current.loading).toBe(false);
+	});
+
+	it('loadMore appends the next page and advances the offset by the browse-bucket length', async () => {
+		const page1 = makePage(25);
+		const page2 = [makeRoom({ _id: 'r-extra' as any })];
+		mockGetTeamListRoom
+			.mockResolvedValueOnce({ success: true, rooms: page1 })
+			.mockResolvedValueOnce({ success: true, rooms: page2 });
+
+		const { result } = renderHook(() => useTeamChannels('team-123'));
+		await waitFor(() => expect(result.current.list).toHaveLength(25));
+
+		act(() => {
+			result.current.loadMore();
+		});
+
+		await waitFor(() => expect(result.current.list).toHaveLength(26));
+		expect(mockGetTeamListRoom).toHaveBeenNthCalledWith(2, expect.objectContaining({ offset: 25 }));
+	});
+
+	it('stops loading once a short page sets `end` (no further fetch)', async () => {
+		mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: makePage(1) });
+
+		const { result } = renderHook(() => useTeamChannels('team-123'));
+		await waitFor(() => expect(result.current.list).toHaveLength(1));
+
+		act(() => {
+			result.current.loadMore();
+		});
+
+		await waitFor(() => expect(result.current.loadingMore).toBe(false));
+		expect(mockGetTeamListRoom).toHaveBeenCalledTimes(1);
+	});
+
+	it('the loadingMore guard prevents a concurrent fetch while one is in flight', async () => {
+		let resolveFirst: (value: any) => void = () => {};
+		mockGetTeamListRoom
+			.mockImplementationOnce(
+				() =>
+					new Promise(res => {
+						resolveFirst = res;
+					})
+			)
+			.mockResolvedValue({ success: true, rooms: makePage(1) });
+
+		const { result } = renderHook(() => useTeamChannels('team-123'));
+		await waitFor(() => expect(result.current.loadingMore).toBe(true));
+
+		act(() => {
+			result.current.loadMore();
+		});
+		expect(mockGetTeamListRoom).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			resolveFirst({ success: true, rooms: makePage(25) });
+		});
+		await waitFor(() => expect(result.current.list).toHaveLength(25));
+	});
+
+	it('onSearchChangeText resets the search bucket, marks loading, and loads filtered results', async () => {
+		mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: makePage(2, 'browse') });
+
+		const { result } = renderHook(() => useTeamChannels('team-123'));
+		await waitFor(() => expect(result.current.list).toHaveLength(2));
+
+		act(() => {
+			result.current.startSearch();
+		});
+		expect(result.current.isSearching).toBe(true);
+
+		mockGetTeamListRoom.mockClear();
+		mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [makeRoom({ _id: 'match' as any })] });
+
+		act(() => {
+			result.current.onSearchChangeText('design');
+		});
+
+		await waitFor(
+			() => expect(mockGetTeamListRoom).toHaveBeenCalledWith(expect.objectContaining({ offset: 0, filter: 'design' })),
+			{ timeout: 2000 }
+		);
+		await waitFor(() => expect(result.current.list).toEqual([expect.objectContaining({ _id: 'match' })]));
+		expect(result.current.searchText).toBe('design');
+	});
+
+	it('cancelSearch restores the preserved browse bucket without a new fetch', async () => {
+		const browse = makePage(2, 'browse');
+		mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: browse });
+
+		const { result } = renderHook(() => useTeamChannels('team-123'));
+		await waitFor(() => expect(result.current.list).toHaveLength(2));
+
+		act(() => {
+			result.current.startSearch();
+		});
+
+		mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: [makeRoom({ _id: 'match' as any })] });
+		act(() => {
+			result.current.onSearchChangeText('design');
+		});
+		await waitFor(() => expect(result.current.list).toEqual([expect.objectContaining({ _id: 'match' })]));
+
+		const callsBeforeCancel = mockGetTeamListRoom.mock.calls.length;
+
+		act(() => {
+			result.current.cancelSearch();
+		});
+
+		await waitFor(() => expect(result.current.isSearching).toBe(false));
+		expect(result.current.list).toEqual(browse);
+		expect(mockGetTeamListRoom).toHaveBeenCalledTimes(callsBeforeCancel);
+	});
+
+	it('updateItem patches a matching browse item; removeItem drops it', async () => {
+		const browse = [makeRoom({ _id: 'r1' as any, teamDefault: false }), makeRoom({ _id: 'r2' as any })];
+		mockGetTeamListRoom.mockResolvedValue({ success: true, rooms: browse });
+
+		const { result } = renderHook(() => useTeamChannels('team-123'));
+		await waitFor(() => expect(result.current.list).toHaveLength(2));
+
+		act(() => {
+			result.current.updateItem('r1' as any, { teamDefault: true });
+		});
+		await waitFor(() => expect(result.current.list.find(i => i._id === ('r1' as any))?.teamDefault).toBe(true));
+
+		act(() => {
+			result.current.removeItem('r1' as any);
+		});
+		await waitFor(() => expect(result.current.list.map(i => i._id)).toEqual(['r2']));
+	});
+});

--- a/app/views/TeamChannelsView/useTeamChannels.ts
+++ b/app/views/TeamChannelsView/useTeamChannels.ts
@@ -1,0 +1,165 @@
+import { Keyboard } from 'react-native';
+import { useEffect, useReducer } from 'react';
+
+import { type ERoomType } from '../../definitions/ERoomType';
+import { textInputDebounceTime } from '../../lib/constants/debounceConfig';
+import { useDebounce } from '../../lib/methods/helpers';
+import log, { events, logEvent } from '../../lib/methods/helpers/log';
+import { getTeamListRoom } from '../../lib/services/restApi';
+
+const API_FETCH_COUNT = 25;
+
+export interface IItem {
+	_id: ERoomType;
+	fname: string;
+	customFields: object;
+	broadcast: boolean;
+	encrypted: boolean;
+	name: string;
+	t: string;
+	msgs: number;
+	usersCount: number;
+	u: { _id: string; name: string };
+	ts: string;
+	ro: boolean;
+	teamId: string;
+	default: boolean;
+	sysMes: boolean;
+	_updatedAt: string;
+	teamDefault: boolean;
+}
+
+interface ITeamChannelsState {
+	loading: boolean;
+	loadingMore: boolean;
+	data: IItem[];
+	isSearching: boolean;
+	searchText: string | null;
+	search: IItem[];
+	end: boolean;
+}
+
+type TeamChannelsStateUpdate = Partial<ITeamChannelsState> | ((state: ITeamChannelsState) => Partial<ITeamChannelsState>);
+
+const stateReducer = (state: ITeamChannelsState, update: TeamChannelsStateUpdate): ITeamChannelsState => ({
+	...state,
+	...(typeof update === 'function' ? update(state) : update)
+});
+
+const initialState: ITeamChannelsState = {
+	loading: true,
+	loadingMore: false,
+	data: [],
+	isSearching: false,
+	searchText: '',
+	search: [],
+	end: false
+};
+
+export const useTeamChannels = (teamId: string) => {
+	'use memo';
+
+	const [state, updateState] = useReducer(stateReducer, initialState);
+	const { loading, loadingMore, data, isSearching, searchText, search } = state;
+
+	const load = useDebounce(async () => {
+		// useDebounce keeps a ref to the latest callback, so this always reads fresh state
+		const { loadingMore, data, search, isSearching, searchText, end } = state;
+		const length = isSearching ? search.length : data.length;
+		if (loadingMore || end) {
+			return;
+		}
+
+		updateState({ loadingMore: true });
+		try {
+			const result = await getTeamListRoom({
+				teamId,
+				offset: length,
+				count: API_FETCH_COUNT,
+				type: 'all',
+				filter: searchText
+			});
+
+			if (result.success) {
+				const newState: Partial<ITeamChannelsState> = {
+					loading: false,
+					loadingMore: false,
+					end: result.rooms.length < API_FETCH_COUNT
+				};
+
+				if (isSearching) {
+					newState.search = [...search, ...result.rooms] as IItem[];
+				} else {
+					newState.data = [...data, ...result.rooms] as IItem[];
+				}
+
+				updateState(newState);
+			} else {
+				updateState({ loading: false, loadingMore: false });
+			}
+		} catch (e) {
+			log(e);
+			updateState({ loading: false, loadingMore: false });
+		}
+	}, 300);
+
+	const onSearchChangeText = useDebounce((text: string) => {
+		updateState({
+			searchText: text,
+			search: [],
+			loading: !!text,
+			loadingMore: false,
+			end: false
+		});
+		if (text) {
+			load();
+		}
+	}, textInputDebounceTime);
+
+	const startSearch = () => {
+		logEvent(events.TC_SEARCH);
+		updateState({ isSearching: true });
+	};
+
+	const cancelSearch = () => {
+		logEvent(events.TC_CANCEL_SEARCH);
+		if (!isSearching) {
+			return;
+		}
+		Keyboard.dismiss();
+		updateState({
+			searchText: null,
+			isSearching: false,
+			search: [],
+			loadingMore: false,
+			end: false
+		});
+	};
+
+	const updateItem = (id: IItem['_id'], patch: Partial<IItem>) => {
+		updateState(prev => ({ data: prev.data.map(item => (item._id === id ? { ...item, ...patch } : item)) }));
+	};
+
+	const removeItem = (id: string) => {
+		updateState(prev => ({ data: prev.data.filter(item => item._id !== id) }));
+	};
+
+	// Run the initial channels load when the hook mounts; `load` is a stable debounced ref, so this fires once
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	return {
+		list: isSearching ? search : data,
+		loading,
+		loadingMore,
+		isSearching,
+		searchText,
+		loadMore: load,
+		startSearch,
+		cancelSearch,
+		onSearchChangeText,
+		updateItem,
+		removeItem
+	};
+};


### PR DESCRIPTION
## Proposed changes

Migrates `app/views/TeamChannelsView` from a class component to a function component, then extracts its logic into focused, testable units.

Migration: the class was wrapped in five HOCs (`connect`, `withTheme`, `withActionSheet`, `withDimensions`, `withMasterDetail`), now replaced with the equivalent hooks (`useAppSelector` + `shallowEqual`, `useTheme`, `useActionSheet`, `useWindowDimensions`, `useMasterDetail`) plus `useAppNavigation` / `useAppRoute`. The component opts into React Compiler auto-memoization via a `'use memo'` directive.

Extractions (behavior-preserving):

- `useTeamChannels(teamId)` — view-local paginated browse/search list engine. It keeps separate browse and search buckets so cancelling a search restores the browse list without re-fetching.
- `useTeamChannelPermissions` (shared, `app/lib/hooks`) — reactive create-permission hooks built on `usePermissions`. `AddChannelTeamView` now consumes these instead of defining the logic locally, and the view's "create" affordance is derived reactively rather than stored in `useState`.
- `getChannelActionPermissions` — pure async channel-action permission policy. Its three checks now run in parallel via `Promise.all` instead of serially.

The mount effect was slimmed so it no longer re-runs on permission-slice reference changes (its dependencies are now just the team id and navigation).

This also fixes a latent bug in `usePermissions`' `useSubscriptionRoles`: its effect dependency was `[]`, so it never re-subscribed when a room id arrived asynchronously. It now depends on `[rid]` and re-subscribes, guarded by a `{rid, roles}` state shape so roles from a previous room id can never leak after the id changes. All existing callers that pass a stable id are unaffected.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-28

## How to test or reproduce

1. Open a Team, then open its Channels view (Team header > kebab menu > Team Channels).
2. Verify the list loads, scrolling paginates more channels, and the header shows the team title.
3. Tap the search icon; type to filter channels; tap the close button and confirm the browse list is restored instantly (no re-fetch).
4. Long-press a channel to open the action sheet; verify the auto-join toggle, remove, and delete options appear according to your permissions and behave correctly.
5. From `AddChannelTeamView`, confirm "Create New" / "Add Existing" still appear according to your permissions.
6. On a tablet (master-detail layout), confirm the same behavior.

Unit tests cover the extracted units and the view. Run them with:

```
TZ=UTC pnpm test --testPathPattern='(TeamChannels|useTeamChannelPermissions|usePermissions|channelActionPermissions|useTeamChannels)'
```

## Screenshots

No visual changes — pure refactor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

## Further comments

The navigation header is a reactive effect mirroring local state, so handlers only update state and the effect re-applies the correct header (search vs. normal), following the existing `CannedResponsesListView` pattern.

The list engine and the permission hooks were extracted from the view so each has a single responsibility and can be unit-tested in isolation. The permission hooks are reactive (they re-derive as roles change), replacing the previous one-shot async permission reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team channels now support smoother search, pagination, and loading states in the channel list.
  * Channel actions are more consistently available based on your permissions and server version.
  * The screen now adapts its header between search and channel management controls more reliably.

* **Bug Fixes**
  * Fixed stale channel permission and subscription data from carrying over when switching teams or rooms.
  * Improved handling when a team can’t be found, including clearer navigation and error behavior.
  * Channel list updates now reflect add, remove, and auto-join changes more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
