### PR TITLE
feat: role-targeted expiration messages

### DIFF
--- a/app/containers/markdown/__snapshots__/Markdown.test.tsx.snap
+++ b/app/containers/markdown/__snapshots__/Markdown.test.tsx.snap
@@ -5882,7 +5882,7 @@ exports[`Story Snapshots: Timestamp should match snapshot 1`] = `
             ]
           }
         >
-           a year ago 
+           2 years ago 
         </Text>
       </Text>
     </Text>

--- a/app/definitions/IServer.ts
+++ b/app/definitions/IServer.ts
@@ -14,6 +14,14 @@ export type TSVMessage = {
 	subtitle?: string;
 	description?: string;
 	type: 'info' | 'alert' | 'error';
+	/**
+	 * Roles allowed to see this message. When omitted (or empty), the message is
+	 * shown to every user. When present, the message is only shown to users whose
+	 * roles intersect this list (e.g. `['admin']` targets workspace admins only).
+	 * Clients that predate this field ignore it and keep showing the message to
+	 * everyone, so the field is backward compatible.
+	 */
+	roles?: string[];
 	params?: Record<string, unknown>;
 	link: string;
 };

--- a/app/lib/methods/checkSupportedVersions.test.ts
+++ b/app/lib/methods/checkSupportedVersions.test.ts
@@ -608,4 +608,49 @@ describe('checkSupportedVersions role targeting', () => {
 		expect(result.status).toBe('supported');
 		expect(result.message).toBeUndefined();
 	});
+
+	describe('enforcement window', () => {
+		const buildEnforcementSupportedVersions = (roles?: string[]): ISupportedVersionsData => ({
+			timestamp: TODAY,
+			enforcementStartDate: '2023-04-15T00:00:00.000Z',
+			messages: [
+				{
+					remainingDays: 15,
+					title: 'targeted',
+					subtitle: 'subtitle_token',
+					description: 'description_token',
+					type: 'info',
+					...(roles ? { roles } : {}),
+					link: 'Docs page'
+				}
+			],
+			i18n: MOCK_I18N,
+			versions: [
+				{
+					version: '1.4.0',
+					expiration: '2023-03-10T00:00:00.000Z'
+				}
+			]
+		});
+
+		test('does not warn a non-targeted user during the enforcement grace window', () => {
+			const result = checkSupportedVersions({
+				supportedVersions: buildEnforcementSupportedVersions(['admin']),
+				serverVersion: '1.4.0',
+				userRoles: ['user']
+			});
+			expect(result.status).toBe('supported');
+			expect(result.message).toBeUndefined();
+		});
+
+		test('warns a targeted user during the enforcement grace window', () => {
+			expect(
+				checkSupportedVersions({
+					supportedVersions: buildEnforcementSupportedVersions(['admin']),
+					serverVersion: '1.4.0',
+					userRoles: ['admin']
+				})
+			).toMatchObject({ status: 'warn', message: { title: 'targeted' } });
+		});
+	});
 });

--- a/app/lib/methods/checkSupportedVersions.test.ts
+++ b/app/lib/methods/checkSupportedVersions.test.ts
@@ -1,4 +1,4 @@
-import { type ISupportedVersionsData } from '../../definitions';
+import { type ISupportedVersionsData, type TSVMessage } from '../../definitions';
 import { checkSupportedVersions, getMessage } from './checkSupportedVersions';
 
 const MOCK_I18N = {
@@ -517,5 +517,95 @@ describe('getMessage', () => {
 			type: 'info',
 			link: 'Docs page'
 		});
+	});
+
+	describe('role targeting', () => {
+		const buildMessages = (roles?: string[]): TSVMessage[] => [
+			{
+				remainingDays: 15,
+				title: 'targeted',
+				subtitle: 'subtitle_token',
+				description: 'description_token',
+				type: 'info',
+				...(roles ? { roles } : {}),
+				link: 'Docs page'
+			}
+		];
+
+		test('shows a message with no roles to every user', () => {
+			expect(
+				getMessage({ messages: buildMessages(), expiration: '2023-04-10T00:00:00.000Z', userRoles: ['user'] })
+			).toMatchObject({ title: 'targeted' });
+		});
+
+		test('shows a role-targeted message when the user has the role', () => {
+			expect(
+				getMessage({ messages: buildMessages(['admin']), expiration: '2023-04-10T00:00:00.000Z', userRoles: ['admin', 'user'] })
+			).toMatchObject({ title: 'targeted' });
+		});
+
+		test('hides a role-targeted message from users without the role', () => {
+			expect(
+				getMessage({ messages: buildMessages(['admin']), expiration: '2023-04-10T00:00:00.000Z', userRoles: ['user'] })
+			).toBeUndefined();
+		});
+
+		test('hides a role-targeted message when user roles are unknown', () => {
+			expect(getMessage({ messages: buildMessages(['admin']), expiration: '2023-04-10T00:00:00.000Z' })).toBeUndefined();
+		});
+	});
+});
+
+describe('checkSupportedVersions role targeting', () => {
+	const buildSupportedVersions = (roles?: string[]): ISupportedVersionsData => ({
+		timestamp: TODAY,
+		enforcementStartDate: TODAY,
+		messages: [
+			{
+				remainingDays: 15,
+				title: 'targeted',
+				subtitle: 'subtitle_token',
+				description: 'description_token',
+				type: 'info',
+				...(roles ? { roles } : {}),
+				link: 'Docs page'
+			}
+		],
+		i18n: MOCK_I18N,
+		versions: [
+			{
+				version: '1.4.0',
+				expiration: '2023-04-10T00:00:00.000Z'
+			}
+		]
+	});
+
+	test('shows a role-targeted message when the user has the role', () => {
+		expect(
+			checkSupportedVersions({
+				supportedVersions: buildSupportedVersions(['admin']),
+				serverVersion: '1.4.0',
+				userRoles: ['admin', 'user']
+			})
+		).toMatchObject({ status: 'warn', message: { title: 'targeted' } });
+	});
+
+	test('hides a role-targeted message from users without the role', () => {
+		const result = checkSupportedVersions({
+			supportedVersions: buildSupportedVersions(['admin']),
+			serverVersion: '1.4.0',
+			userRoles: ['user']
+		});
+		expect(result.status).toBe('supported');
+		expect(result.message).toBeUndefined();
+	});
+
+	test('hides a role-targeted message when user roles are unknown', () => {
+		const result = checkSupportedVersions({
+			supportedVersions: buildSupportedVersions(['admin']),
+			serverVersion: '1.4.0'
+		});
+		expect(result.status).toBe('supported');
+		expect(result.message).toBeUndefined();
 	});
 });

--- a/app/lib/methods/checkSupportedVersions.ts
+++ b/app/lib/methods/checkSupportedVersions.ts
@@ -5,17 +5,32 @@ import dayjs from '../dayjs';
 import { type ISupportedVersionsData, type TSVDictionary, type TSVMessage, type TSVStatus } from '../../definitions';
 import builtInSupportedVersions from '../../../app-supportedversions.json';
 
+const messageMatchesUserRoles = (message: TSVMessage, userRoles?: string[]): boolean => {
+	// No targeting on the message → show to everyone (default behavior).
+	if (!message.roles?.length) {
+		return true;
+	}
+	// Targeting set but user roles unknown → don't show, honoring the restriction.
+	if (!userRoles?.length) {
+		return false;
+	}
+	return message.roles.some(role => userRoles.includes(role));
+};
+
 export const getMessage = ({
 	messages,
-	expiration
+	expiration,
+	userRoles
 }: {
 	messages?: TSVMessage[];
 	expiration?: string;
+	userRoles?: string[];
 }): TSVMessage | undefined => {
 	if (!messages?.length || !expiration || dayjs(expiration).diff(new Date(), 'days') < 0) {
 		return;
 	}
-	const sortedMessages = messages.sort((a, b) => a.remainingDays - b.remainingDays);
+	const eligibleMessages = messages.filter(message => messageMatchesUserRoles(message, userRoles));
+	const sortedMessages = eligibleMessages.sort((a, b) => a.remainingDays - b.remainingDays);
 	return sortedMessages.find(({ remainingDays }) => dayjs(expiration).diff(new Date(), 'hours') <= remainingDays * 24);
 };
 
@@ -31,10 +46,12 @@ const getStatus = ({ expiration, message }: { expiration?: string; message?: TSV
 
 export const checkSupportedVersions = function ({
 	supportedVersions,
-	serverVersion
+	serverVersion,
+	userRoles
 }: {
 	supportedVersions?: ISupportedVersionsData;
 	serverVersion: string;
+	userRoles?: string[];
 }): {
 	status: TSVStatus;
 	message?: TSVMessage;
@@ -56,14 +73,15 @@ export const checkSupportedVersions = function ({
 	const messages =
 		exception?.messages || (exception ? sv.exceptions?.messages : undefined) || versionInfo?.messages || sv.messages;
 	const expiration = exception?.expiration || versionInfo?.expiration;
-	const message = getMessage({ messages, expiration });
+	const message = getMessage({ messages, expiration, userRoles });
 	const status = getStatus({ message, expiration });
 
 	// TODO: enforcement start date is temp only. Remove after a few releases.
 	if (status === 'expired' && sv?.enforcementStartDate && new Date(sv.enforcementStartDate) > new Date()) {
 		const enforcementMessage = getMessage({
 			messages,
-			expiration: sv.enforcementStartDate
+			expiration: sv.enforcementStartDate,
+			userRoles
 		});
 		return {
 			status: 'warn',

--- a/app/lib/methods/checkSupportedVersions.ts
+++ b/app/lib/methods/checkSupportedVersions.ts
@@ -83,12 +83,15 @@ export const checkSupportedVersions = function ({
 			expiration: sv.enforcementStartDate,
 			userRoles
 		});
-		return {
-			status: 'warn',
-			message: enforcementMessage,
-			i18n: enforcementMessage ? sv?.i18n : undefined,
-			expiration: sv.enforcementStartDate
-		};
+		if (enforcementMessage) {
+			return {
+				status: 'warn',
+				message: enforcementMessage,
+				i18n: sv?.i18n,
+				expiration: sv.enforcementStartDate
+			};
+		}
+		return { status: 'supported', expiration: sv.enforcementStartDate };
 	}
 
 	return {

--- a/app/sagas/selectServer.ts
+++ b/app/sagas/selectServer.ts
@@ -118,9 +118,11 @@ const getServerInfoSaga = function* getServerInfoSaga({ server, raiseError = tru
 		if (!serverRecord) {
 			throw new Error('Server not found');
 		}
+		const userRoles = (yield* appSelector(state => state.login?.user?.roles)) ?? [];
 		const supportedVersionsResult = yield* call(checkSupportedVersions, {
 			supportedVersions: serverRecord.supportedVersions,
-			serverVersion: serverRecord.version
+			serverVersion: serverRecord.version,
+			userRoles
 		});
 		yield put(setSupportedVersions(supportedVersionsResult));
 


### PR DESCRIPTION
Jira: [ARCH-2192](https://rocketchat.atlassian.net/browse/ARCH-2192)

## Proposal

Honor the optional `roles` field on supportedVersions `messages` so the signed payload can restrict a version-expiration warning to specific roles (e.g. workspace admins), instead of showing it to every logged-in user.

This is the **mobile** side of the same contract change shipped on desktop in [RocketChat/Rocket.Chat.Electron#3371](https://github.com/RocketChat/Rocket.Chat.Electron/pull/3371). The `supportedVersions` payload is a shared contract (produced by cloud, consumed by desktop **and** mobile); this PR makes mobile respect the `roles` field too.

## Behavior

- `roles` **omitted or empty** → message shown to everyone. Keeps current behavior; the field is backward compatible.
- `roles` **present** → message shown only to users whose roles intersect the list.
- `roles` present but the client doesn't know the user's roles → message is **not** shown (honors the restriction).

## Why mobile is simpler than desktop

The desktop app had **no notion of user role**, so most of #3371 was plumbing to acquire roles — a `setUserRoles` bridge, a `/api/v1/me` REST fallback, a `WEBVIEW_USER_ROLES_CHANGED` action + reducer, and a per-server `userRoles` field.

Mobile is the native client and **already has the logged-in user's roles in Redux** (`state.login.user.roles`, also persisted in the WatermelonDB `User` model). So none of that plumbing is needed — only the two pieces that matter port over: the `roles` type field and the role-filtering of expiration messages.

## Changes

- `TSVMessage.roles?: string[]` — `app/definitions/IServer.ts`
- `messageMatchesUserRoles` filter + a `userRoles` param threaded through `getMessage` and both `checkSupportedVersions` branches (normal + enforcement-start-date) — `app/lib/methods/checkSupportedVersions.ts`
- Source the current user's roles from the Redux login state at the single saga call site (`getServerInfoSaga`) — `app/sagas/selectServer.ts`
- Tests: `getMessage` role filtering + `checkSupportedVersions` role targeting (7 new cases) — `app/lib/methods/checkSupportedVersions.test.ts`

## Notes

- Filtering is client-side UX, not a security boundary.
- `checkSupportedVersions` runs once per server-select/resume and stores the result in the `supportedVersions` Redux slice. On the resume path `setUser` runs before the check, so roles are available. On a first-ever fresh login roles may not yet be populated, in which case a role-targeted message surfaces on the next launch — consistent with desktop's async-roles semantics and acceptable for a non-urgent deprecation notice.
- The `roles` field on the shared `supportedVersions` contract should be agreed centrally so all clients honor it; this is the mobile side, matching the desktop change in #3371.

## Verification

- \`pnpm tsc\` clean
- \`eslint\` clean on changed files
- \`TZ=UTC pnpm test --testPathPattern='checkSupportedVersions'\` → 45 passed (incl. 7 new)

[ARCH-2192]: https://rocketchat.atlassian.net/browse/ARCH-2192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version warnings and notices can now be targeted to specific user roles.
  * Role-targeted messages are shown only when the user’s roles intersect; untargeted messages still display to everyone.

* **Bug Fixes**
  * Role targeting is applied consistently for both standard version checks and enforcement-related warnings, including the enforcement-start-date override behavior.

* **Tests**
  * Added coverage to verify role-targeted selection, warning behavior, and grace/enforcement timing for targeted vs non-targeted users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->