### PR TITLE
fix: render list separators consistently by snapping row heights to the pixel grid

### DIFF
--- a/app/containers/ActionSheet/ActionSheet.tsx
+++ b/app/containers/ActionSheet/ActionSheet.tsx
@@ -19,6 +19,7 @@ import { Handle } from './Handle';
 import { type TActionSheetOptions } from './Provider';
 import BottomSheetContent from './BottomSheetContent';
 import { HANDLE_HEIGHT, useActionSheetDetents } from './useActionSheetDetents';
+import { useActionSheetItemHeight } from './useActionSheetItemHeight';
 import styles from './styles';
 
 export const ACTION_SHEET_ANIMATION_DURATION = 250;
@@ -26,7 +27,7 @@ export const ACTION_SHEET_ANIMATION_DURATION = 250;
 const ActionSheet = memo(
 	forwardRef(({ children }: { children: ReactElement }, ref) => {
 		const { colors } = useTheme();
-		const { height: windowHeight, width: windowWidth, fontScale } = useWindowDimensions();
+		const { height: windowHeight, width: windowWidth } = useWindowDimensions();
 		const sheetRef = useRef<TrueSheet>(null);
 		const handleRef = useRef<View>(null);
 		const [data, setData] = useState<TActionSheetOptions>({} as TActionSheetOptions);
@@ -38,7 +39,7 @@ const ActionSheet = memo(
 		// To avoid content hiding behind navigation bar on older Android versions
 		const isNewAndroid = isAndroid && Number(Platform.Version) >= 36;
 		const bottom = isIOS || isNewAndroid ? 0 : windowHeight * 0.03;
-		const itemHeight = 48 * fontScale;
+		const itemHeight = useActionSheetItemHeight();
 
 		const handleContentLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
 			setContentHeight(layout.height);

--- a/app/containers/ActionSheet/BottomSheetContent.tsx
+++ b/app/containers/ActionSheet/BottomSheetContent.tsx
@@ -1,4 +1,4 @@
-import { FlatList, Text, useWindowDimensions, View, type ViewProps } from 'react-native';
+import { FlatList, Text, View, type ViewProps } from 'react-native';
 import { memo, type ReactElement } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -10,6 +10,7 @@ import { type TActionSheetOptionsItem } from './Provider';
 import styles from './styles';
 import * as List from '../List';
 import Touch from '../Touch';
+import { useActionSheetItemHeight } from './useActionSheetItemHeight';
 
 interface IBottomSheetContentProps {
 	hasCancel?: boolean;
@@ -39,8 +40,7 @@ const BottomSheetContent = memo(
 
 		const { colors } = useTheme();
 		const { bottom } = useSafeAreaInsets();
-		const { fontScale } = useWindowDimensions();
-		const height = 48 * fontScale;
+		const height = useActionSheetItemHeight();
 		const paddingBottom = isAndroid ? bottom + height : bottom;
 		const minHeightStyle = isAndroid || !contentMinHeight ? undefined : { minHeight: contentMinHeight };
 

--- a/app/containers/ActionSheet/Item.tsx
+++ b/app/containers/ActionSheet/Item.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Text, useWindowDimensions, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { CustomIcon } from '../CustomIcon';
 import { useTheme } from '../../theme';
@@ -9,6 +9,7 @@ import { type TActionSheetOptionsItem } from './Provider';
 import styles from './styles';
 import { LISTENER } from '../Toast';
 import Touch from '../Touch';
+import { useActionSheetItemHeight } from './useActionSheetItemHeight';
 
 export interface IActionSheetItem {
 	item: TActionSheetOptionsItem;
@@ -20,7 +21,7 @@ export const Item = memo(({ item, hide }: IActionSheetItem) => {
 
 	const enabled = item?.enabled ?? true;
 	const { colors } = useTheme();
-	const { fontScale } = useWindowDimensions();
+	const height = useActionSheetItemHeight();
 	const onPress = () => {
 		if (enabled) {
 			hide();
@@ -37,7 +38,6 @@ export const Item = memo(({ item, hide }: IActionSheetItem) => {
 	if (!enabled) {
 		color = colors.fontDisabled;
 	}
-	const height = 48 * fontScale;
 	const accessibilityLabel = item?.accessibilityLabel || (item?.subtitle ? `${item.title}. ${item.subtitle}` : item.title);
 
 	return (

--- a/app/containers/ActionSheet/useActionSheetDetents.ts
+++ b/app/containers/ActionSheet/useActionSheetDetents.ts
@@ -1,6 +1,7 @@
 import type { SheetDetent } from '@lodev09/react-native-true-sheet';
 import { useMemo } from 'react';
-import { useWindowDimensions } from 'react-native';
+
+import { useActionSheetItemHeight } from './useActionSheetItemHeight';
 
 const ACTION_SHEET_MIN_HEIGHT_FRACTION = 0.15;
 const ACTION_SHEET_MAX_HEIGHT_FRACTION = 0.75;
@@ -47,8 +48,7 @@ export function useActionSheetDetents({
 	hasCancel = false,
 	contentHeight
 }: UseActionSheetDetentsParams): { detents: SheetDetent[]; maxHeight: number; scrollEnabled: boolean } {
-	const { fontScale } = useWindowDimensions();
-	const CANCEL_HEIGHT = 48 * fontScale;
+	const CANCEL_HEIGHT = useActionSheetItemHeight();
 
 	return useMemo(() => {
 		const maxHeight = windowHeight * ACTION_SHEET_MAX_HEIGHT_FRACTION;
@@ -90,5 +90,5 @@ export function useActionSheetDetents({
 		}
 
 		return { detents, maxHeight, scrollEnabled };
-	}, [bottomInset, contentHeight, hasCancel, headerHeight, itemHeight, optionsLength, snaps, windowHeight]);
+	}, [bottomInset, CANCEL_HEIGHT, contentHeight, hasCancel, headerHeight, itemHeight, optionsLength, snaps, windowHeight]);
 }

--- a/app/containers/ActionSheet/useActionSheetDetents.ts
+++ b/app/containers/ActionSheet/useActionSheetDetents.ts
@@ -1,8 +1,6 @@
 import type { SheetDetent } from '@lodev09/react-native-true-sheet';
 import { useMemo } from 'react';
 
-import { useActionSheetItemHeight } from './useActionSheetItemHeight';
-
 const ACTION_SHEET_MIN_HEIGHT_FRACTION = 0.15;
 const ACTION_SHEET_MAX_HEIGHT_FRACTION = 0.75;
 const SCROLL_ENABLED_THRESHOLD = 0.6;
@@ -48,15 +46,13 @@ export function useActionSheetDetents({
 	hasCancel = false,
 	contentHeight
 }: UseActionSheetDetentsParams): { detents: SheetDetent[]; maxHeight: number; scrollEnabled: boolean } {
-	const CANCEL_HEIGHT = useActionSheetItemHeight();
-
 	return useMemo(() => {
 		const maxHeight = windowHeight * ACTION_SHEET_MAX_HEIGHT_FRACTION;
 		const hasOptions = optionsLength > 0;
 
 		const maxSnap = hasOptions
 			? Math.min(
-					(itemHeight + 0.5) * optionsLength + HANDLE_HEIGHT + headerHeight + bottomInset + (hasCancel ? CANCEL_HEIGHT : 0),
+					(itemHeight + 0.5) * optionsLength + HANDLE_HEIGHT + headerHeight + bottomInset + (hasCancel ? itemHeight : 0),
 					maxHeight
 			  )
 			: 0;
@@ -72,7 +68,7 @@ export function useActionSheetDetents({
 				scrollEnabled = true;
 			} else {
 				const measuredHeight =
-					optionsLength * itemHeight + HANDLE_HEIGHT + headerHeight + bottomInset + (hasCancel ? CANCEL_HEIGHT : 0);
+					optionsLength * itemHeight + HANDLE_HEIGHT + headerHeight + bottomInset + (hasCancel ? itemHeight : 0);
 
 				scrollEnabled = false;
 				detents = [heightToDetent(Math.round(measuredHeight), windowHeight)];
@@ -90,5 +86,5 @@ export function useActionSheetDetents({
 		}
 
 		return { detents, maxHeight, scrollEnabled };
-	}, [bottomInset, CANCEL_HEIGHT, contentHeight, hasCancel, headerHeight, itemHeight, optionsLength, snaps, windowHeight]);
+	}, [bottomInset, contentHeight, hasCancel, headerHeight, itemHeight, optionsLength, snaps, windowHeight]);
 }

--- a/app/containers/ActionSheet/useActionSheetItemHeight.ts
+++ b/app/containers/ActionSheet/useActionSheetItemHeight.ts
@@ -2,7 +2,7 @@ import { PixelRatio, useWindowDimensions } from 'react-native';
 
 export const ACTION_SHEET_ITEM_HEIGHT = 48;
 
-export const useActionSheetItemHeight = () => {
+export const useActionSheetItemHeight = (): number => {
 	const { fontScale } = useWindowDimensions();
 	return PixelRatio.roundToNearestPixel(ACTION_SHEET_ITEM_HEIGHT * fontScale);
 };

--- a/app/containers/ActionSheet/useActionSheetItemHeight.ts
+++ b/app/containers/ActionSheet/useActionSheetItemHeight.ts
@@ -1,0 +1,8 @@
+import { PixelRatio, useWindowDimensions } from 'react-native';
+
+export const ACTION_SHEET_ITEM_HEIGHT = 48;
+
+export const useActionSheetItemHeight = () => {
+	const { fontScale } = useWindowDimensions();
+	return PixelRatio.roundToNearestPixel(ACTION_SHEET_ITEM_HEIGHT * fontScale);
+};

--- a/app/containers/DirectoryItem/index.tsx
+++ b/app/containers/DirectoryItem/index.tsx
@@ -1,5 +1,5 @@
 import { memo, type ReactElement } from 'react';
-import { Text, View, type ViewStyle } from 'react-native';
+import { PixelRatio, Text, View, type ViewStyle } from 'react-native';
 
 import Touch from '../Touch';
 import Avatar from '../Avatar';
@@ -49,7 +49,7 @@ const DirectoryItem = ({
 }: IDirectoryItem): ReactElement => {
 	const { colors } = useTheme();
 	const { fontScale } = useResponsiveLayout();
-	const height = ROW_HEIGHT * fontScale;
+	const height = PixelRatio.roundToNearestPixel(ROW_HEIGHT * fontScale);
 
 	return (
 		<View testID={testID} accessible accessibilityLabel={`${title || ''} ${rightLabel || ''}`} importantForAccessibility='yes'>

--- a/app/containers/List/ListItem.tsx
+++ b/app/containers/List/ListItem.tsx
@@ -1,6 +1,7 @@
 import { useMemo, memo, type ReactElement } from 'react';
 import {
 	I18nManager,
+	PixelRatio,
 	type StyleProp,
 	StyleSheet,
 	Text,
@@ -172,7 +173,11 @@ const Content = memo(
 
 		return (
 			<View
-				style={[styles.container, disabled && styles.disabled, { height: (heightContainer || BASE_HEIGHT) * fontScale }]}
+				style={[
+					styles.container,
+					disabled && styles.disabled,
+					{ height: PixelRatio.roundToNearestPixel((heightContainer || BASE_HEIGHT) * fontScale) }
+				]}
 				testID={testID}
 				accessible={!shouldDisableAccessibility}
 				accessibilityLabel={handleAcessibilityLabel}

--- a/app/containers/MessageActions/Header.tsx
+++ b/app/containers/MessageActions/Header.tsx
@@ -39,6 +39,8 @@ const ITEM_MARGIN = 8;
 
 const styles = StyleSheet.create({
 	container: {
+		height: HEADER_HEIGHT,
+		justifyContent: 'center',
 		alignItems: 'center',
 		marginHorizontal: CONTAINER_MARGIN,
 		paddingBottom: 16

--- a/app/containers/ServerItem/__snapshots__/ServerItem.test.tsx.snap
+++ b/app/containers/ServerItem/__snapshots__/ServerItem.test.tsx.snap
@@ -89,11 +89,16 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "padding": 12,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "padding": 12,
+              },
+              {
+                "height": 68,
+              },
+            ]
           }
         >
           <ViewManagerAdapter_ExpoImage
@@ -315,11 +320,16 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "padding": 12,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "padding": 12,
+              },
+              {
+                "height": 68,
+              },
+            ]
           }
         >
           <ViewManagerAdapter_ExpoImage
@@ -541,11 +551,16 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "padding": 12,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "padding": 12,
+              },
+              {
+                "height": 68,
+              },
+            ]
           }
         >
           <ViewManagerAdapter_ExpoImage
@@ -699,7 +714,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -720,7 +735,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
               "width": 390,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -901,11 +916,16 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -1056,7 +1076,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -1077,7 +1097,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
               "width": 390,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -1258,11 +1278,16 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -1491,11 +1516,16 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "padding": 12,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "padding": 12,
+              },
+              {
+                "height": 68,
+              },
+            ]
           }
         >
           <ViewManagerAdapter_ExpoImage
@@ -1717,11 +1747,16 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "padding": 12,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "padding": 12,
+              },
+              {
+                "height": 68,
+              },
+            ]
           }
         >
           <ViewManagerAdapter_ExpoImage
@@ -1943,11 +1978,16 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
       >
         <View
           style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "padding": 12,
-            }
+            [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "padding": 12,
+              },
+              {
+                "height": 68,
+              },
+            ]
           }
         >
           <ViewManagerAdapter_ExpoImage

--- a/app/containers/ServerItem/index.tsx
+++ b/app/containers/ServerItem/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Text, View } from 'react-native';
+import { PixelRatio, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 
 import * as List from '../List';
@@ -29,7 +29,8 @@ const defaultLogo = require('../../static/images/logo.png');
 
 const ServerItem = memo(({ item, onPress, onDeletePress, hasCheck }: IServerItem) => {
 	const { colors } = useTheme();
-	const { width } = useResponsiveLayout();
+	const { width, fontScale } = useResponsiveLayout();
+	const height = PixelRatio.roundToNearestPixel(ROW_HEIGHT * fontScale);
 
 	const iconName = hasCheck ? 'radio-checked' : 'radio-unchecked';
 	const iconColor = hasCheck ? colors.badgeBackgroundLevel2 : colors.strokeMedium;
@@ -48,7 +49,7 @@ const ServerItem = memo(({ item, onPress, onDeletePress, hasCheck }: IServerItem
 			onDeletePress={onDeletePress}
 			testID={`server-item-${item.id}`}
 			width={width}>
-			<View style={styles.serverItemContainer}>
+			<View style={[styles.serverItemContainer, { height }]}>
 				{item.iconURL ? (
 					<Image
 						source={{

--- a/app/containers/ServerItem/styles.ts
+++ b/app/containers/ServerItem/styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from 'react-native';
 
 import sharedStyles from '../../views/Styles';
 
-export const ROW_HEIGHT = 56;
+export const ROW_HEIGHT = 68;
 export const ACTION_WIDTH = 80;
 export const SMALL_SWIPE = ACTION_WIDTH / 2;
 export const LONG_SWIPE = ACTION_WIDTH * 2.5;

--- a/app/containers/UserItem.tsx
+++ b/app/containers/UserItem.tsx
@@ -1,16 +1,16 @@
-import { Pressable, type StyleProp, StyleSheet, Text, View, type ViewStyle } from 'react-native';
+import { Pressable, PixelRatio, type StyleProp, StyleSheet, Text, View, type ViewStyle } from 'react-native';
 
 import Avatar from './Avatar';
 import { CustomIcon, type TIconsName } from './CustomIcon';
 import sharedStyles from '../views/Styles';
 import { isIOS } from '../lib/methods/helpers';
 import { useTheme } from '../theme';
+import { useResponsiveLayout } from '../lib/hooks/useResponsiveLayout/useResponsiveLayout';
 import i18n from '../i18n';
 
+const ROW_HEIGHT = 54;
+
 const styles = StyleSheet.create({
-	button: {
-		height: 54
-	},
 	container: {
 		flexDirection: 'row'
 	},
@@ -48,6 +48,8 @@ interface IUserItem {
 
 const UserItem = ({ name, username, onPress, testID, onLongPress, style, icon, iconColor, isChecked }: IUserItem) => {
 	const { colors } = useTheme();
+	const { fontScale } = useResponsiveLayout();
+	const height = PixelRatio.roundToNearestPixel(ROW_HEIGHT * fontScale);
 	let label = `${name}`;
 	if (icon) {
 		label = `${name} ${isChecked ? i18n.t('Selected') : i18n.t('Unselected')}`;
@@ -65,7 +67,7 @@ const UserItem = ({ name, username, onPress, testID, onLongPress, style, icon, i
 			})}
 			accessibilityLabel={label}
 			accessibilityRole='button'>
-			<View style={[styles.container, styles.button, style]}>
+			<View style={[styles.container, { height }, style]}>
 				<Avatar text={username} size={30} style={styles.avatar} />
 				<View style={styles.textContainer}>
 					<Text style={[styles.name, { color: colors.fontDefault }]} numberOfLines={1}>

--- a/app/ee/omnichannel/views/QueueListView.tsx
+++ b/app/ee/omnichannel/views/QueueListView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, memo } from 'react';
 import { type CompositeNavigationProp, useNavigation } from '@react-navigation/native';
 import { type NativeStackNavigationOptions, type NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { FlatList, type ListRenderItem, useWindowDimensions } from 'react-native';
+import { FlatList, type ListRenderItem } from 'react-native';
 import { shallowEqual, useSelector } from 'react-redux';
 
 import I18n from '../../../i18n';
@@ -20,6 +20,7 @@ import { type MasterDetailInsideStackParamList } from '../../../stacks/MasterDet
 import { getRoomAvatar, getRoomTitle, getUidDirectMessage, isIOS, isTablet } from '../../../lib/methods/helpers';
 import { useResponsiveLayout } from '../../../lib/hooks/useResponsiveLayout/useResponsiveLayout';
 import { useMasterDetail } from '../../../lib/hooks/useMasterDetail';
+import { DisplayMode } from '../../../lib/constants/constantDisplayMode';
 
 type TNavigation = CompositeNavigationProp<
 	NativeStackNavigationProp<ChatsStackParamList, 'QueueListView'>,
@@ -34,8 +35,7 @@ const QueueListView = memo(() => {
 	const navigation = useNavigation<TNavigation>();
 	const getScrollRef = useRef<FlatList<IOmnichannelRoom>>(null);
 	const { colors } = useTheme();
-	const { width } = useResponsiveLayout();
-	const { fontScale } = useWindowDimensions();
+	const { width, rowHeight, rowHeightCondensed } = useResponsiveLayout();
 
 	const { username } = useSelector(
 		(state: IApplicationState) => ({
@@ -69,10 +69,10 @@ const QueueListView = memo(() => {
 	}, [isMasterDetail, navigation]);
 
 	const getItemLayout = (_data: ArrayLike<IOmnichannelRoom> | null | undefined, index: number) => {
-		const rowHeight = 75 * fontScale;
+		const height = displayMode === DisplayMode.Condensed ? rowHeightCondensed : rowHeight;
 		return {
-			length: rowHeight,
-			offset: rowHeight * index,
+			length: height,
+			offset: height * index,
 			index
 		};
 	};

--- a/app/lib/hooks/useResponsiveLayout/useResponsiveLayout.tsx
+++ b/app/lib/hooks/useResponsiveLayout/useResponsiveLayout.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, type ReactNode } from 'react';
-import { useWindowDimensions } from 'react-native';
+import { PixelRatio, useWindowDimensions } from 'react-native';
 
 interface IResponsiveLayoutContextData {
 	fontScale: number;
@@ -27,8 +27,8 @@ const ResponsiveLayoutProvider = ({ children }: IResponsiveFontScaleProviderProp
 	const isLargeFontScale = fontScale > FONT_SCALE_LIMIT;
 	// `fontScaleLimited` applies the `FONT_SCALE_LIMIT` to prevent layout issues on large font sizes.
 	const fontScaleLimited = isLargeFontScale ? FONT_SCALE_LIMIT : fontScale;
-	const rowHeight = BASE_ROW_HEIGHT * fontScale;
-	const rowHeightCondensed = BASE_ROW_HEIGHT_CONDENSED * fontScale;
+	const rowHeight = PixelRatio.roundToNearestPixel(BASE_ROW_HEIGHT * fontScale);
+	const rowHeightCondensed = PixelRatio.roundToNearestPixel(BASE_ROW_HEIGHT_CONDENSED * fontScale);
 
 	return (
 		<ResponsiveLayoutContext.Provider

--- a/app/views/CannedResponsesListView/DepartmentFilter/DepartmentItemFilter.tsx
+++ b/app/views/CannedResponsesListView/DepartmentFilter/DepartmentItemFilter.tsx
@@ -1,10 +1,11 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { PixelRatio, StyleSheet, Text, View } from 'react-native';
 
 import { type ILivechatDepartment } from '../../../definitions/ILivechatDepartment';
 import { useTheme } from '../../../theme';
 import Touch from '../../../containers/Touch';
 import { CustomIcon } from '../../../containers/CustomIcon';
 import sharedStyles from '../../Styles';
+import { useResponsiveLayout } from '../../../lib/hooks/useResponsiveLayout/useResponsiveLayout';
 
 interface IDepartmentItemFilter {
 	currentDepartment: ILivechatDepartment;
@@ -17,7 +18,6 @@ export const ROW_HEIGHT = 44;
 const styles = StyleSheet.create({
 	container: {
 		paddingVertical: 11,
-		height: ROW_HEIGHT,
 		paddingHorizontal: 16,
 		flexDirection: 'row',
 		alignItems: 'center'
@@ -31,11 +31,13 @@ const styles = StyleSheet.create({
 
 const DepartmentItemFilter = ({ currentDepartment, value, onPress }: IDepartmentItemFilter) => {
 	const { colors } = useTheme();
+	const { fontScale } = useResponsiveLayout();
+	const height = PixelRatio.roundToNearestPixel(ROW_HEIGHT * fontScale);
 	const iconName = currentDepartment?._id === value?._id ? 'check' : null;
 
 	return (
 		<Touch onPress={() => onPress(value)} style={{ backgroundColor: colors.surfaceRoom }}>
-			<View style={styles.container}>
+			<View style={[styles.container, { height }]}>
 				<Text style={[styles.text, { color: colors.fontSecondaryInfo }]}>{value?.name}</Text>
 				{iconName ? <CustomIcon name={iconName} size={22} color={colors.fontSecondaryInfo} /> : null}
 			</View>

--- a/app/views/NewServerView/components/ServersHistoryItem/__snapshots__/ServersHistoryItem.test.tsx.snap
+++ b/app/views/NewServerView/components/ServersHistoryItem/__snapshots__/ServersHistoryItem.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -37,7 +37,7 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -218,12 +218,16 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -330,7 +334,7 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -351,7 +355,7 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -532,12 +536,16 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -644,7 +652,7 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -665,7 +673,7 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -846,12 +854,16 @@ exports[`Story Snapshots: Content should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -963,7 +975,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -984,7 +996,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -1165,12 +1177,16 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -1277,7 +1293,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -1298,7 +1314,7 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -1479,12 +1495,16 @@ exports[`Story Snapshots: SwipeActions should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -1596,7 +1616,7 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#EC0D2A",
@@ -1617,7 +1637,7 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -1798,12 +1818,16 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -1910,7 +1934,7 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#BB3E4E",
@@ -1931,7 +1955,7 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -2112,12 +2136,16 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage
@@ -2224,7 +2252,7 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
             "right": 0,
           },
           {
-            "height": 68,
+            "height": 80,
           },
           {
             "backgroundColor": "#BB3E4E",
@@ -2245,7 +2273,7 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
               "width": 350,
             },
             {
-              "height": 68,
+              "height": 80,
             },
             [Function],
           ]
@@ -2426,12 +2454,16 @@ exports[`Story Snapshots: Themes should match snapshot 1`] = `
           >
             <View
               style={
-                {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "minHeight": 56,
-                  "padding": 12,
-                }
+                [
+                  {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "padding": 12,
+                  },
+                  {
+                    "height": 68,
+                  },
+                ]
               }
             >
               <ViewManagerAdapter_ExpoImage

--- a/app/views/NewServerView/components/ServersHistoryItem/index.tsx
+++ b/app/views/NewServerView/components/ServersHistoryItem/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Text, View } from 'react-native';
+import { PixelRatio, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 
 import styles, { ROW_HEIGHT } from './styles';
@@ -21,7 +21,8 @@ const defaultLogo = require('../../../../static/images/logo.png');
 
 const ServersHistoryItem = memo(({ item, onPress, onDeletePress }: IServersHistoryItem) => {
 	const { colors } = useTheme();
-	const { width } = useResponsiveLayout();
+	const { width, fontScale } = useResponsiveLayout();
+	const height = PixelRatio.roundToNearestPixel(ROW_HEIGHT * fontScale);
 
 	const accessibilityLabel = item.username ? `${item.url}, ${item.username}` : item.url;
 	const accessibilityHint = I18n.t('Activate_to_select_server_Available_actions_delete');
@@ -34,7 +35,7 @@ const ServersHistoryItem = memo(({ item, onPress, onDeletePress }: IServersHisto
 			width={width}
 			accessibilityLabel={accessibilityLabel}
 			accessibilityHint={accessibilityHint}>
-			<View style={styles.container}>
+			<View style={[styles.container, { height }]}>
 				<Image source={item.iconURL ? { uri: item.iconURL } : defaultLogo} style={styles.serverIcon} contentFit='contain' />
 
 				<View style={styles.textContainer}>

--- a/app/views/NewServerView/components/ServersHistoryItem/styles.ts
+++ b/app/views/NewServerView/components/ServersHistoryItem/styles.ts
@@ -2,14 +2,13 @@ import { StyleSheet } from 'react-native';
 
 import sharedStyles from '../../../Styles';
 
-export const ROW_HEIGHT = 56;
+export const ROW_HEIGHT = 68;
 
 export default StyleSheet.create({
 	container: {
 		flexDirection: 'row',
 		alignItems: 'center',
-		padding: 12,
-		minHeight: ROW_HEIGHT
+		padding: 12
 	},
 	serverIcon: {
 		width: 44,

--- a/app/views/SelectServerView.tsx
+++ b/app/views/SelectServerView.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useLayoutEffect, useState } from 'react';
-import { FlatList } from 'react-native';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { FlatList, PixelRatio } from 'react-native';
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Q } from '@nozbe/watermelondb';
 import { useNavigation } from '@react-navigation/native';
@@ -14,8 +14,8 @@ import { type ShareInsideStackParamList } from '../definitions/navigationTypes';
 import { type TServerModel } from '../definitions';
 import { useAppSelector } from '../lib/hooks/useAppSelector';
 import { selectServerRequest } from '../actions/server';
+import { useResponsiveLayout } from '../lib/hooks/useResponsiveLayout/useResponsiveLayout';
 
-const getItemLayout = (_data: any, index: number) => ({ length: ROW_HEIGHT, offset: ROW_HEIGHT * index, index });
 const keyExtractor = (item: TServerModel) => item.id;
 
 const SelectServerView = () => {
@@ -24,6 +24,15 @@ const SelectServerView = () => {
 
 	const server = useAppSelector(state => state.server.server);
 	const navigation = useNavigation<NativeStackNavigationProp<ShareInsideStackParamList, 'SelectServerView'>>();
+	const { fontScale } = useResponsiveLayout();
+
+	const getItemLayout = useCallback(
+		(_data: any, index: number) => {
+			const height = PixelRatio.roundToNearestPixel(ROW_HEIGHT * fontScale);
+			return { length: height, offset: height * index, index };
+		},
+		[fontScale]
+	);
 
 	useLayoutEffect(() => {
 		navigation.setOptions({
@@ -56,7 +65,7 @@ const SelectServerView = () => {
 					<ServerItem onPress={() => select(item.id, item.version)} item={item} hasCheck={item.id === server} />
 				)}
 				keyExtractor={keyExtractor}
-				getItemLayout={getItemLayout} // Refactor row_height
+				getItemLayout={getItemLayout}
 				ItemSeparatorComponent={List.Separator}
 				contentContainerStyle={List.styles.contentContainerStyleFlatList}
 				ListHeaderComponent={List.Separator}

--- a/app/views/SelectServerView.tsx
+++ b/app/views/SelectServerView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
-import { FlatList, PixelRatio } from 'react-native';
+import { FlatList, PixelRatio, StyleSheet } from 'react-native';
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Q } from '@nozbe/watermelondb';
 import { useNavigation } from '@react-navigation/native';
@@ -29,7 +29,7 @@ const SelectServerView = () => {
 	const getItemLayout = useCallback(
 		(_data: any, index: number) => {
 			const height = PixelRatio.roundToNearestPixel(ROW_HEIGHT * fontScale);
-			return { length: height, offset: height * index, index };
+			return { length: height, offset: (height + StyleSheet.hairlineWidth) * index, index };
 		},
 		[fontScale]
 	);

--- a/app/views/ShareListView/index.tsx
+++ b/app/views/ShareListView/index.tsx
@@ -1,6 +1,6 @@
 import { type Dispatch } from 'redux';
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { BackHandler, FlatList, Keyboard, type NativeEventSubscription, Text, View } from 'react-native';
+import { BackHandler, FlatList, Keyboard, type NativeEventSubscription, PixelRatio, Text, View } from 'react-native';
 import * as FileSystem from 'expo-file-system/legacy';
 import { connect } from 'react-redux';
 import * as mime from 'react-native-mime-types';
@@ -63,7 +63,10 @@ interface IShareListViewProps extends INavigationOption {
 	dispatch: Dispatch;
 }
 
-const getItemLayout = (data: any, index: number) => ({ length: data.length, offset: ROW_HEIGHT * index, index });
+const getItemLayout = (_data: any, index: number) => {
+	const rowHeight = PixelRatio.roundToNearestPixel(ROW_HEIGHT * PixelRatio.getFontScale());
+	return { length: rowHeight, offset: rowHeight * index, index };
+};
 const keyExtractor = (item: TSubscriptionModel) => item.rid;
 
 class ShareListView extends Component<IShareListViewProps, IState> {

--- a/app/views/ShareListView/index.tsx
+++ b/app/views/ShareListView/index.tsx
@@ -1,6 +1,6 @@
 import { type Dispatch } from 'redux';
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { BackHandler, FlatList, Keyboard, type NativeEventSubscription, PixelRatio, Text, View } from 'react-native';
+import { BackHandler, FlatList, Keyboard, type NativeEventSubscription, PixelRatio, StyleSheet, Text, View } from 'react-native';
 import * as FileSystem from 'expo-file-system/legacy';
 import { connect } from 'react-redux';
 import * as mime from 'react-native-mime-types';
@@ -65,7 +65,7 @@ interface IShareListViewProps extends INavigationOption {
 
 const getItemLayout = (_data: any, index: number) => {
 	const rowHeight = PixelRatio.roundToNearestPixel(ROW_HEIGHT * PixelRatio.getFontScale());
-	return { length: rowHeight, offset: rowHeight * index, index };
+	return { length: rowHeight, offset: (rowHeight + StyleSheet.hairlineWidth) * index, index };
 };
 const keyExtractor = (item: TSubscriptionModel) => item.rid;
 

--- a/app/views/TeamChannelsView.tsx
+++ b/app/views/TeamChannelsView.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Component } from 'react';
 
 import { deleteRoom } from '../actions/room';
-import { type DisplayMode } from '../lib/constants/constantDisplayMode';
+import { DisplayMode } from '../lib/constants/constantDisplayMode';
 import { textInputDebounceTime } from '../lib/constants/debounceConfig';
 import { themes } from '../lib/constants/colors';
 import { type TActionSheetOptions, type TActionSheetOptionsItem, withActionSheet } from '../containers/ActionSheet';
@@ -19,6 +19,7 @@ import { type IApplicationState, type IBaseScreen, type TSubscriptionModel } fro
 import { ERoomType } from '../definitions/ERoomType';
 import { withDimensions } from '../lib/hooks/withDimensions';
 import { withMasterDetail } from '../lib/hooks/useMasterDetail';
+import { BASE_ROW_HEIGHT, BASE_ROW_HEIGHT_CONDENSED } from '../lib/hooks/useResponsiveLayout/useResponsiveLayout';
 import I18n from '../i18n';
 import database from '../lib/database';
 import { CustomIcon } from '../containers/CustomIcon';
@@ -33,14 +34,6 @@ import { getRoomInfo, getTeamListRoom, updateTeamRoom, removeTeamRoom } from '..
 
 const API_FETCH_COUNT = 25;
 
-const getItemLayout = (data: ArrayLike<IItem> | null | undefined, index: number) => {
-	const rowHeight = 75 * PixelRatio.getFontScale();
-	return {
-		length: data?.length || 0,
-		offset: rowHeight * index,
-		index
-	};
-};
 const keyExtractor = (item: IItem) => item._id;
 
 export interface IItem {
@@ -515,6 +508,17 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 		showActionSheet({ options });
 	};
 
+	getItemLayout = (_data: ArrayLike<IItem> | null | undefined, index: number) => {
+		const { displayMode } = this.props;
+		const base = displayMode === DisplayMode.Condensed ? BASE_ROW_HEIGHT_CONDENSED : BASE_ROW_HEIGHT;
+		const rowHeight = PixelRatio.roundToNearestPixel(base * PixelRatio.getFontScale());
+		return {
+			length: rowHeight,
+			offset: rowHeight * index,
+			index
+		};
+	};
+
 	renderItem = ({ item }: { item: IItem }) => {
 		const { StoreLastMessage, useRealName, width, showAvatar, displayMode } = this.props;
 		return (
@@ -561,7 +565,7 @@ class TeamChannelsView extends Component<ITeamChannelsViewProps, ITeamChannelsVi
 				extraData={isSearching ? search : data}
 				keyExtractor={keyExtractor}
 				renderItem={this.renderItem}
-				getItemLayout={getItemLayout}
+				getItemLayout={this.getItemLayout}
 				removeClippedSubviews={isIOS}
 				keyboardShouldPersistTaps='always'
 				onEndReached={() => this.load()}


### PR DESCRIPTION
## Proposed changes

Some lists intermittently failed to render the 1px row separator, and others rendered it with non-uniform thickness. Reported on RoomsListView and the MessageActions action sheet, but the defect affected most shared list-row components.

Root cause: when a row's rendered height in DP does not land on the device physical-pixel grid, the hairline separator anti-aliases below visibility on some rows and across multiple physical pixels on others. As cumulative row offsets drift fractionally, each successive separator lands at a different sub-pixel phase, so some vanish and some thicken.

Fix: snap each row container height to the pixel grid with `PixelRatio.roundToNearestPixel(height * fontScale)`, so every separator sits at an integer physical-pixel offset and renders as a crisp, uniform hairline. The snap is a no-op where the height was already integer-px and corrective otherwise, so it is always safe. Applied to every shared list-row component:

- RoomItem and RoomsListView, via the `useResponsiveLayout` row-height single source of truth
- ActionSheet Item, via a new `useActionSheetItemHeight` hook (covers MessageActions)
- List.Item, DirectoryItem, UserItem, ServerItem, ServersHistoryItem, DepartmentItemFilter

Also fixes a secondary defect: incorrect `getItemLayout` scroll-math in SelectServerView, QueueListView, TeamChannelsView and ShareListView. Two of them used the array length as the per-row pixel height, and offsets ignored both pixel-snapping and the condensed display mode. These screens do not call `scrollToIndex`, so the prior impact was mis-sized scroll indicators rather than broken scrolling.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1344

## How to test or reproduce

On a device whose pixel density produces fractional physical-pixel row heights (for example a 2.625x Android device), open lists such as RoomsListView, the MessageActions action sheet, the server list, and Admin/settings lists. Before the fix, separators are missing on some rows and uneven on others. After the fix, every separator renders as a uniform hairline. Verified on-device by measuring a flat separator pitch (RoomsListView 217px, ActionSheet 140px).

## Screenshots

| Before  |  After |
|---|---|
|  <img width="350" alt="Captura de Tela 2026-07-01 à(s) 14 45 38" src="https://github.com/user-attachments/assets/e129df2f-7f15-4407-afe5-7b22145f6adf" />| <img width="350" alt="Captura de Tela 2026-07-01 à(s) 14 44 50" src="https://github.com/user-attachments/assets/e61d8c6d-fb19-481e-a8e6-fb91728f5696" /> |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The snap uses `PixelRatio.get()` (device density, constant per device) for grid alignment and multiplies by `fontScale` so rows still grow with the user's font-size setting. Unit suite is green (1770/1770) with no snapshot regressions beyond the two row components whose explicit height legitimately changed.

https://claude.ai/code/session_01CrrW51BkNx2qDu1PZWgK5y


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing and row/item sizing across lists and pickers by rounding scaled heights to pixel-perfect values for more consistent text scaling.
  * Updated ActionSheets and bottom sheet content to use a shared responsive item-height calculation, including detent sizing behavior.
  * Refined FlatList scrolling and virtualization by adjusting `getItemLayout` to use pixel-rounded, display-mode-aware row heights.
  * Updated relevant row height constants (e.g., ServerItem/ServersHistoryItem) and aligned header layout height/centering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->