### PR TITLE
docs: rename ubiquitous language glossary to CONTEXT and add message state vocabulary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Rocket.Chat React Native mobile client. Single-package React Native app (not a m
 - React 19.1, React Native 0.81, Expo 54
 - TypeScript with strict mode, baseUrl set to `app/` (imports resolve from there)
 - Node: engines `>=18`, volta pins 24.13.1
-- Read UBIQUITOUS_LANGUAGE.md
+- Read CONTEXT.md
 
 ## Commands
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,15 @@
 | **Room History**    | Older Messages of a Room fetched on demand from the server (distinct from **Server History**)                                      | Message history        |
 | **Jump to Message** | Re-position the Room view onto a target Message that may be far from the Live Tail or not yet synced — fetches a surrounding Chunk | Scroll to message      |
 
+## Message Interaction & Position State
+
+Two distinct kinds of transient per-Room state drive how the Room view renders Messages. They have different owners and are migrated independently, so keep them apart.
+
+| Term                  | Definition                                                                              | Owner                          | Scope                                                                |
+| --------------------- | --------------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------- |
+| **Interaction state** | Which Message is selected and the current Message action — reply, quote, edit, or react | A per-Room interaction store   | Migrated to the per-Room store as part of the Message row work       |
+| **Positional state**  | Which Message is highlighted and the jump or scroll position                            | The Room view scroll machinery | Stays with the Room view scroll machinery and is migrated separately |
+
 ## Users & Roles
 
 | Term            | Definition                                                                         | Aliases to avoid        |

--- a/app/lib/services/voip/docs/README.md
+++ b/app/lib/services/voip/docs/README.md
@@ -12,4 +12,4 @@ Entry point for documentation of the peer-to-peer audio call subsystem. VoIP is 
 
 ## Glossary
 
-Domain terms used throughout these docs are defined in the project glossary at `../../../../UBIQUITOUS_LANGUAGE.md` under "Video & Voice".
+Domain terms used throughout these docs are defined in the project glossary at `../../../../CONTEXT.md` under "Video & Voice".

--- a/app/views/RoomView/docs/ARCHITECTURE.md
+++ b/app/views/RoomView/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Room Message Loading Architecture
 
-Load-bearing reference for how the Room view loads, observes, and re-positions Messages. Read this before `FLOWS.md` — that document assumes the vocabulary defined here. Domain terms (Message Window, Live Tail, Anchored Window, Chunk, Gap, Loader Row) are defined in the repo glossary `UBIQUITOUS_LANGUAGE.md` under "Message Loading"; this document uses them as defined there.
+Load-bearing reference for how the Room view loads, observes, and re-positions Messages. Read this before `FLOWS.md` — that document assumes the vocabulary defined here. Domain terms (Message Window, Live Tail, Anchored Window, Chunk, Gap, Loader Row) are defined in the repo glossary `CONTEXT.md` under "Message Loading"; this document uses them as defined there.
 
 ## Overview
 


### PR DESCRIPTION
## Proposed changes

Rename the ubiquitous-language glossary `UBIQUITOUS_LANGUAGE.md` to `CONTEXT.md` (git history preserved) and update its three references across the codebase.

Adds a **Message Interaction & Position State** section that records the shared domain vocabulary for two kinds of transient message state, since they are owned by different parts of the app and migrated independently:

- **Interaction state** — the current selection plus the reply/quote/edit/react action; owned by the per-Room interaction store.
- **Positional state** — the highlighted message plus jump/scroll position; owned by the Room view scroll machinery.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1345

## How to test or reproduce

Documentation only — no runtime behaviour changes. To verify:

- `CONTEXT.md` exists at the repo root and contains the **Message Interaction & Position State** section.
- `UBIQUITOUS_LANGUAGE.md` no longer exists.
- The three references resolve to the new filename:
  - `CLAUDE.md`
  - `app/lib/services/voip/docs/README.md`
  - `app/views/RoomView/docs/ARCHITECTURE.md`

## Screenshots

N/A — documentation only.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The glossary rename is done with `git mv` so blame/history follow the file (detected as a 94%-similarity rename). This PR is documentation-only and intentionally carries no code changes, so it can merge independently of the related model work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance and cross-references to use the new shared context glossary.
  * Added clearer definitions for two separate transient message-related states, including where each lives and how each is handled.
  * Aligned room and VoIP documentation with the updated glossary location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->