### PR TITLE
perf: memoize @json model fields

### DIFF
--- a/app/containers/ReactionsList/index.tsx
+++ b/app/containers/ReactionsList/index.tsx
@@ -30,7 +30,7 @@ const useRoutes = (reactions: IReaction[] | undefined) => {
 		};
 	}
 
-	const sortedReactions = reactions?.sort((reaction1, reaction2) => reaction2.usernames.length - reaction1.usernames.length);
+	const sortedReactions = [...reactions].sort((reaction1, reaction2) => reaction2.usernames.length - reaction1.usernames.length);
 	const routes: IRoute[] = sortedReactions.map(reaction => ({
 		key: reaction.emoji,
 		title: reaction.emoji,

--- a/app/lib/database/model/CustomEmoji.js
+++ b/app/lib/database/model/CustomEmoji.js
@@ -10,7 +10,7 @@ export default class CustomEmoji extends Model {
 
 	@field('name') name;
 
-	@json('aliases', sanitizer) aliases;
+	@json('aliases', sanitizer, { memo: true }) aliases;
 
 	@field('extension') extension;
 

--- a/app/lib/database/model/Message.js
+++ b/app/lib/database/model/Message.js
@@ -18,13 +18,13 @@ export default class Message extends Model {
 
 	@date('ts') ts;
 
-	@json('u', sanitizer) u;
+	@json('u', sanitizer, { memo: true }) u;
 
 	@relation('subscriptions', 'rid') subscription;
 
 	@field('alias') alias;
 
-	@json('parse_urls', sanitizer) parseUrls;
+	@json('parse_urls', sanitizer, { memo: true }) parseUrls;
 
 	@field('groupable') groupable;
 
@@ -32,9 +32,9 @@ export default class Message extends Model {
 
 	@field('emoji') emoji;
 
-	@json('attachments', sanitizer) attachments;
+	@json('attachments', sanitizer, { memo: true }) attachments;
 
-	@json('urls', sanitizer) urls;
+	@json('urls', sanitizer, { memo: true }) urls;
 
 	@date('_updated_at') _updatedAt;
 
@@ -44,9 +44,9 @@ export default class Message extends Model {
 
 	@field('starred') starred;
 
-	@json('edited_by', sanitizer) editedBy;
+	@json('edited_by', sanitizer, { memo: true }) editedBy;
 
-	@json('reactions', sanitizer) reactions;
+	@json('reactions', sanitizer, { memo: true }) reactions;
 
 	@field('role') role;
 
@@ -62,29 +62,29 @@ export default class Message extends Model {
 
 	@date('tlm') tlm;
 
-	@json('replies', sanitizer) replies;
+	@json('replies', sanitizer, { memo: true }) replies;
 
-	@json('mentions', sanitizer) mentions;
+	@json('mentions', sanitizer, { memo: true }) mentions;
 
-	@json('channels', sanitizer) channels;
+	@json('channels', sanitizer, { memo: true }) channels;
 
 	@field('unread') unread;
 
 	@field('auto_translate') autoTranslate;
 
-	@json('translations', sanitizer) translations;
+	@json('translations', sanitizer, { memo: true }) translations;
 
 	@field('tmsg') tmsg;
 
-	@json('blocks', sanitizer) blocks;
+	@json('blocks', sanitizer, { memo: true }) blocks;
 
 	@field('e2e') e2e;
 
 	@field('tshow') tshow;
 
-	@json('md', sanitizer) md;
+	@json('md', sanitizer, { memo: true }) md;
 
-	@json('content', sanitizer) content;
+	@json('content', sanitizer, { memo: true }) content;
 
 	@field('comment') comment;
 

--- a/app/lib/database/model/Permission.js
+++ b/app/lib/database/model/Permission.js
@@ -8,7 +8,7 @@ export const PERMISSIONS_TABLE = 'permissions';
 export default class Permission extends Model {
 	static table = PERMISSIONS_TABLE;
 
-	@json('roles', sanitizer) roles;
+	@json('roles', sanitizer, { memo: true }) roles;
 
 	@date('_updated_at') _updatedAt;
 }

--- a/app/lib/database/model/Room.js
+++ b/app/lib/database/model/Room.js
@@ -8,7 +8,7 @@ export const ROOMS_TABLE = 'rooms';
 export default class Room extends Model {
 	static table = ROOMS_TABLE;
 
-	@json('custom_fields', sanitizer) customFields;
+	@json('custom_fields', sanitizer, { memo: true }) customFields;
 
 	@field('broadcast') broadcast;
 
@@ -18,15 +18,15 @@ export default class Room extends Model {
 
 	@field('ro') ro;
 
-	@json('v', sanitizer) v;
+	@json('v', sanitizer, { memo: true }) v;
 
-	@json('served_by', sanitizer) servedBy;
+	@json('served_by', sanitizer, { memo: true }) servedBy;
 
 	@field('department_id') departmentId;
 
-	@json('livechat_data', sanitizer) livechatData;
+	@json('livechat_data', sanitizer, { memo: true }) livechatData;
 
-	@json('tags', sanitizer) tags;
+	@json('tags', sanitizer, { memo: true }) tags;
 
 	@field('avatar_etag') avatarETag;
 }

--- a/app/lib/database/model/Setting.js
+++ b/app/lib/database/model/Setting.js
@@ -14,7 +14,7 @@ export default class Setting extends Model {
 
 	@field('value_as_number') valueAsNumber;
 
-	@json('value_as_array', sanitizer) valueAsArray;
+	@json('value_as_array', sanitizer, { memo: true }) valueAsArray;
 
 	@date('_updated_at') _updatedAt;
 }

--- a/app/lib/database/model/Subscription.js
+++ b/app/lib/database/model/Subscription.js
@@ -37,7 +37,7 @@ export default class Subscription extends Model {
 
 	@field('alert') alert;
 
-	@json('roles', sanitizer) roles;
+	@json('roles', sanitizer, { memo: true }) roles;
 
 	@field('unread') unread;
 
@@ -45,11 +45,11 @@ export default class Subscription extends Model {
 
 	@field('group_mentions') groupMentions;
 
-	@json('tunread', sanitizer) tunread;
+	@json('tunread', sanitizer, { memo: true }) tunread;
 
-	@json('tunread_user', sanitizer) tunreadUser;
+	@json('tunread_user', sanitizer, { memo: true }) tunreadUser;
 
-	@json('tunread_group', sanitizer) tunreadGroup;
+	@json('tunread_group', sanitizer, { memo: true }) tunreadGroup;
 
 	@date('room_updated_at') roomUpdatedAt;
 
@@ -77,11 +77,11 @@ export default class Subscription extends Model {
 
 	@field('notifications') notifications;
 
-	@json('muted', sanitizer) muted;
+	@json('muted', sanitizer, { memo: true }) muted;
 
-	@json('unmuted', sanitizer) unmuted;
+	@json('unmuted', sanitizer, { memo: true }) unmuted;
 
-	@json('ignored', sanitizer) ignored;
+	@json('ignored', sanitizer, { memo: true }) ignored;
 
 	@field('broadcast') broadcast;
 
@@ -97,7 +97,7 @@ export default class Subscription extends Model {
 
 	@field('auto_translate_language') autoTranslateLanguage;
 
-	@json('last_message', sanitizer) lastMessage;
+	@json('last_message', sanitizer, { memo: true }) lastMessage;
 
 	@children('messages') messages;
 
@@ -109,25 +109,25 @@ export default class Subscription extends Model {
 
 	@field('hide_mention_status') hideMentionStatus;
 
-	@json('sys_mes', sanitizer) sysMes;
+	@json('sys_mes', sanitizer, { memo: true }) sysMes;
 
-	@json('uids', sanitizer) uids;
+	@json('uids', sanitizer, { memo: true }) uids;
 
-	@json('usernames', sanitizer) usernames;
+	@json('usernames', sanitizer, { memo: true }) usernames;
 
-	@json('visitor', sanitizer) visitor;
+	@json('visitor', sanitizer, { memo: true }) visitor;
 
 	@field('department_id') departmentId;
 
-	@json('served_by', sanitizer) servedBy;
+	@json('served_by', sanitizer, { memo: true }) servedBy;
 
-	@json('livechat_data', sanitizer) livechatData;
+	@json('livechat_data', sanitizer, { memo: true }) livechatData;
 
-	@json('tags', sanitizer) tags;
+	@json('tags', sanitizer, { memo: true }) tags;
 
 	@field('e2e_key') E2EKey;
 
-	@json('old_room_keys', sanitizer) oldRoomKeys;
+	@json('old_room_keys', sanitizer, { memo: true }) oldRoomKeys;
 
 	@field('e2e_suggested_key') E2ESuggestedKey;
 
@@ -135,7 +135,7 @@ export default class Subscription extends Model {
 
 	@field('e2e_key_id') e2eKeyId;
 
-	@json('users_waiting_for_e2e_keys', sanitizer) usersWaitingForE2EKeys;
+	@json('users_waiting_for_e2e_keys', sanitizer, { memo: true }) usersWaitingForE2EKeys;
 
 	@field('avatar_etag') avatarETag;
 
@@ -147,19 +147,19 @@ export default class Subscription extends Model {
 
 	@field('users_count') usersCount;
 
-	@json('source', sanitizer) source;
+	@json('source', sanitizer, { memo: true }) source;
 
 	@field('disable_notifications') disableNotifications;
 
 	@field('federated') federated;
 
-	@json('abac_attributes', sanitizer) abacAttributes;
+	@json('abac_attributes', sanitizer, { memo: true }) abacAttributes;
 
-	@json('federation', sanitizer) federation;
+	@json('federation', sanitizer, { memo: true }) federation;
 
 	@field('status') status;
 
-	@json('inviter', sanitizer) inviter;
+	@json('inviter', sanitizer, { memo: true }) inviter;
 
 	asPlain() {
 		return {

--- a/app/lib/database/model/Thread.js
+++ b/app/lib/database/model/Thread.js
@@ -18,13 +18,13 @@ export default class Thread extends Model {
 
 	@date('ts') ts;
 
-	@json('u', sanitizer) u;
+	@json('u', sanitizer, { memo: true }) u;
 
 	@relation('subscriptions', 'rid') subscription;
 
 	@field('alias') alias;
 
-	@json('parse_urls', sanitizer) parseUrls;
+	@json('parse_urls', sanitizer, { memo: true }) parseUrls;
 
 	@field('groupable') groupable;
 
@@ -32,9 +32,9 @@ export default class Thread extends Model {
 
 	@field('emoji') emoji;
 
-	@json('attachments', sanitizer) attachments;
+	@json('attachments', sanitizer, { memo: true }) attachments;
 
-	@json('urls', sanitizer) urls;
+	@json('urls', sanitizer, { memo: true }) urls;
 
 	@date('_updated_at') _updatedAt;
 
@@ -44,9 +44,9 @@ export default class Thread extends Model {
 
 	@field('starred') starred;
 
-	@json('edited_by', sanitizer) editedBy;
+	@json('edited_by', sanitizer, { memo: true }) editedBy;
 
-	@json('reactions', sanitizer) reactions;
+	@json('reactions', sanitizer, { memo: true }) reactions;
 
 	@field('role') role;
 
@@ -62,19 +62,19 @@ export default class Thread extends Model {
 
 	@date('tlm') tlm;
 
-	@json('replies', sanitizer) replies;
+	@json('replies', sanitizer, { memo: true }) replies;
 
-	@json('mentions', sanitizer) mentions;
+	@json('mentions', sanitizer, { memo: true }) mentions;
 
-	@json('channels', sanitizer) channels;
+	@json('channels', sanitizer, { memo: true }) channels;
 
 	@field('unread') unread;
 
 	@field('auto_translate') autoTranslate;
 
-	@json('translations', sanitizer) translations;
+	@json('translations', sanitizer, { memo: true }) translations;
 
-	@json('content', sanitizer) content;
+	@json('content', sanitizer, { memo: true }) content;
 
 	@field('e2e') e2e;
 

--- a/app/lib/database/model/ThreadMessage.js
+++ b/app/lib/database/model/ThreadMessage.js
@@ -18,7 +18,7 @@ export default class ThreadMessage extends Model {
 
 	@date('ts') ts;
 
-	@json('u', sanitizer) u;
+	@json('u', sanitizer, { memo: true }) u;
 
 	@relation('subscriptions', 'subscription_id') subscription;
 
@@ -26,7 +26,7 @@ export default class ThreadMessage extends Model {
 
 	@field('alias') alias;
 
-	@json('parse_urls', sanitizer) parseUrls;
+	@json('parse_urls', sanitizer, { memo: true }) parseUrls;
 
 	@field('groupable') groupable;
 
@@ -34,9 +34,9 @@ export default class ThreadMessage extends Model {
 
 	@field('emoji') emoji;
 
-	@json('attachments', sanitizer) attachments;
+	@json('attachments', sanitizer, { memo: true }) attachments;
 
-	@json('urls', sanitizer) urls;
+	@json('urls', sanitizer, { memo: true }) urls;
 
 	@date('_updated_at') _updatedAt;
 
@@ -46,9 +46,9 @@ export default class ThreadMessage extends Model {
 
 	@field('starred') starred;
 
-	@json('edited_by', sanitizer) editedBy;
+	@json('edited_by', sanitizer, { memo: true }) editedBy;
 
-	@json('reactions', sanitizer) reactions;
+	@json('reactions', sanitizer, { memo: true }) reactions;
 
 	@field('role') role;
 
@@ -62,23 +62,23 @@ export default class ThreadMessage extends Model {
 
 	@date('tlm') tlm;
 
-	@json('replies', sanitizer) replies;
+	@json('replies', sanitizer, { memo: true }) replies;
 
-	@json('mentions', sanitizer) mentions;
+	@json('mentions', sanitizer, { memo: true }) mentions;
 
-	@json('channels', sanitizer) channels;
+	@json('channels', sanitizer, { memo: true }) channels;
 
 	@field('unread') unread;
 
 	@field('auto_translate') autoTranslate;
 
-	@json('translations', sanitizer) translations;
+	@json('translations', sanitizer, { memo: true }) translations;
 
 	@field('draft_message') draftMessage;
 
 	@field('e2e') e2e;
 
-	@json('content', sanitizer) content;
+	@json('content', sanitizer, { memo: true }) content;
 
 	asPlain() {
 		return {

--- a/app/lib/database/model/User.js
+++ b/app/lib/database/model/User.js
@@ -16,5 +16,5 @@ export default class User extends Model {
 
 	@field('avatar_etag') avatarETag;
 
-	@json('roles', sanitizer) roles;
+	@json('roles', sanitizer, { memo: true }) roles;
 }

--- a/app/lib/database/model/servers/Server.js
+++ b/app/lib/database/model/servers/Server.js
@@ -35,7 +35,7 @@ export default class Server extends Model {
 
 	@field('e2e_enable') E2E_Enable;
 
-	@json('supported_versions', sanitizer) supportedVersions;
+	@json('supported_versions', sanitizer, { memo: true }) supportedVersions;
 
 	@date('supported_versions_warning_at') supportedVersionsWarningAt;
 

--- a/app/lib/database/model/servers/User.js
+++ b/app/lib/database/model/servers/User.js
@@ -20,7 +20,7 @@ export default class User extends Model {
 
 	@field('statusText') statusText;
 
-	@json('roles', sanitizer) roles;
+	@json('roles', sanitizer, { memo: true }) roles;
 
 	@field('avatar_etag') avatarETag;
 

--- a/app/lib/encryption/room.ts
+++ b/app/lib/encryption/room.ts
@@ -727,9 +727,9 @@ export default class EncryptionRoom {
 				const messageFromDB = await getMessageById(messageId);
 				if (messageFromDB && messageFromDB.e2e === 'done') {
 					const decryptedQuoteMessage = mapMessageFromDB(messageFromDB);
-					message.attachments = message.attachments || [];
 					const quoteAttachment = createQuoteAttachment(decryptedQuoteMessage, url);
-					return message.attachments.push(quoteAttachment);
+					message.attachments = [...(message.attachments || []), quoteAttachment];
+					return;
 				}
 
 				// From API
@@ -738,9 +738,8 @@ export default class EncryptionRoom {
 					return;
 				}
 				const decryptedQuoteMessage = await this.decrypt(mapMessageFromAPI(quotedMessageObject));
-				message.attachments = message.attachments || [];
 				const quoteAttachment = createQuoteAttachment(decryptedQuoteMessage as IMessage, url);
-				return message.attachments.push(quoteAttachment);
+				message.attachments = [...(message.attachments || []), quoteAttachment];
 			})
 		);
 		return message;


### PR DESCRIPTION
## Proposed changes

Switch every `@json`-decorated WatermelonDB model field to the memoized form, `@json('col', sanitizer, { memo: true })`, across all 11 models (67 fields total). With memoization the decorator caches the `[rawValue, sanitized]` pair and returns the same object reference on every read while the underlying raw column string is unchanged. Today this is render-neutral; it sets up per-field re-render bailout for the consumers that adopt reference equality in later work.

Because the memo cache is invalidated only when the raw column string changes, mutating a memoized value in place would silently corrupt the cache (the mutated object is returned again with a stale identity). This PR converts the two remaining in-place mutations of these fields to replacement:

- `ReactionsList` sorts a **copy** (`[...reactions].sort(...)`) instead of sorting the `reactions` field in place.
- The encryption quote-attachment decryption **reassigns** `message.attachments = [...]` instead of `push()`-ing into the existing array.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1346

## How to test or reproduce

No behaviour change is expected — this is a reference-stability refactor. To confirm there is no re-render regression:

1. Open a room with reactions and an encrypted quoted reply; verify reactions render and sort correctly and the quoted attachment decrypts.
2. Profile a representative room before and after the change (React DevTools). Measured here on device: target `MessageContainer` had **0 re-renders** (first-mount only) and the `RoomView` control had **0 re-renders** in all trials of both the baseline and the memoized bundle. Commit totals stayed in the same band. The swap is render-neutral; the benefit lands when consumers start relying on the stable references.

`pnpm lint` (0 errors) and `TZ=UTC pnpm test` (1770 passing) are green locally.

## Screenshots

N/A — no UI changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The two mutation fixes are required for correctness once `{ memo: true }` is in place — without them a sort or an attachment append would return a stale cached reference. They are intentionally bundled with the memo swap rather than split out, since in isolation they are no-ops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling across messages, threads, rooms, users, permissions, and custom emojis to avoid unnecessary reprocessing and side effects.
  * Fixed a reactions list update so it no longer changes the original input while sorting.
  * Made quote attachment handling safer by appending data immutably, helping prevent attachment-related inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->