### PR TITLE
chore: migrate mobile-crypto to BouncyCastle on Android

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -49,6 +49,7 @@ runs:
         echo -e "org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" >> ./gradle.properties
         echo -e "android.useAndroidX=true" >> ./gradle.properties
         echo -e "android.enableJetifier=true" >> ./gradle.properties
+        echo -e "android.jetifier.ignorelist=bcprov-jdk18on" >> ./gradle.properties
         echo -e "reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64" >> ./gradle.properties
         echo -e "newArchEnabled=true" >> ./gradle.properties
         echo -e "hermesEnabled=true" >> ./gradle.properties

--- a/.github/workflows/e2e-build-android.yml
+++ b/.github/workflows/e2e-build-android.yml
@@ -101,6 +101,7 @@ jobs:
           echo -e "org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" >> ./gradle.properties
           echo -e "android.useAndroidX=true" >> ./gradle.properties
           echo -e "android.enableJetifier=true" >> ./gradle.properties
+          echo -e "android.jetifier.ignorelist=bcprov-jdk18on" >> ./gradle.properties
           echo -e "reactNativeArchitectures=x86_64" >> ./gradle.properties
           echo -e "APPLICATION_ID=chat.rocket.android" >> ./gradle.properties
           echo -e "newArchEnabled=true" >> ./gradle.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,6 +95,14 @@ android {
         manifestPlaceholders = [BugsnagAPIKey: BugsnagAPIKey as String]
     }
 
+    packaging {
+        resources {
+            // bcprov-jdk18on and its transitive jspecify both ship this OSGi bundle
+            // manifest inside their multi-release jars; it is unused on Android.
+            excludes += ["META-INF/versions/9/OSGI-INF/MANIFEST.MF"]
+        }
+    }
+
     signingConfigs {
         release {
             v1SigningEnabled false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,6 +21,9 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+# Skip Jetifier for BouncyCastle: it is AndroidX-clean and ships Java 25 multi-release
+# classes that Jetifier's bundled ASM cannot parse (unsupported class file major version 69)
+android.jetifier.ignorelist=bcprov-jdk18on
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -248,7 +248,7 @@ PODS:
   - MMKV (2.2.4):
     - MMKVCore (~> 2.2.4)
   - MMKVCore (2.2.4)
-  - MobileCrypto (0.3.0):
+  - MobileCrypto (0.4.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4023,7 +4023,7 @@ SPEC CHECKSUMS:
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   MMKV: 1a8e7dbce7f9cad02c52e1b1091d07bd843aefaf
   MMKVCore: f2dd4c9befea04277a55e84e7812f930537993df
-  MobileCrypto: 382f541e04405f45c323b11a404d3cc4546d0669
+  MobileCrypto: cbe4be11a33b5888e77861de9346fa5d3fccc8ac
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroMmkv: 4a2d747ce97a4ae740b3cb3a3853366813faf831
   NitroModules: 18e41c298d86fc753fc754969fa9f84044e70711
@@ -4136,6 +4136,6 @@ SPEC CHECKSUMS:
   Yoga: 1e91d83a5286cfd3b725eade59274c92270540d4
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 4a928f36cea73defa438bb62e3a52a85a0b5f71a
+PODFILE CHECKSUM: 9ef0d302aac0150cec49089c7c416db32bb9d3ec
 
 COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@react-navigation/native-stack": "^7.17.5",
 		"@rocket.chat/media-signaling": "1.0.0-rc.1",
 		"@rocket.chat/message-parser": "0.31.31",
-		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5",
+		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#main",
 		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#mobile",
 		"@rocket.chat/ui-kit": "^0.39.0",
 		"axios": "0.30.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@react-navigation/native-stack": "^7.17.5",
 		"@rocket.chat/media-signaling": "1.0.0-rc.1",
 		"@rocket.chat/message-parser": "0.31.31",
-		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#main",
+		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5",
 		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#mobile",
 		"@rocket.chat/ui-kit": "^0.39.0",
 		"axios": "0.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: 0.31.31
         version: 0.31.31
       '@rocket.chat/mobile-crypto':
-        specifier: RocketChat/rocket.chat-mobile-crypto#adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5
-        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: RocketChat/rocket.chat-mobile-crypto#main
+        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/69a0a250dd7c6ff0808eb659d7202be1cae7fa1c(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@rocket.chat/sdk':
         specifier: RocketChat/Rocket.Chat.js.SDK#mobile
         version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/b6d2b3f25b0ff8283dd71faf6dae720c47fecd8f
@@ -2447,8 +2447,8 @@ packages:
   '@rocket.chat/message-parser@0.31.31':
     resolution: {integrity: sha512-YWHdin2ejndwgQJXlHIzAmQB+xvZLeEOqOkPq8RxdyTjAaGo1DbBCrc0aU7u0LOUnGN+jm3H4grnYdI9SPwitA==}
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5':
-    resolution: {gitHosted: true, integrity: sha512-SG6J3uBJycW9YPMEYoD5d20cpxuLMVLy5sAWiGG1jQwMJddq8FCCB7ixTrfAaKiX5VlDoI7Ch4G//ocjczqGOQ==, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5}
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/69a0a250dd7c6ff0808eb659d7202be1cae7fa1c':
+    resolution: {gitHosted: true, integrity: sha512-v3uaVCYlj9gGZkAZe3JWQkhlGaRyahmnagbMSKtSnl+6WuLNxaPOf0GjJKVuxBdqkXPPhr23JIihVlch3FVeCQ==, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/69a0a250dd7c6ff0808eb659d7202be1cae7fa1c}
     version: 0.4.0
     peerDependencies:
       react: '*'
@@ -10462,7 +10462,7 @@ snapshots:
     dependencies:
       tldts: 5.7.112
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/69a0a250dd7c6ff0808eb659d7202be1cae7fa1c(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: 0.31.31
         version: 0.31.31
       '@rocket.chat/mobile-crypto':
-        specifier: RocketChat/rocket.chat-mobile-crypto#main
-        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: RocketChat/rocket.chat-mobile-crypto#adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5
+        version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@rocket.chat/sdk':
         specifier: RocketChat/Rocket.Chat.js.SDK#mobile
         version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/b6d2b3f25b0ff8283dd71faf6dae720c47fecd8f
@@ -2447,9 +2447,9 @@ packages:
   '@rocket.chat/message-parser@0.31.31':
     resolution: {integrity: sha512-YWHdin2ejndwgQJXlHIzAmQB+xvZLeEOqOkPq8RxdyTjAaGo1DbBCrc0aU7u0LOUnGN+jm3H4grnYdI9SPwitA==}
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0':
-    resolution: {gitHosted: true, integrity: sha512-gk3YAmpBh34zGwDH+j5gjFFvHyvkXCm3jdTUe1EdLfyjzhi9sU6xUYH8JjgVlJ6NnGxxCO5hmsdn6QRkB3vL7g==, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0}
-    version: 0.3.0
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5':
+    resolution: {gitHosted: true, integrity: sha512-SG6J3uBJycW9YPMEYoD5d20cpxuLMVLy5sAWiGG1jQwMJddq8FCCB7ixTrfAaKiX5VlDoI7Ch4G//ocjczqGOQ==, tarball: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5}
+    version: 0.4.0
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -10462,7 +10462,7 @@ snapshots:
     dependencies:
       tldts: 5.7.112
 
-  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/5a390be1271bfe3d4b4e8c7ae870249f2c9a8cb0(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+  '@rocket.chat/mobile-crypto@https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0)


### PR DESCRIPTION
## Proposed changes

Bumps the `@rocket.chat/mobile-crypto` dependency to the build that migrates the Android crypto implementation off the unmaintained SpongyCastle fork (`com.madgag.spongycastle`) onto BouncyCastle (`org.bouncycastle:bcprov-jdk18on:1.84`). The swap is mechanical — identical class names, no logic changes — and the library is only ever used as plain classes (never registered as a JCE provider), so there is no collision with Android's platform BouncyCastle namespace.

This PR is the consumer-side change only. It pins the dependency to the crypto commit `adbcf7cde4469f31efe1d4bc72a98a0ced1b80f5` and refreshes the lockfiles:

- `package.json` / `pnpm-lock.yaml` — repin `@rocket.chat/mobile-crypto`
- `ios/Podfile.lock` — MobileCrypto `0.3.0` → `0.4.0`

The upstream library change lives in RocketChat/rocket.chat-mobile-crypto#15.

## Issue(s)

- https://rocketchat.atlassian.net/browse/NATIVE-1284
- Upstream library PR: https://github.com/RocketChat/rocket.chat-mobile-crypto/pull/15

## How to test or reproduce

E2E encryption exercises the migrated code paths (RSA OAEP/PKCS#1, PBKDF2). On both platforms:

1. Build and run the app.
2. Open an end-to-end encrypted room, send and receive messages, verify they decrypt correctly.
3. Confirm existing encrypted history still reads (byte-compatibility with the previous SpongyCastle output).

The upstream PR verified byte-compatibility with a known-answer harness (31/31 fixed-vector KATs pass on Android API 36, expected values shared with iOS).

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The dependency is pinned to a commit on the upstream feature branch rather than `#main`, because RocketChat/rocket.chat-mobile-crypto#15 is not yet merged. Before this can ship to `develop`, that PR should be merged and the pin moved back to the resulting `#main` commit. Note the upstream PR currently has red `lint` and `test` checks (unit tests are tracked separately in NATIVE-1378).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build reliability by skipping Jetifier processing for a compatible dependency that could cause build failures.
  * Updated Android build settings so this compatibility rule is applied consistently during Android and E2E build workflows.
  * Excluded a problematic packaged manifest file to help prevent Android packaging issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->