### PR TITLE
ci: build arm64-v8a alongside x86_64 in the Android E2E APK

### DIFF
--- a/.github/workflows/e2e-build-android.yml
+++ b/.github/workflows/e2e-build-android.yml
@@ -101,7 +101,7 @@ jobs:
           echo -e "org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" >> ./gradle.properties
           echo -e "android.useAndroidX=true" >> ./gradle.properties
           echo -e "android.enableJetifier=true" >> ./gradle.properties
-          echo -e "reactNativeArchitectures=x86_64" >> ./gradle.properties
+          echo -e "reactNativeArchitectures=arm64-v8a,x86_64" >> ./gradle.properties
           echo -e "APPLICATION_ID=chat.rocket.android" >> ./gradle.properties
           echo -e "newArchEnabled=true" >> ./gradle.properties
           echo -e "hermesEnabled=true" >> ./gradle.properties


### PR DESCRIPTION
## Proposed changes

The CI E2E Android build produced an **x86_64-only** release APK, so the artifact could not be installed on an Apple Silicon (arm64) emulator — `INSTALL_FAILED_NO_MATCHING_ABIS` — and current Android emulators refuse to boot x86_64 system images on an aarch64 host. Contributors and automated agents on M-series Macs therefore could not download and run the exact CI E2E build; they had to rebuild it from source.

This builds the E2E APK as a **universal APK** containing `arm64-v8a` and `x86_64`. The same downloadable artifact now installs on the CI x86_64 emulator and on a local arm64 emulator.

CI test behavior is unchanged — the CI emulator is still x86_64 and simply uses its own ABI slice. Scope is limited to `e2e-build-android.yml`; the store release lanes already build all ABIs.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1388

## How to test or reproduce

1. Trigger the PR pipeline so the E2E Android build runs.
2. Download the resulting `Android APK` artifact and confirm it carries both ABIs: `unzip -l app-release.apk | grep 'lib/'` should list `lib/arm64-v8a` and `lib/x86_64`.
3. On an Apple Silicon Mac, create an arm64 emulator (`pixel_7_pro`, API 34, `google_apis`, `arm64-v8a`), boot it, and `adb install -r app-release.apk` — the install succeeds where the previous x86_64-only APK failed.
4. Confirm the existing x86_64 E2E shards still pass unchanged.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The added build cost is small and mostly cache-elided: the cached native object directory (`android/app/.cxx`) makes the second ABI a hit on JS-only PRs, so those add ~0. Only native-changing PRs or a cold cache pay the extra ABI compile (~4–5 min on the E2E build step). The APK's native-lib payload roughly doubles in size.

Considered alternatives: (1) rebuilding arm64 locally — zero CI cost but slow and awkward for automated agents; (2) a separate parallel arm64-only job — no gate impact but a whole extra build's runner-minutes and a second artifact. The universal APK was chosen for the simplest, single-artifact workflow given the native cache already absorbs most of the cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android E2E build compatibility by supporting both `arm64-v8a` and `x86_64` architectures (instead of `x86_64` only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->