### PR TITLE
ci: resolve Node from package.json instead of the broken lts/* alias

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 'lts/*'
+        node-version-file: 'package.json'
         cache: 'pnpm'
 
     - name: Install JS dependencies


### PR DESCRIPTION
## Proposed changes

`actions/setup-node` can no longer resolve the `lts/*` alias — it fails with `Unable to find LTS release '*' for Node version 'lts/*'`. This breaks the shared **Setup Node** composite action (`.github/actions/setup-node`), which every workflow depends on, so ESLint, tests, Prettier, and the Android/iOS builds all fail at the *Checkout and Setup Node* step before any real work runs.

This points `node-version-file` at `package.json`, so `setup-node` reads `volta.node` (`24.13.1`) — the same version used locally via Volta — as the single source of truth. It removes the fragile alias and keeps CI and local dev on the same Node version.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1389

## How to test or reproduce

1. Before: any PR pipeline shows `format` and `ESLint and Test` failing within seconds at *Checkout and Setup Node* with `Unable to find LTS release '*'`.
2. After: the Setup Node step resolves Node `24.13.1` from `package.json` and the checks proceed to their real work.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The alias `lts/*` was the only fragile Node reference routed through the shared composite; every workflow uses that composite, so this single change fixes them all. `organize_translations.yml` pins `node-version: 18` directly and is unaffected. Reading from `package.json` (Volta first, then `engines`) means future Node bumps happen in one place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js setup used in automation to follow the version defined in the project’s package configuration, making local and CI environments more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->