### PR TITLE
fix: hold keyboard focus on the rooms list for hardware-keyboard navigation

### DIFF
--- a/app/containers/Header/components/HeaderButton/Common.tsx
+++ b/app/containers/Header/components/HeaderButton/Common.tsx
@@ -1,7 +1,7 @@
-import { memo } from 'react';
+import { forwardRef, memo } from 'react';
 import { StackActions, useNavigation } from '@react-navigation/native';
 import { type StyleProp, type ViewStyle } from 'react-native';
-import { withKeyboardFocus } from 'react-native-external-keyboard';
+import { type KeyboardFocus, withKeyboardFocus } from 'react-native-external-keyboard';
 
 import I18n from '../../../../i18n';
 import { isIOS } from '../../../../lib/methods/helpers/deviceInfo';
@@ -17,33 +17,32 @@ interface IHeaderButtonCommon extends IHeaderButtonItem {
 }
 
 // Left
-export const Drawer = ({
-	navigation,
-	testID,
-	style = {},
-	onPress = () => navigation?.toggleDrawer(),
-	...props
-}: IHeaderButtonCommon) => {
-	const { colors } = useTheme();
+export const Drawer = forwardRef<KeyboardFocus, IHeaderButtonCommon>(
+	({ navigation, testID, style = {}, onPress = () => navigation?.toggleDrawer(), ...props }, ref) => {
+		const { colors } = useTheme();
 
-	const item = (
-		<ItemChildren
-			autoFocus
-			accessibilityLabel={I18n.t('Menu')}
-			iconName='hamburguer'
-			onPress={onPress}
-			testID={testID}
-			color={colors.fontDefault}
-			{...props}
-		/>
-	);
+		const item = (
+			<ItemChildren
+				ref={ref}
+				autoFocus
+				accessibilityLabel={I18n.t('Menu')}
+				iconName='hamburguer'
+				onPress={onPress}
+				testID={testID}
+				color={colors.fontDefault}
+				{...props}
+			/>
+		);
 
-	return (
-		<Container style={style} left>
-			{item}
-		</Container>
-	);
-};
+		return (
+			<Container style={style} left>
+				{item}
+			</Container>
+		);
+	}
+);
+
+Drawer.displayName = 'HeaderButton.Drawer';
 
 export const CloseModal = memo(({ testID, onPress, ...props }: IHeaderButtonCommon) => {
 	const { dispatch } = useNavigation();

--- a/app/views/RoomsListView/hooks/useHeader.tsx
+++ b/app/views/RoomsListView/hooks/useHeader.tsx
@@ -1,9 +1,12 @@
-import { useNavigation } from '@react-navigation/native';
-import { useCallback, useContext, useLayoutEffect, useState } from 'react';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { useCallback, useContext, useLayoutEffect, useRef, useState } from 'react';
+import { InteractionManager } from 'react-native';
+import { type KeyboardFocus } from 'react-native-external-keyboard';
 
 import * as HeaderButton from '../../../containers/Header/components/HeaderButton';
 import i18n from '../../../i18n';
 import { useAppSelector } from '../../../lib/hooks/useAppSelector';
+import { useIsAccessibilityNavigationEnabled } from '../../../lib/hooks/useIsAccessibilityNavigationEnabled';
 import { useMasterDetail } from '../../../lib/hooks/useMasterDetail';
 import { usePermissions } from '../../../lib/hooks/usePermissions';
 import { isTablet } from '../../../lib/methods/helpers';
@@ -18,6 +21,8 @@ export const useHeader = () => {
 
 	const { searchEnabled, search, startSearch, stopSearch } = useContext(RoomsSearchContext);
 	const [options, setOptions] = useState<any>(null);
+	const isAccessibilityNavigationEnabled = useIsAccessibilityNavigationEnabled();
+	const drawerButtonRef = useRef<KeyboardFocus>(null);
 	const supportedVersionsStatus = useAppSelector(state => state.supportedVersions.status);
 	const requirePasswordChange = useAppSelector(state => getUserSelector(state).requirePasswordChange);
 	const isMasterDetail = useMasterDetail();
@@ -101,6 +106,7 @@ export const useHeader = () => {
 		const options = {
 			headerLeft: () => (
 				<HeaderButton.Drawer
+					ref={drawerButtonRef}
 					navigation={navigation}
 					testID='rooms-list-view-sidebar'
 					onPress={
@@ -170,6 +176,22 @@ export const useHeader = () => {
 		stopSearch,
 		search
 	]);
+
+	// The rooms list header persists across native-stack navigation, so autoFocus (mount-only)
+	// won't re-fire on back-return or after the list/banner render asynchronously. Re-assert focus
+	// on the drawer button every time the screen is focused so external-keyboard/screen-reader
+	// navigation always starts from a known element. Regular touch users are left untouched.
+	useFocusEffect(
+		useCallback(() => {
+			if (!isAccessibilityNavigationEnabled) {
+				return;
+			}
+			const task = InteractionManager.runAfterInteractions(() => {
+				drawerButtonRef.current?.focus();
+			});
+			return () => task.cancel();
+		}, [isAccessibilityNavigationEnabled])
+	);
 
 	return { options };
 };


### PR DESCRIPTION
## Proposed changes

On the rooms list, when a screen reader or an external (hardware) keyboard is connected, keyboard focus was only established once — on mount — through the drawer (hamburger) button's `autoFocus`. After returning from a room, or after the list re-rendered asynchronously, nothing held focus. With focus unset, the first D-pad key press let the platform focus search reach the off-screen, closed navigation drawer, and pressing Enter opened Settings instead of the intended room.

This makes the rooms list re-assert keyboard focus onto the drawer button whenever the screen regains focus and accessibility navigation is active:

- `RoomsListView` now uses `useFocusEffect` + `InteractionManager.runAfterInteractions` to move focus onto the drawer button after the navigation transition and any pending list work settle. It is gated on `useIsAccessibilityNavigationEnabled()` (screen reader or external keyboard), so touch users are never affected, and the task is cancelled on cleanup.
- `HeaderButton.Drawer` is now a `forwardRef` that forwards its ref to the keyboard-focus-wrapped item, exposing the imperative `focus()` handle. `autoFocus` is unchanged and the ref is opt-in, so every other `HeaderButton.Drawer` caller behaves exactly as before.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1263

## How to test or reproduce

Requires an Android emulator with a physical keyboard enabled (`hw.keyboard=yes`).

1. Connect/enable a hardware keyboard and open the app on the rooms list.
2. Without touching the screen, press D-pad `Right, Right, Down, Down, Enter`.
3. Expected: a room opens and the message composer is visible.
4. Before this change, focus was unset so the sequence could open Settings instead of a room.

Covered by the `keyboard-navigation-room.yaml` Maestro flow (shard 14, keyboard-enabled AVD), which fails before this change and passes after it.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The keyboard-navigation Maestro flow only asserts that some room opened; a follow-up could assert the specific target room to tighten it. Separately, hiding the closed drawer's contents from screen-reader (TalkBack/VoiceOver) traversal is a distinct accessibility concern that should be addressed and verified on-device with a screen reader in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard and screen-reader navigation in the header by keeping the drawer button focused when returning to the screen.
  * Header controls now behave more consistently for accessibility users, with no change to the visible layout or primary action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->