### PR TITLE
fix: ignore user not working reliably on e2e tests

### DIFF
--- a/.maestro/tests/room/ignoreuser.yaml
+++ b/.maestro/tests/room/ignoreuser.yaml
@@ -84,6 +84,12 @@ tags:
       ROOM: ${output.room.name}
 - evalScript: ${output.utils.sendMessage(output.otherUser.username, output.otherUser.password, output.room._id, 'message-01')}
 - evalScript: ${output.utils.sendMessage(output.otherUser.username, output.otherUser.password, output.room._id, 'message-02')}
+# wait for the last message to render before tapping the header, otherwise the list
+# is still regrouping rows and the press gets cancelled mid-gesture
+- extendedWaitUntil:
+    visible:
+      id: 'message-content-message-02'
+    timeout: 60000
 - extendedWaitUntil:
     visible:
       id: 'username-header-${output.otherUser.username}'

--- a/app/lib/methods/helpers/handleIgnore.ts
+++ b/app/lib/methods/helpers/handleIgnore.ts
@@ -4,7 +4,7 @@ import EventEmitter from './events';
 import log from './log';
 import { ignoreUser } from '../../services/restApi';
 
-export const handleIgnore = async (userId: string, ignore: boolean, rid: string) => {
+export const handleIgnore = async (userId: string, ignore: boolean, rid: string): Promise<boolean> => {
 	try {
 		await ignoreUser({
 			rid,
@@ -13,7 +13,9 @@ export const handleIgnore = async (userId: string, ignore: boolean, rid: string)
 		});
 		const message = I18n.t(ignore ? 'User_has_been_ignored' : 'User_has_been_unignored');
 		EventEmitter.emit(LISTENER, { message });
+		return true;
 	} catch (e) {
 		log(e);
+		return false;
 	}
 };

--- a/app/views/RoomActionsView/index.tsx
+++ b/app/views/RoomActionsView/index.tsx
@@ -486,8 +486,11 @@ class RoomActionsView extends Component<IRoomActionsViewProps, IRoomActionsViewS
 		const { room } = this.state;
 		const { rid, blocker } = room;
 		const { member } = this.state;
+		// member may not be fetched yet; the other user's id is derivable from the subscription
+		const blockedUserId = member._id || getUidDirectMessage(room);
+		if (!blockedUserId) return;
 		try {
-			await toggleBlockUser(rid, member._id as string, !blocker);
+			await toggleBlockUser(rid, blockedUserId as string, !blocker);
 		} catch (e) {
 			logEvent(events.RA_TOGGLE_BLOCK_USER_F);
 			log(e);

--- a/app/views/RoomInfoView/index.test.tsx
+++ b/app/views/RoomInfoView/index.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { type ReactNode } from 'react';
+
+import RoomInfoView from './index';
+import { mockedStore } from '../../reducers/mockedStore';
+import { initStore } from '../../lib/store/auxStore';
+import { setUser } from '../../actions/login';
+import { getUserInfo, toggleBlockUser } from '../../lib/services/restApi';
+
+let mockRouteParams: Record<string, unknown> = {};
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+	...jest.requireActual('@react-navigation/native'),
+	useRoute: () => ({ params: mockRouteParams }),
+	useNavigation: () => ({ addListener: jest.fn(() => jest.fn()), setOptions: jest.fn(), navigate: mockNavigate })
+}));
+
+jest.mock('../../lib/database/services/Subscription', () => ({
+	getSubscriptionByRoomId: jest.fn().mockResolvedValue(null)
+}));
+
+jest.mock('../../lib/methods/helpers', () => ({
+	...jest.requireActual('../../lib/methods/helpers'),
+	hasPermission: jest.fn().mockResolvedValue([false])
+}));
+
+jest.mock('../../lib/services/restApi', () => ({
+	getUserInfo: jest.fn(() => new Promise(() => {})),
+	getRoomInfo: jest.fn(),
+	getVisitorInfo: jest.fn(),
+	toggleBlockUser: jest.fn().mockResolvedValue(true),
+	ignoreUser: jest.fn().mockResolvedValue(true)
+}));
+
+jest.mock('../../lib/methods/createDirectMessage', () => ({
+	createDirectMessage: jest.fn()
+}));
+
+jest.mock('../../lib/hooks/useMasterDetail', () => ({
+	useMasterDetail: () => false
+}));
+
+jest.mock('../../lib/hooks/useVideoConf', () => ({
+	useVideoConf: () => ({ callEnabled: false, disabledTooltip: false, showInitCallActionSheet: jest.fn() })
+}));
+
+jest.mock('../../lib/hooks/useNewMediaCall', () => ({
+	useNewMediaCall: () => ({ openNewMediaCall: jest.fn(), hasMediaCallPermission: false, isInActiveCall: false })
+}));
+
+jest.mock('../../lib/services/voip/isInActiveVoipCall', () => ({
+	useIsInActiveVoipCall: () => false
+}));
+
+jest.mock('./hooks', () => ({
+	useE2EEWarning: () => false
+}));
+
+jest.mock('../../containers/ActionSheet', () => ({
+	useActionSheet: () => ({ showActionSheet: jest.fn() })
+}));
+
+jest.mock('../../containers/Header/components/HeaderButton', () => ({
+	Container: () => null,
+	Item: () => null,
+	CloseModal: () => null
+}));
+
+jest.mock('./components/RoomInfoViewAvatar', () => () => null);
+jest.mock('./components/RoomInfoViewTitle', () => () => null);
+jest.mock('./components/RoomInfoViewBody', () => () => null);
+
+const Wrapper = ({ children }: { children: ReactNode }) => <Provider store={mockedStore}>{children}</Provider>;
+
+const dmRoom = {
+	rid: 'dm-rid',
+	t: 'd',
+	uids: ['logged-user-id', 'other-user-id'],
+	usernames: ['me.user', 'other.user'],
+	name: 'other.user',
+	blocker: false
+};
+
+describe('RoomInfoView block/ignore user', () => {
+	beforeAll(() => {
+		initStore(mockedStore);
+		mockedStore.dispatch(setUser({ id: 'logged-user-id' }));
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		// member arrives from RoomActionsView possibly without _id (its own fetch may not have resolved yet)
+		mockRouteParams = {
+			rid: 'dm-rid',
+			t: 'd',
+			fromRid: 'dm-rid',
+			room: dmRoom,
+			member: { username: 'other.user', status: 'online' }
+		};
+	});
+
+	it('blocks the DM user even when member param has no _id yet', async () => {
+		const { getByText } = render(<RoomInfoView />, { wrapper: Wrapper });
+		const blockButton = await waitFor(() => getByText('Block'));
+		fireEvent.press(blockButton);
+		await waitFor(() => expect(toggleBlockUser).toHaveBeenCalled());
+		expect(toggleBlockUser).toHaveBeenCalledWith('dm-rid', 'other-user-id', true);
+	});
+
+	it('fetches full user info when member param has no _id', async () => {
+		render(<RoomInfoView />, { wrapper: Wrapper });
+		await waitFor(() => expect(getUserInfo).toHaveBeenCalledWith('other-user-id'));
+	});
+});

--- a/app/views/RoomInfoView/index.tsx
+++ b/app/views/RoomInfoView/index.tsx
@@ -273,15 +273,35 @@ const RoomInfoView = (): ReactElement => {
 		logEvent(events.RI_TOGGLE_BLOCK_USER);
 		try {
 			await toggleBlockUser(r.rid, userBlocked, !blocker);
+			const updatedRoom = { ...r, blocker: !blocker };
+			if (roomFromRid) {
+				setRoomFromRid(updatedRoom);
+			} else {
+				setRoom(updatedRoom);
+			}
 		} catch (e) {
 			log(e);
 		}
 	};
 
-	const handleIgnoreUser = () => {
+	const handleIgnoreUser = async () => {
 		const r = roomFromRid || room;
 		const isIgnored = r?.ignored?.includes?.(roomUser._id);
-		if (r?.rid) handleIgnore(roomUser._id, !isIgnored, r?.rid);
+		if (!r?.rid) return;
+		const shouldIgnore = !isIgnored;
+		const success = await handleIgnore(roomUser._id, shouldIgnore, r?.rid);
+		if (success) {
+			const currentIgnored = r?.ignored || [];
+			const updatedIgnored = shouldIgnore
+				? [...currentIgnored, roomUser._id]
+				: currentIgnored.filter((id: string) => id !== roomUser._id);
+			const updatedRoom = { ...r, ignored: updatedIgnored };
+			if (roomFromRid) {
+				setRoomFromRid(updatedRoom);
+			} else {
+				setRoom(updatedRoom);
+			}
+		}
 	};
 
 	const handleReportUser = () => {

--- a/app/views/RoomInfoView/index.tsx
+++ b/app/views/RoomInfoView/index.tsx
@@ -170,15 +170,22 @@ const RoomInfoView = (): ReactElement => {
 		}
 	};
 
+	// member may arrive without _id (RoomActionsView forwards it before its own fetch resolves)
+	const resolveRoomUserId = (r?: ISubscription) => {
+		if (roomUser._id) return roomUser._id;
+		const derived = getUidDirectMessage({ ...(r || { rid, t }), itsMe });
+		return derived && derived !== r?.rid ? derived : undefined;
+	};
+
 	const loadUser = async () => {
-		if (isEmpty(roomUser)) {
+		if (!roomUser._id) {
 			try {
 				const roomUserId = getUidDirectMessage({ ...(room || { rid, t }), itsMe });
 				const result = await getUserInfo(roomUserId);
 				if (result.success) {
 					const { user } = result;
 					const r = handleRoles(user);
-					setRoomUser({ ...user, roles: r });
+					setRoomUser({ ...roomUser, ...user, roles: r });
 				}
 			} catch {
 				// do nothing
@@ -267,9 +274,9 @@ const RoomInfoView = (): ReactElement => {
 
 	const handleBlockUser = async () => {
 		const r = roomFromRid || room;
-		const userBlocked = roomUser._id;
+		const userBlocked = resolveRoomUserId(r);
 		const blocker = r?.blocker;
-		if (!r?.rid) return;
+		if (!r?.rid || !userBlocked) return;
 		logEvent(events.RI_TOGGLE_BLOCK_USER);
 		try {
 			await toggleBlockUser(r.rid, userBlocked, !blocker);
@@ -286,15 +293,14 @@ const RoomInfoView = (): ReactElement => {
 
 	const handleIgnoreUser = async () => {
 		const r = roomFromRid || room;
-		const isIgnored = r?.ignored?.includes?.(roomUser._id);
-		if (!r?.rid) return;
+		const userId = resolveRoomUserId(r);
+		if (!r?.rid || !userId) return;
+		const isIgnored = r?.ignored?.includes?.(userId);
 		const shouldIgnore = !isIgnored;
-		const success = await handleIgnore(roomUser._id, shouldIgnore, r?.rid);
+		const success = await handleIgnore(userId, shouldIgnore, r?.rid);
 		if (success) {
 			const currentIgnored = r?.ignored || [];
-			const updatedIgnored = shouldIgnore
-				? [...currentIgnored, roomUser._id]
-				: currentIgnored.filter((id: string) => id !== roomUser._id);
+			const updatedIgnored = shouldIgnore ? [...currentIgnored, userId] : currentIgnored.filter((id: string) => id !== userId);
 			const updatedRoom = { ...r, ignored: updatedIgnored };
 			if (roomFromRid) {
 				setRoomFromRid(updatedRoom);
@@ -342,7 +348,7 @@ const RoomInfoView = (): ReactElement => {
 						handleReportUser={handleReportUser}
 						isDirect={isDirect}
 						room={room || roomUser}
-						roomUserId={roomUser?._id}
+						roomUserId={roomUser?._id || roomUserId}
 						roomFromRid={roomFromRid}
 						serverVersion={serverVersion}
 						itsMe={itsMe}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

Fixes the `ignore-user` E2E flakiness for good. Two independent failure modes were found and fixed:

1. **Block/Ignore silently failing with an undefined user id.** `RoomActionsView` fetches the DM member asynchronously and forwards it to `RoomInfoView` on navigation. When navigation happens before that fetch resolves, `member` arrives as a non-empty object (presence fields only) without `_id`. `RoomInfoView.loadUser` gated its own fetch on `isEmpty(member)`, so the id stayed undefined forever, and tapping Block/Ignore called the server with `blocked: undefined`. The `blockUser` Meteor method answers `Internal server error [500]` for that input (verified against the server with a raw DDP client), the error was swallowed, the button never toggled, and the test's 60s poll for "Unblock" timed out — matching the CI first-attempt failure exactly. The fix derives the target user id from the subscription `uids` (`getUidDirectMessage`) whenever `member._id` is missing, gates `loadUser` on the missing `_id` instead of `isEmpty`, and bails out rather than calling the server with undefined. Same fallback applied to `RoomActionsView.toggleBlockUser`.

2. **Username-header tap cancelled by list re-render.** The flow taps the message author's header right after the two test messages are posted via API. When the tap is injected while the message list is still regrouping rows, the press gets cancelled mid-gesture and the user info screen never opens ("Ignore" never becomes visible). The flow now waits for the last sent message to render before tapping.

## Issue(s)	
https://rocketchat.atlassian.net/browse/NATIVE-1261

## How to test or reproduce

- `TZ=UTC pnpm test --testPathPattern='RoomInfoView/index.test'` — new regression test renders `RoomInfoView` with a `member` param lacking `_id` and asserts `toggleBlockUser` is called with the real user id (red before the fix).
- `maestro test .maestro/tests/room/ignoreuser.yaml -e APP_ID=<app-id>` against a dev build. Before the fix a local block/unblock toggle loop failed 3/3 with the 500 described above; after the fix it passed 3/3 (45 toggles) and the full flow passes repeatedly.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The optimistic UI update from the previous commit remains useful, but it only masked the first failure mode when the member fetch won the race. The undefined-id path was the actual root cause of the remaining flakes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block/ignore actions in DM room info so they work even when the other user’s ID isn’t loaded yet.
  * User details now load more reliably and preserve existing info while fetching missing data.
  * Ignore/block updates now return clearer success or failure results.

* **Tests**
  * Added coverage for the block/ignore flow in DM room info, including cases where the member ID is missing.
  * Updated an automation flow to wait for messages to fully render before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->