### PR TITLE
refactor: apply useCustomEmoji

### DIFF
--- a/app/containers/Avatar/Avatar.stories.tsx
+++ b/app/containers/Avatar/Avatar.stories.tsx
@@ -1,8 +1,12 @@
 import { StyleSheet } from 'react-native';
 
+import { setCustomEmojis } from '../../actions/customEmojis';
+import { mockedStore } from '../../reducers/mockedStore';
 import Status from '../Status/Status';
 import sharedStyles from '../../views/Styles';
 import Avatar from './Avatar';
+
+mockedStore.dispatch(setCustomEmojis({ troll: { name: 'troll', extension: 'jpg' } }));
 
 const styles = StyleSheet.create({
 	custom: {
@@ -40,9 +44,7 @@ export const WithETag = () => (
 
 export const WithoutETag = () => <Avatar type='d' text='djorkaeff.alexandre' server={server} size={56} />;
 
-export const Emoji = () => (
-	<Avatar emoji='troll' getCustomEmoji={() => ({ name: 'troll', extension: 'jpg' })} server={server} size={56} />
-);
+export const Emoji = () => <Avatar emoji='troll' server={server} size={56} />;
 
 export const Direct = () => <Avatar text='diego.mello' server={server} type='d' size={56} />;
 

--- a/app/containers/Avatar/Avatar.tsx
+++ b/app/containers/Avatar/Avatar.tsx
@@ -7,7 +7,6 @@ import Emoji from '../markdown/components/emoji/Emoji';
 import { getAvatarURL } from '../../lib/methods/helpers/getAvatarUrl';
 import { SubscriptionType } from '../../definitions';
 import { type IAvatar } from './interfaces';
-import MarkdownContext from '../markdown/contexts/MarkdownContext';
 import I18n from '../../i18n';
 import Touch from '../Touch';
 
@@ -21,7 +20,6 @@ const Avatar = memo(
 		token,
 		onPress,
 		emoji,
-		getCustomEmoji,
 		avatarETag,
 		isStatic,
 		rid,
@@ -51,16 +49,11 @@ const Avatar = memo(
 		let image;
 		if (emoji) {
 			image = (
-				<MarkdownContext.Provider
-					value={{
-						getCustomEmoji
-					}}>
-					<Emoji
-						block={{ type: 'EMOJI', value: { type: 'PLAIN_TEXT', value: emoji }, shortCode: emoji }}
-						style={avatarStyle}
-						isAvatar={true}
-					/>
-				</MarkdownContext.Provider>
+				<Emoji
+					block={{ type: 'EMOJI', value: { type: 'PLAIN_TEXT', value: emoji }, shortCode: emoji }}
+					style={avatarStyle}
+					isAvatar={true}
+				/>
 			);
 		} else {
 			let uri = avatar;

--- a/app/containers/Avatar/AvatarContainer.tsx
+++ b/app/containers/Avatar/AvatarContainer.tsx
@@ -17,7 +17,6 @@ const AvatarContainer = ({
 	type,
 	children,
 	onPress,
-	getCustomEmoji,
 	isStatic,
 	rid,
 	accessibilityLabel,
@@ -61,7 +60,6 @@ const AvatarContainer = ({
 			userId={id}
 			token={token}
 			onPress={onPress}
-			getCustomEmoji={getCustomEmoji}
 			isStatic={isStatic}
 			rid={rid}
 			blockUnauthenticatedAccess={blockUnauthenticatedAccess}

--- a/app/containers/Avatar/AvatarWithEdit.tsx
+++ b/app/containers/Avatar/AvatarWithEdit.tsx
@@ -39,7 +39,6 @@ const AvatarWithEdit = ({
 	type,
 	children,
 	onPress,
-	getCustomEmoji,
 	isStatic,
 	rid,
 	handleEdit,
@@ -62,7 +61,6 @@ const AvatarWithEdit = ({
 				borderRadius={borderRadius}
 				type={type}
 				onPress={onPress}
-				getCustomEmoji={getCustomEmoji}
 				isStatic={isStatic}
 				rid={rid}>
 				{children}

--- a/app/containers/Avatar/interfaces.ts
+++ b/app/containers/Avatar/interfaces.ts
@@ -1,8 +1,6 @@
 import { type ReactElement } from 'react';
 import { type ViewStyle } from 'react-native';
 
-import { type TGetCustomEmoji } from '../../definitions/IEmoji';
-
 export interface IAvatar {
 	server?: string;
 	style?: ViewStyle;
@@ -16,7 +14,6 @@ export interface IAvatar {
 	userId?: string;
 	token?: string;
 	onPress?: () => void;
-	getCustomEmoji?: TGetCustomEmoji;
 	avatarETag?: string;
 	isStatic?: boolean | string;
 	rid?: string;

--- a/app/containers/ReactionsList/AllTab.tsx
+++ b/app/containers/ReactionsList/AllTab.tsx
@@ -4,22 +4,19 @@ import { Text, View, FlatList } from 'react-native';
 import Emoji from '../message/Emoji';
 import { useTheme } from '../../theme';
 import { type IReaction } from '../../definitions';
-import { type TGetCustomEmoji } from '../../definitions/IEmoji';
 import I18n from '../../i18n';
 import styles from './styles';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 
 interface IAllReactionsListItemProps {
-	getCustomEmoji: TGetCustomEmoji;
 	item: IReaction;
 }
 
 interface IAllTabProps {
-	getCustomEmoji: TGetCustomEmoji;
 	reactions?: IReaction[];
 }
 
-const AllReactionsListItem = ({ item, getCustomEmoji }: IAllReactionsListItemProps) => {
+const AllReactionsListItem = ({ item }: IAllReactionsListItemProps) => {
 	const { colors } = useTheme();
 	const useRealName = useAppSelector(state => state.settings.UI_Use_Real_Name);
 	const username = useAppSelector(state => state.login.user.username);
@@ -48,7 +45,6 @@ const AllReactionsListItem = ({ item, getCustomEmoji }: IAllReactionsListItemPro
 				content={item.emoji}
 				standardEmojiStyle={styles.allTabStandardEmojiStyle}
 				customEmojiStyle={styles.allTabCustomEmojiStyle}
-				getCustomEmoji={getCustomEmoji}
 			/>
 			<View style={styles.textContainer}>
 				<Text style={[styles.allListNPeopleReacted, { color: colors.fontDefault }]}>
@@ -60,12 +56,12 @@ const AllReactionsListItem = ({ item, getCustomEmoji }: IAllReactionsListItemPro
 	);
 };
 
-const AllTab = ({ reactions, getCustomEmoji }: IAllTabProps): ReactElement => (
+const AllTab = ({ reactions }: IAllTabProps): ReactElement => (
 	<View style={styles.allTabContainer} testID='reactionsListAllTab'>
 		<FlatList
 			data={reactions}
 			contentContainerStyle={styles.listContainer}
-			renderItem={({ item }) => <AllReactionsListItem item={item} getCustomEmoji={getCustomEmoji} />}
+			renderItem={({ item }) => <AllReactionsListItem item={item} />}
 			keyExtractor={item => item.emoji}
 		/>
 	</View>

--- a/app/containers/ReactionsList/ReactionsList.stories.tsx
+++ b/app/containers/ReactionsList/ReactionsList.stories.tsx
@@ -1,18 +1,17 @@
 import { View } from 'react-native';
 
-import { type TGetCustomEmoji, type ICustomEmoji } from '../../definitions';
 import ReactionsList from '.';
 import { mockedStore as store } from '../../reducers/mockedStore';
 import { updateSettings } from '../../actions/settings';
+import { setCustomEmojis } from '../../actions/customEmojis';
 
-const getCustomEmoji: TGetCustomEmoji = content => {
-	const customEmoji = {
-		marioparty: { name: content, extension: 'gif' },
-		react_rocket: { name: content, extension: 'png' },
-		nyan_rocket: { name: content, extension: 'png' }
-	}[content] as ICustomEmoji;
-	return customEmoji;
-};
+store.dispatch(
+	setCustomEmojis({
+		marioparty: { name: 'marioparty', extension: 'gif' },
+		react_rocket: { name: 'react_rocket', extension: 'png' },
+		nyan_rocket: { name: 'nyan_rocket', extension: 'png' }
+	})
+);
 
 const reactions = [
 	{
@@ -51,7 +50,7 @@ export const ReactionsListStory = () => {
 	store.dispatch(updateSettings('UI_Use_Real_Name', false));
 	return (
 		<View style={{ paddingVertical: 10, flex: 1 }}>
-			<ReactionsList getCustomEmoji={getCustomEmoji} reactions={reactions} />
+			<ReactionsList reactions={reactions} />
 		</View>
 	);
 };
@@ -60,7 +59,7 @@ export const ReactionsListFullName = () => {
 	store.dispatch(updateSettings('UI_Use_Real_Name', true));
 	return (
 		<View style={{ paddingVertical: 10, flex: 1 }}>
-			<ReactionsList getCustomEmoji={getCustomEmoji} reactions={reactions} />
+			<ReactionsList reactions={reactions} />
 		</View>
 	);
 };

--- a/app/containers/ReactionsList/ReactionsList.test.tsx
+++ b/app/containers/ReactionsList/ReactionsList.test.tsx
@@ -105,15 +105,11 @@ const mockStore = createStore(
 			server: {
 				server: 'https://open.rocket.chat',
 				version: '6.0.0'
-			}
+			},
+			customEmojis: {}
 		}
 	) => state
 );
-
-const mockGetCustomEmoji = (emoji: string) => ({
-	name: emoji,
-	extension: 'png'
-});
 
 const mockReactions: IReaction[] = [
 	{
@@ -138,13 +134,13 @@ describe('ReactionsList Integration Tests', () => {
 	});
 
 	it('renders empty ReactionsList when no reactions', () => {
-		renderWithRedux(<ReactionsList getCustomEmoji={mockGetCustomEmoji} reactions={[]} />);
+		renderWithRedux(<ReactionsList reactions={[]} />);
 		expect(screen.getByTestId('reactionsList')).toBeOnTheScreen();
 		expect(screen.getByTestId('reactionsListAllTab')).toBeOnTheScreen();
 	});
 
 	it('renders ReactionsList with reactions and allows navigation between tabs', () => {
-		renderWithRedux(<ReactionsList getCustomEmoji={mockGetCustomEmoji} reactions={mockReactions} />);
+		renderWithRedux(<ReactionsList reactions={mockReactions} />);
 
 		// Verify All tab content
 		expect(screen.getByText('4 people reacted')).toBeOnTheScreen();
@@ -185,14 +181,15 @@ describe('ReactionsList Integration Tests', () => {
 					server: {
 						server: 'https://open.rocket.chat',
 						version: '6.0.0'
-					}
+					},
+					customEmojis: {}
 				}
 			) => state
 		);
 
 		render(
 			<Provider store={storeWithoutRealNames}>
-				<ReactionsList getCustomEmoji={mockGetCustomEmoji} reactions={mockReactions} />
+				<ReactionsList reactions={mockReactions} />
 			</Provider>
 		);
 
@@ -227,7 +224,7 @@ describe('ReactionsList Integration Tests', () => {
 			}
 		];
 
-		renderWithRedux(<ReactionsList getCustomEmoji={mockGetCustomEmoji} reactions={customReactions} />);
+		renderWithRedux(<ReactionsList reactions={customReactions} />);
 
 		// Verify custom emoji is rendered
 		expect(screen.getByTestId('tab-:custom_emoji:')).toBeOnTheScreen();

--- a/app/containers/ReactionsList/ReactionsList.test.tsx
+++ b/app/containers/ReactionsList/ReactionsList.test.tsx
@@ -2,6 +2,7 @@ import { type ReactElement, type ReactNode } from 'react';
 import { screen, render, fireEvent, within } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
+import { Image as ExpoImage } from 'expo-image';
 
 import ReactionsList from './index';
 import { type IReaction } from '../../definitions';
@@ -215,6 +216,30 @@ describe('ReactionsList Integration Tests', () => {
 	});
 
 	it('handles custom emojis correctly', () => {
+		const storeWithCustomEmoji = createStore(
+			(
+				state = {
+					settings: {
+						UI_Use_Real_Name: true
+					},
+					login: {
+						user: {
+							id: 'user123',
+							username: 'testuser',
+							name: 'Test User'
+						}
+					},
+					server: {
+						server: 'https://open.rocket.chat',
+						version: '6.0.0'
+					},
+					customEmojis: {
+						custom_emoji: { name: 'custom_emoji', extension: 'png' }
+					}
+				}
+			) => state
+		);
+
 		const customReactions: IReaction[] = [
 			{
 				_id: 'reaction3',
@@ -224,11 +249,18 @@ describe('ReactionsList Integration Tests', () => {
 			}
 		];
 
-		renderWithRedux(<ReactionsList reactions={customReactions} />);
+		render(
+			<Provider store={storeWithCustomEmoji}>
+				<ReactionsList reactions={customReactions} />
+			</Provider>
+		);
 
-		// Verify custom emoji is rendered
 		expect(screen.getByTestId('tab-:custom_emoji:')).toBeOnTheScreen();
 		expect(screen.getByText('1 person reacted')).toBeOnTheScreen();
+
+		// Resolves against the store and renders as a custom emoji image, not the shortname text
+		expect(screen.UNSAFE_getAllByType(ExpoImage).length).toBeGreaterThan(0);
+		expect(screen.queryByText(':custom_emoji:')).toBeNull();
 	});
 });
 

--- a/app/containers/ReactionsList/index.tsx
+++ b/app/containers/ReactionsList/index.tsx
@@ -1,6 +1,5 @@
 import { Text, View } from 'react-native';
 
-import { type TGetCustomEmoji } from '../../definitions/IEmoji';
 import { type IReaction } from '../../definitions';
 import I18n from '../../i18n';
 import styles from './styles';
@@ -10,7 +9,6 @@ import { TabView } from '../TabView';
 import Emoji from '../message/Emoji';
 
 interface IReactionsListProps {
-	getCustomEmoji: TGetCustomEmoji;
 	reactions?: IReaction[];
 }
 
@@ -50,12 +48,12 @@ const useRoutes = (reactions: IReaction[] | undefined) => {
 	};
 };
 
-const ReactionsList = ({ reactions, getCustomEmoji }: IReactionsListProps) => {
+const ReactionsList = ({ reactions }: IReactionsListProps) => {
 	const { routes, sortedReactions } = useRoutes(reactions);
 
 	const renderScene = ({ route }: { route: IRoute }) => {
 		if (route.key === 'all') {
-			return <AllTab reactions={sortedReactions} getCustomEmoji={getCustomEmoji} />;
+			return <AllTab reactions={sortedReactions} />;
 		}
 		if (route.emoji && route.usernames && route.names) {
 			return <UsersList emoji={route.emoji} usernames={route.usernames} names={route.names} />;
@@ -74,12 +72,7 @@ const ReactionsList = ({ reactions, getCustomEmoji }: IReactionsListProps) => {
 		if (tab.emoji) {
 			return (
 				<View style={styles.tabBarItem}>
-					<Emoji
-						content={tab.emoji}
-						standardEmojiStyle={styles.standardEmojiStyle}
-						customEmojiStyle={styles.customEmojiStyle}
-						getCustomEmoji={getCustomEmoji}
-					/>
+					<Emoji content={tab.emoji} standardEmojiStyle={styles.standardEmojiStyle} customEmojiStyle={styles.customEmojiStyle} />
 					<Text style={[styles.reactionCount, { color }]}>{tab.usernames?.length}</Text>
 				</View>
 			);

--- a/app/containers/markdown/Markdown.stories.tsx
+++ b/app/containers/markdown/Markdown.stories.tsx
@@ -2,8 +2,9 @@ import { ScrollView, StyleSheet, View } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 
 import Markdown, { MarkdownPreview } from '.';
+import { setCustomEmojis } from '../../actions/customEmojis';
+import { mockedStore } from '../../reducers/mockedStore';
 import { themes } from '../../lib/constants/colors';
-import { type TGetCustomEmoji, type ICustomEmoji } from '../../definitions/IEmoji';
 
 const theme = 'light';
 
@@ -27,14 +28,12 @@ d
 e`;
 const sequentialEmptySpacesText = 'a       b                                                                             c';
 
-const getCustomEmoji: TGetCustomEmoji = content => {
-	const customEmoji = {
-		marioparty: { name: content, extension: 'gif' },
-		react_rocket: { name: content, extension: 'png' },
-		nyan_rocket: { name: content, extension: 'png' }
-	}[content] as ICustomEmoji;
-	return customEmoji;
+const customEmojis = {
+	marioparty: { name: 'marioparty', extension: 'gif' },
+	react_rocket: { name: 'react_rocket', extension: 'png' },
+	nyan_rocket: { name: 'nyan_rocket', extension: 'png' }
 };
+mockedStore.dispatch(setCustomEmojis(customEmojis));
 
 export default {
 	title: 'Markdown',
@@ -94,8 +93,8 @@ export const Emoji = () => (
 	<View style={styles.container}>
 		<Markdown msg='Unicode: 😃😇👍' />
 		<Markdown msg='Shortnames: :joy: :+1:' />
-		<Markdown msg='Custom emojis: :react_rocket: :nyan_rocket: :marioparty:' getCustomEmoji={getCustomEmoji} />
-		<Markdown msg='😃 :+1: :marioparty:' getCustomEmoji={getCustomEmoji} />
+		<Markdown msg='Custom emojis: :react_rocket: :nyan_rocket: :marioparty:' />
+		<Markdown msg='😃 :+1: :marioparty:' />
 	</View>
 );
 

--- a/app/containers/markdown/components/emoji/Emoji.tsx
+++ b/app/containers/markdown/components/emoji/Emoji.tsx
@@ -1,4 +1,3 @@
-import { useContext } from 'react';
 import { Text, View, useWindowDimensions } from 'react-native';
 import { type Emoji as EmojiProps } from '@rocket.chat/message-parser';
 
@@ -7,8 +6,8 @@ import useShortnameToUnicode from '../../../../lib/hooks/useShortnameToUnicode';
 import { useTheme } from '../../../../theme';
 import styles from '../../styles';
 import CustomEmoji from '../../../EmojiPicker/CustomEmoji';
-import MarkdownContext from '../../contexts/MarkdownContext';
 import { useAppSelector } from '../../../../lib/hooks/useAppSelector';
+import { useCustomEmoji } from '../../../../lib/hooks/useCustomEmoji';
 import { getUserSelector } from '../../../../selectors/login';
 import { useResponsiveLayout } from '../../../../lib/hooks/useResponsiveLayout/useResponsiveLayout';
 
@@ -34,7 +33,7 @@ function getEmojiToken(block: EmojiProps, isAvatar: boolean) {
 
 const Emoji = ({ block, isBigEmoji, style = {}, index, isAvatar = false }: IEmojiProps) => {
 	const { colors } = useTheme();
-	const { getCustomEmoji } = useContext(MarkdownContext);
+	const getCustomEmoji = useCustomEmoji();
 	const { fontScale } = useWindowDimensions();
 	const { fontScaleLimited } = useResponsiveLayout();
 	const { formatShortnameToUnicode } = useShortnameToUnicode();

--- a/app/containers/markdown/contexts/MarkdownContext.ts
+++ b/app/containers/markdown/contexts/MarkdownContext.ts
@@ -9,7 +9,6 @@ interface IMarkdownContext {
 	useRealName?: boolean;
 	username?: string;
 	navToRoomInfo?: Function;
-	getCustomEmoji?: Function;
 	onLinkPress?: Function;
 	textStyle?: StyleProp<TextStyle>;
 }

--- a/app/containers/markdown/index.tsx
+++ b/app/containers/markdown/index.tsx
@@ -5,7 +5,6 @@ import type { Root } from '@rocket.chat/message-parser';
 import isEmpty from 'lodash/isEmpty';
 
 import { type IUserMention, type IUserChannel, type TOnLinkPress } from './interfaces';
-import { type TGetCustomEmoji } from '../../definitions/IEmoji';
 import MarkdownContext from './contexts/MarkdownContext';
 import LineBreak from './components/LineBreak';
 import { KaTeX } from './components/Katex';
@@ -26,7 +25,6 @@ interface IMarkdownProps {
 	msg?: string | null;
 	md?: Root;
 	mentions?: IUserMention[];
-	getCustomEmoji?: TGetCustomEmoji;
 	username?: string;
 	useRealName?: boolean;
 	channels?: IUserChannel[];
@@ -109,7 +107,6 @@ const Markdown: FC<IMarkdownProps> = ({
 	navToRoomInfo,
 	useRealName,
 	username = '',
-	getCustomEmoji,
 	onLinkPress,
 	isTranslated,
 	textStyle
@@ -133,7 +130,6 @@ const Markdown: FC<IMarkdownProps> = ({
 		useRealName,
 		username,
 		navToRoomInfo,
-		getCustomEmoji,
 		onLinkPress,
 		textStyle
 	};

--- a/app/containers/message/Components/Attachments/AttachedActions.tsx
+++ b/app/containers/message/Components/Attachments/AttachedActions.tsx
@@ -13,7 +13,7 @@ export type TElement = {
 	text: string;
 };
 
-const AttachedActions = ({ attachment, getCustomEmoji }: { attachment: IAttachment; getCustomEmoji: TGetCustomEmoji }) => {
+const AttachedActions = ({ attachment }: { attachment: IAttachment; getCustomEmoji: TGetCustomEmoji }) => {
 	'use memo';
 
 	const { onAnswerButtonPress } = useContext(MessageContext);
@@ -41,7 +41,7 @@ const AttachedActions = ({ attachment, getCustomEmoji }: { attachment: IAttachme
 	});
 	return (
 		<>
-			<Markdown msg={attachment.text} getCustomEmoji={getCustomEmoji} />
+			<Markdown msg={attachment.text} />
 			{attachedButtons}
 		</>
 	);

--- a/app/containers/message/Components/Attachments/AttachedActions.tsx
+++ b/app/containers/message/Components/Attachments/AttachedActions.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 
 import Button from '../../../Button';
 import MessageContext from '../../Context';
-import { type IAttachment, type TGetCustomEmoji } from '../../../../definitions';
+import { type IAttachment } from '../../../../definitions';
 import openLink from '../../../../lib/methods/helpers/openLink';
 import Markdown from '../../../markdown';
 
@@ -13,7 +13,7 @@ export type TElement = {
 	text: string;
 };
 
-const AttachedActions = ({ attachment }: { attachment: IAttachment; getCustomEmoji: TGetCustomEmoji }) => {
+const AttachedActions = ({ attachment }: { attachment: IAttachment }) => {
 	'use memo';
 
 	const { onAnswerButtonPress } = useContext(MessageContext);

--- a/app/containers/message/Components/Attachments/Attachments.stories.tsx
+++ b/app/containers/message/Components/Attachments/Attachments.stories.tsx
@@ -54,7 +54,7 @@ export const SingleImageOldServer = () => (
 	<Provider store={oldServerStore}>
 		<MessageContext.Provider value={mockMessageContext}>
 			<View style={{ padding: 10, width: 350 }}>
-				<Attachments attachments={[MOCK_IMAGE_WITH_ALT]} getCustomEmoji={() => null} timeFormat='LT' />
+				<Attachments attachments={[MOCK_IMAGE_WITH_ALT]} timeFormat='LT' />
 			</View>
 		</MessageContext.Provider>
 	</Provider>
@@ -65,7 +65,7 @@ export const SingleImageNewServer = () => (
 	<Provider store={newServerStore}>
 		<MessageContext.Provider value={mockMessageContext}>
 			<View style={{ padding: 10, width: 350 }}>
-				<Attachments attachments={[MOCK_IMAGE_WITH_ALT]} getCustomEmoji={() => null} timeFormat='LT' />
+				<Attachments attachments={[MOCK_IMAGE_WITH_ALT]} timeFormat='LT' />
 			</View>
 		</MessageContext.Provider>
 	</Provider>
@@ -76,7 +76,7 @@ export const SingleImageNoAlt = () => (
 	<Provider store={newServerStore}>
 		<MessageContext.Provider value={mockMessageContext}>
 			<View style={{ padding: 10, width: 350 }}>
-				<Attachments attachments={[MOCK_IMAGE_1]} getCustomEmoji={() => null} timeFormat='LT' />
+				<Attachments attachments={[MOCK_IMAGE_1]} timeFormat='LT' />
 			</View>
 		</MessageContext.Provider>
 	</Provider>
@@ -87,7 +87,7 @@ export const MultipleImagesNewServer = () => (
 	<Provider store={newServerStore}>
 		<MessageContext.Provider value={mockMessageContext}>
 			<View style={{ padding: 10, width: 350 }}>
-				<Attachments attachments={MOCK_MULTIPLE_IMAGES} getCustomEmoji={() => null} timeFormat='LT' />
+				<Attachments attachments={MOCK_MULTIPLE_IMAGES} timeFormat='LT' />
 			</View>
 		</MessageContext.Provider>
 	</Provider>
@@ -98,7 +98,7 @@ export const MultipleImagesOldServer = () => (
 	<Provider store={oldServerStore}>
 		<MessageContext.Provider value={mockMessageContext}>
 			<View style={{ padding: 10, width: 350 }}>
-				<Attachments attachments={MOCK_MULTIPLE_IMAGES.slice(0, 4)} getCustomEmoji={() => null} timeFormat='LT' />
+				<Attachments attachments={MOCK_MULTIPLE_IMAGES.slice(0, 4)} timeFormat='LT' />
 			</View>
 		</MessageContext.Provider>
 	</Provider>

--- a/app/containers/message/Components/Attachments/Attachments.tsx
+++ b/app/containers/message/Components/Attachments/Attachments.tsx
@@ -14,7 +14,7 @@ import { getMessageFromAttachment } from '../../utils';
 import { isContentAttachment } from './utils';
 
 const Attachments: FC<IMessageAttachments> = memo(
-	({ attachments, timeFormat, showAttachment, getCustomEmoji, author }: IMessageAttachments) => {
+	({ attachments, timeFormat, showAttachment, author }: IMessageAttachments) => {
 		'use memo';
 
 		const { translateLanguage } = useContext(MessageContext);
@@ -34,7 +34,6 @@ const Attachments: FC<IMessageAttachments> = memo(
 						key={file.image_url}
 						file={file}
 						showAttachment={showAttachment}
-						getCustomEmoji={getCustomEmoji}
 						author={author}
 						msg={msg}
 						imagePreview={file.image_preview}
@@ -44,30 +43,15 @@ const Attachments: FC<IMessageAttachments> = memo(
 			}
 
 			if (file.audio_url) {
-				return <Audio key={file.audio_url} file={file} getCustomEmoji={getCustomEmoji} author={author} msg={msg} />;
+				return <Audio key={file.audio_url} file={file} author={author} msg={msg} />;
 			}
 
 			if (file.video_url) {
-				return (
-					<Video
-						key={file.video_url}
-						file={file}
-						showAttachment={showAttachment}
-						getCustomEmoji={getCustomEmoji}
-						author={author}
-						msg={msg}
-					/>
-				);
+				return <Video key={file.video_url} file={file} showAttachment={showAttachment} author={author} msg={msg} />;
 			}
 
 			if (file.actions && file.actions.length > 0) {
-				return (
-					<AttachedActions
-						key={file.title_link || file.message_link || `actions-${index}`}
-						attachment={file}
-						getCustomEmoji={getCustomEmoji}
-					/>
-				);
+				return <AttachedActions key={file.title_link || file.message_link || `actions-${index}`} attachment={file} />;
 			}
 			if (typeof file.collapsed === 'boolean') {
 				return (
@@ -75,7 +59,6 @@ const Attachments: FC<IMessageAttachments> = memo(
 						key={file.title_link || file.message_link || `collapsible-${index}`}
 						attachment={file}
 						timeFormat={timeFormat}
-						getCustomEmoji={getCustomEmoji}
 					/>
 				);
 			}
@@ -86,7 +69,6 @@ const Attachments: FC<IMessageAttachments> = memo(
 						key={file.title_link || file.message_link || `reply-${index}`}
 						attachment={file}
 						timeFormat={timeFormat}
-						getCustomEmoji={getCustomEmoji}
 						showAttachment={showAttachment}
 						msg={msg}
 					/>

--- a/app/containers/message/Components/Attachments/Audio.tsx
+++ b/app/containers/message/Components/Attachments/Audio.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import { View } from 'react-native';
 
 import { type IAttachment, type IUserMessage } from '../../../../definitions';
-import { type TGetCustomEmoji } from '../../../../definitions/IEmoji';
 import AudioPlayer from '../../../AudioPlayer';
 import Markdown from '../../../markdown';
 import MessageContext from '../../Context';
@@ -10,7 +9,6 @@ import { useMediaAutoDownload } from '../../hooks/useMediaAutoDownload';
 
 interface IMessageAudioProps {
 	file: IAttachment;
-	getCustomEmoji: TGetCustomEmoji;
 	author?: IUserMessage;
 	msg?: string;
 }

--- a/app/containers/message/Components/Attachments/Audio.tsx
+++ b/app/containers/message/Components/Attachments/Audio.tsx
@@ -15,7 +15,7 @@ interface IMessageAudioProps {
 	msg?: string;
 }
 
-const MessageAudio = ({ file, getCustomEmoji, author, msg }: IMessageAudioProps) => {
+const MessageAudio = ({ file, author, msg }: IMessageAudioProps) => {
 	'use memo';
 
 	const { user, id, rid } = useContext(MessageContext);
@@ -23,7 +23,7 @@ const MessageAudio = ({ file, getCustomEmoji, author, msg }: IMessageAudioProps)
 
 	return (
 		<View style={{ gap: 4 }}>
-			{msg ? <Markdown msg={msg} username={user.username} getCustomEmoji={getCustomEmoji} /> : null}
+			{msg ? <Markdown msg={msg} username={user.username} /> : null}
 			<AudioPlayer msgId={id} fileUri={url} downloadState={status} onPlayButtonPress={onPress} rid={rid} />
 		</View>
 	);

--- a/app/containers/message/Components/Attachments/CollapsibleQuote/CollapsibleQuote.stories.tsx
+++ b/app/containers/message/Components/Attachments/CollapsibleQuote/CollapsibleQuote.stories.tsx
@@ -28,7 +28,7 @@ export const Item = () => (
 				onLongPress: () => {},
 				user: { username: 'Marcos' }
 			}}>
-			<CollapsibleQuote attachment={testAttachment} getCustomEmoji={() => null} timeFormat='LT' />
+			<CollapsibleQuote attachment={testAttachment} timeFormat='LT' />
 		</MessageContext.Provider>
 	</View>
 );

--- a/app/containers/message/Components/Attachments/CollapsibleQuote/CollapsibleQuote.test.tsx
+++ b/app/containers/message/Components/Attachments/CollapsibleQuote/CollapsibleQuote.test.tsx
@@ -21,8 +21,6 @@ const testAttachment = {
 	collapsed: true
 };
 
-const mockFn = jest.fn();
-
 const initialMockedStoreState = () => {
 	mockedStore.dispatch(
 		setUser({
@@ -44,7 +42,7 @@ const Render = () => (
 				onLongPress: () => {},
 				user: { username: 'Marcos' }
 			}}>
-			<CollapsibleQuote attachment={testAttachment} getCustomEmoji={mockFn} timeFormat='LT' />
+			<CollapsibleQuote attachment={testAttachment} timeFormat='LT' />
 		</MessageContext.Provider>
 	</Provider>
 );

--- a/app/containers/message/Components/Attachments/CollapsibleQuote/index.tsx
+++ b/app/containers/message/Components/Attachments/CollapsibleQuote/index.tsx
@@ -84,7 +84,7 @@ interface IMessageReply {
 }
 
 const AttText = memo(
-	({ text, getCustomEmoji }: IMessageAttText) => {
+	({ text }: IMessageAttText) => {
 		'use memo';
 
 		const { user } = useContext(MessageContext);
@@ -93,13 +93,13 @@ const AttText = memo(
 			return null;
 		}
 
-		return <Markdown msg={text} username={user.username} getCustomEmoji={getCustomEmoji} />;
+		return <Markdown msg={text} username={user.username} />;
 	},
 	(prevProps, nextProps) => prevProps.text === nextProps.text
 );
 
 const Fields = memo(
-	({ attachment, getCustomEmoji }: IMessageFields) => {
+	({ attachment }: IMessageFields) => {
 		'use memo';
 
 		const { theme } = useTheme();
@@ -116,7 +116,7 @@ const Fields = memo(
 						<Text testID='collapsibleQuoteTouchableFieldTitle' style={[styles.fieldTitle, { color: themes[theme].fontDefault }]}>
 							{field.title}
 						</Text>
-						<Markdown msg={field?.value || ''} username={user.username} getCustomEmoji={getCustomEmoji} />
+						<Markdown msg={field?.value || ''} username={user.username} />
 					</View>
 				))}
 			</>

--- a/app/containers/message/Components/Attachments/CollapsibleQuote/index.tsx
+++ b/app/containers/message/Components/Attachments/CollapsibleQuote/index.tsx
@@ -5,7 +5,6 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { themes } from '../../../../../lib/constants/colors';
 import { type IAttachment } from '../../../../../definitions/IAttachment';
-import { type TGetCustomEmoji } from '../../../../../definitions/IEmoji';
 import { CustomIcon } from '../../../../CustomIcon';
 import { useTheme } from '../../../../../theme';
 import sharedStyles from '../../../../../views/Styles';
@@ -69,18 +68,15 @@ const styles = StyleSheet.create({
 
 interface IMessageAttText {
 	text?: string;
-	getCustomEmoji: TGetCustomEmoji;
 }
 
 interface IMessageFields {
 	attachment: IAttachment;
-	getCustomEmoji: TGetCustomEmoji;
 }
 
 interface IMessageReply {
 	attachment: IAttachment;
 	timeFormat?: string;
-	getCustomEmoji: TGetCustomEmoji;
 }
 
 const AttText = memo(
@@ -126,7 +122,7 @@ const Fields = memo(
 );
 
 const CollapsibleQuote = memo(
-	({ attachment, getCustomEmoji }: IMessageReply) => {
+	({ attachment }: IMessageReply) => {
 		'use memo';
 
 		const { theme } = useTheme();
@@ -177,8 +173,8 @@ const CollapsibleQuote = memo(
 							<View style={styles.authorContainer}>
 								<Text style={[styles.title, { color: fontSecondaryInfo }]}>{attachment.title}</Text>
 							</View>
-							{!collapsed && <AttText text={attachment.text} getCustomEmoji={getCustomEmoji} />}
-							{!collapsed && <Fields attachment={attachment} getCustomEmoji={getCustomEmoji} />}
+							{!collapsed && <AttText text={attachment.text} />}
+							{!collapsed && <Fields attachment={attachment} />}
 						</View>
 						<View style={styles.iconContainer}>
 							<CustomIcon name={!collapsed ? 'chevron-up' : 'chevron-down'} size={22} color={strokeMedium} />

--- a/app/containers/message/Components/Attachments/Image/Container.tsx
+++ b/app/containers/message/Components/Attachments/Image/Container.tsx
@@ -12,15 +12,7 @@ import { WidthAwareView } from '../../WidthAwareView';
 import { useAltTextSupported } from '../../../../../lib/hooks/useAltTextSupported';
 import I18n from '../../../../../i18n';
 
-const ImageContainer = ({
-	file,
-	showAttachment,
-	getCustomEmoji,
-	author,
-	msg,
-	imagePreview,
-	imageType
-}: IImageContainer): ReactElement | null => {
+const ImageContainer = ({ file, showAttachment, author, msg, imagePreview, imageType }: IImageContainer): ReactElement | null => {
 	'use memo';
 
 	const { user } = useContext(MessageContext);
@@ -52,7 +44,7 @@ const ImageContainer = ({
 	if (msg) {
 		return (
 			<View style={{ gap: 4 }}>
-				<Markdown msg={msg} username={user.username} getCustomEmoji={getCustomEmoji} />
+				<Markdown msg={msg} username={user.username} />
 				{image}
 			</View>
 		);

--- a/app/containers/message/Components/Attachments/Image/definitions.ts
+++ b/app/containers/message/Components/Attachments/Image/definitions.ts
@@ -1,11 +1,9 @@
 import { type IAttachment, type IUserMessage } from '../../../../../definitions';
-import { type TGetCustomEmoji } from '../../../../../definitions/IEmoji';
 import { type TDownloadState } from '../../../../../lib/methods/handleMediaDownload';
 
 export interface IImageContainer {
 	file: IAttachment;
 	showAttachment?: (file: IAttachment) => void;
-	getCustomEmoji?: TGetCustomEmoji;
 	author?: IUserMessage;
 	msg?: string;
 	imagePreview?: string;

--- a/app/containers/message/Components/Attachments/Quote.tsx
+++ b/app/containers/message/Components/Attachments/Quote.tsx
@@ -10,7 +10,7 @@ import { getMessageFromAttachment } from '../../utils';
 import { isQuoteAttachment } from './utils';
 
 const Quote: FC<IMessageAttachments> = memo(
-	({ attachments, timeFormat, showAttachment, getCustomEmoji }: IMessageAttachments) => {
+	({ attachments, timeFormat, showAttachment }: IMessageAttachments) => {
 		'use memo';
 
 		const { translateLanguage } = useContext(MessageContext);
@@ -24,16 +24,7 @@ const Quote: FC<IMessageAttachments> = memo(
 		const quotesElements = quotes.map((file: IAttachment, index: number) => {
 			const msg = getMessageFromAttachment(file, translateLanguage);
 
-			return (
-				<Reply
-					key={index}
-					attachment={file}
-					timeFormat={timeFormat}
-					getCustomEmoji={getCustomEmoji}
-					msg={msg}
-					showAttachment={showAttachment}
-				/>
-			);
+			return <Reply key={index} attachment={file} timeFormat={timeFormat} msg={msg} showAttachment={showAttachment} />;
 		});
 
 		return <View style={{ gap: 4 }}>{quotesElements}</View>;

--- a/app/containers/message/Components/Attachments/Reply.tsx
+++ b/app/containers/message/Components/Attachments/Reply.tsx
@@ -120,7 +120,7 @@ const Title = memo(
 );
 
 const Description = memo(
-	({ attachment, getCustomEmoji }: { attachment: IAttachment; getCustomEmoji: TGetCustomEmoji }) => {
+	({ attachment }: { attachment: IAttachment; getCustomEmoji: TGetCustomEmoji }) => {
 		'use memo';
 
 		const { user } = useContext(MessageContext);
@@ -140,7 +140,7 @@ const Description = memo(
 			return <MarkdownPreview msg={text} numberOfLines={0} />;
 		}
 
-		return <Markdown msg={text} username={user.username} getCustomEmoji={getCustomEmoji} />;
+		return <Markdown msg={text} username={user.username} />;
 	},
 	(prevProps, nextProps) => {
 		if (prevProps.attachment.text !== nextProps.attachment.text) {
@@ -173,15 +173,7 @@ const UrlImage = memo(
 );
 
 const Fields = memo(
-	({
-		attachment,
-		theme,
-		getCustomEmoji
-	}: {
-		attachment: IAttachment;
-		theme: TSupportedThemes;
-		getCustomEmoji: TGetCustomEmoji;
-	}) => {
+	({ attachment, theme }: { attachment: IAttachment; theme: TSupportedThemes; getCustomEmoji: TGetCustomEmoji }) => {
 		'use memo';
 
 		const { user } = useContext(MessageContext);
@@ -195,7 +187,7 @@ const Fields = memo(
 				{attachment.fields.map(field => (
 					<View key={field.title} style={[styles.fieldContainer, { width: field.short ? '50%' : '100%' }]}>
 						<Text style={[styles.fieldTitle, { color: themes[theme].fontDefault }]}>{field.title}</Text>
-						<Markdown msg={field?.value || ''} username={user.username} getCustomEmoji={getCustomEmoji} />
+						<Markdown msg={field?.value || ''} username={user.username} />
 					</View>
 				))}
 			</View>
@@ -280,7 +272,7 @@ const Reply = memo(
 						<UrlImage image={attachment.thumb_url} />
 					</View>
 				</Touchable>
-				{msg ? <Markdown msg={msg} username={user.username} getCustomEmoji={getCustomEmoji} /> : null}
+				{msg ? <Markdown msg={msg} username={user.username} /> : null}
 			</View>
 		);
 	},

--- a/app/containers/message/Components/Attachments/Reply.tsx
+++ b/app/containers/message/Components/Attachments/Reply.tsx
@@ -3,7 +3,7 @@ import { useContext, useState, memo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 
-import { type IAttachment, type TGetCustomEmoji } from '../../../../definitions';
+import { type IAttachment } from '../../../../definitions';
 import { themes } from '../../../../lib/constants/colors';
 import { fileDownloadAndPreview } from '../../../../lib/methods/helpers';
 import { formatAttachmentUrl } from '../../../../lib/methods/helpers/formatAttachmentUrl';
@@ -95,7 +95,6 @@ const styles = StyleSheet.create({
 interface IMessageReply {
 	attachment: IAttachment;
 	timeFormat?: string;
-	getCustomEmoji: TGetCustomEmoji;
 	msg?: string;
 	showAttachment?: (file: IAttachment) => void;
 }
@@ -120,7 +119,7 @@ const Title = memo(
 );
 
 const Description = memo(
-	({ attachment }: { attachment: IAttachment; getCustomEmoji: TGetCustomEmoji }) => {
+	({ attachment }: { attachment: IAttachment }) => {
 		'use memo';
 
 		const { user } = useContext(MessageContext);
@@ -173,7 +172,7 @@ const UrlImage = memo(
 );
 
 const Fields = memo(
-	({ attachment, theme }: { attachment: IAttachment; theme: TSupportedThemes; getCustomEmoji: TGetCustomEmoji }) => {
+	({ attachment, theme }: { attachment: IAttachment; theme: TSupportedThemes }) => {
 		'use memo';
 
 		const { user } = useContext(MessageContext);
@@ -198,7 +197,7 @@ const Fields = memo(
 );
 
 const Reply = memo(
-	({ attachment, timeFormat, getCustomEmoji, msg, showAttachment }: IMessageReply) => {
+	({ attachment, timeFormat, msg, showAttachment }: IMessageReply) => {
 		'use memo';
 
 		const [loading, setLoading] = useState(false);
@@ -244,20 +243,10 @@ const Reply = memo(
 					<View style={styles.attachmentContainer}>
 						<View style={styles.titleAndDescriptionContainer}>
 							<Title attachment={attachment} timeFormat={timeFormat} theme={theme} />
-							<Description attachment={attachment} getCustomEmoji={getCustomEmoji} />
-							<Quote
-								attachments={attachment.attachments}
-								getCustomEmoji={getCustomEmoji}
-								timeFormat={timeFormat}
-								showAttachment={showAttachment}
-							/>
-							<Attachments
-								attachments={attachment.attachments}
-								getCustomEmoji={getCustomEmoji}
-								timeFormat={timeFormat}
-								showAttachment={showAttachment}
-							/>
-							<Fields attachment={attachment} getCustomEmoji={getCustomEmoji} theme={theme} />
+							<Description attachment={attachment} />
+							<Quote attachments={attachment.attachments} timeFormat={timeFormat} showAttachment={showAttachment} />
+							<Attachments attachments={attachment.attachments} timeFormat={timeFormat} showAttachment={showAttachment} />
+							<Fields attachment={attachment} theme={theme} />
 							{loading ? (
 								<View style={styles.backdrop}>
 									<View

--- a/app/containers/message/Components/Attachments/Video.tsx
+++ b/app/containers/message/Components/Attachments/Video.tsx
@@ -3,7 +3,6 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { type IUserMessage } from '../../../../definitions';
 import { type IAttachment } from '../../../../definitions/IAttachment';
-import { type TGetCustomEmoji } from '../../../../definitions/IEmoji';
 import I18n from '../../../../i18n';
 import { fileDownload, isIOS } from '../../../../lib/methods/helpers';
 import EventEmitter from '../../../../lib/methods/helpers/events';
@@ -37,7 +36,6 @@ const styles = StyleSheet.create({
 interface IMessageVideo {
 	file: IAttachment;
 	showAttachment?: (file: IAttachment) => void;
-	getCustomEmoji: TGetCustomEmoji;
 	author?: IUserMessage;
 	msg?: string;
 }

--- a/app/containers/message/Components/Attachments/Video.tsx
+++ b/app/containers/message/Components/Attachments/Video.tsx
@@ -70,7 +70,7 @@ const Thumbnail = ({ status, encrypted = false }: { status: TDownloadState; encr
 	);
 };
 
-const Video = ({ file, showAttachment, getCustomEmoji, author, msg }: IMessageVideo): ReactElement | null => {
+const Video = ({ file, showAttachment, author, msg }: IMessageVideo): ReactElement | null => {
 	'use memo';
 
 	const { user } = useContext(MessageContext);
@@ -101,7 +101,7 @@ const Video = ({ file, showAttachment, getCustomEmoji, author, msg }: IMessageVi
 
 	return (
 		<View style={{ gap: 4 }}>
-			{msg ? <Markdown msg={msg} username={user.username} getCustomEmoji={getCustomEmoji} /> : null}
+			{msg ? <Markdown msg={msg} username={user.username} /> : null}
 			<Touchable onPress={_onPress} style={messageStyles.image}>
 				<Thumbnail status={status} encrypted={isEncrypted} />
 			</Touchable>

--- a/app/containers/message/Content.test.tsx
+++ b/app/containers/message/Content.test.tsx
@@ -28,7 +28,6 @@ const baseProps: Partial<IMessageContent> = {
 	isTranslated: false,
 	isHeader: false,
 	hasError: false,
-	getCustomEmoji: jest.fn(),
 	navToRoomInfo: jest.fn()
 };
 

--- a/app/containers/message/Content.tsx
+++ b/app/containers/message/Content.tsx
@@ -64,7 +64,6 @@ const Content = memo(
 				<Markdown
 					msg={props.msg}
 					md={props.type !== 'e2e' ? props.md : undefined}
-					getCustomEmoji={props.getCustomEmoji}
 					username={user.username}
 					channels={props.channels}
 					mentions={props.mentions}

--- a/app/containers/message/Emoji.tsx
+++ b/app/containers/message/Emoji.tsx
@@ -2,13 +2,15 @@ import { memo } from 'react';
 import { Text } from 'react-native';
 
 import useShortnameToUnicode from '../../lib/hooks/useShortnameToUnicode';
+import { useCustomEmoji } from '../../lib/hooks/useCustomEmoji';
 import CustomEmoji from '../EmojiPicker/CustomEmoji';
 import { type IMessageEmoji } from './interfaces';
 
 const Emoji = memo(
-	({ content, standardEmojiStyle, customEmojiStyle, getCustomEmoji }: IMessageEmoji) => {
+	({ content, standardEmojiStyle, customEmojiStyle }: IMessageEmoji) => {
 		'use memo';
 
+		const getCustomEmoji = useCustomEmoji();
 		const parsedContent = content.replace(/^:|:$/g, '');
 		const emoji = getCustomEmoji(parsedContent);
 		const { formatShortnameToUnicode } = useShortnameToUnicode();

--- a/app/containers/message/Message.stories.tsx
+++ b/app/containers/message/Message.stories.tsx
@@ -70,15 +70,6 @@ const responsiveLayoutProviderLargeFontValue = (fontScale: number) => ({
 	height: 800
 });
 
-const getCustomEmoji = (content: string) => {
-	const customEmoji = {
-		marioparty: { name: content, extension: 'gif' },
-		react_rocket: { name: content, extension: 'png' },
-		nyan_rocket: { name: content, extension: 'png' }
-	}[content];
-	return customEmoji;
-};
-
 export default {
 	title: 'Message',
 	decorators: [
@@ -101,7 +92,6 @@ export const Message = (props: any) => (
 			ts={date}
 			timeFormat='LT'
 			isHeader
-			getCustomEmoji={getCustomEmoji}
 			theme={_theme}
 			{...props}
 		/>
@@ -118,7 +108,6 @@ const MessageLargeFont = (props: any) => (
 			ts={date}
 			timeFormat='LT'
 			isHeader
-			getCustomEmoji={getCustomEmoji}
 			theme={_theme}
 			{...props}
 		/>

--- a/app/containers/message/Message.stories.tsx
+++ b/app/containers/message/Message.stories.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../lib/hooks/useResponsiveLayout/useResponsiveLayout';
 import { mockedStore as store } from '../../reducers/mockedStore';
 import { updateSettings } from '../../actions/settings';
+import { setCustomEmojis } from '../../actions/customEmojis';
 
 const _theme = 'light';
 
@@ -51,6 +52,13 @@ const longText =
 	'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
 
 store.dispatch(updateSettings('API_Embed', true));
+store.dispatch(
+	setCustomEmojis({
+		marioparty: { name: 'marioparty', extension: 'gif' },
+		react_rocket: { name: 'react_rocket', extension: 'png' },
+		nyan_rocket: { name: 'nyan_rocket', extension: 'png' }
+	})
+);
 
 const responsiveLayoutProviderLargeFontValue = (fontScale: number) => ({
 	fontScale,

--- a/app/containers/message/MessageAvatar.tsx
+++ b/app/containers/message/MessageAvatar.tsx
@@ -16,7 +16,7 @@ export const AvatarContainer = ({ children }: { children?: ReactElement | null }
 	return <View style={{ width, alignItems: 'flex-end' }}>{children}</View>;
 };
 
-const MessageAvatar = memo(({ isHeader, avatar, author, small, navToRoomInfo, emoji, getCustomEmoji }: IMessageAvatar) => {
+const MessageAvatar = memo(({ isHeader, avatar, author, small, navToRoomInfo, emoji }: IMessageAvatar) => {
 	'use memo';
 
 	const { user } = useContext(MessageContext);
@@ -41,7 +41,6 @@ const MessageAvatar = memo(({ isHeader, avatar, author, small, navToRoomInfo, em
 					size={size}
 					borderRadius={4}
 					onPress={onPress}
-					getCustomEmoji={getCustomEmoji}
 					avatar={avatar}
 					emoji={emoji}
 				/>

--- a/app/containers/message/Preview.tsx
+++ b/app/containers/message/Preview.tsx
@@ -1,30 +1,24 @@
 import Message from './index';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 import { getUserSelector } from '../../selectors/login';
-import { type TAnyMessageModel, type TGetCustomEmoji } from '../../definitions';
+import { type TAnyMessageModel } from '../../definitions';
 
 const MessagePreview = ({ message }: { message: TAnyMessageModel }) => {
 	'use memo';
 
-	const { user, baseUrl, Message_TimeFormat, customEmojis, useRealName } = useAppSelector(state => ({
+	const { user, baseUrl, Message_TimeFormat, useRealName } = useAppSelector(state => ({
 		user: getUserSelector(state),
 		baseUrl: state.server.server,
 		Message_TimeFormat: state.settings.Message_TimeFormat as string,
-		customEmojis: state.customEmojis,
 		useRealName: state.settings.UI_Use_Real_Name as boolean
 	}));
 
-	const getCustomEmoji: TGetCustomEmoji = name => {
-		const emoji = customEmojis[name];
-		return emoji ?? null;
-	};
 	return (
 		<Message
 			item={message}
 			user={user}
 			rid={message.rid}
 			baseUrl={baseUrl}
-			getCustomEmoji={getCustomEmoji}
 			timeFormat={Message_TimeFormat}
 			useRealName={useRealName}
 			isPreview

--- a/app/containers/message/Reactions.test.tsx
+++ b/app/containers/message/Reactions.test.tsx
@@ -37,13 +37,11 @@ const TestWrapper = ({ initialReactions }: { initialReactions: IReaction[] }) =>
 					onReactionPress: handleReactionPress,
 					onReactionLongPress: jest.fn()
 				}}>
-				<Reactions reactions={reactions} getCustomEmoji={getCustomEmoji} />
+				<Reactions reactions={reactions} />
 			</MessageContext.Provider>
 		</Provider>
 	);
 };
-
-const getCustomEmoji = jest.fn();
 
 it('renders all reactions and AddReaction button', () => {
 	const reactions: IReaction[] = [

--- a/app/containers/message/Reactions.tsx
+++ b/app/containers/message/Reactions.tsx
@@ -10,7 +10,6 @@ import { BUTTON_HIT_SLOP } from './utils';
 import { themes } from '../../lib/constants/colors';
 import { type TSupportedThemes, useTheme } from '../../theme';
 import MessageContext from './Context';
-import { type TGetCustomEmoji } from '../../definitions/IEmoji';
 
 interface IReaction {
 	_id: string;
@@ -20,13 +19,11 @@ interface IReaction {
 
 interface IMessageReaction {
 	reaction: IReaction;
-	getCustomEmoji: TGetCustomEmoji;
 	theme: TSupportedThemes;
 }
 
 interface IMessageReactions {
 	reactions?: IReaction[];
-	getCustomEmoji: TGetCustomEmoji;
 }
 
 const AddReaction = memo(({ theme }: { theme: TSupportedThemes }) => {
@@ -52,7 +49,7 @@ const AddReaction = memo(({ theme }: { theme: TSupportedThemes }) => {
 	);
 });
 
-const Reaction = memo(({ reaction, getCustomEmoji, theme }: IMessageReaction) => {
+const Reaction = memo(({ reaction, theme }: IMessageReaction) => {
 	'use memo';
 
 	const { onReactionPress, onReactionLongPress, user } = useContext(MessageContext);
@@ -76,19 +73,14 @@ const Reaction = memo(({ reaction, getCustomEmoji, theme }: IMessageReaction) =>
 					styles.reactionContainer,
 					{ borderColor: reacted ? themes[theme].badgeBackgroundLevel2 : themes[theme].strokeLight, height }
 				]}>
-				<Emoji
-					content={reaction.emoji}
-					standardEmojiStyle={styles.reactionEmoji}
-					customEmojiStyle={styles.reactionCustomEmoji}
-					getCustomEmoji={getCustomEmoji}
-				/>
+				<Emoji content={reaction.emoji} standardEmojiStyle={styles.reactionEmoji} customEmojiStyle={styles.reactionCustomEmoji} />
 				<Text style={[styles.reactionCount, { color: themes[theme].badgeBackgroundLevel2 }]}>{reaction.usernames.length}</Text>
 			</View>
 		</Touchable>
 	);
 });
 
-const Reactions = memo(({ reactions, getCustomEmoji }: IMessageReactions) => {
+const Reactions = memo(({ reactions }: IMessageReactions) => {
 	'use memo';
 
 	const { theme } = useTheme();
@@ -99,7 +91,7 @@ const Reactions = memo(({ reactions, getCustomEmoji }: IMessageReactions) => {
 	return (
 		<View style={styles.reactionsContainer}>
 			{reactions.map(reaction => (
-				<Reaction key={reaction.emoji} reaction={reaction} getCustomEmoji={getCustomEmoji} theme={theme} />
+				<Reaction key={reaction.emoji} reaction={reaction} theme={theme} />
 			))}
 			<AddReaction theme={theme} />
 		</View>

--- a/app/containers/message/index.tsx
+++ b/app/containers/message/index.tsx
@@ -7,7 +7,7 @@ import { debounce } from '../../lib/methods/helpers';
 import { getMessageTranslation } from './utils';
 import { type TSupportedThemes, withTheme } from '../../theme';
 import openLink from '../../lib/methods/helpers/openLink';
-import { type IAttachment, type TAnyMessageModel, type TGetCustomEmoji } from '../../definitions';
+import { type IAttachment, type TAnyMessageModel } from '../../definitions';
 import { type IRoomInfoParam } from '../../views/SearchMessagesView';
 import { E2E_MESSAGE_TYPE, E2E_STATUS } from '../../lib/constants/keys';
 import { messagesStatus } from '../../lib/constants/messagesStatus';
@@ -37,7 +37,6 @@ interface IMessageContainerProps {
 	status?: number;
 	isIgnored?: boolean;
 	highlighted?: boolean;
-	getCustomEmoji: TGetCustomEmoji;
 	onLongPress?: (item: TAnyMessageModel) => void;
 	onReactionPress?: (emoji: string, id: string) => void;
 	onEncryptedPress?: () => void;
@@ -71,7 +70,6 @@ interface IMessageContainerState {
 
 class MessageContainer extends Component<IMessageContainerProps, IMessageContainerState> {
 	static defaultProps = {
-		getCustomEmoji: () => null,
 		onLongPress: () => {},
 		blockAction: () => {},
 		archived: false,
@@ -367,7 +365,6 @@ class MessageContainer extends Component<IMessageContainerProps, IMessageContain
 			autoTranslateRoom,
 			autoTranslateLanguage,
 			navToRoomInfo = () => {},
-			getCustomEmoji,
 			isThreadRoom,
 			handleEnterCall,
 			blockAction,
@@ -496,7 +493,6 @@ class MessageContainer extends Component<IMessageContainerProps, IMessageContain
 					isEncrypted={this.isEncrypted}
 					hasError={this.hasError}
 					showAttachment={showAttachment}
-					getCustomEmoji={getCustomEmoji}
 					navToRoomInfo={navToRoomInfo}
 					handleEnterCall={handleEnterCall}
 					blockAction={blockAction}

--- a/app/containers/message/interfaces.ts
+++ b/app/containers/message/interfaces.ts
@@ -3,9 +3,9 @@ import { type StyleProp } from 'react-native';
 import { type ImageStyle } from 'expo-image';
 
 import { type IUserChannel } from '../markdown/interfaces';
-import { type TGetCustomEmoji } from '../../definitions/IEmoji';
 import {
 	type IAttachment,
+	type IReaction,
 	type IThread,
 	type IUrl,
 	type IUserMention,
@@ -76,7 +76,6 @@ export interface IMessageEmoji {
 	content: string;
 	standardEmojiStyle: { fontSize: number };
 	customEmojiStyle: StyleProp<ImageStyle>;
-	getCustomEmoji: TGetCustomEmoji;
 }
 
 export interface IMessageThread extends Pick<IThread, 'msg' | 'tcount' | 'tlm' | 'id'> {
@@ -116,7 +115,7 @@ export interface IMessageInner
 	blocks: [];
 	urls?: IUrl[];
 	isPreview?: boolean;
-	getCustomEmoji: TGetCustomEmoji;
+	reactions?: IReaction[];
 }
 
 export interface IMessage extends IMessageRepliedThread, IMessageInner, IMessageAvatar {

--- a/app/containers/message/interfaces.ts
+++ b/app/containers/message/interfaces.ts
@@ -19,7 +19,6 @@ export interface IMessageAttachments {
 	attachments?: IAttachment[];
 	timeFormat?: string;
 	showAttachment?: (file: IAttachment) => void;
-	getCustomEmoji: TGetCustomEmoji;
 	author?: IUserMessage;
 }
 
@@ -30,7 +29,6 @@ export interface IMessageAvatar {
 	author?: IUserMessage;
 	small?: boolean;
 	navToRoomInfo: (navParam: IRoomInfoParam) => void;
-	getCustomEmoji: TGetCustomEmoji;
 }
 
 export interface IMessageBlocks {
@@ -59,7 +57,6 @@ export interface IMessageContent {
 	md?: Root;
 	isEdited: boolean;
 	isEncrypted: boolean;
-	getCustomEmoji: TGetCustomEmoji;
 	channels?: IUserChannel[];
 	mentions?: IUserMention[];
 	navToRoomInfo: (navParam: IRoomInfoParam) => void;
@@ -119,6 +116,7 @@ export interface IMessageInner
 	blocks: [];
 	urls?: IUrl[];
 	isPreview?: boolean;
+	getCustomEmoji: TGetCustomEmoji;
 }
 
 export interface IMessage extends IMessageRepliedThread, IMessageInner, IMessageAvatar {

--- a/app/definitions/IEmoji.ts
+++ b/app/definitions/IEmoji.ts
@@ -22,8 +22,6 @@ export interface ICustomEmojis {
 
 export type TGetCustomEmoji = (name: string) => ICustomEmoji | null;
 
-export const resolveCustomEmoji = (customEmojis: ICustomEmojis, name: string): ICustomEmoji | null => customEmojis[name] ?? null;
-
 export type TFrequentlyUsedEmojiModel = IFrequentlyUsedEmoji & Model;
 
 export interface ICustomEmojiModel {

--- a/app/definitions/IEmoji.ts
+++ b/app/definitions/IEmoji.ts
@@ -22,6 +22,8 @@ export interface ICustomEmojis {
 
 export type TGetCustomEmoji = (name: string) => ICustomEmoji | null;
 
+export const resolveCustomEmoji = (customEmojis: ICustomEmojis, name: string): ICustomEmoji | null => customEmojis[name] ?? null;
+
 export type TFrequentlyUsedEmojiModel = IFrequentlyUsedEmoji & Model;
 
 export interface ICustomEmojiModel {

--- a/app/lib/hooks/useCustomEmoji.test.ts
+++ b/app/lib/hooks/useCustomEmoji.test.ts
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 
-import { useCustomEmoji } from './useCustomEmoji';
-import { resolveCustomEmoji } from '../../definitions';
+import { resolveCustomEmoji, useCustomEmoji } from './useCustomEmoji';
 
 const customEmojis = { nyan_rocket: { name: 'nyan_rocket', extension: 'png' } };
 

--- a/app/lib/hooks/useCustomEmoji.test.ts
+++ b/app/lib/hooks/useCustomEmoji.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useCustomEmoji } from './useCustomEmoji';
+import { resolveCustomEmoji } from '../../definitions';
+
+const customEmojis = { nyan_rocket: { name: 'nyan_rocket', extension: 'png' } };
+
+jest.mock('./useAppSelector', () => ({
+	useAppSelector: (selector: (state: any) => any) => selector({ customEmojis })
+}));
+
+describe('resolveCustomEmoji', () => {
+	it('returns the emoji when the name is registered', () => {
+		expect(resolveCustomEmoji(customEmojis, 'nyan_rocket')).toBe(customEmojis.nyan_rocket);
+	});
+
+	it('returns null when the name is not registered', () => {
+		expect(resolveCustomEmoji(customEmojis, 'unknown')).toBeNull();
+	});
+});
+
+describe('useCustomEmoji', () => {
+	it('returns a getter resolving against state.customEmojis', () => {
+		const { result } = renderHook(() => useCustomEmoji());
+
+		expect(result.current('nyan_rocket')).toBe(customEmojis.nyan_rocket);
+		expect(result.current('unknown')).toBeNull();
+	});
+});

--- a/app/lib/hooks/useCustomEmoji.ts
+++ b/app/lib/hooks/useCustomEmoji.ts
@@ -1,0 +1,9 @@
+import { type TGetCustomEmoji, resolveCustomEmoji } from '../../definitions';
+import { useAppSelector } from './useAppSelector';
+
+export const useCustomEmoji = (): TGetCustomEmoji => {
+	'use memo';
+
+	const customEmojis = useAppSelector(state => state.customEmojis);
+	return name => resolveCustomEmoji(customEmojis, name);
+};

--- a/app/lib/hooks/useCustomEmoji.ts
+++ b/app/lib/hooks/useCustomEmoji.ts
@@ -1,5 +1,7 @@
-import { type TGetCustomEmoji, resolveCustomEmoji } from '../../definitions';
+import { type ICustomEmojis, type TGetCustomEmoji } from '../../definitions';
 import { useAppSelector } from './useAppSelector';
+
+export const resolveCustomEmoji = (customEmojis: ICustomEmojis, name: string) => customEmojis[name] ?? null;
 
 export const useCustomEmoji = (): TGetCustomEmoji => {
 	'use memo';

--- a/app/views/MessagesView/index.tsx
+++ b/app/views/MessagesView/index.tsx
@@ -28,9 +28,7 @@ import {
 	type IAttachment,
 	type IMessage,
 	type TAnyMessageModel,
-	type IUrl,
-	type TGetCustomEmoji,
-	type ICustomEmoji
+	type IUrl
 } from '../../definitions';
 import { getFiles, getMessages, getPinnedMessages, togglePinMessage, toggleStarMessage } from '../../lib/services/restApi';
 import { type TNavigation } from '../../stacks/stackType';
@@ -51,7 +49,6 @@ interface IMessagesViewProps {
 		NativeStackNavigationProp<MasterDetailInsideStackParamList & TNavigation>
 	>;
 	route: RouteProp<ChatsStackParamList, 'MessagesView'>;
-	customEmojis: { [key: string]: ICustomEmoji };
 	theme: TSupportedThemes;
 	showActionSheet: (params: { options: string[]; hasCancel: boolean }) => void;
 	useRealName: boolean;
@@ -176,7 +173,6 @@ class MessagesView extends Component<IMessagesViewProps, IMessagesViewState> {
 			attachments: item.attachments || [],
 			useRealName,
 			showAttachment: this.showAttachment,
-			getCustomEmoji: this.getCustomEmoji,
 			navToRoomInfo: this.navToRoomInfo,
 			onPress: () => this.jumpToMessage({ item }),
 			rid: this.rid
@@ -303,15 +299,6 @@ class MessagesView extends Component<IMessagesViewProps, IMessagesViewState> {
 		}
 	};
 
-	getCustomEmoji: TGetCustomEmoji = name => {
-		const { customEmojis } = this.props;
-		const emoji = customEmojis[name];
-		if (emoji) {
-			return emoji;
-		}
-		return null;
-	};
-
 	showAttachment = (attachment: IAttachment) => {
 		const { navigation } = this.props;
 		navigation.navigate('AttachmentView', { attachment });
@@ -385,7 +372,6 @@ class MessagesView extends Component<IMessagesViewProps, IMessagesViewState> {
 const mapStateToProps = (state: IApplicationState) => ({
 	baseUrl: state.server.server,
 	user: getUserSelector(state),
-	customEmojis: state.customEmojis,
 	useRealName: state.settings.UI_Use_Real_Name
 });
 

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -6,7 +6,6 @@ import {
 	type ILastMessage,
 	type ILoggedUser,
 	type TSubscriptionModel,
-	type ICustomEmojis,
 	type TMessageAction
 } from '../../definitions';
 import { type IActionSheetProvider } from '../../containers/ActionSheet';
@@ -21,7 +20,6 @@ export interface IRoomViewProps extends IActionSheetProvider, IBaseScreen<ChatsS
 	Hide_System_Messages?: string[];
 	baseUrl: string;
 	serverVersion: string | null;
-	customEmojis: ICustomEmojis;
 	isMasterDetail: boolean;
 	replyBroadcast: Function;
 	width: number;

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -70,7 +70,6 @@ import {
 	type TAnyMessageModel,
 	type TSubscriptionModel,
 	type IEmoji,
-	type TGetCustomEmoji,
 	type RoomType
 } from '../../definitions';
 import { E2E_MESSAGE_TYPE, E2E_STATUS } from '../../lib/constants/keys';
@@ -932,7 +931,7 @@ class RoomView extends Component<IRoomViewProps, IRoomViewState> {
 	onReactionLongPress = (message: TAnyMessageModel) => {
 		const { showActionSheet } = this.props;
 		this.handleCloseEmoji(showActionSheet, {
-			children: <ReactionsList reactions={message?.reactions} getCustomEmoji={this.getCustomEmoji} />,
+			children: <ReactionsList reactions={message?.reactions} />,
 			snaps: ['50%'],
 			enableContentPanningGesture: false,
 			fullContainer: true
@@ -1127,15 +1126,6 @@ class RoomView extends Component<IRoomViewProps, IRoomViewState> {
 			Review.pushPositiveEvent();
 		});
 		this.resetAction();
-	};
-
-	getCustomEmoji: TGetCustomEmoji = name => {
-		const { customEmojis } = this.props;
-		const emoji = customEmojis[name];
-		if (emoji) {
-			return emoji;
-		}
-		return null;
 	};
 
 	setLastOpen = (lastOpen: Date | null) => this.setState({ lastOpen });
@@ -1505,7 +1495,6 @@ class RoomView extends Component<IRoomViewProps, IRoomViewState> {
 					autoTranslateRoom={canAutoTranslate && 'id' in room && room.autoTranslate}
 					autoTranslateLanguage={'id' in room ? room.autoTranslateLanguage : undefined}
 					navToRoomInfo={this.navToRoomInfo}
-					getCustomEmoji={this.getCustomEmoji}
 					handleEnterCall={this.handleEnterCall}
 					blockAction={this.blockAction}
 					threadBadgeColor={this.getBadgeColor(item?.id)}
@@ -1741,7 +1730,6 @@ const mapStateToProps = (state: IApplicationState) => ({
 	isAuthenticated: state.login.isAuthenticated,
 	Message_GroupingPeriod: state.settings.Message_GroupingPeriod as number,
 	Message_TimeFormat: state.settings.Message_TimeFormat as string,
-	customEmojis: state.customEmojis,
 	baseUrl: state.server.server,
 	serverVersion: state.server.version,
 	Message_Read_Receipt_Enabled: state.settings.Message_Read_Receipt_Enabled as boolean,

--- a/app/views/SearchMessagesView/index.tsx
+++ b/app/views/SearchMessagesView/index.tsx
@@ -36,9 +36,7 @@ import {
 	type IAttachment,
 	type ISubscription,
 	SubscriptionType,
-	type TSubscriptionModel,
-	type TGetCustomEmoji,
-	type ICustomEmoji
+	type TSubscriptionModel
 } from '../../definitions';
 import { searchMessages } from '../../lib/services/restApi';
 import { type TNavigation } from '../../stacks/stackType';
@@ -74,9 +72,6 @@ interface ISearchMessagesViewProps extends INavigationOption {
 	user: IUser;
 	baseUrl: string;
 	serverVersion: string;
-	customEmojis: {
-		[key: string]: ICustomEmoji;
-	};
 	theme: TSupportedThemes;
 	useRealName: boolean;
 	isMasterDetail: boolean;
@@ -210,15 +205,6 @@ class SearchMessagesView extends Component<ISearchMessagesViewProps, ISearchMess
 		await this.getMessages(searchText, true);
 	}, textInputDebounceTime);
 
-	getCustomEmoji: TGetCustomEmoji = name => {
-		const { customEmojis } = this.props;
-		const emoji = customEmojis[name];
-		if (emoji) {
-			return emoji;
-		}
-		return null;
-	};
-
 	showAttachment = (attachment: IAttachment) => {
 		const { navigation } = this.props;
 		navigation.navigate('AttachmentView', { attachment });
@@ -297,7 +283,6 @@ class SearchMessagesView extends Component<ISearchMessagesViewProps, ISearchMess
 				timeFormat='MMM Do YYYY, h:mm:ss a'
 				isThreadRoom
 				showAttachment={this.showAttachment}
-				getCustomEmoji={this.getCustomEmoji}
 				navToRoomInfo={this.navToRoomInfo}
 				useRealName={useRealName}
 				theme={theme}
@@ -357,8 +342,7 @@ const mapStateToProps = (state: any) => ({
 	serverVersion: state.server.version,
 	baseUrl: state.server.server,
 	user: getUserSelector(state),
-	useRealName: state.settings.UI_Use_Real_Name,
-	customEmojis: state.customEmojis
+	useRealName: state.settings.UI_Use_Real_Name
 });
 
 export default connect(mapStateToProps)(withTheme(withMasterDetail(withSafeAreaInsets(SearchMessagesView))));


### PR DESCRIPTION
## Proposed changes

The markdown component tree now sources custom emoji itself instead of having a `getCustomEmoji` function threaded down through props.

- Ports the `useCustomEmoji` hook (reads `state.customEmojis` from Redux) and the `resolveCustomEmoji` helper, alongside a companion test.
- The leaf markdown `Emoji` component calls `useCustomEmoji()` directly. `getCustomEmoji` is removed from `IMarkdownProps` and from `MarkdownContext`, and `Avatar`'s manual `MarkdownContext.Provider` wrapper is deleted.
- Prunes the now-dead `getCustomEmoji` prop threading from the Attachments chain (`Attachments`, `Audio`, `Video`, `Reply`, `Quote`, `CollapsibleQuote`, `Image`, `AttachedActions`), the Avatar chain, and the `Message` -> `Content` path.
- `Message` keeps its own `getCustomEmoji` prop for the non-markdown consumers (`Reactions`, message `Emoji`, `ReactionsList`).

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1402

## How to test or reproduce

Open a room whose messages contain custom emoji, in message bodies, replies, quotes, attachment fields, and avatars. Custom emoji render exactly as before. Behavior is preserved end to end.

## Screenshots

No visual changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The change is behavior-preserving: `tsc --noEmit`, scoped ESLint, and Prettier are clean, and the touched suites pass with zero snapshot changes. Stories and tests seed the store via `setCustomEmojis` instead of building a fake `getCustomEmoji` fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom emojis are now resolved from centralized app state, consistently across avatars, messages, reactions, quotes/replies, attachments, and markdown/emoji tokens.
* **Bug Fixes**
  * Removed per-component custom-emoji callback wiring to avoid missing or mismatched custom emoji rendering in previews and various views.
* **Refactor**
  * Custom emoji lookup is now handled via a shared hook, and markdown emoji rendering no longer relies on a markdown context.
* **Documentation**
  * Updated Storybook to seed custom emojis via app state instead of passing callbacks.
* **Tests**
  * Added/updated tests to validate custom emoji resolution from app state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->