### PR TITLE
fix: re-subscribe room streams after re-authentication on reconnect

### DIFF
--- a/app/lib/methods/subscriptions/room.test.ts
+++ b/app/lib/methods/subscriptions/room.test.ts
@@ -139,9 +139,9 @@ describe('RoomSubscription', () => {
 		});
 	});
 
-	describe('handleConnected', () => {
+	describe('handleLogin', () => {
 		it('calls subscribeRoom, dispatches clearUserTyping, loads missed messages, and reads', async () => {
-			await sub.handleConnected();
+			await sub.handleLogin();
 
 			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
 			expect(mockStoreDispatch).toHaveBeenCalledWith(clearUserTyping());
@@ -151,7 +151,7 @@ describe('RoomSubscription', () => {
 		it('handles subscribeRoom rejection gracefully', async () => {
 			mockSubscribeRoom.mockRejectedValueOnce(new Error('boom'));
 
-			await expect(sub.handleConnected()).resolves.toBeUndefined();
+			await expect(sub.handleLogin()).resolves.toBeUndefined();
 		});
 	});
 
@@ -166,11 +166,11 @@ describe('RoomSubscription', () => {
 	});
 
 	describe('DDP subscription recovery after forceReopen', () => {
-		it('handleConnected re-subscribes the room to restore lost DDP subscriptions', async () => {
+		it('handleLogin re-subscribes the room to restore lost DDP subscriptions', async () => {
 			await sub.subscribe();
 			mockSubscribeRoom.mockClear();
 
-			await sub.handleConnected();
+			await sub.handleLogin();
 
 			expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
 			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
@@ -191,14 +191,14 @@ describe('RoomSubscription', () => {
 			mockSubscribeRoom.mockResolvedValueOnce([staleSub]).mockResolvedValueOnce([freshSub]);
 
 			await sub.subscribe();
-			await sub.handleConnected();
+			await sub.handleLogin();
 			await sub.unsubscribe();
 
 			expect(staleSub.unsubscribe).toHaveBeenCalledTimes(1);
 			expect(freshSub.unsubscribe).toHaveBeenCalledTimes(1);
 		});
 
-		it('does not accumulate subscriptions across repeated handleConnected calls (simulates sequential reopen)', async () => {
+		it('does not accumulate subscriptions across repeated handleLogin calls (simulates sequential reopen)', async () => {
 			const first = { unsubscribe: jest.fn(() => Promise.resolve()) };
 			const second = { unsubscribe: jest.fn(() => Promise.resolve()) };
 			mockSubscribeRoom.mockResolvedValueOnce([first]).mockResolvedValueOnce([second]);
@@ -207,13 +207,13 @@ describe('RoomSubscription', () => {
 			expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
 
 			// First reopen → tears down [first], creates [second]
-			await sub.handleConnected();
+			await sub.handleLogin();
 			expect(mockSubscribeRoom).toHaveBeenCalledTimes(2);
 			expect(first.unsubscribe).toHaveBeenCalledTimes(1);
 			expect(second.unsubscribe).not.toHaveBeenCalled();
 
 			// Second reopen → tears down [second], creates []
-			await sub.handleConnected();
+			await sub.handleLogin();
 			expect(mockSubscribeRoom).toHaveBeenCalledTimes(3);
 			expect(second.unsubscribe).toHaveBeenCalledTimes(1);
 
@@ -223,11 +223,11 @@ describe('RoomSubscription', () => {
 			expect(second.unsubscribe).toHaveBeenCalledTimes(1);
 		});
 
-		it('does not call onStreamData inside handleConnected (listeners persist across reopen)', async () => {
+		it('does not call onStreamData inside handleLogin (listeners persist across reopen)', async () => {
 			await sub.subscribe();
 			mockOnStreamData.mockClear();
 
-			await sub.handleConnected();
+			await sub.handleLogin();
 
 			expect(mockOnStreamData).not.toHaveBeenCalled();
 		});
@@ -235,7 +235,7 @@ describe('RoomSubscription', () => {
 		it('re-subscribes on the authenticated "login" event, not the pre-auth "connected" event', async () => {
 			await sub.subscribe();
 
-			expect(mockOnStreamData).toHaveBeenCalledWith('login', sub.handleConnected);
+			expect(mockOnStreamData).toHaveBeenCalledWith('login', sub.handleLogin);
 			expect(mockOnStreamData).not.toHaveBeenCalledWith('connected', expect.anything());
 		});
 
@@ -247,30 +247,30 @@ describe('RoomSubscription', () => {
 			await sub.subscribe();
 			mockSubscribeRoom.mockClear();
 
-			await expect(sub.handleConnected()).resolves.toBeUndefined();
+			await expect(sub.handleLogin()).resolves.toBeUndefined();
 			expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
 			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
 		});
 	});
 
 	describe('isAlive guard', () => {
-		it('handleConnected does nothing once the subscription is no longer alive (race with unsubscribe)', async () => {
+		it('handleLogin does nothing once the subscription is no longer alive (race with unsubscribe)', async () => {
 			await sub.subscribe();
 			await sub.unsubscribe();
 			jest.clearAllMocks();
 
-			await sub.handleConnected();
+			await sub.handleLogin();
 
 			expect(mockSubscribeRoom).not.toHaveBeenCalled();
 			expect(loadMissedMessages).not.toHaveBeenCalled();
 			expect(mockStoreDispatch).not.toHaveBeenCalled();
 		});
 
-		it('handleConnected re-subscribes while the subscription is still alive', async () => {
+		it('handleLogin re-subscribes while the subscription is still alive', async () => {
 			await sub.subscribe();
 			mockSubscribeRoom.mockClear();
 
-			await sub.handleConnected();
+			await sub.handleLogin();
 
 			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
 		});

--- a/app/lib/methods/subscriptions/room.test.ts
+++ b/app/lib/methods/subscriptions/room.test.ts
@@ -231,6 +231,26 @@ describe('RoomSubscription', () => {
 
 			expect(mockOnStreamData).not.toHaveBeenCalled();
 		});
+
+		it('re-subscribes on the authenticated "login" event, not the pre-auth "connected" event', async () => {
+			await sub.subscribe();
+
+			expect(mockOnStreamData).toHaveBeenCalledWith('login', sub.handleConnected);
+			expect(mockOnStreamData).not.toHaveBeenCalledWith('connected', expect.anything());
+		});
+
+		it('survives a poisoned subscription array (undefined entry from a rejected sub) and still re-subscribes', async () => {
+			// A pre-auth subscribe rejected by the server (nosub) resolves to undefined inside Promise.all.
+			const freshSub = { unsubscribe: jest.fn(() => Promise.resolve()) };
+			mockSubscribeRoom.mockResolvedValueOnce([undefined as any]).mockResolvedValueOnce([freshSub]);
+
+			await sub.subscribe();
+			mockSubscribeRoom.mockClear();
+
+			await expect(sub.handleConnected()).resolves.toBeUndefined();
+			expect(mockSubscribeRoom).toHaveBeenCalledTimes(1);
+			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
+		});
 	});
 
 	describe('isAlive guard', () => {

--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -51,7 +51,7 @@ export default class RoomSubscription {
 		}
 		this.promises = sdk.subscribeRoom(this.rid);
 
-		this.connectedListener = sdk.onStreamData('connected', this.handleConnected);
+		this.connectedListener = sdk.onStreamData('login', this.handleConnected);
 		this.disconnectedListener = sdk.onStreamData('close', this.handleClose);
 		this.notifyRoomListener = sdk.onStreamData('stream-notify-room', this.handleNotifyRoomReceived);
 		this.messageReceivedListener = sdk.onStreamData('stream-room-messages', this.handleMessageReceived);
@@ -70,7 +70,7 @@ export default class RoomSubscription {
 		if (this.promises) {
 			try {
 				const subscriptions = (await this.promises) || [];
-				subscriptions.forEach(sub => sub.unsubscribe().catch(() => console.log('unsubscribeRoom')));
+				subscriptions.forEach(sub => sub?.unsubscribe?.().catch(() => console.log('unsubscribeRoom')));
 			} catch (e) {
 				// do nothing
 			}
@@ -100,7 +100,7 @@ export default class RoomSubscription {
 		try {
 			if (this.promises) {
 				const oldSubs = await this.promises;
-				oldSubs.forEach(sub => sub.unsubscribe().catch(() => {}));
+				oldSubs?.forEach(sub => sub?.unsubscribe?.().catch(() => {}));
 			}
 			this.promises = sdk.subscribeRoom(this.rid);
 			await this.promises;

--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -34,7 +34,7 @@ export default class RoomSubscription {
 	private rid: string;
 	private isAlive: boolean;
 	private promises?: Promise<TSubscriptionModel[]>;
-	private connectedListener?: Promise<any>;
+	private loginListener?: Promise<any>;
 	private disconnectedListener?: Promise<any>;
 	private notifyRoomListener?: Promise<any>;
 	private messageReceivedListener?: Promise<any>;
@@ -51,7 +51,7 @@ export default class RoomSubscription {
 		}
 		this.promises = sdk.subscribeRoom(this.rid);
 
-		this.connectedListener = sdk.onStreamData('login', this.handleConnected);
+		this.loginListener = sdk.onStreamData('login', this.handleLogin);
 		this.disconnectedListener = sdk.onStreamData('close', this.handleClose);
 		this.notifyRoomListener = sdk.onStreamData('stream-notify-room', this.handleNotifyRoomReceived);
 		this.messageReceivedListener = sdk.onStreamData('stream-room-messages', this.handleMessageReceived);
@@ -76,7 +76,7 @@ export default class RoomSubscription {
 			}
 		}
 		reduxStore.dispatch(clearUserTyping());
-		this.removeListener(this.connectedListener);
+		this.removeListener(this.loginListener);
 		this.removeListener(this.disconnectedListener);
 		this.removeListener(this.notifyRoomListener);
 		this.removeListener(this.messageReceivedListener);
@@ -93,7 +93,7 @@ export default class RoomSubscription {
 		}
 	};
 
-	handleConnected = async () => {
+	handleLogin = async () => {
 		if (!this.isAlive) {
 			return;
 		}


### PR DESCRIPTION
## Proposed changes

After the app is backgrounded and foregrounded **twice**, room updates stop syncing — message edits don't render, new messages from the same sender don't appear, and reactions stop coming in — until the user clears the cache.

Root cause is a two-part defect in `app/lib/methods/subscriptions/room.ts`, both introduced by #7426:

1. **Re-subscribe fired pre-auth.** On reconnect, `handleConnected` was bound to the raw DDP `'connected'` event, which fires at the WebSocket handshake, *before* login completes. The room stream subscriptions require an authenticated session, so the server rejects them with `nosub: not-allowed`. Those rejected subscriptions resolve to `undefined` inside `this.promises`.
2. **Crash on the next reconnect.** The following reconnect's `handleConnected` iterates `this.promises` to tear down the old subscriptions and calls `.unsubscribe()` on each entry. The `undefined` entry from step 1 throws, the function aborts before it re-subscribes, and the room stream stays permanently dead.

This is why it takes **two** cycles: cycle 1 poisons the subscription array with an `undefined`, cycle 2 crashes on it and never restores the stream.

The fix:
- Bind re-subscription to the authenticated `'login'` DDP event (emitted after the login method result) instead of the pre-auth `'connected'` event, so subscriptions are sent with a valid session and the server accepts them.
- Guard the teardown loops against `undefined`/rejected entries (`sub?.unsubscribe?.()`) so a poisoned array can never abort the re-subscribe path again.

## Issue(s)

https://rocketchat.atlassian.net/browse/SUP-1073

Regression introduced by #7426 (`fix: re-subscribe room streams on DDP reconnect`) — this PR is a direct follow-up.

Related reconnect / app-lifecycle work for context:
- #7362 — `fix: re-subscribe rooms stream after forced socket reopen`
- #7380 — `fix: keep live socket on deeplink login (prevent orphan WebSocket clobber)`
- #7345 — `fix: Drain lost hangups on WebSocket reconnect`
- #7120 — `fix: presence not updating after app resumes from background`

## How to test or reproduce

1. Open a DM or channel.
2. Background the app, wait for the socket to drop, foreground it. Wait for reconnect. **Repeat once** (two full background/foreground cycles).
3. From another client, in the same room: edit a message, send a new message, add a reaction.

**Before:** none of the three appear in the app until the cache is cleared.
**After:** all three sync normally after both cycles.

## Screenshots

Android, same DM. The socket drop/reconnect is forced with airplane-mode toggles on the emulator (equivalent to the background/foreground cycles on a real device, but reliable to reproduce). After the reconnect cycles, another client edits a message, adds a `:rocket:` reaction, and sends a new message.

**Before (buggy build) — room stream dies, updates never arrive**

The edit, the reaction, and the new message are all sent from the other client but none of them render in the open room — the stream stays dead until the cache is cleared.

https://github.com/user-attachments/assets/693d2b0a-610e-422e-b41d-ef8be5a6d2e8


**After (fixed build) — stream recovers, updates sync live**

Same steps on the fixed build. After the reconnect cycles the message edit, the `:rocket:` reaction, and the new message all sync into the open room on camera.

https://github.com/user-attachments/assets/c9480365-2329-4d03-bcda-7ee8f0c9e369



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

### Post-mortem

**Symptom.** Room updates silently stopped after two background/foreground cycles; no error surfaced to the user, and only a cache clear recovered it.

**Why it survived review in #7426.** The re-subscribe fix in #7426 was correct in shape but wired to the wrong event. On a *single* reconnect, binding to `'connected'` still appears to work in casual testing — the failure only compounds on the *second* cycle once the subscription array holds an `undefined`. Manual QA that backgrounds once doesn't reveal it.

**How it was found.** Built a tight, device-level feedback loop: a script that drives one offline background/foreground cycle on the Android emulator plus a REST helper that edits/posts/reacts in the target DM, then instrumented the DDP subscription lifecycle with tagged timeline logs. The logs showed the `nosub: not-allowed` rejection on the pre-auth `'connected'` re-subscribe, the resulting `undefined` in `this.promises`, and the `undefined.unsubscribe()` throw on the next cycle.

**What would have prevented it.** The distinction between the pre-auth `'connected'` handshake and the post-auth `'login'` event is load-bearing and easy to miss. Regression tests were added at the subscription seam asserting (a) re-subscription binds to `'login'`, not `'connected'`, and (b) a poisoned subscription array (an `undefined` entry) never aborts re-subscribe. Longer term, any reconnect-time re-subscribe should assert an authenticated session before issuing subscriptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room subscription recovery to re-establish subscriptions on login events more reliably after reconnects.
  * Enhanced teardown behavior so cleanup continues safely even if prior subscriptions are missing or already closed.
  * Prevented recovery from running more than once across repeated recoveries and reopen cycles.

* **Tests**
  * Expanded lifecycle tests to validate correct re-registration after login recovery, including partial/failed subscription scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
