### PR TITLE
chore: e2e-selection narrow evidence (throwaway — do not merge)

### DIFF
--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -1,3 +1,4 @@
+// e2e-selection evidence check — throwaway, do not merge
 import { Component, createRef, type RefObject } from 'react';
 import { AccessibilityInfo, InteractionManager, PixelRatio, Text, View } from 'react-native';
 import { connect } from 'react-redux';


### PR DESCRIPTION
Throwaway PR to capture a real `build-pr.yml` `e2e-shards` run URL for the **narrow** scenario (RoomView-only diff). Evidence for #7476. Will be closed once the run URL is captured.