### PR TITLE
chore: e2e-selection docs-only skip evidence (throwaway — do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ We’d love to hear about [your experience](https://survey.zohopublic.com/zs/e4B
 
 ### Subscribe for Updates
 Once a month our marketing team releases an email update with news about product releases, company related topics, events and use cases. [Sign up!](https://rocket.chat/newsletter/?utm_source=github&utm_medium=readme&utm_campaign=community)
+
+<!-- e2e-selection evidence check — throwaway, do not merge -->


### PR DESCRIPTION
Throwaway PR to capture a real `build-pr.yml` `e2e-shards` run URL for the **confident-zero skip** scenario (docs-only diff → should_run=false). Evidence for #7476. Will be closed once the run URL is captured.