### PR TITLE
chore(ios): regenerate Podfile.lock to drop expo-av pod

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -33,9 +33,6 @@ PODS:
   - DoubleConversion (1.1.6)
   - EXApplication (55.0.16):
     - ExpoModulesCore
-  - EXAV (16.0.8):
-    - ExpoModulesCore
-    - ReactCommon/turbomodule/core
   - EXConstants (55.0.16):
     - ExpoModulesCore
   - Expo (55.0.27):
@@ -3835,7 +3832,6 @@ DEPENDENCIES:
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXApplication (from `../node_modules/expo-application/ios`)
-  - EXAV (from `../node_modules/expo-av/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
   - Expo (from `../node_modules/expo`)
   - ExpoAppleAuthentication (from `../node_modules/expo-apple-authentication/ios`)
@@ -4019,8 +4015,6 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec"
   EXApplication:
     :path: "../node_modules/expo-application/ios"
-  EXAV:
-    :path: "../node_modules/expo-av/ios"
   EXConstants:
     :path: "../node_modules/expo-constants/ios"
   Expo:
@@ -4301,7 +4295,6 @@ SPEC CHECKSUMS:
   BVLinearGradient: 7815a70ab485b7b155186dd0cc836363e0288cad
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXApplication: a1413100c36551bef1d775fc6c64147286962bf8
-  EXAV: b60fcf142fae6684d295bc28cd7cfcb3335570ea
   EXConstants: dadbeba983acc30f855a919658a2b34fbd86615d
   Expo: 51382a688834720d1625afd48a5deffc399b35ec
   ExpoAppleAuthentication: 3b97261aceb8528d9f4cb55b6cb687058ee467b6


### PR DESCRIPTION
## Proposed changes

`expo-av` was removed from the dependency tree when its usages were stubbed out during the RN 0.83 / Expo 55 upgrade, but `ios/Podfile.lock` still pinned the now-absent `EXAV` pod. This regenerates the lock so it matches `package.json` and `node_modules` — dropping the `EXAV` entry from `PODS`, `DEPENDENCIES`, `EXTERNAL SOURCES`, and `SPEC CHECKSUMS`.

This PR also acts as the validation vehicle for the fully-assembled `chore/rn-0.83-expo-55` integration branch: it runs the native iOS/Android builds and the E2E/Maestro shards against the complete upgrade stack.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1239

## How to test or reproduce

- `pnpm pod-install` on the branch produces no further diff to `ios/Podfile.lock`.
- iOS build resolves Pods with no reference to `EXAV`.
- CI native build + E2E lanes pass green on both platforms.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Further comments

Base is `chore/rn-0.83-expo-55`, not `develop` — per the integration-branch model for the RN 0.83 / Expo 55 upgrade epic.
