### PR TITLE
feat: re-enable typeset math rendering in messages

### DIFF
--- a/app/containers/markdown/components/Katex.test.tsx
+++ b/app/containers/markdown/components/Katex.test.tsx
@@ -1,0 +1,52 @@
+import { type Root } from '@rocket.chat/message-parser';
+import { act, render } from '@testing-library/react-native';
+import { type StyleProp, StyleSheet, type ViewStyle } from 'react-native';
+import { type WebViewMessageEvent } from 'react-native-webview';
+
+import Markdown from '..';
+
+interface IKatexMockProps {
+	expression: string;
+	onMessage: (event: WebViewMessageEvent) => void;
+	style: StyleProp<ViewStyle>;
+}
+
+jest.mock('react-native-katex', () => {
+	const { View } = require('react-native');
+	return {
+		__esModule: true,
+		default: ({ expression, onMessage, style }: IKatexMockProps) => (
+			<View testID='katex-webview' onMessage={onMessage} style={style}>
+				{expression}
+			</View>
+		)
+	};
+});
+
+const blockMd: Root = [{ type: 'KATEX', value: 'x^2' }];
+const inlineMd: Root = [{ type: 'PARAGRAPH', value: [{ type: 'INLINE_KATEX', value: 'x^2' }] }];
+
+describe('KaTeX rendering', () => {
+	it('routes a KATEX block node to the Katex WebView, not the $$...$$ code fallback', () => {
+		const { getByTestId, queryByText } = render(<Markdown msg='$$x^2$$' md={blockMd} />);
+
+		expect(getByTestId('katex-webview')).toBeTruthy();
+		expect(queryByText('$$x^2$$')).toBeNull();
+	});
+
+	it('keeps inline katex as raw source', () => {
+		const { getByText, queryByTestId } = render(<Markdown msg='$x^2$' md={inlineMd} />);
+
+		expect(getByText('$x^2$')).toBeTruthy();
+		expect(queryByTestId('katex-webview')).toBeNull();
+	});
+
+	it('resizes to the height posted by the WebView', () => {
+		const { getByTestId } = render(<Markdown msg='$$x^2$$' md={blockMd} />);
+		const webView = getByTestId('katex-webview');
+
+		act(() => webView.props.onMessage({ nativeEvent: { data: '120' } }));
+
+		expect(StyleSheet.flatten(getByTestId('katex-webview').props.style).height).toBe(120);
+	});
+});

--- a/app/containers/markdown/components/Katex.tsx
+++ b/app/containers/markdown/components/Katex.tsx
@@ -1,16 +1,53 @@
 import { type KaTeX as KaTeXProps } from '@rocket.chat/message-parser';
-import { type ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
+import { type StyleProp, type ViewStyle } from 'react-native';
+import Katex from 'react-native-katex';
+import { type WebViewMessageEvent } from 'react-native-webview';
 
-import { Code } from './code';
 import InlineCode from './InlineCode';
+import { isAndroid } from '../../../lib/methods/helpers/deviceInfo';
+import { useTheme } from '../../../theme';
 
 interface IKaTeXProps {
 	value: KaTeXProps['value'];
 }
 
-export const KaTeX = ({ value }: IKaTeXProps): ReactElement => (
-	<Code value={[{ type: 'CODE_LINE', value: { type: 'PLAIN_TEXT', value: `$$${value}$$` } }]} />
-);
+const INITIAL_HEIGHT = 20;
+
+const injectedJavaScript = `window.ReactNativeWebView.postMessage(String(document.body.scrollHeight)); true;`;
+
+// Center horizontally and reset margins, but omit the fork default's height:100%:
+// with a full-height body scrollHeight reflects the container, breaking the height handshake.
+const inlineStyle = (color: string) => `
+body { color: ${color}; margin: 0; display: flex; justify-content: center; }
+.katex { margin: 0; }
+`;
+
+export const KaTeX = ({ value }: IKaTeXProps): ReactElement => {
+	const { colors } = useTheme();
+	const [height, setHeight] = useState(INITIAL_HEIGHT);
+
+	const onMessage = (event: WebViewMessageEvent) => {
+		const newHeight = Number(event.nativeEvent.data);
+		if (!Number.isNaN(newHeight) && newHeight > 0) {
+			setHeight(newHeight);
+		}
+	};
+
+	const androidCrashWorkaround: StyleProp<ViewStyle> = isAndroid ? { opacity: 0.99, overflow: 'hidden' } : {};
+
+	return (
+		<Katex
+			expression={value}
+			displayMode
+			throwOnError={false}
+			inlineStyle={inlineStyle(colors.fontDefault)}
+			injectedJavaScript={injectedJavaScript}
+			onMessage={onMessage}
+			style={[{ flex: 1, height, backgroundColor: 'transparent' }, androidCrashWorkaround]}
+		/>
+	);
+};
 
 export const InlineKaTeX = ({ value }: IKaTeXProps): ReactElement => (
 	<InlineCode value={{ type: 'PLAIN_TEXT', value: `$${value}$` }} />

--- a/app/containers/markdown/components/Katex.tsx
+++ b/app/containers/markdown/components/Katex.tsx
@@ -14,7 +14,15 @@ interface IKaTeXProps {
 
 const INITIAL_HEIGHT = 20;
 
-const injectedJavaScript = `window.ReactNativeWebView.postMessage(String(document.body.scrollHeight)); true;`;
+// Re-post height after layout settles: an initial read misses late glyph/webfont
+// metrics (e.g. \Huge), leaving the container too short and clipping the expression.
+const injectedJavaScript = `
+	function postHeight() { window.ReactNativeWebView.postMessage(String(document.body.scrollHeight)); }
+	postHeight();
+	new ResizeObserver(postHeight).observe(document.body);
+	if (document.fonts && document.fonts.ready) document.fonts.ready.then(postHeight);
+	true;
+`;
 
 // Center horizontally and reset margins, but omit the fork default's height:100%:
 // with a full-height body scrollHeight reflects the container, breaking the height handshake.

--- a/app/containers/message/__snapshots__/Message.test.tsx.snap
+++ b/app/containers/message/__snapshots__/Message.test.tsx.snap
@@ -63803,41 +63803,7 @@ exports[`Story Snapshots: Katex should match snapshot 1`] = `
                                 }
                               }
                             >
-                              <View
-                                style={
-                                  [
-                                    {
-                                      "borderRadius": 4,
-                                      "borderWidth": 1,
-                                      "padding": 4,
-                                    },
-                                    {
-                                      "backgroundColor": "#E4E7EA",
-                                      "borderColor": "#CBCED1",
-                                    },
-                                  ]
-                                }
-                              >
-                                <Text
-                                  style={
-                                    [
-                                      {
-                                        "backgroundColor": "transparent",
-                                        "fontFamily": "Courier New",
-                                        "fontSize": 16,
-                                        "fontWeight": "400",
-                                        "lineHeight": 22,
-                                        "textAlign": "left",
-                                      },
-                                      {
-                                        "color": "#2F343D",
-                                      },
-                                    ]
-                                  }
-                                >
-                                  $$ \\color{black} \\colorbox{white}{ \\boxed{ \\begin{matrix} \\;\\;\\;\\; \\overlinesegment {\\underlinesegment{ \\Huge Test\\; Test \\; in \\; Test} } & \\\\ \\;\\;\\textit{develop}\\end{matrix} } }$$
-                                </Text>
-                              </View>
+                              <View />
                             </View>
                           </View>
                         </View>
@@ -64264,41 +64230,7 @@ exports[`Story Snapshots: KatexArray should match snapshot 1`] = `
                                 }
                               }
                             >
-                              <View
-                                style={
-                                  [
-                                    {
-                                      "borderRadius": 4,
-                                      "borderWidth": 1,
-                                      "padding": 4,
-                                    },
-                                    {
-                                      "backgroundColor": "#E4E7EA",
-                                      "borderColor": "#CBCED1",
-                                    },
-                                  ]
-                                }
-                              >
-                                <Text
-                                  style={
-                                    [
-                                      {
-                                        "backgroundColor": "transparent",
-                                        "fontFamily": "Courier New",
-                                        "fontSize": 16,
-                                        "fontWeight": "400",
-                                        "lineHeight": 22,
-                                        "textAlign": "left",
-                                      },
-                                      {
-                                        "color": "#2F343D",
-                                      },
-                                    ]
-                                  }
-                                >
-                                  $$ \\begin{array}{|c|c|c|c|c|c|} \\hline \\text{testing} & \\text{testingII} & \\text{testing III} & \\text{testing IV} & \\text{testV} & \\text{testVI} \\\\ \\hline \\text{TEST} & \\text{TEST} & \\text{TEST} & \\text{TEST} & \\text{TEST} & \\text{TEST} \\\\ \\hline\\text{TEST} & \\text{✅} & \\text{test} & \\text{test} & \\text{test} & \\text{✅} \\\\ \\hline \\end{array} $$
-                                </Text>
-                              </View>
+                              <View />
                             </View>
                           </View>
                         </View>
@@ -64725,41 +64657,7 @@ exports[`Story Snapshots: KatexArrayLargeFont should match snapshot 1`] = `
                                 }
                               }
                             >
-                              <View
-                                style={
-                                  [
-                                    {
-                                      "borderRadius": 4,
-                                      "borderWidth": 1,
-                                      "padding": 4,
-                                    },
-                                    {
-                                      "backgroundColor": "#E4E7EA",
-                                      "borderColor": "#CBCED1",
-                                    },
-                                  ]
-                                }
-                              >
-                                <Text
-                                  style={
-                                    [
-                                      {
-                                        "backgroundColor": "transparent",
-                                        "fontFamily": "Courier New",
-                                        "fontSize": 16,
-                                        "fontWeight": "400",
-                                        "lineHeight": 22,
-                                        "textAlign": "left",
-                                      },
-                                      {
-                                        "color": "#2F343D",
-                                      },
-                                    ]
-                                  }
-                                >
-                                  $$ \\begin{array}{|c|c|c|c|c|c|} \\hline \\text{testing} & \\text{testingII} & \\text{testing III} & \\text{testing IV} & \\text{testV} & \\text{testVI} \\\\ \\hline \\text{TEST} & \\text{TEST} & \\text{TEST} & \\text{TEST} & \\text{TEST} & \\text{TEST} \\\\ \\hline\\text{TEST} & \\text{✅} & \\text{test} & \\text{test} & \\text{test} & \\text{✅} \\\\ \\hline \\end{array} $$
-                                </Text>
-                              </View>
+                              <View />
                             </View>
                           </View>
                         </View>
@@ -65186,41 +65084,7 @@ exports[`Story Snapshots: KatexLargeFont should match snapshot 1`] = `
                                 }
                               }
                             >
-                              <View
-                                style={
-                                  [
-                                    {
-                                      "borderRadius": 4,
-                                      "borderWidth": 1,
-                                      "padding": 4,
-                                    },
-                                    {
-                                      "backgroundColor": "#E4E7EA",
-                                      "borderColor": "#CBCED1",
-                                    },
-                                  ]
-                                }
-                              >
-                                <Text
-                                  style={
-                                    [
-                                      {
-                                        "backgroundColor": "transparent",
-                                        "fontFamily": "Courier New",
-                                        "fontSize": 16,
-                                        "fontWeight": "400",
-                                        "lineHeight": 22,
-                                        "textAlign": "left",
-                                      },
-                                      {
-                                        "color": "#2F343D",
-                                      },
-                                    ]
-                                  }
-                                >
-                                  $$ \\color{black} \\colorbox{white}{ \\boxed{ \\begin{matrix} \\;\\;\\;\\; \\overlinesegment {\\underlinesegment{ \\Huge Test\\; Test \\; in \\; Test} } & \\\\ \\;\\;\\textit{develop}\\end{matrix} } }$$
-                                </Text>
-                              </View>
+                              <View />
                             </View>
                           </View>
                         </View>

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"react-native-gesture-handler": "~2.30.1",
 		"react-native-image-crop-picker": "RocketChat/react-native-image-crop-picker#f028aac24373d05166747ef6d9e59bb037fe3224",
 		"react-native-incall-manager": "^4.2.1",
+		"react-native-katex": "git+https://github.com/RocketChat/react-native-katex.git",
 		"react-native-keyboard-controller": "1.18.5",
 		"react-native-linear-gradient": "2.6.2",
 		"react-native-localize": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       react-native-incall-manager:
         specifier: ^4.2.1
         version: 4.2.1(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))
+      react-native-katex:
+        specifier: git+https://github.com/RocketChat/react-native-katex.git
+        version: https://codeload.github.com/RocketChat/react-native-katex/tar.gz/37e579804fe238732d8a4b06dec073610ab062b1(react-native-webview@13.16.0(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       react-native-keyboard-controller:
         specifier: 1.18.5
         version: 1.18.5(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
@@ -6579,6 +6582,14 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-katex@https://codeload.github.com/RocketChat/react-native-katex/tar.gz/37e579804fe238732d8a4b06dec073610ab062b1:
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/RocketChat/react-native-katex/tar.gz/37e579804fe238732d8a4b06dec073610ab062b1}
+    version: 1.3.0
+    peerDependencies:
+      react: '>=16'
+      react-native: '*'
+      react-native-webview: '>=13'
 
   react-native-keyboard-controller@1.18.5:
     resolution: {integrity: sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==}
@@ -15641,6 +15652,12 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-native: 0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7)
+
+  react-native-katex@https://codeload.github.com/RocketChat/react-native-katex/tar.gz/37e579804fe238732d8a4b06dec073610ab062b1(react-native-webview@13.16.0(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-native: 0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7)
+      react-native-webview: 13.16.0(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
 
   react-native-keyboard-controller@1.18.5(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7))(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
     dependencies:


### PR DESCRIPTION
## Proposed changes

Typeset LaTeX math was removed to unblock the RN 0.83 / Expo 55 bump — the renderer relied on the abandoned native `react-native-math-view`, and KaTeX message-parser nodes were degraded to raw LaTeX source. This restores typeset rendering on a new-architecture-safe stack:

- **Block math** (`$$…$$`, including `array`/`matrix` environments) renders typeset via KaTeX-in-a-WebView, re-adding the RocketChat `react-native-katex` fork. It is pure JS and bundles the KaTeX CSS/JS, so there is no native code for the new architecture to break. Height is dynamic: the WebView posts its `scrollHeight` back and the container resizes to fit the expression.
- **Inline math** (`$…$`) intentionally stays raw source. A WebView cannot render inline within a text run, and the native module that previously made inline typeset work is gone.

The height handshake re-posts on `ResizeObserver` and `document.fonts.ready`, so tall expressions (large glyphs and late-loading webfonts) resize the container instead of clipping mid-content.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1377

## How to test or reproduce

- Send a block expression with an `array`/`matrix` environment and a tall one (e.g. `\Huge`); confirm both render typeset and the message fits the full expression with no clipping, on **iOS and Android**.
- Send inline math such as `$x^2$`; confirm it shows as raw source.

Verified on iOS simulator + Android emulator via the `Message/Katex`, `Message/KatexArray`, and `Message/InlineKatex` stories.

## Screenshots

Drop each image into the matching cell (click the cell, then drag the PNG in — GitHub uploads it and inserts the `![…](…)` inline):

| Case | iOS | Android |
|---|---|---|
| Block `Katex` — `\Huge` boxed matrix, full render, no clip | <img width="1206" height="2622" alt="ios-katex-block" src="https://github.com/user-attachments/assets/e2406df7-5d28-44cb-9b76-d952ec1b6416" /> | <img width="1440" height="3120" alt="Screenshot_1783693994" src="https://github.com/user-attachments/assets/7a3f1cbc-6e74-417a-8bce-d1ff943e2eb6" />|
| Block `KatexArray` — array/matrix env, full grid | <img width="1206" height="2622" alt="ios-katex-array" src="https://github.com/user-attachments/assets/e8724c2a-2e15-4992-a9b4-b3ab322f425d" /> | <img width="1440" height="3120" alt="Screenshot_1783693988" src="https://github.com/user-attachments/assets/4370b26e-709b-445e-9f82-7cfe74dcc062" /> |
| `InlineKatex` — raw source by design | raw `$x^2$` (unchanged) | raw `$x^2$` (unchanged) |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Targets the RN 0.83 / Expo 55 integration branch, where the native math renderer was removed. Inline typeset is deliberately out of scope (no inline-capable, new-arch-safe renderer today); readers still see the inline source.
