### PR TITLE
chore: bump react-native-localize to 3.7.0

### DIFF
--- a/__mocks__/react-native-localize.js
+++ b/__mocks__/react-native-localize.js
@@ -1,2 +1,2 @@
 export const initialConstants = null;
-export const findBestAvailableLanguage = () => null;
+export const findBestLanguageTag = () => null;

--- a/app/i18n/index.ts
+++ b/app/i18n/index.ts
@@ -182,7 +182,7 @@ export const setLanguage = (l: string) => {
 i18n.translations = { en: translations.en?.() };
 const defaultLanguage = { languageTag: 'en', isRTL: false };
 const availableLanguages = Object.keys(translations);
-const { languageTag } = RNLocalize.findBestAvailableLanguage(availableLanguages) || defaultLanguage;
+const { languageTag } = RNLocalize.findBestLanguageTag(availableLanguages) || defaultLanguage;
 
 // @ts-ignore
 i18n.isTranslated = (text?: string) => text in englishJson;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3475,8 +3475,34 @@ PODS:
     - SocketRocket
     - TOCropViewController (~> 2.7.4)
     - Yoga
-  - RNLocalize (2.1.1):
+  - RNLocalize (3.7.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNReanimated (4.2.1):
     - boost
     - DoubleConversion
@@ -4443,7 +4469,7 @@ SPEC CHECKSUMS:
   RNFileViewer: f9424017fa643c115c1444e11292e84fb16ddd68
   RNGestureHandler: 8cf03fa922e1677e7ff1e3d352921ba1a7444ff0
   RNImageCropPicker: 0a63af4b79e514c1edd6c3152f19300c5ed85312
-  RNLocalize: ca86348d88b9a89da0e700af58d428ab3f343c4e
+  RNLocalize: c46dd4008dc8990a098fcafd6ee051122a1ccfda
   RNReanimated: fbcb7fd8da5b0b088401542c58fb5d266388f1cf
   RNScreens: 199799bdab32fa1e17ebf938b06fec52033e81e5
   RNSVG: 282c14a0d61ce7231e2f4aa213c618171f1dced5

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"react-native-katex": "git+https://github.com/RocketChat/react-native-katex.git",
 		"react-native-keyboard-controller": "1.18.5",
 		"react-native-linear-gradient": "2.6.2",
-		"react-native-localize": "2.1.1",
+		"react-native-localize": "3.7.0",
 		"react-native-mime-types": "2.3.0",
 		"react-native-mmkv": "4.3.1",
 		"react-native-modal": "13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: 2.6.2
         version: 2.6.2(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       react-native-localize:
-        specifier: 2.1.1
-        version: 2.1.1(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))
+        specifier: 3.7.0
+        version: 3.7.0(@expo/config-plugins@55.0.10)(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
       react-native-mime-types:
         specifier: 2.3.0
         version: 2.3.0
@@ -6607,10 +6607,18 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-localize@2.1.1:
-    resolution: {integrity: sha512-+uyz2/b0vyLq19fcb7r1qU1gqmzbp3aC6EMTvOVXwfBuiN+aJXR/fDdFOJJ8D7+bLccKeuS2zBDrazh+ZayX/g==}
+  react-native-localize@3.7.0:
+    resolution: {integrity: sha512-6Ohx+zZzycC6zhNVBGM/u1U+O6Ww29YIFseeyXqsKcO/pTfjLcdE40IUJF4SVVwrdh00IMJwy90HjLGUaeqK7Q==}
     peerDependencies:
-      react-native: '>=0.60.0'
+      '@expo/config-plugins': '*'
+      react: '*'
+      react-native: '*'
+      react-native-macos: '*'
+    peerDependenciesMeta:
+      '@expo/config-plugins':
+        optional: true
+      react-native-macos:
+        optional: true
 
   react-native-mime-types@2.3.0:
     resolution: {integrity: sha512-9l/kkT1QM0i0xAKkOADkP6jIMhqiS+R/eSKBS/lsUmuMYMqboClyrwTFFZwUcaVIN0SpeH4wOKhYTqCnFgRsEw==}
@@ -15674,9 +15682,12 @@ snapshots:
       react: 19.2.7
       react-native: 0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7)
 
-  react-native-localize@2.1.1(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7)):
+  react-native-localize@3.7.0(@expo/config-plugins@55.0.10)(react-native@0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
     dependencies:
+      react: 19.2.7
       react-native: 0.83.10(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@expo/config-plugins': 55.0.10
 
   react-native-mime-types@2.3.0:
     dependencies:


### PR DESCRIPTION
## Proposed changes

Bumps `react-native-localize` 2.1.1 → 3.7.0. The 3.x line ships a TurboModule, so the module now runs natively on the New Architecture instead of riding the default-on interop layer.

The only breaking API change affecting us is `findBestAvailableLanguage` → `findBestLanguageTag`; the single call site (and its test mock) are updated. No behavior change.

## Issue(s)

Part of the RN 0.83 / Expo 55 upgrade — getting risky modules off the New-Arch interop layer. [NATIVE-1234](https://rocketchat.atlassian.net/browse/NATIVE-1234)

## How to test or reproduce

1. Fresh install on a device whose system language matches one of the app's supported locales.
2. Launch the app — the UI should auto-select the best matching language, same as before.
3. Verify on both iOS and Android.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments


[NATIVE-1234]: https://rocketchat.atlassian.net/browse/NATIVE-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language and locale detection during app startup.
  * Preserved English as the fallback language when the device locale cannot be determined.

* **Chores**
  * Updated the localization support package to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->