### PR TITLE
fix: race updating same record on concurrent message stream events

### DIFF
--- a/app/lib/methods/subscriptions/room.test.ts
+++ b/app/lib/methods/subscriptions/room.test.ts
@@ -1,6 +1,9 @@
 import RoomSubscription from './room';
 import { loadMissedMessages } from '../loadMissedMessages';
 import { clearUserTyping } from '../../../actions/usersTyping';
+import { getMessageById } from '../../database/services/Message';
+import { getThreadById } from '../../database/services/Thread';
+import log from '../helpers/log';
 
 const mockSubscribeRoom = jest.fn<Promise<unknown[]>, [string]>(() => Promise.resolve([]));
 const mockOnStreamData = jest.fn<Promise<{ stop: jest.Mock }>, [string, (...args: unknown[]) => void]>(() =>
@@ -86,6 +89,7 @@ jest.mock('../../encryption', () => ({
 const mockDbBatch = jest.fn().mockResolvedValue(undefined);
 const mockDbGet = jest.fn();
 jest.mock('../../database', () => {
+	let writerQueue: Promise<unknown> = Promise.resolve();
 	const mockModel = {
 		prepareCreate: jest.fn(() => ({})),
 		prepareUpdate: jest.fn(() => ({})),
@@ -97,7 +101,11 @@ jest.mock('../../database', () => {
 		default: {
 			active: {
 				get: (...args: unknown[]) => mockDbGet(...args) ?? mockModel,
-				write: jest.fn((callback: () => Promise<void>) => callback()),
+				write: jest.fn((callback: () => Promise<void>) => {
+					const run = writerQueue.then(() => callback());
+					writerQueue = run.catch(() => undefined);
+					return run;
+				}),
 				batch: (...args: unknown[]) => mockDbBatch(...args)
 			}
 		}
@@ -273,6 +281,50 @@ describe('RoomSubscription', () => {
 			await sub.handleLogin();
 
 			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
+		});
+	});
+
+	describe('updateMessage concurrency', () => {
+		const makeRecord = (debugName: string) => ({
+			_preparedState: null as string | null,
+			prepareUpdate(recordUpdater: (m: any) => void) {
+				if (this._preparedState) {
+					throw new Error(`Cannot update a record with pending changes (${debugName})`);
+				}
+				recordUpdater(this);
+				this._preparedState = 'update';
+				return this;
+			}
+		});
+
+		it('does not throw "pending changes" when two stream events for the same message id arrive concurrently', async () => {
+			const _id = 'KXse45i7gGYE8j4Xb';
+			const messageRecord = makeRecord(`messages#${_id}`);
+			const threadRecord = makeRecord(`threads#${_id}`);
+			(getMessageById as jest.Mock).mockResolvedValue(messageRecord);
+			(getThreadById as jest.Mock).mockResolvedValue(threadRecord);
+			// db.batch commits prepared records, clearing their pending state (like the real writer).
+			mockDbBatch.mockImplementation((...items: any[]) => {
+				items.forEach(item => {
+					if (item && typeof item === 'object' && '_preparedState' in item) {
+						item._preparedState = null;
+					}
+				});
+				return Promise.resolve(undefined);
+			});
+
+			const message = { _id, rid, tlm: { $date: 1 } } as any;
+
+			// updateMessage's promise never resolves on the happy path, so fire both and flush the queues.
+			sub.updateMessage({ ...message });
+			sub.updateMessage({ ...message });
+			await Array.from({ length: 10 }).reduce<Promise<unknown>>(
+				chain => chain.then(() => new Promise(resolve => setImmediate(resolve))),
+				Promise.resolve()
+			);
+
+			const loggedPendingChanges = (log as jest.Mock).mock.calls.some(([err]) => /pending changes/.test(err?.message));
+			expect(loggedPendingChanges).toBe(false);
 		});
 	});
 });

--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -265,20 +265,23 @@ export default class RoomSubscription {
 		readMessages(this.rid, new Date());
 	}, 300);
 
-	updateMessage = (message: IMessage): Promise<void> =>
-		new Promise(async resolve => {
-			if (this.rid !== message.rid) {
-				return resolve();
-			}
+	updateMessage = async (message: IMessage): Promise<void> => {
+		if (this.rid !== message.rid) {
+			return;
+		}
 
+		const db = database.active;
+		const msgCollection = db.get('messages');
+		const threadsCollection = db.get('threads');
+		const threadMessagesCollection = db.get('thread_messages');
+
+		// Decrypt the message if necessary
+		message = (await Encryption.decryptMessage(message)) as IMessage;
+
+		// Serialize reads, prepares and the batch under the writer lock so concurrent stream
+		// events for the same id can't call prepareUpdate on a record with pending changes.
+		await db.write(async () => {
 			const batch: TMessageModel[] | TThreadModel[] | TThreadMessageModel[] = [];
-			const db = database.active;
-			const msgCollection = db.get('messages');
-			const threadsCollection = db.get('threads');
-			const threadMessagesCollection = db.get('thread_messages');
-
-			// Decrypt the message if necessary
-			message = (await Encryption.decryptMessage(message)) as IMessage;
 
 			// Create or update message
 			try {
@@ -389,10 +392,9 @@ export default class RoomSubscription {
 				}
 			}
 
-			await db.write(async () => {
-				await db.batch(...batch);
-			});
+			await db.batch(...batch);
 		});
+	};
 
 	handleMessageReceived = async (ddpMessage: IDDPMessage) => {
 		try {


### PR DESCRIPTION
## Proposed changes

Concurrent `stream-room-messages` events for the same message id could throw `Cannot update a record with pending changes (messages#…)` / `(threads#…)`.

WatermelonDB caches a record instance per id and `prepareUpdate` marks it with a pending state that is only cleared when the batch commits. `updateMessage` built its batch (calling `prepareUpdate`) **outside** `db.write`, and `handleMessageReceived` is a raw stream listener that is not serialized. When two events for the same id arrived close together, both grabbed the same cached record and the second `prepareUpdate` threw. The error was swallowed and logged as a warning, silently dropping that update.

The fix moves the reads, prepares and batch inside a single `db.write` so the WatermelonDB writer lock serializes concurrent `updateMessage` calls: the second call waits until the first commits (clearing the pending state) before preparing. Decryption stays outside the lock.

`updateMessage` is also converted to a plain `async` function, fixing a happy-path promise that never resolved (the previous `new Promise` never called `resolve()` after `db.write`, so the awaiting caller hung and the follow-up read never fired).

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1421

## How to test or reproduce

Hard to reproduce by hand (a timing race between two stream events for the same message). Covered by an added regression test that fires two concurrent `updateMessage` calls for the same id and asserts no "pending changes" error is logged. The test's `db.write` mock serializes like the real writer lock, so it goes red on the old code and green on the fix.

`TZ=UTC pnpm test --testPathPattern='subscriptions/room.test'`

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The same prepare-outside-writer pattern may exist in other `onStreamData` handlers that call `prepare*` before `db.write`; not swept in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message update handling during concurrent operations.
  * Prevented erroneous “pending changes” errors when multiple updates are processed at the same time.
  * Ensured related message and thread updates are committed together for greater consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->