### PR TITLE
fix: reuse stale upload record instead of blocking re-send

### DIFF
--- a/app/lib/methods/sendFileMessage/sendFileMessage.ts
+++ b/app/lib/methods/sendFileMessage/sendFileMessage.ts
@@ -7,7 +7,7 @@ import i18n from '../../../i18n';
 import database from '../../database';
 import FileUpload from '../helpers/fileUpload';
 import log from '../helpers/log';
-import { copyFileToCacheDirectoryIfNeeded, getUploadPath, persistUploadError, uploadQueue } from './utils';
+import { copyFileToCacheDirectoryIfNeeded, getUploadPath, isUploadActive, persistUploadError, uploadQueue } from './utils';
 import { type IFormData } from '../helpers/fileUpload/definitions';
 
 export async function sendFileMessage(
@@ -30,8 +30,17 @@ export async function sendFileMessage(
 		let uploadRecord: TUploadModel;
 		try {
 			uploadRecord = await uploadsCollection.find(uploadPath);
-			if (uploadRecord.id && !isForceTryAgain) {
-				return Alert.alert(i18n.t('FileUpload_Error'), i18n.t('Upload_in_progress'));
+			if (uploadRecord.id) {
+				if (isUploadActive(fileInfo.path, rid) && !isForceTryAgain) {
+					return Alert.alert(i18n.t('FileUpload_Error'), i18n.t('Upload_in_progress'));
+				}
+				// Record left behind by a crashed or failed upload: reset and reuse it.
+				await db.write(async () => {
+					await uploadRecord?.update(u => {
+						u.error = false;
+						u.progress = 0;
+					});
+				});
 			}
 		} catch (error) {
 			try {

--- a/app/lib/methods/sendFileMessage/sendFileMessage.ts
+++ b/app/lib/methods/sendFileMessage/sendFileMessage.ts
@@ -1,13 +1,9 @@
-import { sanitizedRaw } from '@nozbe/watermelondb/RawRecord';
 import { settings as RocketChatSettings } from '@rocket.chat/sdk';
-import { Alert } from 'react-native';
 
 import { type IUser, type TSendFileMessageFileInfo, type TUploadModel } from '../../../definitions';
-import i18n from '../../../i18n';
 import database from '../../database';
 import FileUpload from '../helpers/fileUpload';
-import log from '../helpers/log';
-import { copyFileToCacheDirectoryIfNeeded, getUploadPath, isUploadActive, persistUploadError, uploadQueue } from './utils';
+import { copyFileToCacheDirectoryIfNeeded, createUploadRecord, persistUploadError, uploadQueue } from './utils';
 import { type IFormData } from '../helpers/fileUpload/definitions';
 
 export async function sendFileMessage(
@@ -19,46 +15,17 @@ export async function sendFileMessage(
 	isForceTryAgain?: boolean
 ): Promise<void> {
 	let uploadPath: string | null = '';
+	let uploadRecord: TUploadModel | null;
 	try {
 		const { id, token } = user;
 		const uploadUrl = `${server}/api/v1/rooms.upload/${rid}`;
 		fileInfo.rid = rid;
 
 		const db = database.active;
-		const uploadsCollection = db.get('uploads');
-		uploadPath = getUploadPath(fileInfo.path, rid);
-		let uploadRecord: TUploadModel;
-		try {
-			uploadRecord = await uploadsCollection.find(uploadPath);
-			if (uploadRecord.id) {
-				if (isUploadActive(fileInfo.path, rid) && !isForceTryAgain) {
-					return Alert.alert(i18n.t('FileUpload_Error'), i18n.t('Upload_in_progress'));
-				}
-				// Record left behind by a crashed or failed upload: reset and reuse it.
-				await db.write(async () => {
-					await uploadRecord?.update(u => {
-						u.error = false;
-						u.progress = 0;
-					});
-				});
-			}
-		} catch (error) {
-			try {
-				await db.write(async () => {
-					uploadRecord = await uploadsCollection.create(u => {
-						u._raw = sanitizedRaw({ id: uploadPath }, uploadsCollection.schema);
-						Object.assign(u, fileInfo);
-						if (tmid) {
-							u.tmid = tmid;
-						}
-						if (u.subscription) {
-							u.subscription.id = rid;
-						}
-					});
-				});
-			} catch (e) {
-				return log(e);
-			}
+
+		[uploadPath, uploadRecord] = await createUploadRecord({ rid, fileInfo, tmid, isForceTryAgain });
+		if (!uploadPath || !uploadRecord) {
+			return;
 		}
 
 		fileInfo.path = await copyFileToCacheDirectoryIfNeeded(fileInfo.path, fileInfo.name);

--- a/app/lib/methods/sendFileMessage/utils.test.ts
+++ b/app/lib/methods/sendFileMessage/utils.test.ts
@@ -1,0 +1,81 @@
+import { Alert } from 'react-native';
+
+import { createUploadRecord, getUploadPath, uploadQueue } from './utils';
+
+jest.mock('react-native', () => ({ Alert: { alert: jest.fn() } }));
+jest.mock('../../../i18n', () => ({ t: (k: string) => k }));
+jest.mock('../helpers/log', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../database/services/Upload', () => ({ getUploadByPath: jest.fn() }));
+jest.mock('@nozbe/watermelondb/RawRecord', () => ({ sanitizedRaw: (raw: unknown) => raw }));
+
+const mockFind = jest.fn();
+const mockCreate = jest.fn();
+
+jest.mock('../../database', () => ({
+	__esModule: true,
+	default: {
+		active: {
+			get: () => ({ find: mockFind, create: mockCreate, schema: {} }),
+			write: (cb: () => Promise<unknown>) => cb()
+		}
+	}
+}));
+
+const fileInfo = { rid: 'GENERAL', path: '/tmp/pic.jpg', name: 'pic.jpg' } as any;
+const uploadPath = getUploadPath(fileInfo.path, fileInfo.rid);
+
+beforeEach(() => {
+	mockFind.mockReset();
+	mockCreate.mockReset();
+	(Alert.alert as jest.Mock).mockReset();
+	Object.keys(uploadQueue).forEach(k => delete uploadQueue[k]);
+});
+
+describe('createUploadRecord', () => {
+	it('blocks with alert when the upload is actively in progress', async () => {
+		mockFind.mockResolvedValue({ id: uploadPath });
+		uploadQueue[uploadPath] = {} as any;
+
+		const result = await createUploadRecord({ rid: 'GENERAL', fileInfo, tmid: undefined });
+
+		expect(result).toEqual([null, null]);
+		expect(Alert.alert).toHaveBeenCalled();
+	});
+
+	it('reuses a stale record left by a crashed/failed upload instead of blocking', async () => {
+		const stale: any = { id: uploadPath, update: jest.fn((cb: (u: any) => void) => cb(stale)) };
+		mockFind.mockResolvedValue(stale);
+		// uploadQueue is empty -> no live upload -> record is stale
+
+		const [path, record] = await createUploadRecord({ rid: 'GENERAL', fileInfo, tmid: undefined });
+
+		expect(Alert.alert).not.toHaveBeenCalled();
+		expect(path).toBe(uploadPath);
+		expect(record).toBe(stale);
+	});
+
+	it('reuses the existing record when force-retry', async () => {
+		const existing: any = { id: uploadPath, update: jest.fn((cb: (u: any) => void) => cb(existing)) };
+		mockFind.mockResolvedValue(existing);
+
+		const [path, record] = await createUploadRecord({ rid: 'GENERAL', fileInfo, tmid: undefined, isForceTryAgain: true });
+
+		expect(path).toBe(uploadPath);
+		expect(record).toBe(existing);
+	});
+
+	it('creates a new record when none exists', async () => {
+		mockFind.mockRejectedValue(new Error('not found'));
+		const created = { id: uploadPath };
+		mockCreate.mockImplementation((cb: (u: any) => void) => {
+			const u: any = {};
+			cb(u);
+			return created;
+		});
+
+		const [path, record] = await createUploadRecord({ rid: 'GENERAL', fileInfo, tmid: undefined });
+
+		expect(path).toBe(uploadPath);
+		expect(record).toBe(created);
+	});
+});

--- a/app/lib/methods/sendFileMessage/utils.test.ts
+++ b/app/lib/methods/sendFileMessage/utils.test.ts
@@ -57,9 +57,11 @@ describe('createUploadRecord', () => {
 	it('reuses the existing record when force-retry', async () => {
 		const existing: any = { id: uploadPath, update: jest.fn((cb: (u: any) => void) => cb(existing)) };
 		mockFind.mockResolvedValue(existing);
+		uploadQueue[uploadPath] = {} as any;
 
 		const [path, record] = await createUploadRecord({ rid: 'GENERAL', fileInfo, tmid: undefined, isForceTryAgain: true });
 
+		expect(Alert.alert).not.toHaveBeenCalled();
 		expect(path).toBe(uploadPath);
 		expect(record).toBe(existing);
 	});

--- a/app/lib/methods/sendFileMessage/utils.ts
+++ b/app/lib/methods/sendFileMessage/utils.ts
@@ -74,9 +74,18 @@ export const createUploadRecord = async ({
 	let uploadRecord: TUploadModel | null = null;
 	try {
 		uploadRecord = await uploadsCollection.find(uploadPath);
-		if (uploadRecord.id && !isForceTryAgain) {
-			Alert.alert(i18n.t('FileUpload_Error'), i18n.t('Upload_in_progress'));
-			return [null, null];
+		if (uploadRecord.id) {
+			if (isUploadActive(fileInfo.path, rid) && !isForceTryAgain) {
+				Alert.alert(i18n.t('FileUpload_Error'), i18n.t('Upload_in_progress'));
+				return [null, null];
+			}
+			// Record left behind by a crashed or failed upload: reset and reuse it.
+			await db.write(async () => {
+				await uploadRecord?.update(u => {
+					u.error = false;
+					u.progress = 0;
+				});
+			});
 		}
 	} catch (error) {
 		try {


### PR DESCRIPTION
## Proposed changes

An upload record left behind in the local DB by a crashed or failed upload permanently blocked re-sending the same file. On the next (non–"try again") send of that file the app threw `Couldn't create upload record` and showed an "Upload in progress" alert, even though nothing was uploading.

Root cause: the guard in `createUploadRecord` treated *"a record with this path exists in the DB"* as *"an upload is in progress"*. That is wrong after a crash/restart — the DB row survives, but the real in-progress signal is the in-memory `uploadQueue`, which is empty.

Fix: show the "Upload in progress" alert and bail only when the upload is **actually active** (`isUploadActive`). Otherwise the existing row is a stale orphan — reset its `error`/`progress` and reuse it so the send proceeds. Applied to both the V2 path (`createUploadRecord`) and the legacy V1 path (`sendFileMessage.ts`, servers < 6.10).

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1422

## How to test or reproduce

1. Start uploading a file, then force-kill the app mid-upload (or trigger an upload failure before the request is queued) so an `uploads` row is left behind.
2. Reopen the app and send the **same** file again (normal send, not the "try again" button).
3. Before: fails with `Couldn't create upload record` / "Upload in progress". After: the file uploads normally.
4. Also verify a genuinely in-flight duplicate send of the same file still shows "Upload in progress".

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Two related items intentionally left out of scope: (1) the native ObjC-interop exception that can crash the app mid-upload (a separate de-interop/symbolication track — this PR only makes the JS side resilient to the orphan it leaves), and (2) the `catch` branch that logs `Upload cancelled` and silently swallows genuine early-failure errors without rethrowing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - File uploads are now retryable when a previous upload record is stale or incomplete.
  - Duplicate attempts are blocked only when an upload is actively in progress for the same item.
  - Retrying now clears any leftover error and resets upload progress before resuming.

- **Tests**
  - Added unit test coverage for active uploads, stale record reuse, forced retries, and creation of a new upload record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
