### PR TITLE
fix: harden e2e CI against Android ANR dialog and iOS Maestro driver timeout

### DIFF
--- a/.github/scripts/run-maestro.sh
+++ b/.github/scripts/run-maestro.sh
@@ -7,7 +7,7 @@ FLOWS_DIR=".maestro/tests"
 MAIN_REPORT="maestro-report.xml"
 MAX_RERUN_ROUNDS="${MAX_RERUN_ROUNDS:-2}"
 RERUN_REPORT_PREFIX="maestro-rerun"
-export MAESTRO_DRIVER_STARTUP_TIMEOUT="${MAESTRO_DRIVER_STARTUP_TIMEOUT:-120000}"
+export MAESTRO_DRIVER_STARTUP_TIMEOUT="${MAESTRO_DRIVER_STARTUP_TIMEOUT:-300000}"
 
 # Linux has timeout, macOS has gtimeout (Homebrew coreutils)
 TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"

--- a/.maestro/helpers/launch-app.yaml
+++ b/.maestro/helpers/launch-app.yaml
@@ -19,4 +19,10 @@ tags:
             platform: Android
           commands:
             - tapOn: 'Close App'
+      - runFlow:
+          when:
+            visible: ".*isn't responding.*"
+            platform: Android
+          commands:
+            - tapOn: 'Wait'
       - assertVisible: 'Add workspace'


### PR DESCRIPTION
## Proposed changes

Two recurring e2e shard failures are environmental, not app regressions. This PR hardens the CI harness against both:

- **Android ANR dialog** — `launch-app.yaml` now dismisses any Android "isn't responding" system dialog (regex `.*isn't responding.*`) inside the launch retry block, before the onboarding assertion. It taps **Wait** rather than **Close app** because the dialog belongs to the System UI process, not the app under test, so `launchApp clearState` retries never clear it. The existing Pixel Launcher handler is kept.
- **iOS Maestro driver startup timeout** — raised the default `MAESTRO_DRIVER_STARTUP_TIMEOUT` in `run-maestro.sh` from `120000` to `300000`. Cold simulators can spend 2-3 minutes in post-boot Data Migration / Waiting on System App, so the first XCUITest driver install exceeded the previous 2-minute budget. The value is a ceiling, not a wait — healthy runs pay nothing.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1423

## How to test or reproduce

Both changes are verified by a green e2e run on this PR: Android shards no longer die on the "System UI isn't responding" dialog, and iOS shards no longer produce empty JUnit output from a driver-startup timeout on cold simulators.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

CI-config only — no app source touched, so there is no unit-test surface. Effectiveness is provable only by a green e2e run (acceptance criterion 3).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app launch reliability on Android by automatically selecting “Wait” when an “isn’t responding” prompt appears.
  * Increased the maximum startup wait time for automated app launches, reducing failures on slower devices or environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->