### PR TITLE
fix: restore Away status option on servers 8.6.0 and above

### DIFF
--- a/app/views/StatusView/index.test.tsx
+++ b/app/views/StatusView/index.test.tsx
@@ -113,16 +113,6 @@ describe('StatusView', () => {
 			expect(screen.queryByTestId('status-view-clear-after')).toBeNull();
 		});
 
-		it('should always show away option regardless of server version', () => {
-			mockedStore.dispatch(setUser({ id: 'user-id', username: 'user', status: 'online', statusText: '' }));
-			mockedStore.dispatch(selectServerSuccess({ server: 'https://example.com', version: '8.6.0', name: 'Test' }));
-			mockedStore.dispatch(addSettings({ Accounts_AllowInvisibleStatusOption: true }));
-
-			renderStatusView();
-
-			expect(screen.getByTestId('status-view-away')).toBeOnTheScreen();
-		});
-
 		it('should render status text input', () => {
 			mockedStore.dispatch(setUser({ id: 'user-id', username: 'user', status: 'online', statusText: '' }));
 			mockedStore.dispatch(selectServerSuccess({ server: 'https://example.com', version: '8.6.0', name: 'Test' }));

--- a/app/views/StatusView/index.test.tsx
+++ b/app/views/StatusView/index.test.tsx
@@ -113,18 +113,8 @@ describe('StatusView', () => {
 			expect(screen.queryByTestId('status-view-clear-after')).toBeNull();
 		});
 
-		it('should hide away option on server >= 8.6.0 when user is not away', () => {
+		it('should always show away option regardless of server version', () => {
 			mockedStore.dispatch(setUser({ id: 'user-id', username: 'user', status: 'online', statusText: '' }));
-			mockedStore.dispatch(selectServerSuccess({ server: 'https://example.com', version: '8.6.0', name: 'Test' }));
-			mockedStore.dispatch(addSettings({ Accounts_AllowInvisibleStatusOption: true }));
-
-			renderStatusView();
-
-			expect(screen.queryByTestId('status-view-away')).toBeNull();
-		});
-
-		it('should show away option on server >= 8.6.0 when user is away', () => {
-			mockedStore.dispatch(setUser({ id: 'user-id', username: 'user', status: 'away', statusText: '' }));
 			mockedStore.dispatch(selectServerSuccess({ server: 'https://example.com', version: '8.6.0', name: 'Test' }));
 			mockedStore.dispatch(addSettings({ Accounts_AllowInvisibleStatusOption: true }));
 

--- a/app/views/StatusView/index.tsx
+++ b/app/views/StatusView/index.tsx
@@ -191,7 +191,6 @@ const StatusView = (): ReactElement => {
 
 	const statusType = STATUS.filter(s => {
 		if (s.id === 'offline' && !Accounts_AllowInvisibleStatusOption) return false;
-		if (supportsStatusExpiry && s.id === 'away' && user.status !== 'away') return false;
 		return true;
 	});
 


### PR DESCRIPTION
## Proposed changes

We previously removed the "Away" status option from the Edit Status screen on servers `>= 8.6.0`. This reverses that change so the Away option is always available regardless of server version.

## Issue(s)
<!-- Link the relevant issue here if one exists -->
https://rocketchat.atlassian.net/browse/CORE-2431

## How to test or reproduce

1. Connect to a server `>= 8.6.0`.
2. Open Edit Status (profile → status).
3. The "Away" option should now be visible even when the current status is online/busy/offline.

## Screenshots

<!-- Add if applicable -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The test `should hide away option on server >= 8.6.0 when user is not away` / `...when user is away` was collapsed into a single `should always show away option regardless of server version` test reflecting the reverted behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Away” status option is now consistently available in the status selector, regardless of server version or the user’s current status.
* **Tests**
  * Updated the StatusView test coverage to reflect the new, always-visible “Away” option behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->