### PR TITLE
fix: silent message loss after notification

### DIFF
--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -140,4 +140,54 @@ describe('Encryption.encryptMessage', () => {
 		expect(result).toBe(baseMessage);
 		expect(mockRoomEncrypt).not.toHaveBeenCalled();
 	});
+
+	describe('decryptMessages', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+			(encryption as any).roomInstances = {};
+		});
+
+		it('returns successfully decrypted messages when one fails (was Promise.all that aborted the batch)', async () => {
+			const good = { _id: 'm1', rid: 'r1', msg: 'good' } as any;
+			const bad = { _id: 'm2', rid: 'r2', msg: 'bad', t: 'e2e' } as any;
+			mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+			mockHasSessionKey.mockReturnValue(true);
+			mockRoomEncrypt.mockResolvedValueOnce({ ...good, msg: 'decrypted' });
+			mockRoomEncrypt.mockRejectedValueOnce(new Error('decrypt failed'));
+			// getRoomInstance creates a new EncryptionRoom for each rid via the mock
+			mockSubFind.mockResolvedValue({ encrypted: true });
+
+			const result = await encryption.decryptMessages([good, bad]);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]._id).toBe('m1');
+		});
+
+		it('returns empty array when ALL messages fail decryption (does not throw)', async () => {
+			const msgs = [
+				{ _id: 'm1', rid: 'r1', msg: 'bad1', t: 'e2e' },
+				{ _id: 'm2', rid: 'r2', msg: 'bad2', t: 'e2e' }
+			] as any;
+			mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+			mockHasSessionKey.mockReturnValue(true);
+			mockRoomEncrypt.mockRejectedValue(new Error('decrypt failed'));
+			mockSubFind.mockResolvedValue({ encrypted: true });
+
+			const result = await encryption.decryptMessages(msgs);
+
+			expect(result).toEqual([]);
+		});
+
+		it('returns all messages unchanged for non-E2E room (short-circuits decryptMessage)', async () => {
+			const msgs = [
+				{ _id: 'm1', rid: 'r1', msg: 'hello' },
+				{ _id: 'm2', rid: 'r2', msg: 'world' }
+			] as any;
+
+			const result = await encryption.decryptMessages(msgs);
+
+			expect(result).toHaveLength(2);
+			expect(mockRoomEncrypt).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/app/lib/encryption/encryption.ts
+++ b/app/lib/encryption/encryption.ts
@@ -649,8 +649,10 @@ class Encryption {
 	}
 
 	// Decrypt multiple messages
-	decryptMessages = (messages: Partial<IMessage>[]) =>
-		Promise.all(messages.map((m: Partial<IMessage>) => this.decryptMessage(m as IMessage)));
+	decryptMessages = async (messages: Partial<IMessage>[]) => {
+		const results = await Promise.allSettled(messages.map((m: Partial<IMessage>) => this.decryptMessage(m as IMessage)));
+		return results.filter(r => r.status === 'fulfilled').map(r => (r as PromiseFulfilledResult<IMessage>).value);
+	};
 
 	// Decrypt multiple subscriptions
 	decryptSubscriptions = (subscriptions: ISubscription[]) => {

--- a/app/lib/methods/loadMissedMessages.test.ts
+++ b/app/lib/methods/loadMissedMessages.test.ts
@@ -1,0 +1,91 @@
+import { loadMissedMessages } from './loadMissedMessages';
+import updateMessages from './updateMessages';
+
+const mockSdkGet = jest.fn();
+jest.mock('../services/sdk', () => ({
+	__esModule: true,
+	default: {
+		get: (...args: unknown[]) => mockSdkGet(...args)
+	}
+}));
+
+jest.mock('./updateMessages', () => ({
+	__esModule: true,
+	default: jest.fn<Promise<number | void>, [unknown]>(() => Promise.resolve(0))
+}));
+
+jest.mock('./helpers', () => ({
+	compareServerVersion: jest.fn(() => true)
+}));
+
+jest.mock('../store/auxStore', () => ({
+	store: {
+		getState: () => ({ server: { version: '7.1.0' } })
+	}
+}));
+
+jest.mock('../database/services/Subscription', () => ({
+	getSubscriptionByRoomId: jest.fn(() => Promise.resolve({ lastOpen: new Date(1000) }))
+}));
+
+describe('loadMissedMessages', () => {
+	const rid = 'test-room-id';
+	const lastOpen = new Date(1000);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('awaits all recursive pagination pages before resolving (was fire-and-forget)', async () => {
+		const page1 = {
+			updated: [{ _id: 'm1', rid, msg: 'hello' }],
+			deleted: [],
+			cursor: { next: 'cursor2' }
+		};
+		const page2 = {
+			updated: [{ _id: 'm2', rid, msg: 'world' }],
+			deleted: [],
+			cursor: { next: null }
+		};
+		mockSdkGet
+			.mockResolvedValueOnce({ result: page1 })
+			.mockResolvedValueOnce({ result: { deleted: [], cursor: { next: null } } })
+			.mockResolvedValueOnce({ result: page2 });
+
+		await loadMissedMessages({ rid, lastOpen });
+
+		expect(updateMessages).toHaveBeenCalledTimes(2);
+		expect(updateMessages).toHaveBeenNthCalledWith(1, { rid, update: page1.updated, remove: page1.deleted });
+		expect(updateMessages).toHaveBeenNthCalledWith(2, { rid, update: page2.updated, remove: page2.deleted });
+	});
+
+	it('rejects when a recursive page fails (was silently swallowed)', async () => {
+		const page1 = {
+			updated: [{ _id: 'm1', rid, msg: 'hello' }],
+			deleted: [],
+			cursor: { next: 'cursor2' }
+		};
+		mockSdkGet
+			.mockResolvedValueOnce({ result: page1 })
+			.mockResolvedValueOnce({ result: { deleted: [], cursor: { next: null } } })
+			.mockRejectedValueOnce(new Error('network error'));
+
+		await expect(loadMissedMessages({ rid, lastOpen })).rejects.toThrow('network error');
+		expect(updateMessages).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not recurse when there are no more pages', async () => {
+		const page1 = {
+			updated: [{ _id: 'm1', rid, msg: 'hello' }],
+			deleted: [],
+			cursor: { next: null }
+		};
+		mockSdkGet
+			.mockResolvedValueOnce({ result: page1 })
+			.mockResolvedValueOnce({ result: { deleted: [], cursor: { next: null } } });
+
+		await loadMissedMessages({ rid, lastOpen });
+
+		expect(updateMessages).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/lib/methods/loadMissedMessages.ts
+++ b/app/lib/methods/loadMissedMessages.ts
@@ -109,7 +109,7 @@ export async function loadMissedMessages(args: {
 		await updateMessages({ rid: args.rid, update: updated, remove: deleted });
 
 		if (deletedNext || updatedNext) {
-			loadMissedMessages({
+			await loadMissedMessages({
 				rid: args.rid,
 				lastOpen: args.lastOpen,
 				updatedNext,

--- a/app/lib/methods/loadThreadMessages.ts
+++ b/app/lib/methods/loadThreadMessages.ts
@@ -52,7 +52,6 @@ export function loadThreadMessages({ tmid, rid }: { tmid: string; rid: string })
 								if (threadMessage.tmid) {
 									tm.rid = threadMessage.tmid;
 								}
-								delete threadMessage.tmid;
 							})
 						)
 					);
@@ -67,7 +66,6 @@ export function loadThreadMessages({ tmid, rid }: { tmid: string; rid: string })
 								if (threadMessage.tmid) {
 									tm.rid = threadMessage.tmid;
 								}
-								delete threadMessage.tmid;
 							})
 						);
 					});

--- a/app/lib/methods/updateMessages.ts
+++ b/app/lib/methods/updateMessages.ts
@@ -135,7 +135,6 @@ export default async function updateMessages({
 					if (threadMessage.tmid) {
 						tm.rid = threadMessage.tmid;
 					}
-					delete threadMessage.tmid;
 				})
 			)
 		);
@@ -193,7 +192,6 @@ export default async function updateMessages({
 						if (threadMessage.tmid) {
 							tm.rid = threadMessage.tmid;
 						}
-						delete threadMessage.tmid;
 					})
 				);
 			} catch {


### PR DESCRIPTION
## Proposed changes

Fixes three bugs that cause messages to arrive as push notifications but silently fail to appear in the chat view.

### 1. `Encryption.decryptMessages` — `Promise.all` kills entire `db.write` batch (E2E rooms)

`Promise.all` causes the entire `db.write()` callback to reject when any single message decryption throws. `Promise.allSettled` prevents one bad message from aborting the entire batch.

### 2. `loadMissedMessages` — fire-and-forget recursive pagination

The recursive call to load the next page was not awaited. If page 2+ fails (network timeout, server error), all subsequent messages are silently lost. Adding `await` ensures pages sequence correctly.

### 3. `updateMessages` / `loadThreadMessages` — `delete threadMessage.tmid` corrupts input

The mutation runs before the `msgsToCreate`/`msgsToUpdate` closures execute during `db.batch()`, corrupting the original `update` array and thread-message update closures.

## How to test or reproduce

1. Enable E2E encryption. Send multiple messages — one failed decryption no longer aborts all writes.
2. Have >50 unread messages, open via notification — all appear instead of only the first 50.
3. Thread replies no longer corrupt the update array.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
