### PR TITLE
fix: silent message loss and sync race after reconnect

### DIFF
--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -58,6 +58,7 @@ jest.mock('../database', () => ({
 }));
 
 const mockRoomEncrypt = jest.fn();
+const mockRoomDecrypt = jest.fn();
 const mockHasSessionKey = jest.fn();
 const mockHandshake = jest.fn().mockResolvedValue(undefined);
 jest.mock('./room', () => ({
@@ -65,7 +66,8 @@ jest.mock('./room', () => ({
 	default: jest.fn().mockImplementation(() => ({
 		handshake: mockHandshake,
 		hasSessionKey: () => mockHasSessionKey(),
-		encrypt: (m: any) => mockRoomEncrypt(m)
+		encrypt: (m: any) => mockRoomEncrypt(m),
+		decrypt: (m: any) => mockRoomDecrypt(m)
 	}))
 }));
 
@@ -148,17 +150,18 @@ describe('Encryption.encryptMessage', () => {
 		});
 
 		it('returns successfully decrypted messages when one fails (was Promise.all that aborted the batch)', async () => {
-			const good = { _id: 'm1', rid: 'r1', msg: 'good' } as any;
+			const good = { _id: 'm1', rid: 'r1', msg: 'good', t: 'e2e' } as any;
 			const bad = { _id: 'm2', rid: 'r2', msg: 'bad', t: 'e2e' } as any;
 			mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
 			mockHasSessionKey.mockReturnValue(true);
-			mockRoomEncrypt.mockResolvedValueOnce({ ...good, msg: 'decrypted' });
-			mockRoomEncrypt.mockRejectedValueOnce(new Error('decrypt failed'));
+			mockRoomDecrypt.mockResolvedValueOnce({ ...good, msg: 'decrypted' });
+			mockRoomDecrypt.mockRejectedValueOnce(new Error('decrypt failed'));
 			// getRoomInstance creates a new EncryptionRoom for each rid via the mock
 			mockSubFind.mockResolvedValue({ encrypted: true });
 
 			const result = await encryption.decryptMessages([good, bad]);
 
+			expect(mockRoomDecrypt).toHaveBeenCalledTimes(2);
 			expect(result).toHaveLength(1);
 			expect(result[0]._id).toBe('m1');
 		});
@@ -170,11 +173,12 @@ describe('Encryption.encryptMessage', () => {
 			] as any;
 			mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
 			mockHasSessionKey.mockReturnValue(true);
-			mockRoomEncrypt.mockRejectedValue(new Error('decrypt failed'));
+			mockRoomDecrypt.mockRejectedValue(new Error('decrypt failed'));
 			mockSubFind.mockResolvedValue({ encrypted: true });
 
 			const result = await encryption.decryptMessages(msgs);
 
+			expect(mockRoomDecrypt).toHaveBeenCalledTimes(2);
 			expect(result).toEqual([]);
 		});
 
@@ -187,7 +191,7 @@ describe('Encryption.encryptMessage', () => {
 			const result = await encryption.decryptMessages(msgs);
 
 			expect(result).toHaveLength(2);
-			expect(mockRoomEncrypt).not.toHaveBeenCalled();
+			expect(mockRoomDecrypt).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -164,6 +164,7 @@ describe('Encryption.encryptMessage', () => {
 			expect(mockRoomDecrypt).toHaveBeenCalledTimes(2);
 			expect(result).toHaveLength(1);
 			expect(result[0]._id).toBe('m1');
+			expect(result[0].msg).toBe('decrypted');
 		});
 
 		it('returns empty array when ALL messages fail decryption (does not throw)', async () => {

--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -140,4 +140,54 @@ describe('Encryption.encryptMessage', () => {
 		expect(result).toBe(baseMessage);
 		expect(mockRoomEncrypt).not.toHaveBeenCalled();
 	});
+
+	describe('decryptMessages', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+			(encryption as any).roomInstances = {};
+		});
+
+		it('returns successfully decrypted messages when one fails (was Promise.all that aborted the batch)', async () => {
+			const good = { _id: 'm1', rid: 'r1', msg: 'good' } as any;
+			const bad = { _id: 'm2', rid: 'r2', msg: 'bad', t: 'e2e' } as any;
+			mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+			mockHasSessionKey.mockReturnValue(true);
+			mockRoomEncrypt.mockResolvedValueOnce({ ...good, msg: 'decrypted' });
+			mockRoomEncrypt.mockRejectedValueOnce(new Error('decrypt failed'));
+			// getRoomInstance creates a new EncryptionRoom for each rid via the mock
+			mockSubFind.mockResolvedValue({ encrypted: true });
+
+			const result = await encryption.decryptMessages([good, bad]);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]._id).toBe('m1');
+		});
+
+		it('returns empty array when ALL messages fail decryption (does not throw)', async () => {
+			const msgs = [
+				{ _id: 'm1', rid: 'r1', msg: 'bad1', t: 'e2e' },
+				{ _id: 'm2', rid: 'r2', msg: 'bad2', t: 'e2e' }
+			] as any;
+			mockGetState.mockReturnValue({ settings: { E2E_Enable: true } });
+			mockHasSessionKey.mockReturnValue(true);
+			mockRoomEncrypt.mockRejectedValue(new Error('decrypt failed'));
+			mockSubFind.mockResolvedValue({ encrypted: true });
+
+			const result = await encryption.decryptMessages(msgs);
+
+			expect(result).toEqual([]);
+		});
+
+		it('returns all messages unchanged for non-E2E room (short-circuits decryptMessage)', async () => {
+			const msgs = [
+				{ _id: 'm1', rid: 'r1', msg: 'hello' },
+				{ _id: 'm2', rid: 'r2', msg: 'world' }
+			] as any;
+
+			const result = await encryption.decryptMessages(msgs);
+
+			expect(result).toHaveLength(2);
+			expect(mockRoomEncrypt).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/app/lib/encryption/encryption.ts
+++ b/app/lib/encryption/encryption.ts
@@ -649,9 +649,9 @@ class Encryption {
 	}
 
 	// Decrypt multiple messages
-	decryptMessages = async (messages: Partial<IMessage>[]) => {
+	decryptMessages = async (messages: Partial<IMessage>[]): Promise<IMessage[]> => {
 		const results = await Promise.allSettled(messages.map((m: Partial<IMessage>) => this.decryptMessage(m as IMessage)));
-		return results.filter(r => r.status === 'fulfilled').map(r => (r as PromiseFulfilledResult<IMessage>).value);
+		return results.filter((r): r is PromiseFulfilledResult<IMessage> => r.status === 'fulfilled').map(r => r.value);
 	};
 
 	// Decrypt multiple subscriptions

--- a/app/lib/encryption/encryption.ts
+++ b/app/lib/encryption/encryption.ts
@@ -649,8 +649,10 @@ class Encryption {
 	}
 
 	// Decrypt multiple messages
-	decryptMessages = (messages: Partial<IMessage>[]) =>
-		Promise.all(messages.map((m: Partial<IMessage>) => this.decryptMessage(m as IMessage)));
+	decryptMessages = async (messages: Partial<IMessage>[]) => {
+		const results = await Promise.allSettled(messages.map((m: Partial<IMessage>) => this.decryptMessage(m as IMessage)));
+		return results.filter(r => r.status === 'fulfilled').map(r => (r as PromiseFulfilledResult<IMessage>).value);
+	};
 
 	// Decrypt multiple subscriptions
 	decryptSubscriptions = (subscriptions: ISubscription[]) => {

--- a/app/lib/methods/loadMissedMessages.test.ts
+++ b/app/lib/methods/loadMissedMessages.test.ts
@@ -31,7 +31,7 @@ jest.mock('../services/sdk', () => ({
 	}
 }));
 
-const flush = () => new Promise(resolve => setImmediate(resolve));
+const flushPendingMicrotasks = (): Promise<void> => new Promise(resolve => setImmediate(resolve));
 
 describe('loadMissedMessages pagination', () => {
 	beforeEach(() => {
@@ -58,7 +58,7 @@ describe('loadMissedMessages pagination', () => {
 		});
 
 		const promise = loadMissedMessages({ rid: 'room1' });
-		await flush();
+		await flushPendingMicrotasks();
 
 		// page 1 has landed and been persisted; page 2's fetch is in flight
 		expect(mockUpdateMessages).toHaveBeenCalledTimes(1);
@@ -68,7 +68,7 @@ describe('loadMissedMessages pagination', () => {
 		promise.then(() => {
 			settled = true;
 		});
-		await flush();
+		await flushPendingMicrotasks();
 		expect(settled).toBe(false);
 
 		resolvePage2({ result: { updated: [{ _id: 'm2' }], cursor: { next: null } } });

--- a/app/lib/methods/loadMissedMessages.test.ts
+++ b/app/lib/methods/loadMissedMessages.test.ts
@@ -1,0 +1,110 @@
+import { loadMissedMessages } from './loadMissedMessages';
+
+const mockUpdateMessages = jest.fn<Promise<number>, [unknown]>(() => Promise.resolve(0));
+jest.mock('./updateMessages', () => ({
+	__esModule: true,
+	default: (args: unknown) => mockUpdateMessages(args)
+}));
+
+const mockGetSubscriptionByRoomId = jest.fn<Promise<{ lastOpen: Date }>, [string]>(() =>
+	Promise.resolve({ lastOpen: new Date('2024-01-01T00:00:00.000Z') })
+);
+jest.mock('../database/services/Subscription', () => ({
+	getSubscriptionByRoomId: (rid: string) => mockGetSubscriptionByRoomId(rid)
+}));
+
+jest.mock('./helpers', () => ({
+	compareServerVersion: jest.fn(() => true)
+}));
+
+jest.mock('../store/auxStore', () => ({
+	store: {
+		getState: () => ({ server: { version: '7.1.0' } })
+	}
+}));
+
+const mockSdkGet = jest.fn();
+jest.mock('../services/sdk', () => ({
+	__esModule: true,
+	default: {
+		get: (...args: unknown[]) => mockSdkGet(...args)
+	}
+}));
+
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+describe('loadMissedMessages pagination', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('does not resolve until every recursive page has been fetched and persisted', async () => {
+		let resolvePage2: (value: unknown) => void = () => {};
+		const page2Promise = new Promise(resolve => {
+			resolvePage2 = resolve;
+		});
+
+		mockSdkGet.mockImplementation((_endpoint: string, params: { type: 'UPDATED' | 'DELETED'; next: number }) => {
+			if (params.type === 'UPDATED' && params.next !== 999) {
+				// page 1 - UPDATED: reports more pages via cursor.next
+				return Promise.resolve({ result: { updated: [{ _id: 'm1' }], cursor: { next: 999 } } });
+			}
+			if (params.type === 'DELETED') {
+				// page 1 - DELETED: nothing more to fetch
+				return Promise.resolve({ result: { deleted: [], cursor: { next: null } } });
+			}
+			// page 2 - UPDATED (next: 999): deferred, held open by the test
+			return page2Promise;
+		});
+
+		const promise = loadMissedMessages({ rid: 'room1' });
+		await flush();
+
+		// page 1 has landed and been persisted; page 2's fetch is in flight
+		expect(mockUpdateMessages).toHaveBeenCalledTimes(1);
+		expect(mockUpdateMessages).toHaveBeenCalledWith({ rid: 'room1', update: [{ _id: 'm1' }], remove: [] });
+
+		let settled = false;
+		promise.then(() => {
+			settled = true;
+		});
+		await flush();
+		expect(settled).toBe(false);
+
+		resolvePage2({ result: { updated: [{ _id: 'm2' }], cursor: { next: null } } });
+		await promise;
+
+		expect(settled).toBe(true);
+		expect(mockUpdateMessages).toHaveBeenCalledTimes(2);
+		expect(mockUpdateMessages).toHaveBeenLastCalledWith({ rid: 'room1', update: [{ _id: 'm2' }], remove: [] });
+	});
+
+	it('walks a 3-page cursor chain in order and terminates once cursor.next is null', async () => {
+		const responses = [
+			{ result: { updated: [{ _id: 'm1' }], cursor: { next: 200 } } }, // page 1 - UPDATED
+			{ result: { deleted: [], cursor: { next: null } } }, // page 1 - DELETED
+			{ result: { updated: [{ _id: 'm2' }], cursor: { next: 300 } } }, // page 2 - UPDATED
+			{ result: { updated: [{ _id: 'm3' }], cursor: { next: null } } } // page 3 - UPDATED
+		];
+		let callIndex = 0;
+		mockSdkGet.mockImplementation(() => Promise.resolve(responses[callIndex++]));
+
+		await loadMissedMessages({ rid: 'room1' });
+
+		expect(mockSdkGet).toHaveBeenCalledTimes(4);
+		expect(mockUpdateMessages).toHaveBeenCalledTimes(3);
+		expect(mockUpdateMessages).toHaveBeenNthCalledWith(1, { rid: 'room1', update: [{ _id: 'm1' }], remove: [] });
+		expect(mockUpdateMessages).toHaveBeenNthCalledWith(2, { rid: 'room1', update: [{ _id: 'm2' }], remove: [] });
+		expect(mockUpdateMessages).toHaveBeenNthCalledWith(3, { rid: 'room1', update: [{ _id: 'm3' }], remove: [] });
+	});
+
+	it('propagates a rejection from any page to the caller instead of swallowing it', async () => {
+		mockSdkGet
+			.mockResolvedValueOnce({ result: { updated: [{ _id: 'm1' }], cursor: { next: 200 } } }) // page 1 - UPDATED
+			.mockResolvedValueOnce({ result: { deleted: [], cursor: { next: null } } }) // page 1 - DELETED
+			.mockRejectedValueOnce(new Error('network drop')); // page 2 - UPDATED
+
+		await expect(loadMissedMessages({ rid: 'room1' })).rejects.toThrow('network drop');
+		expect(mockUpdateMessages).toHaveBeenCalledTimes(1);
+	});
+});

--- a/app/lib/methods/loadMissedMessages.ts
+++ b/app/lib/methods/loadMissedMessages.ts
@@ -109,7 +109,7 @@ export async function loadMissedMessages(args: {
 		await updateMessages({ rid: args.rid, update: updated, remove: deleted });
 
 		if (deletedNext || updatedNext) {
-			loadMissedMessages({
+			await loadMissedMessages({
 				rid: args.rid,
 				lastOpen: args.lastOpen,
 				updatedNext,

--- a/app/lib/methods/loadThreadMessages.ts
+++ b/app/lib/methods/loadThreadMessages.ts
@@ -52,7 +52,6 @@ export function loadThreadMessages({ tmid, rid }: { tmid: string; rid: string })
 								if (threadMessage.tmid) {
 									tm.rid = threadMessage.tmid;
 								}
-								delete threadMessage.tmid;
 							})
 						)
 					);
@@ -67,7 +66,6 @@ export function loadThreadMessages({ tmid, rid }: { tmid: string; rid: string })
 								if (threadMessage.tmid) {
 									tm.rid = threadMessage.tmid;
 								}
-								delete threadMessage.tmid;
 							})
 						);
 					});

--- a/app/lib/methods/subscriptions/room.test.ts
+++ b/app/lib/methods/subscriptions/room.test.ts
@@ -126,7 +126,7 @@ jest.mock('../../database/services/ThreadMessage', () => ({
 	getThreadMessageById: jest.fn()
 }));
 
-const flush = () => new Promise(resolve => setImmediate(resolve));
+const flushPendingMicrotasks = (): Promise<void> => new Promise(resolve => setImmediate(resolve));
 
 describe('RoomSubscription', () => {
 	const rid = 'test-room-id';
@@ -308,7 +308,7 @@ describe('RoomSubscription', () => {
 			// User opens the room; reconnect fires the login event and the missed-message sync starts.
 			await sub.subscribe();
 			const loginPromise = sub.handleLogin();
-			await flush(); // let handleLogin reach the loadMissedMessages await and register it as pending
+			await flushPendingMicrotasks(); // let handleLogin reach the loadMissedMessages await and register it as pending
 
 			// User presses back before the sync resolves -> RoomView unmount calls unsubscribe().
 			let unsubSettled = false;
@@ -317,9 +317,9 @@ describe('RoomSubscription', () => {
 			});
 
 			// Give unsubscribe every chance to run ahead if it (wrongly) didn't wait on the sync.
-			await flush();
-			await flush();
-			await flush();
+			await flushPendingMicrotasks();
+			await flushPendingMicrotasks();
+			await flushPendingMicrotasks();
 			expect(unsubSettled).toBe(false);
 			expect(updateLastOpen).not.toHaveBeenCalled();
 
@@ -342,7 +342,7 @@ describe('RoomSubscription', () => {
 
 			await sub.subscribe();
 			const loginPromise = sub.handleLogin();
-			await flush();
+			await flushPendingMicrotasks();
 
 			const unsubPromise = sub.unsubscribe();
 			rejectSync(new Error('network drop'));
@@ -372,16 +372,16 @@ describe('RoomSubscription', () => {
 
 			await sub.subscribe();
 			const firstLogin = sub.handleLogin();
-			await flush();
+			await flushPendingMicrotasks();
 			const secondLogin = sub.handleLogin();
-			await flush();
+			await flushPendingMicrotasks();
 
 			// The first sync settling must not clear tracking for the still-pending second one.
 			resolveFirst();
 			await firstLogin;
 
 			const unsubPromise = sub.unsubscribe();
-			await flush();
+			await flushPendingMicrotasks();
 			expect(updateLastOpen).not.toHaveBeenCalled();
 
 			resolveSecond();

--- a/app/lib/methods/subscriptions/room.test.ts
+++ b/app/lib/methods/subscriptions/room.test.ts
@@ -1,6 +1,8 @@
 import RoomSubscription from './room';
 import { loadMissedMessages } from '../loadMissedMessages';
+import { updateLastOpen } from '../updateLastOpen';
 import { clearUserTyping } from '../../../actions/usersTyping';
+import { unsubscribeRoom } from '../../../actions/room';
 import { getMessageById } from '../../database/services/Message';
 import { getThreadById } from '../../database/services/Thread';
 import log from '../helpers/log';
@@ -123,6 +125,8 @@ jest.mock('../../database/services/Thread', () => ({
 jest.mock('../../database/services/ThreadMessage', () => ({
 	getThreadMessageById: jest.fn()
 }));
+
+const flush = () => new Promise(resolve => setImmediate(resolve));
 
 describe('RoomSubscription', () => {
 	const rid = 'test-room-id';
@@ -281,6 +285,110 @@ describe('RoomSubscription', () => {
 			await sub.handleLogin();
 
 			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
+		});
+	});
+
+	describe('unsubscribe', () => {
+		it('calls updateLastOpen immediately when there is no pending sync', async () => {
+			await sub.subscribe();
+
+			await sub.unsubscribe();
+
+			expect(updateLastOpen).toHaveBeenCalledWith(rid);
+		});
+
+		it('user opens the room (sync starts), presses back mid-sync: unsubscribe itself stays pending until the sync settles, then calls updateLastOpen', async () => {
+			let resolveSync: () => void = () => {};
+			(loadMissedMessages as jest.Mock).mockReturnValueOnce(
+				new Promise<void>(resolve => {
+					resolveSync = resolve;
+				})
+			);
+
+			// User opens the room; reconnect fires the login event and the missed-message sync starts.
+			await sub.subscribe();
+			const loginPromise = sub.handleLogin();
+			await flush(); // let handleLogin reach the loadMissedMessages await and register it as pending
+
+			// User presses back before the sync resolves -> RoomView unmount calls unsubscribe().
+			let unsubSettled = false;
+			const unsubPromise = sub.unsubscribe().then(() => {
+				unsubSettled = true;
+			});
+
+			// Give unsubscribe every chance to run ahead if it (wrongly) didn't wait on the sync.
+			await flush();
+			await flush();
+			await flush();
+			expect(unsubSettled).toBe(false);
+			expect(updateLastOpen).not.toHaveBeenCalled();
+
+			// Only once the in-flight sync actually completes does unsubscribe unblock and write lastOpen.
+			resolveSync();
+			await loginPromise;
+			await unsubPromise;
+
+			expect(unsubSettled).toBe(true);
+			expect(updateLastOpen).toHaveBeenCalledWith(rid);
+		});
+
+		it('does not call updateLastOpen when the pending sync rejects, but still completes cleanup', async () => {
+			let rejectSync: (e: Error) => void = () => {};
+			(loadMissedMessages as jest.Mock).mockReturnValueOnce(
+				new Promise<void>((_, reject) => {
+					rejectSync = reject;
+				})
+			);
+
+			await sub.subscribe();
+			const loginPromise = sub.handleLogin();
+			await flush();
+
+			const unsubPromise = sub.unsubscribe();
+			rejectSync(new Error('network drop'));
+			await loginPromise;
+			await unsubPromise;
+
+			expect(updateLastOpen).not.toHaveBeenCalled();
+			expect(log).toHaveBeenCalled();
+			expect(mockStoreDispatch).toHaveBeenCalledWith(unsubscribeRoom(rid));
+			expect(mockStoreDispatch).toHaveBeenCalledWith(clearUserTyping());
+		});
+
+		it('when a second reconnect starts a new sync before the first settles, unsubscribe waits on the most recent one', async () => {
+			let resolveFirst: () => void = () => {};
+			let resolveSecond: () => void = () => {};
+			(loadMissedMessages as jest.Mock)
+				.mockReturnValueOnce(
+					new Promise<void>(resolve => {
+						resolveFirst = resolve;
+					})
+				)
+				.mockReturnValueOnce(
+					new Promise<void>(resolve => {
+						resolveSecond = resolve;
+					})
+				);
+
+			await sub.subscribe();
+			const firstLogin = sub.handleLogin();
+			await flush();
+			const secondLogin = sub.handleLogin();
+			await flush();
+
+			// The first sync settling must not clear tracking for the still-pending second one.
+			resolveFirst();
+			await firstLogin;
+
+			const unsubPromise = sub.unsubscribe();
+			await flush();
+			expect(updateLastOpen).not.toHaveBeenCalled();
+
+			resolveSecond();
+			await secondLogin;
+			await unsubPromise;
+
+			expect(updateLastOpen).toHaveBeenCalledWith(rid);
 		});
 	});
 

--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -38,6 +38,7 @@ export default class RoomSubscription {
 	private disconnectedListener?: Promise<any>;
 	private notifyRoomListener?: Promise<any>;
 	private messageReceivedListener?: Promise<any>;
+	private pendingSync?: Promise<void>;
 
 	constructor(rid: string) {
 		this.rid = rid;
@@ -64,9 +65,22 @@ export default class RoomSubscription {
 
 	unsubscribe = async () => {
 		console.log(`[RCRN] Unsubscribing from room ${this.rid}`);
-		updateLastOpen(this.rid);
+		const { pendingSync } = this;
 		this.isAlive = false;
 		reduxStore.dispatch(unsubscribeRoom(this.rid));
+
+		let syncFailed = false;
+		if (pendingSync) {
+			try {
+				await pendingSync;
+			} catch (e) {
+				syncFailed = true;
+			}
+		}
+		if (!syncFailed) {
+			updateLastOpen(this.rid);
+		}
+
 		if (this.promises) {
 			try {
 				const subscriptions = (await this.promises) || [];
@@ -108,7 +122,15 @@ export default class RoomSubscription {
 				return;
 			}
 			reduxStore.dispatch(clearUserTyping());
-			await loadMissedMessages({ rid: this.rid });
+			const syncPromise = loadMissedMessages({ rid: this.rid });
+			this.pendingSync = syncPromise;
+			try {
+				await syncPromise;
+			} finally {
+				if (this.pendingSync === syncPromise) {
+					this.pendingSync = undefined;
+				}
+			}
 			if (!this.isAlive) {
 				return;
 			}

--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -78,7 +78,7 @@ export default class RoomSubscription {
 			}
 		}
 		if (!syncFailed) {
-			updateLastOpen(this.rid);
+			await updateLastOpen(this.rid);
 		}
 
 		if (this.promises) {

--- a/app/lib/methods/updateMessages.ts
+++ b/app/lib/methods/updateMessages.ts
@@ -135,7 +135,6 @@ export default async function updateMessages({
 					if (threadMessage.tmid) {
 						tm.rid = threadMessage.tmid;
 					}
-					delete threadMessage.tmid;
 				})
 			)
 		);
@@ -193,7 +192,6 @@ export default async function updateMessages({
 						if (threadMessage.tmid) {
 							tm.rid = threadMessage.tmid;
 						}
-						delete threadMessage.tmid;
 					})
 				);
 			} catch {


### PR DESCRIPTION
## Proposed changes

Fixes four bugs that cause messages to arrive as push notifications but silently fail to appear in the chat view.

### 1. `Encryption.decryptMessages` — `Promise.all` kills entire `db.write` batch (E2E rooms)

`Promise.all` causes the entire `db.write()` callback to reject when any single message decryption throws. `Promise.allSettled` prevents one bad message from aborting the entire batch.

### 2. `loadMissedMessages` — fire-and-forget recursive pagination

The recursive call to load the next page was not awaited. If page 2+ fails (network timeout, server error), all subsequent messages are silently lost. Adding `await` ensures pages sequence correctly and rejections propagate.

### 3. `updateMessages` / `loadThreadMessages` — `delete threadMessage.tmid` corrupts input

The mutation ran before the `msgsToCreate`/`msgsToUpdate` closures executed during `db.batch()`, corrupting the original `update` array and thread-message update closures.

### 4. `RoomSubscription.unsubscribe` — writes `lastOpen` while a sync is still in flight or has failed

When a notification/background-tap opens a room while the socket is reconnecting, `handleLogin` starts an `await loadMissedMessages(...)` call. If the user presses back before it resolves, `unsubscribe()` used to call `updateLastOpen` immediately and unconditionally, advancing the sync cursor to "now" regardless of whether the fetch that was supposed to cover the gap actually completed. The next time the room opens, that gap is permanently skipped.

`unsubscribe` now tracks the in-flight sync (`pendingSync`) and waits for it before writing `lastOpen` — and skips the write entirely if the sync rejected, so the next open retries the same gap (message upsert is already idempotent, so re-fetching overlap is safe).

## Issue(s)

## How to test or reproduce

1. Enable E2E encryption. Send multiple messages — one failed decryption no longer aborts all writes.
2. Have >50 unread messages, open via notification — all pages of missed messages appear instead of only the first page.
3. Thread replies no longer corrupt the update array.
4. Invite to a room → disable network → send messages from another client → reconnect → press back before sync completes → reopen the room → previously-skipped messages now appear.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when decrypting message batches, preserving successfully decrypted messages even if others fail.
  * Ensured missed-message synchronization completes across all pages before loading finishes.
  * Improved subscription cleanup and last-open tracking during reconnects and synchronization failures.
  * Preserved thread message references during message creation and updates.
* **Tests**
  * Added coverage for partial decryption, paginated message loading, synchronization failures, and unsubscribe timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->