### PR TITLE
fix: don't stamp lastOpen on room unsubscribe while missed messages are unfetched

### DIFF
--- a/app/lib/methods/subscriptions/room.test.ts
+++ b/app/lib/methods/subscriptions/room.test.ts
@@ -1,5 +1,6 @@
 import RoomSubscription from './room';
 import { loadMissedMessages } from '../loadMissedMessages';
+import { updateLastOpen } from '../updateLastOpen';
 import { clearUserTyping } from '../../../actions/usersTyping';
 import { getMessageById } from '../../database/services/Message';
 import { getThreadById } from '../../database/services/Thread';
@@ -281,6 +282,65 @@ describe('RoomSubscription', () => {
 			await sub.handleLogin();
 
 			expect(mockSubscribeRoom).toHaveBeenCalledWith(rid);
+		});
+	});
+
+	describe('lastOpen stamp on unsubscribe', () => {
+		const flushMicrotasks = () => new Promise(resolve => setImmediate(resolve));
+
+		it('stamps lastOpen when the room closes with no reconnect gap', async () => {
+			await sub.subscribe();
+			await sub.unsubscribe();
+
+			expect(updateLastOpen).toHaveBeenCalledWith(rid);
+		});
+
+		it('stamps lastOpen when the reconnect gap fetch completed before closing', async () => {
+			await sub.subscribe();
+			await sub.handleLogin();
+			await sub.unsubscribe();
+
+			expect(updateLastOpen).toHaveBeenCalledWith(rid);
+		});
+
+		it('does not stamp lastOpen while the reconnect gap fetch is still in flight', async () => {
+			let resolveLoad!: () => void;
+			(loadMissedMessages as jest.Mock).mockImplementationOnce(
+				() =>
+					new Promise<void>(resolve => {
+						resolveLoad = resolve;
+					})
+			);
+
+			await sub.subscribe();
+			const login = sub.handleLogin();
+			await flushMicrotasks();
+			expect(loadMissedMessages).toHaveBeenCalledWith({ rid });
+
+			await sub.unsubscribe();
+
+			expect(updateLastOpen).not.toHaveBeenCalled();
+
+			resolveLoad();
+			await login;
+		});
+
+		it('does not stamp lastOpen when the reconnect gap fetch failed', async () => {
+			(loadMissedMessages as jest.Mock).mockRejectedValueOnce(new Error('network drop'));
+
+			await sub.subscribe();
+			await sub.handleLogin();
+			await sub.unsubscribe();
+
+			expect(updateLastOpen).not.toHaveBeenCalled();
+		});
+
+		it('does not stamp lastOpen when closing after a disconnect with no reconnect', async () => {
+			await sub.subscribe();
+			await sub.handleClose();
+			await sub.unsubscribe();
+
+			expect(updateLastOpen).not.toHaveBeenCalled();
 		});
 	});
 

--- a/app/lib/methods/subscriptions/room.ts
+++ b/app/lib/methods/subscriptions/room.ts
@@ -33,6 +33,10 @@ import markMessagesRead from '../helpers/markMessagesRead';
 export default class RoomSubscription {
 	private rid: string;
 	private isAlive: boolean;
+	// True while messages may be missing locally (disconnect happened and the
+	// missed-messages fetch hasn't succeeded yet). Blocks the lastOpen stamp on
+	// unsubscribe, since stamping "now" would skip the gap on the next sync.
+	private hasMissedMessagesGap: boolean;
 	private promises?: Promise<TSubscriptionModel[]>;
 	private loginListener?: Promise<any>;
 	private disconnectedListener?: Promise<any>;
@@ -42,6 +46,7 @@ export default class RoomSubscription {
 	constructor(rid: string) {
 		this.rid = rid;
 		this.isAlive = true;
+		this.hasMissedMessagesGap = false;
 	}
 
 	subscribe = async () => {
@@ -64,7 +69,9 @@ export default class RoomSubscription {
 
 	unsubscribe = async () => {
 		console.log(`[RCRN] Unsubscribing from room ${this.rid}`);
-		updateLastOpen(this.rid);
+		if (!this.hasMissedMessagesGap) {
+			updateLastOpen(this.rid);
+		}
 		this.isAlive = false;
 		reduxStore.dispatch(unsubscribeRoom(this.rid));
 		if (this.promises) {
@@ -97,6 +104,7 @@ export default class RoomSubscription {
 		if (!this.isAlive) {
 			return;
 		}
+		this.hasMissedMessagesGap = true;
 		try {
 			if (this.promises) {
 				const oldSubs = await this.promises;
@@ -109,6 +117,7 @@ export default class RoomSubscription {
 			}
 			reduxStore.dispatch(clearUserTyping());
 			await loadMissedMessages({ rid: this.rid });
+			this.hasMissedMessagesGap = false;
 			if (!this.isAlive) {
 				return;
 			}
@@ -119,6 +128,7 @@ export default class RoomSubscription {
 	};
 
 	handleClose = () => {
+		this.hasMissedMessagesGap = true;
 		try {
 			reduxStore.dispatch(clearUserTyping());
 		} catch (e) {


### PR DESCRIPTION
## Proposed changes

`subscription.lastOpen` is the cursor used to fetch messages a device missed while offline. Leaving a room (`RoomSubscription.unsubscribe`) stamped `lastOpen` to "now" unconditionally. If the user left the room while the reconnect flow (`handleLogin` → `loadMissedMessages`) was still fetching the offline gap — or after a disconnect where the fetch failed outright — the cursor jumped past messages that were never downloaded. Those messages became permanently invisible on that device: the next sync started from the new cursor and never requested the gap again.

`RoomSubscription` now tracks a `hasMissedMessagesGap` flag: set when the connection drops (`handleClose`) and when `handleLogin` starts, cleared only after `loadMissedMessages` succeeds. `unsubscribe` skips the `lastOpen` stamp while the flag is set, keeping the cursor at the last fully-synced point so the next room open heals the gap. The normal path (no gap) stamps exactly as before.

Verified on an Android emulator with a throttled network: backing out of the room mid-reconnect left `lastOpen` untouched (read directly from SQLite), reopening the room fetched the entire gap, and a subsequent clean back-out stamped normally again.

## Issue(s)

- https://rocketchat.atlassian.net/browse/SUP-1071
- #7499

## How to test or reproduce

1. Log in and open a channel, then enable airplane mode.
2. Send a few messages to that channel from another client/user.
3. Disable airplane mode and press back to leave the room while the header still shows Connecting/Waiting for network (before the missed messages arrive).
4. Reopen the room: all messages sent while offline must be present, with no permanent hole. Before this fix, the messages sent during the offline window never appeared on the device.

Unit tests: `pnpm test --testPathPattern='subscriptions/room'` covers the stamp being skipped while a gap is open (disconnect and in-flight fetch), stamping resuming after a successful fetch, and the unchanged clean path.

## Screenshots

Screen recording of the on-device verification available on request (165s emulator capture: gap created offline → back-press mid-reconnect → reopen shows the full gap healed).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The fix is deliberately scoped to the unsubscribe stamp — the smallest change that stops the cursor from skipping unfetched messages. `lastOpen` is also written by the read-messages path on room open; that write is gap-safe today (it stamps the open time, and the gap is fetched on open), but having two writers for one sync cursor is worth a follow-up discussion on #7499.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room activity tracking during reconnects.
  - Prevented the “last open” timestamp from advancing while missed messages are still being recovered or recovery fails.
  - Ensured timestamps update correctly when closing a room without an unresolved message gap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->