### PR TITLE
fix: UserPreferences.getBool not parsing JSON-string booleans

### DIFF
--- a/app/lib/methods/userPreferences.test.ts
+++ b/app/lib/methods/userPreferences.test.ts
@@ -8,6 +8,13 @@ describe('UserPreferences', () => {
 		expect(userPreferences.getBool('k')).toBe(false);
 	});
 
+	it('getBool parses JSON-string stored boolean', () => {
+		userPreferences.setString('k', JSON.stringify(false));
+		expect(userPreferences.getBool('k')).toBe(false);
+		userPreferences.setString('k', JSON.stringify(true));
+		expect(userPreferences.getBool('k')).toBe(true);
+	});
+
 	it('getBool returns null for unset key', () => {
 		expect(userPreferences.getBool('missing')).toBeNull();
 	});

--- a/app/lib/methods/userPreferences.ts
+++ b/app/lib/methods/userPreferences.ts
@@ -106,6 +106,14 @@ class UserPreferences {
 
 	getBool(key: string): boolean | null {
 		try {
+			const str = this.mmkv.getString(key);
+			if (str !== undefined) {
+				try {
+					return JSON.parse(str);
+				} catch {
+					return null;
+				}
+			}
 			return this.mmkv.getBoolean(key) ?? null;
 		} catch {
 			return null;


### PR DESCRIPTION
## Proposed changes

Fix `getBool` in `UserPreferences` to correctly read booleans stored as JSON strings by `useUserPreferences<boolean>`. Previously, `getBool` only used native MMKV `getBoolean`, which couldn't parse `"false"` (stored as a JSON string) and would return `null`/`undefined`. The fallback now tries `getString` + `JSON.parse` first, then falls back to native `getBoolean`.

This caused the haptic feedback on reconnect (from `RoomView.hapticFeedback`) to ignore `NOTIFICATION_IN_APP_VIBRATION` toggle — vibration played for every pending message replayed on DDP reconnect even when the toggle was off.

## Issue(s)

## How to test or reproduce

1. Go to Settings → Notifications → disable "Vibrate from new messages"
2. Disconnect from network (airplane mode)
3. Reconnect — observe no vibration for replayed messages

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boolean preference handling so values stored as JSON strings are correctly interpreted as `true` or `false`.
  * Invalid stored values continue to return `null` instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->