### PR TITLE
Guard ActionSheet hide() to skip side effects when not visible

### DIFF
--- a/app/containers/ActionSheet/ActionSheet.tsx
+++ b/app/containers/ActionSheet/ActionSheet.tsx
@@ -41,6 +41,7 @@ const ActionSheet = memo(
 		};
 
 		const hide = () => {
+			if (!isVisible) return;
 			sheetRef.current?.dismiss();
 			Keyboard.dismiss();
 			Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);


### PR DESCRIPTION
## Proposed changes

Guard `ActionSheet.hide()` to skip all side effects (haptic, keyboard dismiss, toast) when no sheet is visible. On cold start, `hideActionSheetRef()` was called 3 times via redundant VoIP reset paths — `disconnect()`, `checkVoipPermission`, and the `PERMISSIONS.SET` re-check — each firing `Haptics.impactAsync` despite no sheet being open.

## Issue(s)

https://rocketchat.atlassian.net/browse/SUP-1079

## How to test or reproduce

1. Cold open the app
2. Observe that no unexpected vibration occurs during the connecting/updating/connected header transitions
3. Long-press a room item to open the ActionSheet, then dismiss it — haptic should still fire

## Screenshots

N/A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant dismissal actions when the action sheet is already hidden.
  * Improved reliability by avoiding unnecessary side effects during hidden-state interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->