### PR TITLE
fix: UserPreferences.getBool not parsing JSON-string booleans

### DIFF
--- a/app/lib/methods/userPreferences.test.ts
+++ b/app/lib/methods/userPreferences.test.ts
@@ -8,6 +8,13 @@ describe('UserPreferences', () => {
 		expect(userPreferences.getBool('k')).toBe(false);
 	});
 
+	it('getBool parses JSON-string stored boolean', () => {
+		userPreferences.setString('k', JSON.stringify(false));
+		expect(userPreferences.getBool('k')).toBe(false);
+		userPreferences.setString('k', JSON.stringify(true));
+		expect(userPreferences.getBool('k')).toBe(true);
+	});
+
 	it('getBool returns null for unset key', () => {
 		expect(userPreferences.getBool('missing')).toBeNull();
 	});

--- a/app/lib/methods/userPreferences.test.ts
+++ b/app/lib/methods/userPreferences.test.ts
@@ -15,6 +15,13 @@ describe('UserPreferences', () => {
 		expect(userPreferences.getBool('k')).toBe(true);
 	});
 
+	it('getBool returns null for non-boolean or invalid JSON strings', () => {
+		for (const value of ['1', 'null', '{}', 'not-json']) {
+			userPreferences.setString('k', value);
+			expect(userPreferences.getBool('k')).toBeNull();
+		}
+	});
+
 	it('getBool returns null for unset key', () => {
 		expect(userPreferences.getBool('missing')).toBeNull();
 	});

--- a/app/lib/methods/userPreferences.ts
+++ b/app/lib/methods/userPreferences.ts
@@ -106,6 +106,14 @@ class UserPreferences {
 
 	getBool(key: string): boolean | null {
 		try {
+			const str = this.mmkv.getString(key);
+			if (str !== undefined) {
+				try {
+					return JSON.parse(str);
+				} catch {
+					return null;
+				}
+			}
 			return this.mmkv.getBoolean(key) ?? null;
 		} catch {
 			return null;

--- a/app/lib/methods/userPreferences.ts
+++ b/app/lib/methods/userPreferences.ts
@@ -109,7 +109,8 @@ class UserPreferences {
 			const str = this.mmkv.getString(key);
 			if (str !== undefined) {
 				try {
-					return JSON.parse(str);
+					const parsed: unknown = JSON.parse(str);
+					return typeof parsed === 'boolean' ? parsed : null;
 				} catch {
 					return null;
 				}

--- a/app/lib/methods/userPreferences.ts
+++ b/app/lib/methods/userPreferences.ts
@@ -106,10 +106,10 @@ class UserPreferences {
 
 	getBool(key: string): boolean | null {
 		try {
-			const str = this.mmkv.getString(key);
-			if (str !== undefined) {
+			const storedString = this.mmkv.getString(key);
+			if (storedString !== undefined) {
 				try {
-					const parsed: unknown = JSON.parse(str);
+					const parsed: unknown = JSON.parse(storedString);
 					return typeof parsed === 'boolean' ? parsed : null;
 				} catch {
 					return null;

--- a/app/lib/methods/userPreferences.ts
+++ b/app/lib/methods/userPreferences.ts
@@ -92,6 +92,14 @@ class UserPreferences {
 		this.mmkv = MMKV_INSTANCE;
 	}
 
+	private tryParseJson(value: string): unknown {
+		try {
+			return JSON.parse(value);
+		} catch {
+			return undefined;
+		}
+	}
+
 	getString(key: string): string | null {
 		try {
 			return this.mmkv.getString(key) || null;
@@ -108,12 +116,8 @@ class UserPreferences {
 		try {
 			const storedString = this.mmkv.getString(key);
 			if (storedString !== undefined) {
-				try {
-					const parsed: unknown = JSON.parse(storedString);
-					return typeof parsed === 'boolean' ? parsed : null;
-				} catch {
-					return null;
-				}
+				const parsed = this.tryParseJson(storedString);
+				return typeof parsed === 'boolean' ? parsed : null;
 			}
 			return this.mmkv.getBoolean(key) ?? null;
 		} catch {


### PR DESCRIPTION
## Proposed changes

Fix `getBool` in `UserPreferences` to correctly read booleans stored as JSON strings by `useUserPreferences<boolean>`. Previously, `getBool` only used native MMKV `getBoolean`, which couldn't parse `"false"` (stored as a JSON string) and would return `null`/`undefined`. The fallback now tries `getString` + `JSON.parse` first, then falls back to native `getBoolean`.

This caused the haptic feedback on reconnect (from `RoomView.hapticFeedback`) to ignore `NOTIFICATION_IN_APP_VIBRATION` toggle — vibration played for every pending message replayed on DDP reconnect even when the toggle was off.

## Issue(s)
https://rocketchat.atlassian.net/browse/SUP-1079

## How to test or reproduce

1. Go to Settings → Notifications → disable "Vibrate from new messages"
2. Disconnect from network (airplane mode)
3. Reconnect — observe no vibration for replayed messages

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boolean preference retrieval by correctly handling values saved as JSON-formatted strings (e.g., `"true"` / `"false"`).
  * When a stored value is present but not a valid boolean (or contains invalid JSON), the preference now resolves to `null`, while fallback behavior remains intact.

* **Tests**
  * Added Jest coverage for valid JSON boolean strings and invalid/non-boolean stored values returning `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->