### PR TITLE
fix: apply language at runtime when changed in LanguageView

### DIFF
--- a/app/views/LanguageView/index.test.tsx
+++ b/app/views/LanguageView/index.test.tsx
@@ -47,10 +47,10 @@ jest.mock('../../lib/services/restApi', () => ({
 jest.mock('../../lib/database', () => ({
 	default: {
 		servers: {
+			write: jest.fn((fn: any) => fn()),
 			get: jest.fn(() => ({
-				write: jest.fn((fn: any) => fn())
-			})),
-			find: jest.fn(() => Promise.resolve({ update: jest.fn() }))
+				find: jest.fn(() => Promise.resolve({ update: jest.fn() }))
+			}))
 		}
 	}
 }));

--- a/app/views/LanguageView/index.test.tsx
+++ b/app/views/LanguageView/index.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+
+import LanguageView from './index';
+import * as i18n from '../../i18n';
+
+jest.mock('@react-navigation/native', () => ({
+	useNavigation: () => ({ setOptions: jest.fn(), navigate: jest.fn() })
+}));
+
+jest.mock('../../lib/hooks/useAppSelector', () => ({
+	useAppSelector: () => ({ languageDefault: 'en', id: 'user-id' })
+}));
+
+jest.mock('react-redux', () => ({
+	useDispatch: () => jest.fn()
+}));
+
+jest.mock('../../actions/app', () => ({
+	appStart: jest.fn()
+}));
+
+jest.mock('../../actions/login', () => ({
+	setUser: jest.fn()
+}));
+
+jest.mock('react-native-restart', () => ({
+	Restart: { Restart: jest.fn() }
+}));
+
+jest.mock('react-native', () => {
+	const rn = jest.requireActual('react-native');
+	rn.FlatList = ({ data, renderItem }: any) => (
+		<>
+			{data.map((item: any, index: number) => (
+				<React.Fragment key={item?.value ?? index}>{renderItem({ item, index })}</React.Fragment>
+			))}
+		</>
+	);
+	return rn;
+});
+
+jest.mock('../../lib/services/restApi', () => ({
+	saveUserPreferences: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('../../lib/database', () => ({
+	default: {
+		servers: {
+			get: jest.fn(() => ({
+				write: jest.fn((fn: any) => fn())
+			})),
+			find: jest.fn(() => Promise.resolve({ update: jest.fn() }))
+		}
+	}
+}));
+
+jest.mock('../../i18n', () => {
+	const setLanguage = jest.fn();
+	const i18nMock = {
+		t: (key: string) => key,
+		locale: 'en',
+		translations: { en: {} }
+	};
+	return {
+		__esModule: true,
+		default: i18nMock,
+		setLanguage,
+		isRTL: jest.fn(() => false),
+		LANGUAGES: [
+			{ label: 'English', value: 'en', file: () => ({}) },
+			{ label: 'Español', value: 'es', file: () => ({}) }
+		]
+	};
+});
+
+describe('LanguageView language change', () => {
+	it('applies the selected language at runtime via setLanguage', async () => {
+		const { findByTestId } = render(<LanguageView />);
+
+		const spanishOption = await findByTestId('language-view-es', {}, { timeout: 5000 });
+		fireEvent(spanishOption, 'onPress');
+
+		await waitFor(
+			() => {
+				expect((i18n as any).setLanguage).toHaveBeenCalledWith('es');
+			},
+			{ timeout: 5000 }
+		);
+	});
+});

--- a/app/views/LanguageView/index.tsx
+++ b/app/views/LanguageView/index.tsx
@@ -46,9 +46,11 @@ const LanguageView = () => {
 		dispatch(appStart({ root: RootEnum.ROOT_LOADING, text: I18n.t('Change_language_loading') }));
 
 		// shows loading for at least 300ms
-		await Promise.all([changeLanguage(language), new Promise(resolve => setTimeout(resolve, 300))]);
+		const [changed] = await Promise.all([changeLanguage(language), new Promise(resolve => setTimeout(resolve, 300))]);
 
-		setLanguage(language);
+		if (changed) {
+			setLanguage(language);
+		}
 
 		if (shouldRestart) {
 			await RNRestart.Restart();
@@ -57,7 +59,7 @@ const LanguageView = () => {
 		}
 	};
 
-	const changeLanguage = async (language: string) => {
+	const changeLanguage = async (language: string): Promise<boolean> => {
 		logEvent(events.LANG_SET_LANGUAGE);
 
 		const params: { language?: string } = {};
@@ -74,19 +76,18 @@ const LanguageView = () => {
 			const serversDB = database.servers;
 			const usersCollection = serversDB.get('users');
 			await serversDB.write(async () => {
-				try {
-					const userRecord = await usersCollection.find(id);
-					await userRecord.update(record => {
-						record.language = params.language;
-					});
-				} catch (e) {
-					logEvent(events.LANG_SET_LANGUAGE_F);
-				}
+				const userRecord = await usersCollection.find(id);
+				await userRecord.update(record => {
+					record.language = params.language;
+				});
 			});
+
+			return true;
 		} catch (e) {
 			logEvent(events.LANG_SET_LANGUAGE_F);
 			showErrorAlert(I18n.t('There_was_an_error_while_action', { action: I18n.t('saving_preferences') }));
 			log(e);
+			return false;
 		}
 	};
 

--- a/app/views/LanguageView/index.tsx
+++ b/app/views/LanguageView/index.tsx
@@ -12,7 +12,7 @@ import { setUser } from '../../actions/login';
 import * as List from '../../containers/List';
 import SafeAreaView from '../../containers/SafeAreaView';
 import { RootEnum } from '../../definitions';
-import I18n, { isRTL, LANGUAGES } from '../../i18n';
+import I18n, { isRTL, LANGUAGES, setLanguage } from '../../i18n';
 import database from '../../lib/database';
 import { getUserSelector } from '../../selectors/login';
 import { type SettingsStackParamList } from '../../stacks/types';
@@ -47,6 +47,8 @@ const LanguageView = () => {
 
 		// shows loading for at least 300ms
 		await Promise.all([changeLanguage(language), new Promise(resolve => setTimeout(resolve, 300))]);
+
+		setLanguage(language);
 
 		if (shouldRestart) {
 			await RNRestart.Restart();


### PR DESCRIPTION
## Proposed changes

`LanguageView.changeLanguage` saved the selected language to server preferences, Redux (`setUser`) and the local database, but never invoked `setLanguage` from `app/i18n`. Since `setLanguage` is the only function that updates `i18n.locale`/`i18n.translations` at runtime, the locale stayed stale until a full app restart (where `setLanguage` runs again at module load).

This PR calls `setLanguage(language)` in `submit` right after `changeLanguage` resolves, so the selected language is applied immediately for non-RTL switches. RTL switches still go through the existing `RNRestart` path.

## Issue(s)

Fixes #5823

## How to test or reproduce

1. Open Settings → Language.
2. Pick a different non-RTL language (e.g. English → Spanish).
3. Before this fix: the UI language only changed after terminating and re-opening the app.
4. After this fix: the language updates immediately without a restart.

Regression test added: `app/views/LanguageView/index.test.tsx` renders `LanguageView`, selects the Spanish radio, and asserts `setLanguage` is called with `'es'`. It failed before the fix (since `setLanguage` was never called) and passes after.

## Screenshots

N/A (no visual change, behavior only).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The fix is minimal and scoped to the language-change flow. `setLanguage` is also called for RTL switches, but the subsequent `RNRestart.Restart()` makes that a no-op (the locale is re-applied at cold start anyway).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language selection reliability by applying the selected language only after the change succeeds.
  * Added clearer error handling when saving language preferences fails, including user notification.
* **Tests**
  * Added coverage for selecting Spanish and confirming the language update is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->