### PR TITLE
fix: stop useSubscriptions re-querying on connection state changes

### DIFF
--- a/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
+++ b/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+
+import { useSubscriptions } from './useSubscriptions';
+import database from '../../lib/database';
+
+let queryCallCount = 0;
+
+jest.mock('../../lib/database', () => ({
+	__esModule: true,
+	default: {
+		active: {
+			get: () => ({
+				query: () => ({
+					observeWithColumns: () => {
+						queryCallCount += 1;
+						return {
+							subscribe: (cb: (data: any[]) => void) => {
+								cb([]);
+								return { unsubscribe: jest.fn() };
+							}
+						};
+					}
+				})
+			})
+		}
+	}
+}));
+
+const baseState = {
+	server: { connecting: false, loading: false, connected: true },
+	settings: { UI_Use_Real_Name: false },
+	sortPreferences: { sortBy: 'activity', showUnread: false, showFavorites: false, groupByType: false },
+	login: { user: { roles: [] } }
+};
+
+const rootReducer = (state: any = baseState, action: any) =>
+	action.type === 'UPDATE_SERVER' ? { ...state, server: action.server } : state;
+
+const Harness = () => {
+	useSubscriptions();
+	return null;
+};
+
+describe('useSubscriptions', () => {
+	it('does not re-query on connection state changes', () => {
+		const store = createStore(rootReducer, baseState);
+
+		render(
+			<Provider store={store}>
+				<Harness />
+			</Provider>
+		);
+
+		const initialCalls = queryCallCount;
+		expect(initialCalls).toBeGreaterThanOrEqual(1);
+
+		act(() => {
+			store.dispatch({
+				type: 'UPDATE_SERVER',
+				server: { connecting: true, loading: false, connected: false }
+			});
+		});
+
+		act(() => {
+			store.dispatch({
+				type: 'UPDATE_SERVER',
+				server: { connecting: false, loading: true, connected: false }
+			});
+		});
+
+		expect(queryCallCount).toBe(initialCalls);
+	});
+});

--- a/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
+++ b/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
@@ -7,7 +7,7 @@ import { useSubscriptions } from './useSubscriptions';
 
 let queryCallCount = 0;
 
-jest.mock('../../lib/database', () => ({
+jest.mock('../../../lib/database', () => ({
 	__esModule: true,
 	default: {
 		active: {

--- a/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
+++ b/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, act } from '@testing-library/react-native';
+import { render, act, waitFor } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
@@ -29,7 +29,7 @@ jest.mock('../../lib/database', () => ({
 }));
 
 const baseState = {
-	server: { connecting: false, loading: false, connected: true },
+	server: { server: 'https://open.rocket.chat', connecting: false, loading: false, connected: true },
 	settings: { UI_Use_Real_Name: false },
 	sortPreferences: { sortBy: 'activity', showUnread: false, showFavorites: false, groupByType: false },
 	login: { user: { roles: [] } }
@@ -44,7 +44,7 @@ const Harness = () => {
 };
 
 describe('useSubscriptions', () => {
-	it('does not re-query on connection state changes', () => {
+	it('does not re-query on connection state changes', async () => {
 		const store = createStore(rootReducer, baseState);
 
 		render(
@@ -53,23 +53,27 @@ describe('useSubscriptions', () => {
 			</Provider>
 		);
 
+		await waitFor(() => {
+			expect(queryCallCount).toBeGreaterThanOrEqual(1);
+		});
 		const initialCalls = queryCallCount;
-		expect(initialCalls).toBeGreaterThanOrEqual(1);
 
-		act(() => {
+		await act(async () => {
 			store.dispatch({
 				type: 'UPDATE_SERVER',
-				server: { connecting: true, loading: false, connected: false }
+				server: { server: 'https://open.rocket.chat', connecting: true, loading: false, connected: false }
 			});
 		});
 
-		act(() => {
+		await act(async () => {
 			store.dispatch({
 				type: 'UPDATE_SERVER',
-				server: { connecting: false, loading: true, connected: false }
+				server: { server: 'https://open.rocket.chat', connecting: false, loading: true, connected: false }
 			});
 		});
 
-		expect(queryCallCount).toBe(initialCalls);
+		await waitFor(() => {
+			expect(queryCallCount).toBe(initialCalls);
+		});
 	});
 });

--- a/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
+++ b/app/views/RoomsListView/hooks/useSubscriptions.test.tsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 
 import { useSubscriptions } from './useSubscriptions';
-import database from '../../lib/database';
 
 let queryCallCount = 0;
 

--- a/app/views/RoomsListView/hooks/useSubscriptions.ts
+++ b/app/views/RoomsListView/hooks/useSubscriptions.ts
@@ -39,6 +39,7 @@ export const useSubscriptions = () => {
 	'use memo';
 
 	const useRealName = useAppSelector(state => state.settings.UI_Use_Real_Name);
+	const server = useAppSelector(state => state.server.server);
 	const subscriptionRef = useRef<Subscription>(null);
 	const [subscriptions, setSubscriptions] = useState<TSubscriptionModel[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -123,7 +124,7 @@ export const useSubscriptions = () => {
 		return () => {
 			subscriptionRef.current?.unsubscribe();
 		};
-	}, [isGrouping, sortBy, useRealName, showUnread, showFavorites, groupByType, roles]);
+	}, [isGrouping, sortBy, useRealName, showUnread, showFavorites, groupByType, roles, server]);
 
 	return {
 		subscriptions,

--- a/app/views/RoomsListView/hooks/useSubscriptions.ts
+++ b/app/views/RoomsListView/hooks/useSubscriptions.ts
@@ -39,7 +39,6 @@ export const useSubscriptions = () => {
 	'use memo';
 
 	const useRealName = useAppSelector(state => state.settings.UI_Use_Real_Name);
-	const server = useAppSelector(state => state.server);
 	const subscriptionRef = useRef<Subscription>(null);
 	const [subscriptions, setSubscriptions] = useState<TSubscriptionModel[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -124,7 +123,7 @@ export const useSubscriptions = () => {
 		return () => {
 			subscriptionRef.current?.unsubscribe();
 		};
-	}, [isGrouping, sortBy, useRealName, showUnread, showFavorites, groupByType, roles, server]);
+	}, [isGrouping, sortBy, useRealName, showUnread, showFavorites, groupByType, roles]);
 
 	return {
 		subscriptions,


### PR DESCRIPTION
## Proposed changes

`useSubscriptions` selected the entire `state.server` object and listed it in the `useEffect` dependency array. `state.server` holds connection-state fields (`connecting`, `loading`, `connected`) that change on every transition, so each transition produced a new object reference and re-ran the effect. That re-subscribed and re-queried WatermelonDB on every connection change, making the room list flicker.

The selected `server` value was never used inside the effect body, so this removes the unused selector and its dependency. The query now only re-runs when subscription-relevant preferences actually change.

## Issue(s)

Fixes #7437

## How to test or reproduce

1. Open the app and observe the room list in `RoomsListView`.
2. Before this fix: toggling the connection state (e.g. connecting → connected, or loading → not loading) re-triggers the `useSubscriptions` effect and re-queries the database, causing the room list to flicker on every connection change.
3. After this fix: the effect no longer depends on `state.server`, so connection transitions don't re-query and the list stays stable.

Regression test added: `app/views/RoomsListView/hooks/useSubscriptions.test.tsx` renders a harness using the hook with a mock store and a mocked database, then dispatches two `state.server` connection-state transitions and asserts the database query is not re-run. It failed before the fix (the query ran on each transition) and passes after.

## Screenshots

N/A (behavior only, no visual change).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The fix is minimal and scoped: only the unused `server` selector (and its entry in the dependency array) is removed. No other behavior of the hook changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room subscription handling across server connection state changes.
  * Prevented unnecessary database queries while connection or loading states update.
  * Maintained consistent subscription loading and room grouping behavior for a stable room list experience.

* **Tests**
  * Added coverage verifying that connection and loading state changes do not trigger additional database queries.
  * Confirmed existing subscription behavior remains intact during server state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->