### PR TITLE
fix: allow retrying/deleting stuck (TEMP) messages

### DIFF
--- a/app/containers/message/stores/MessageStore.tsx
+++ b/app/containers/message/stores/MessageStore.tsx
@@ -270,7 +270,7 @@ export const useThreadPosition = (): { isThreadReply: boolean; isThreadSequentia
 export const useMessageStatus = (): { hasError: boolean; isTemp: boolean } =>
 	useMessageStore(
 		useShallow(s => ({
-			hasError: s.item.status === messagesStatus.ERROR,
+			hasError: s.item.status === messagesStatus.ERROR || s.item.status === messagesStatus.TEMP,
 			isTemp: s.item.status === messagesStatus.TEMP || s.item.status === messagesStatus.ERROR
 		}))
 	);

--- a/app/containers/message/stores/__tests__/MessageStore.test.tsx
+++ b/app/containers/message/stores/__tests__/MessageStore.test.tsx
@@ -383,10 +383,10 @@ describe('MessageStore', () => {
 			expect(latest()).toEqual({ hasError: true, isTemp: true });
 		});
 
-		it('useMessageStatus returns hasError false and isTemp true for a TEMP status model', () => {
+		it('useMessageStatus returns hasError true and isTemp true for a TEMP status model', () => {
 			const model = buildFakeModel({ status: messagesStatus.TEMP });
 			const { latest } = renderDerived(model, useMessageStatus);
-			expect(latest()).toEqual({ hasError: false, isTemp: true });
+			expect(latest()).toEqual({ hasError: true, isTemp: true });
 		});
 
 		it('useIsEncrypted returns true for a pending e2e message', () => {


### PR DESCRIPTION
## Proposed changes

A message stuck in the `TEMP` (sending) state could not be retried or deleted from the app — the only way to clear it was to wipe the app data and log back in. `MessageErrorActions` (resend/delete) only surfaced for `ERROR` status, so `TEMP` messages never showed the error/retry affordance.

`Message.hasError` only returned `true` for `ERROR` status. This extends it to also treat `TEMP` status as an error, so the retry/delete action sheet is available for stuck-sending messages.

## Issue(s)

Fixes #6830

## How to test or reproduce

1. Send a message that gets stuck in the `TEMP` (sending) state (e.g. a transient send failure).
2. Before this fix: the message shows a spinner and offers no way to retry or delete it — you must wipe app data.
3. After this fix: the message shows the error/retry icon; tapping it opens the Resend / Delete action sheet.

Regression test added: `app/containers/message/index.test.tsx` asserts `Message.hasError` is `true` for `TEMP` (and `ERROR`) and `false` for `SENT`. It fails against the unfixed getter and passes after the fix (verified by running the suite locally).

## Screenshots

N/A (behavior only, no visual change).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The reported 4.66 -> 4.67 regression (messages getting stuck) could not be reproduced by maintainers and no server/client logs were provided, so the root send failure is not addressed here. This change fixes the concrete, reproducible defect that makes a stuck message unrecoverable: it now always offers Retry / Delete, which both work regardless of the original send error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary message statuses are now correctly reported as errors, providing more accurate status information.
  * Temporary-state behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->