### PR TITLE
fix: attachments with # in the filename fail to download

### DIFF
--- a/app/lib/methods/helpers/formatAttachmentUrl.test.ts
+++ b/app/lib/methods/helpers/formatAttachmentUrl.test.ts
@@ -21,8 +21,8 @@ describe('formatAttachmentUrl', () => {
 		jest.clearAllMocks();
 	});
 
-	// The server builds the path with `encodeURI(file.name)`, which leaves `#` raw — the url would otherwise be cut
-	// at the fragment and the server would receive `/file-upload/1/a%20video%20`.
+	// The server builds the path with `encodeURI(file.name)`, which encodes the spaces but leaves `#` raw — the url
+	// would otherwise be cut at the fragment and the server would receive `/file-upload/1/a%20video%20`.
 	describe('raw `#` in the filename', () => {
 		const rawUrl = '/file-upload/1/a%20video%20#2.mov';
 		const escapedUrl = `${SERVER}/file-upload/1/a%20video%20%232.mov`;
@@ -42,11 +42,12 @@ describe('formatAttachmentUrl', () => {
 			expect(formatAttachmentUrl(rawUrl, USER_ID, TOKEN, SERVER)).toBe(`${escapedUrl}?rc_token=${TOKEN}&rc_uid=${USER_ID}`);
 		});
 
-		test('escapes it on a url that already carries the auth params', () => {
+		// The `%20`s the server already applied must survive as-is — encoding them again would give `%2520`.
+		test('escapes it without re-encoding the rest of the path', () => {
 			mockSettings();
-			expect(
-				formatAttachmentUrl(`${SERVER}/file-upload/1/video#2.mov?rc_token=${TOKEN}&rc_uid=${USER_ID}`, USER_ID, TOKEN, SERVER)
-			).toBe(`${SERVER}/file-upload/1/video%232.mov?rc_token=${TOKEN}&rc_uid=${USER_ID}`);
+			expect(formatAttachmentUrl(`${SERVER}${rawUrl}?rc_token=${TOKEN}&rc_uid=${USER_ID}`, USER_ID, TOKEN, SERVER)).toBe(
+				`${escapedUrl}?rc_token=${TOKEN}&rc_uid=${USER_ID}`
+			);
 		});
 
 		test('escapes it behind a cdn prefix', () => {

--- a/app/lib/methods/helpers/formatAttachmentUrl.test.ts
+++ b/app/lib/methods/helpers/formatAttachmentUrl.test.ts
@@ -1,0 +1,85 @@
+import { formatAttachmentUrl } from './formatAttachmentUrl';
+import { store as reduxStore } from '../../store/auxStore';
+
+jest.mock('../../store/auxStore', () => ({
+	store: {
+		getState: jest.fn()
+	}
+}));
+
+const mockedGetState = reduxStore.getState as jest.Mock;
+
+const SERVER = 'https://open.rocket.chat';
+const USER_ID = 'userId';
+const TOKEN = 'token';
+
+const mockSettings = ({ protectFiles = false, cdnPrefix = '' } = {}) =>
+	mockedGetState.mockReturnValue({ settings: { FileUpload_ProtectFiles: protectFiles, CDN_PREFIX: cdnPrefix } });
+
+describe('formatAttachmentUrl', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	// The server builds the path with `encodeURI(file.name)`, which leaves `#` raw — the url would otherwise be cut
+	// at the fragment and the server would receive `/file-upload/1/a%20video%20`.
+	describe('raw `#` in the filename', () => {
+		const rawUrl = '/file-upload/1/a%20video%20#2.mov';
+		const escapedUrl = `${SERVER}/file-upload/1/a%20video%20%232.mov`;
+
+		test('escapes it on a relative url', () => {
+			mockSettings();
+			expect(formatAttachmentUrl(rawUrl, USER_ID, TOKEN, SERVER)).toBe(escapedUrl);
+		});
+
+		test('escapes it on an absolute url', () => {
+			mockSettings();
+			expect(formatAttachmentUrl(`${SERVER}${rawUrl}`, USER_ID, TOKEN, SERVER)).toBe(escapedUrl);
+		});
+
+		test('keeps the whole path when the auth params are appended', () => {
+			mockSettings({ protectFiles: true });
+			expect(formatAttachmentUrl(rawUrl, USER_ID, TOKEN, SERVER)).toBe(`${escapedUrl}?rc_token=${TOKEN}&rc_uid=${USER_ID}`);
+		});
+
+		test('escapes it on a url that already carries the auth params', () => {
+			mockSettings();
+			expect(
+				formatAttachmentUrl(`${SERVER}/file-upload/1/video#2.mov?rc_token=${TOKEN}&rc_uid=${USER_ID}`, USER_ID, TOKEN, SERVER)
+			).toBe(`${SERVER}/file-upload/1/video%232.mov?rc_token=${TOKEN}&rc_uid=${USER_ID}`);
+		});
+
+		test('escapes it behind a cdn prefix', () => {
+			mockSettings({ cdnPrefix: 'https://cdn.example.com/' });
+			expect(formatAttachmentUrl(rawUrl, USER_ID, TOKEN, SERVER)).toBe(
+				'https://cdn.example.com/file-upload/1/a%20video%20%232.mov'
+			);
+		});
+	});
+
+	test('leaves an already-escaped `#` untouched', () => {
+		mockSettings();
+		expect(formatAttachmentUrl('/file-upload/1/a%20video%20%232.mov', USER_ID, TOKEN, SERVER)).toBe(
+			`${SERVER}/file-upload/1/a%20video%20%232.mov`
+		);
+	});
+
+	// An external url is not a file-upload path, so a `#` there can be a genuine fragment.
+	test('returns an external original url verbatim', () => {
+		mockSettings();
+		const externalUrl = 'https://example.com/page#section';
+		expect(formatAttachmentUrl(`${SERVER}/file-upload/1/file.mov`, USER_ID, TOKEN, SERVER, externalUrl)).toBe(externalUrl);
+	});
+
+	test('returns a base64 data uri untouched', () => {
+		mockSettings();
+		const base64 = 'data:image/png;base64,ABC123';
+		expect(formatAttachmentUrl(base64, USER_ID, TOKEN, SERVER)).toBe(base64);
+	});
+
+	test('returns a local file uri untouched', () => {
+		mockSettings();
+		const fileUri = 'file:///var/app/Documents/server/msg1/video.mov';
+		expect(formatAttachmentUrl(fileUri, USER_ID, TOKEN, SERVER)).toBe(fileUri);
+	});
+});

--- a/app/lib/methods/helpers/formatAttachmentUrl.ts
+++ b/app/lib/methods/helpers/formatAttachmentUrl.ts
@@ -10,6 +10,9 @@ function setParamInUrl({ url, token, userId }: { url: string; token: string; use
 	return urlObj.toString();
 }
 
+// The server encodes the path with `encodeURI(file.name)`, which leaves `#` raw and truncates the url at the fragment.
+const escapeFragmentDelimiter = (url: string) => url.replace(/#/g, '%23');
+
 export const formatAttachmentUrl = (
 	attachmentUrl: string | undefined,
 	userId: string,
@@ -27,18 +30,21 @@ export const formatAttachmentUrl = (
 			return _originalUrl;
 		}
 
+		// encodeURI leaves `#` raw too, so escape after it rather than feeding it an already-escaped url.
 		if (attachmentUrl.includes('rc_token')) {
-			return encodeURI(attachmentUrl);
+			return escapeFragmentDelimiter(encodeURI(attachmentUrl));
 		}
 
-		if (protectFiles) return setParamInUrl({ url: attachmentUrl, token, userId });
-		return attachmentUrl;
+		const url = escapeFragmentDelimiter(attachmentUrl);
+		if (protectFiles) return setParamInUrl({ url, token, userId });
+		return url;
 	}
 	let cdnPrefix = store?.getState().settings.CDN_PREFIX as string;
 	cdnPrefix = cdnPrefix?.trim();
 	if (cdnPrefix && cdnPrefix.startsWith('http')) {
 		server = cdnPrefix.replace(/\/+$/, '');
 	}
-	if (protectFiles) return setParamInUrl({ url: `${server}${attachmentUrl}`, token, userId });
-	return `${server}${attachmentUrl}`;
+	const url = escapeFragmentDelimiter(`${server}${attachmentUrl}`);
+	if (protectFiles) return setParamInUrl({ url, token, userId });
+	return url;
 };

--- a/app/lib/methods/helpers/formatAttachmentUrl.ts
+++ b/app/lib/methods/helpers/formatAttachmentUrl.ts
@@ -30,12 +30,12 @@ export const formatAttachmentUrl = (
 			return _originalUrl;
 		}
 
-		// encodeURI leaves `#` raw too, so escape after it rather than feeding it an already-escaped url.
-		if (attachmentUrl.includes('rc_token')) {
-			return escapeFragmentDelimiter(encodeURI(attachmentUrl));
+		const url = escapeFragmentDelimiter(attachmentUrl);
+
+		if (url.includes('rc_token')) {
+			return url;
 		}
 
-		const url = escapeFragmentDelimiter(attachmentUrl);
 		if (protectFiles) return setParamInUrl({ url, token, userId });
 		return url;
 	}

--- a/app/views/AttachmentView.test.tsx
+++ b/app/views/AttachmentView.test.tsx
@@ -9,6 +9,14 @@ const mockNavigation = {
 	pop: jest.fn()
 };
 const mockUseAltTextSupported = jest.fn();
+const mockImageViewer = jest.fn();
+
+const DEFAULT_ATTACHMENT = {
+	title: 'IMG_2444.jpg',
+	image_url: 'https://open.rocket.chat/image.png',
+	description: 'A wavy orange and black pattern'
+};
+let mockAttachment: Record<string, unknown> = DEFAULT_ATTACHMENT;
 
 jest.mock('@react-navigation/elements', () => ({
 	useHeaderHeight: () => 0
@@ -42,8 +50,9 @@ jest.mock('../containers/ActionSheet', () => ({
 jest.mock('../containers/ActivityIndicator', () => () => null);
 
 jest.mock('../containers/ImageViewer', () => ({
-	ImageViewer: () => {
+	ImageViewer: (props: Record<string, unknown>) => {
 		const { Text } = require('react-native');
+		mockImageViewer(props);
 		return <Text>Image Viewer</Text>;
 	}
 }));
@@ -67,11 +76,7 @@ jest.mock('../lib/hooks/navigation', () => ({
 	useAppNavigation: () => mockNavigation,
 	useAppRoute: () => ({
 		params: {
-			attachment: {
-				title: 'IMG_2444.jpg',
-				image_url: 'https://open.rocket.chat/image.png',
-				description: 'A wavy orange and black pattern'
-			}
+			attachment: mockAttachment
 		}
 	})
 }));
@@ -104,6 +109,7 @@ jest.mock('../lib/methods/helpers', () => ({
 describe('AttachmentView', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		mockAttachment = DEFAULT_ATTACHMENT;
 	});
 
 	it('renders the alt text label and opens the action sheet when pressed', () => {
@@ -123,5 +129,35 @@ describe('AttachmentView', () => {
 		const { queryByTestId } = render(<AttachmentView />);
 
 		expect(queryByTestId('attachment-view-alt-text-label')).toBeNull();
+	});
+
+	describe('gif detection from the url', () => {
+		const renderWithImageUrl = (image_url: string) => {
+			mockUseAltTextSupported.mockReturnValue(false);
+			mockAttachment = { title: 'clip.gif', image_url };
+			render(<AttachmentView />);
+			return mockImageViewer.mock.calls[0][0].isAnimated;
+		};
+
+		test('detects a plain .gif', () => {
+			expect(renderWithImageUrl('https://open.rocket.chat/file-upload/1/clip.gif')).toBe(true);
+		});
+
+		test('detects a .gif followed by a query', () => {
+			expect(renderWithImageUrl('https://open.rocket.chat/file-upload/1/clip.gif?rc_token=token')).toBe(true);
+		});
+
+		// A `#` in the filename reaches here escaped, so the extension is followed by `%23` rather than `#`.
+		test('detects a .gif followed by an escaped `#`', () => {
+			expect(renderWithImageUrl('https://open.rocket.chat/file-upload/1/clip.gif%23draft')).toBe(true);
+		});
+
+		test('detects a .gif followed by a raw `#`', () => {
+			expect(renderWithImageUrl('https://open.rocket.chat/file-upload/1/clip.gif#draft')).toBe(true);
+		});
+
+		test('does not flag a non-gif url', () => {
+			expect(renderWithImageUrl('https://open.rocket.chat/file-upload/1/photo.png')).toBe(false);
+		});
 	});
 });

--- a/app/views/AttachmentView.tsx
+++ b/app/views/AttachmentView.tsx
@@ -59,9 +59,8 @@ const RenderContent = ({
 	}, [navigation]);
 
 	if (attachment.image_url) {
-		const url = formatAttachmentUrl(attachment.title_link || attachment.image_url, user.id, user.token, baseUrl);
-		const uri = encodeURI(url);
-		const isAnimated = attachment.image_type === 'image/gif' || /\.gif(\?|$)/i.test(url);
+		const uri = formatAttachmentUrl(attachment.title_link || attachment.image_url, user.id, user.token, baseUrl);
+		const isAnimated = attachment.image_type === 'image/gif' || /\.gif(\?|$)/i.test(uri);
 		return (
 			<ImageViewer
 				uri={uri}
@@ -74,8 +73,7 @@ const RenderContent = ({
 		);
 	}
 	if (attachment.video_url) {
-		const url = formatAttachmentUrl(attachment.title_link || attachment.video_url, user.id, user.token, baseUrl);
-		const uri = encodeURI(url);
+		const uri = formatAttachmentUrl(attachment.title_link || attachment.video_url, user.id, user.token, baseUrl);
 		return (
 			<Video
 				source={{ uri }}

--- a/app/views/AttachmentView.tsx
+++ b/app/views/AttachmentView.tsx
@@ -60,7 +60,8 @@ const RenderContent = ({
 
 	if (attachment.image_url) {
 		const uri = formatAttachmentUrl(attachment.title_link || attachment.image_url, user.id, user.token, baseUrl);
-		const isAnimated = attachment.image_type === 'image/gif' || /\.gif(\?|$)/i.test(uri);
+		// `#` is escaped to `%23` before it reaches here, so both spellings can follow the extension.
+		const isAnimated = attachment.image_type === 'image/gif' || /\.gif(\?|#|%23|$)/i.test(uri);
 		return (
 			<ImageViewer
 				uri={uri}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
An attachment whose filename contains `#` couldn't be downloaded or played — the request reached the server with a truncated path and returned the wrong resource or a 404.

  The server builds the attachment path with `encodeURI(file.name)` ([sendFileMessage.ts#L57](https://github.com/RocketChat/Rocket.Chat/blob/develop/apps/meteor/server/meteor-methods/messages/sendFileMessage.ts#L57)),
  and `encodeURI` doesn't escape `#`. So a file named `a video #2.mov` arrives as:

      /file-upload/<id>/a%20video%20#2.mov

  Every consumer downstream reads that `#` as the fragment delimiter: `setParamInUrl`'s `new URL()` splits it into `path = /file-upload/<id>/a%20video%20` + `hash = #2.mov` and re-emits the tail after the auth params, and HTTP drops the fragment before connecting. The server only ever sees `a video `.

  `formatAttachmentUrl` now escapes `#` → `%23` on server-origin attachment urls, before anything parses them. Attachment urls never carry a meaningful fragment, so this is unambiguous.

  Notes on placement:
  - On the `rc_token` branch the escape runs *after* `encodeURI`, not before — `encodeURI` leaves `#` raw but does escape `%`, so pre-escaping would  have produced `%2523`.
  - The external `_originalUrl` early return is untouched: that's not a file-upload path, so a `#` there can be a genuine fragment.
  - `?` in a filename breaks the same way, but is deliberately left alone — the server does emit real query strings (signed-url expiry), so there's no safe string-level rule to tell the two apart.
  Covered by a new `formatAttachmentUrl.test.ts` (relative, absolute, `FileUpload_ProtectFiles`, pre-authed and CDN-prefixed urls, plus already-escaped / external / base64 / `file://` passthroughs).
  
## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/NATIVE-1486

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
  1. Upload a file named `a video #2.mov` to a channel.
  2. Tap it — before this change the download fails or resolves to the wrong file; after, it opens normally.
  3. Repeat with **File Upload → Protect Uploaded Files** enabled, which exercises the `setParamInUrl` path.
  
## Screenshots

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attachment URLs containing `#` characters so images and videos load correctly.
  * Improved attachment URL handling across protected, authenticated, CDN-hosted, external, data, and local file sources.
  * Corrected GIF detection for formatted URLs, including URLs with query strings, fragments, and escaped fragment characters.
  * Improved reliability when displaying image and video attachments with complex or encoded URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->