### PR TITLE
fix: ordinal suffix in date and background color

### DIFF
--- a/app/containers/MessageSeparator.tsx
+++ b/app/containers/MessageSeparator.tsx
@@ -42,9 +42,10 @@ const MessageSeparator = ({ ts, unread }: { ts?: Date | string | null; unread?: 
 	}
 
 	const date = ts ? formatLongDate(ts) : null;
-	const unreadLine = { backgroundColor: themes[theme].strokeError };
+	const unreadLine = { backgroundColor: themes[theme].buttonBackgroundDangerDefault };
 	const unreadText = { color: themes[theme].fontDanger };
-	const line = { backgroundColor: themes[theme].strokeLight };
+	const lineBackground = { backgroundColor: themes[theme].strokeLight };
+	
 	if (ts && unread) {
 		return (
 			<View style={styles.container}>
@@ -57,12 +58,12 @@ const MessageSeparator = ({ ts, unread }: { ts?: Date | string | null; unread?: 
 	if (ts) {
 		return (
 			<View style={styles.container}>
-				<View style={[styles.line, line]} />
+				<View style={[styles.line, lineBackground]} />
 				<View
 					style={[styles.label, styles.marginHorizontal, { backgroundColor: themes[theme].buttonBackgroundSecondaryDefault }]}>
 					<Text style={[styles.text, { color: themes[theme].buttonFontSecondary }]}>{date}</Text>
 				</View>
-				<View style={[styles.line, line]} />
+				<View style={[styles.line, lineBackground]} />
 			</View>
 		);
 	}

--- a/app/containers/MessageSeparator.tsx
+++ b/app/containers/MessageSeparator.tsx
@@ -45,7 +45,7 @@ const MessageSeparator = ({ ts, unread }: { ts?: Date | string | null; unread?: 
 	const unreadLine = { backgroundColor: themes[theme].buttonBackgroundDangerDefault };
 	const unreadText = { color: themes[theme].fontDanger };
 	const lineBackground = { backgroundColor: themes[theme].strokeLight };
-	
+
 	if (ts && unread) {
 		return (
 			<View style={styles.container}>

--- a/app/containers/MessageSeparator.tsx
+++ b/app/containers/MessageSeparator.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
-import dayjs from '../lib/dayjs';
+import { formatLongDate } from '../lib/dayjs';
 import I18n from '../i18n';
 import sharedStyles from '../views/Styles';
 import { themes } from '../lib/constants/colors';
@@ -26,6 +26,11 @@ const styles = StyleSheet.create({
 	},
 	marginHorizontal: {
 		marginHorizontal: 14
+	},
+	label: {
+		paddingHorizontal: 8,
+		paddingVertical: 2,
+		borderRadius: 16
 	}
 });
 
@@ -36,9 +41,10 @@ const MessageSeparator = ({ ts, unread }: { ts?: Date | string | null; unread?: 
 		return null;
 	}
 
-	const date = ts ? dayjs(ts).format('LL') : null;
-	const unreadLine = { backgroundColor: themes[theme].buttonBackgroundDangerDefault };
+	const date = ts ? formatLongDate(ts) : null;
+	const unreadLine = { backgroundColor: themes[theme].strokeError };
 	const unreadText = { color: themes[theme].fontDanger };
+	const line = { backgroundColor: themes[theme].strokeLight };
 	if (ts && unread) {
 		return (
 			<View style={styles.container}>
@@ -51,9 +57,12 @@ const MessageSeparator = ({ ts, unread }: { ts?: Date | string | null; unread?: 
 	if (ts) {
 		return (
 			<View style={styles.container}>
-				<View style={[styles.line, { backgroundColor: themes[theme].strokeLight }]} />
-				<Text style={[styles.text, { color: themes[theme].fontSecondaryInfo }, styles.marginHorizontal]}>{date}</Text>
-				<View style={[styles.line, { backgroundColor: themes[theme].strokeLight }]} />
+				<View style={[styles.line, line]} />
+				<View
+					style={[styles.label, styles.marginHorizontal, { backgroundColor: themes[theme].buttonBackgroundSecondaryDefault }]}>
+					<Text style={[styles.text, { color: themes[theme].buttonFontSecondary }]}>{date}</Text>
+				</View>
+				<View style={[styles.line, line]} />
 			</View>
 		);
 	}

--- a/app/containers/message/components/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/app/containers/message/components/__tests__/__snapshots__/Message.test.tsx.snap
@@ -22711,7 +22711,7 @@ exports[`Story Snapshots: DateAndUnreadSeparators should match snapshot 1`] = `
           ]
         }
       >
-        November 10, 2017
+        November 10th, 2017
       </Text>
     </View>
     <A11yOrderView
@@ -23922,27 +23922,42 @@ exports[`Story Snapshots: DateAndUnreadSeparators should match snapshot 1`] = `
           ]
         }
       />
-      <Text
+      <View
         style={
           [
             {
-              "backgroundColor": "transparent",
-              "fontFamily": "Inter",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "textAlign": "left",
-            },
-            {
-              "color": "#6C727A",
+              "borderRadius": 16,
+              "paddingHorizontal": 8,
+              "paddingVertical": 2,
             },
             {
               "marginHorizontal": 14,
             },
+            {
+              "backgroundColor": "#E4E7EA",
+            },
           ]
         }
       >
-        November 10, 2017
-      </Text>
+        <Text
+          style={
+            [
+              {
+                "backgroundColor": "transparent",
+                "fontFamily": "Inter",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "textAlign": "left",
+              },
+              {
+                "color": "#1F2329",
+              },
+            ]
+          }
+        >
+          November 10th, 2017
+        </Text>
+      </View>
       <View
         style={
           [
@@ -24945,7 +24960,7 @@ exports[`Story Snapshots: DateAndUnreadSeparatorsLargeFont should match snapshot
           ]
         }
       >
-        November 10, 2017
+        November 10th, 2017
       </Text>
     </View>
     <A11yOrderView
@@ -26156,27 +26171,42 @@ exports[`Story Snapshots: DateAndUnreadSeparatorsLargeFont should match snapshot
           ]
         }
       />
-      <Text
+      <View
         style={
           [
             {
-              "backgroundColor": "transparent",
-              "fontFamily": "Inter",
-              "fontSize": 14,
-              "fontWeight": "500",
-              "textAlign": "left",
-            },
-            {
-              "color": "#6C727A",
+              "borderRadius": 16,
+              "paddingHorizontal": 8,
+              "paddingVertical": 2,
             },
             {
               "marginHorizontal": 14,
             },
+            {
+              "backgroundColor": "#E4E7EA",
+            },
           ]
         }
       >
-        November 10, 2017
-      </Text>
+        <Text
+          style={
+            [
+              {
+                "backgroundColor": "transparent",
+                "fontFamily": "Inter",
+                "fontSize": 14,
+                "fontWeight": "500",
+                "textAlign": "left",
+              },
+              {
+                "color": "#1F2329",
+              },
+            ]
+          }
+        >
+          November 10th, 2017
+        </Text>
+      </View>
       <View
         style={
           [

--- a/app/lib/dayjs/index.ts
+++ b/app/lib/dayjs/index.ts
@@ -4,6 +4,7 @@ import timezone from 'dayjs/plugin/timezone';
 import calendar from 'dayjs/plugin/calendar';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 
 import 'dayjs/locale/en';
 import 'dayjs/locale/ar';
@@ -36,6 +37,15 @@ dayjs.extend(timezone);
 dayjs.extend(calendar);
 dayjs.extend(relativeTime);
 dayjs.extend(localizedFormat);
+dayjs.extend(advancedFormat);
+
+// Web's date-fns `PPP` (its `LL`) uses an ordinal day in English only; dayjs' `LL` never does.
+const ORDINAL_DAY_LOCALES = ['en'];
+
+export const formatLongDate = (ts: Date | number | string): string => {
+	const date = dayjs(ts);
+	return ORDINAL_DAY_LOCALES.includes(date.locale()) ? date.format('MMMM Do, YYYY') : date.format('LL');
+};
 
 // WatermelonDB hands a message `ts` back as Date, ms number, or ISO string depending on the read path;
 // dayjs parses all three where Number(ts) / new Date(ts) each NaN on one. Normalize to ms since epoch.


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Adds the ordinal day to the message date separator ("August 11th, 2026"), applied only in locales that use it, matching web, where date-fns `PPP` carries the ordinal in English while dayjs' `LL` never does. Also restyles the date
 into a rounded pill using the secondary button tokens, following the web layout.
  
## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/NATIVE-1489

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- open the app;
- Go to a room with old message;
- the message separator must be with ordinal suffix and background color matching the web;

## Screenshots

### Light
| Before | After |
| ----- | ----- |
| <img width="648" height="1406" alt="Simulator Screenshot - iPhone 16 - 2026-08-11 at 19 21 18" src="https://github.com/user-attachments/assets/b68c038f-2e43-40f5-ba3a-6c7861908792" /> | <img width="648" height="1406" alt="Simulator Screenshot - iPhone 16 - 2026-08-11 at 19 22 58" src="https://github.com/user-attachments/assets/bbd6966a-266b-4f12-bac2-95dd40fb7e38" /> |

### Dark
| Before | After |
| ----- | ----- |
| <img width="648" height="1406" alt="Simulator Screenshot - iPhone 16 - 2026-08-11 at 19 21 44" src="https://github.com/user-attachments/assets/21868149-56e9-47b2-a18e-efdf4b2a9dbc" /> | <img width="648" height="1406" alt="Simulator Screenshot - iPhone 16 - 2026-08-11 at 19 22 14" src="https://github.com/user-attachments/assets/281b0c57-6b0c-4830-b446-0c0511656f93" /> |

### Black
| Before | After |
| ----- | ----- |
| <img width="648" height="1406" alt="Simulator Screenshot - iPhone 16 - 2026-08-11 at 19 20 49" src="https://github.com/user-attachments/assets/55f58d43-88f2-45d0-a103-a2fff012e55d" /> | <img width="648" height="1406" alt="Simulator Screenshot - iPhone 16 - 2026-08-11 at 19 22 39" src="https://github.com/user-attachments/assets/ad1dce48-2735-4839-9ed1-b1281f62d9c5" /> |

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added localized long-date formatting for message timestamps.
  * English dates now display ordinal days, while other languages use localized date formats.

* **Style**
  * Updated dated message separators with secondary background and font colors.
  * Added padding, rounded corners, and consistent light divider lines for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->