### PR TITLE
fix: force Google account chooser on OAuth login

### DIFF
--- a/app/containers/LoginServices/__tests__/serviceLogin.test.ts
+++ b/app/containers/LoginServices/__tests__/serviceLogin.test.ts
@@ -1,0 +1,35 @@
+import * as WebBrowser from 'expo-web-browser';
+
+import { onPressGoogle } from '../serviceLogin';
+
+jest.mock('expo-web-browser', () => ({
+	openAuthSessionAsync: jest.fn(() => Promise.resolve({ type: 'dismiss' }))
+}));
+
+jest.mock('../../../lib/services/connect', () => ({
+	loginOAuthOrSso: jest.fn()
+}));
+
+const service = {
+	_id: 'google',
+	name: 'google',
+	service: 'google',
+	authType: 'oauth',
+	buttonColor: '#fff',
+	buttonLabelColor: '#000',
+	clientConfig: { provider: 'google' },
+	serverURL: '',
+	authorizePath: '',
+	clientId: 'client-id',
+	scope: ''
+} as const;
+
+describe('onPressGoogle', () => {
+	it('opens the Google OAuth URL with prompt=select_account', () => {
+		onPressGoogle({ service, server: 'https://mpbila.qa.rocket.chat' });
+
+		const url = (WebBrowser.openAuthSessionAsync as jest.Mock).mock.calls[0][0];
+		expect(url).toContain('accounts.google.com/o/oauth2/auth');
+		expect(url).toContain('prompt=select_account');
+	});
+});

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -54,7 +54,7 @@ export const onPressGoogle = ({ service, server }: IServiceLogin) => {
 	const redirect_uri = `${server}/_oauth/google?close`;
 	const scope = encodeURIComponent('profile email');
 	const state = getOAuthState('redirect');
-	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}&response_type=code`;
+	const params = `?client_id=${clientId}&redirect_uri=${redirect_uri}&scope=${scope}&state=${state}&response_type=code&prompt=select_account`;
 	openOAuthSession(`${endpoint}${params}`);
 };
 


### PR DESCRIPTION
## Proposed changes
Appending `&prompt=select_account` to the Google OAuth authorization URL forces the account chooser to appear on every login, instead of Google silently reusing the previously authenticated session. This lets users pick a different Google account at login time.

## Issue(s)
https://rocketchat.atlassian.net/browse/NATIVE-1493

## How to test or reproduce
1. Open the login screen with Google OAuth enabled on the server
2. Tap **Continue with Google** — the account chooser must appear, even if you already logged in with Google before
3. Select an account and confirm login completes
4. Repeat login; the chooser should appear each time

## Screenshots
N/A

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Google sign-in to prompt users to select an account each time they log in.
* **Tests**
  * Added coverage to verify the Google OAuth flow includes the account-selection prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->