### PR TITLE
chore: adopt the SDK's login types and test against the real lib

### DIFF
--- a/app/containers/Avatar/useAvatarETag.ts
+++ b/app/containers/Avatar/useAvatarETag.ts
@@ -13,7 +13,7 @@ export const useAvatarETag = ({
 	id
 }: {
 	type?: string;
-	username: string;
+	username?: string;
 	text: string;
 	rid?: string;
 	id: string;

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -137,7 +137,10 @@ export const onPressAppleLogin = async () => {
 				AppleAuthentication.AppleAuthenticationScope.EMAIL
 			]
 		});
-		await loginOAuthOrSso({ fullName, email, identityToken });
+		if (!identityToken) {
+			throw new Error('Apple sign-in returned no identity token');
+		}
+		await loginOAuthOrSso({ fullName: fullName ?? {}, email, identityToken });
 	} catch {
 		logEvent(events.ENTER_WITH_APPLE_F);
 	}

--- a/app/containers/LoginServices/serviceLogin.ts
+++ b/app/containers/LoginServices/serviceLogin.ts
@@ -138,7 +138,8 @@ export const onPressAppleLogin = async () => {
 			]
 		});
 		if (!identityToken) {
-			throw new Error('Apple sign-in returned no identity token');
+			logEvent(events.ENTER_WITH_APPLE_F);
+			return;
 		}
 		await loginOAuthOrSso({ fullName: fullName ?? {}, email, identityToken });
 	} catch {

--- a/app/containers/TwoFactor/index.tsx
+++ b/app/containers/TwoFactor/index.tsx
@@ -87,12 +87,13 @@ const TwoFactor = memo(() => {
 	const method = data.method ? methods[data.method] : null;
 	const isEmail = data.method === 'email';
 	const params = data?.params;
+	const emailCodeRecipient = params && 'user' in params ? params.user : undefined;
 
 	const sendEmail = async () => {
 		try {
-			if (params?.user) {
+			if (emailCodeRecipient) {
 				clearErrors();
-				const response = await sendEmailCode(params?.user);
+				const response = await sendEmailCode(emailCodeRecipient);
 
 				if (response.success) {
 					showToast(I18n.t('Two_Factor_Success_message'));

--- a/app/containers/TwoFactor/index.tsx
+++ b/app/containers/TwoFactor/index.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '../../theme';
 import Button from '../Button';
 import sharedStyles from '../../views/Styles';
 import styles from './styles';
-import { type ICredentials } from '../../definitions';
+import { type ILoginCredentials } from '../../definitions';
 import { sendEmailCode } from '../../lib/services/restApi';
 import { useMasterDetail } from '../../lib/hooks/useMasterDetail';
 import Toast from '../Toast';
@@ -38,7 +38,7 @@ interface IMethods {
 }
 
 interface EventListenerMethod {
-	params?: ICredentials;
+	params?: ILoginCredentials;
 	method?: keyof IMethods;
 	submit?: (param: string) => void;
 	cancel?: () => void;

--- a/app/definitions/ICredentials.ts
+++ b/app/definitions/ICredentials.ts
@@ -1,24 +1,12 @@
-import { type AppleAuthenticationFullName } from 'expo-apple-authentication';
-
-export interface ICredentials {
-	resume?: string;
-	user?: string;
-	password?: string;
-	username?: string;
-	ldapPass?: string;
-	ldap?: boolean;
-	ldapOptions?: object;
-	crowdPassword?: string;
-	crowd?: boolean;
-	code?: string;
-	totp?: {
-		login: ICredentials;
-		code: string;
-	};
-	fullName?: AppleAuthenticationFullName | null;
-	email?: string | null;
-	identityToken?: string | null;
-	credentialToken?: string;
-	saml?: boolean;
-	cas?: { credentialToken?: string };
-}
+export type {
+	ICredentialsAppleAPI,
+	ICredentialsAuthenticated,
+	ICredentialsCasAPI,
+	ICredentialsCrowdAPI,
+	ICredentialsLdapAPI,
+	ICredentialsOAuth,
+	ICredentialsPasswordAPI,
+	ICredentialsSamlAPI,
+	ICredentialsTotpAPI,
+	ILoginCredentials as ICredentials
+} from '@rocket.chat/sdk/interfaces';

--- a/app/definitions/ILoggedUser.ts
+++ b/app/definitions/ILoggedUser.ts
@@ -1,13 +1,13 @@
 import type Model from '@nozbe/watermelondb/Model';
 
-import { type IUserEmail, type IUserSettings } from './IUser';
+import { type IUserEmail } from './IUser';
 import { type TStatusSource } from './TStatusSource';
 import { type TUserStatus } from './TUserStatus';
 
 export interface ILoggedUser {
 	id: string;
 	token: string;
-	username: string;
+	username?: string;
 	name?: string;
 	language?: string;
 	status: TUserStatus;
@@ -28,20 +28,6 @@ export interface ILoggedUser {
 	bio?: string;
 	nickname?: string;
 	requirePasswordChange?: boolean;
-}
-
-export interface ILoggedUserResultFromServer extends Omit<
-	ILoggedUser,
-	'enableMessageParserEarlyAdoption' | 'showMessageInMainThread'
-> {
-	settings: IUserSettings;
-}
-
-export interface ILoginResultFromServer {
-	status: string;
-	authToken: string;
-	userId: string;
-	me: ILoggedUserResultFromServer;
 }
 
 export type TLoggedUserModel = ILoggedUser & Model;

--- a/app/definitions/ILoginCredentials.ts
+++ b/app/definitions/ILoginCredentials.ts
@@ -8,5 +8,5 @@ export type {
 	ICredentialsPasswordAPI,
 	ICredentialsSamlAPI,
 	ICredentialsTotpAPI,
-	ILoginCredentials as ICredentials
+	ILoginCredentials
 } from '@rocket.chat/sdk/interfaces';

--- a/app/definitions/IProfile.ts
+++ b/app/definitions/IProfile.ts
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react';
 export interface IProfileParams {
 	realname?: string;
 	name?: string;
-	username: string;
+	username?: string;
 	email: string | null;
 	newPassword: string;
 	currentPassword: string;

--- a/app/definitions/index.ts
+++ b/app/definitions/index.ts
@@ -9,7 +9,7 @@ export * from './ERoomType';
 export * from './IAttachment';
 export * from './ICannedResponse';
 export * from './ICertificate';
-export * from './ICredentials';
+export * from './ILoginCredentials';
 export * from './IEmoji';
 export * from './ILivechatDepartment';
 export * from './ILivechatTag';

--- a/app/lib/hooks/useUserData.ts
+++ b/app/lib/hooks/useUserData.ts
@@ -30,6 +30,9 @@ const useUserData = (rid: string) => {
 					const result = await getUserInfo(rid);
 					if (result.success) {
 						const { user } = result;
+						if (!user.username) {
+							return;
+						}
 						const username = useRealName && user.name ? user.name : user.username;
 						setUser({
 							username,

--- a/app/lib/methods/helpers/events.ts
+++ b/app/lib/methods/helpers/events.ts
@@ -1,4 +1,4 @@
-import { type ICredentials } from '../../../definitions';
+import { type ILoginCredentials } from '../../../definitions';
 import { type IEmitUserInteraction } from '../../../containers/UIKit/interfaces';
 import log from './log';
 
@@ -13,7 +13,7 @@ type TEventEmitterEmmitArgs =
 	| { visible: boolean; onCancel?: null | Function }
 	| { cancel: () => void }
 	| { submit: (param: string) => void }
-	| { params: ICredentials }
+	| { params: ILoginCredentials }
 	| IEmitUserInteraction;
 
 class EventEmitter {

--- a/app/lib/methods/helpers/isReadOnly.ts
+++ b/app/lib/methods/helpers/isReadOnly.ts
@@ -2,7 +2,7 @@ import { store as reduxStore } from '../../store/auxStore';
 import { type ISubscription } from '../../../definitions';
 import { hasPermission } from './helpers';
 
-const canPostReadOnly = async (room: Partial<ISubscription>, username: string) => {
+const canPostReadOnly = async (room: Partial<ISubscription>, username?: string) => {
 	// RC 6.4.0
 	const isUnmuted = !!room?.unmuted?.find(m => m === username);
 	// TODO: this is not reactive. If this permission changes, the component won't be updated
@@ -11,10 +11,10 @@ const canPostReadOnly = async (room: Partial<ISubscription>, username: string) =
 	return permission[0] || isUnmuted;
 };
 
-const isMuted = (room: Partial<ISubscription>, username: string) =>
+const isMuted = (room: Partial<ISubscription>, username?: string) =>
 	room && room.muted && room.muted.find && !!room.muted.find(m => m === username);
 
-export const isReadOnly = async (room: Partial<ISubscription>, username: string): Promise<boolean> => {
+export const isReadOnly = async (room: Partial<ISubscription>, username?: string): Promise<boolean> => {
 	if (room.archived) {
 		return true;
 	}

--- a/app/lib/methods/helpers/parseSamlOrCasRedirect.test.ts
+++ b/app/lib/methods/helpers/parseSamlOrCasRedirect.test.ts
@@ -46,11 +46,8 @@ describe('parseSamlOrCasRedirect', () => {
 			expect(parseSamlOrCasRedirect('https://server.example/login', 'cas', 'sso-token')).toBeNull();
 		});
 
-		it('passes credentialToken through as undefined when ssoToken is not provided', () => {
-			expect(parseSamlOrCasRedirect('https://server.example/_cas/validate/xyz', 'cas')).toEqual({
-				kind: 'cas',
-				payload: { cas: { credentialToken: undefined } }
-			});
+		it('returns null when authType is cas and no ssoToken is provided', () => {
+			expect(parseSamlOrCasRedirect('https://server.example/_cas/validate/xyz', 'cas')).toBeNull();
 		});
 
 		it('returns null when authType is cas and the URL only has a SAML-style token', () => {

--- a/app/lib/methods/helpers/parseSamlOrCasRedirect.ts
+++ b/app/lib/methods/helpers/parseSamlOrCasRedirect.ts
@@ -9,12 +9,9 @@ export type SamlOrCasRedirect =
 
 export const parseSamlOrCasRedirect = (url: string, authType: string, ssoToken?: string): SamlOrCasRedirect => {
 	const parsedUrl = parse(url, true);
-	if (authType === 'saml' && parsedUrl.query?.saml_idp_credentialToken) {
-		const credentialToken = parsedUrl.query.saml_idp_credentialToken || ssoToken;
-		if (!credentialToken) {
-			return null;
-		}
-		return { kind: 'saml', payload: { credentialToken, saml: true } };
+	const samlCredentialToken = parsedUrl.query?.saml_idp_credentialToken;
+	if (authType === 'saml' && samlCredentialToken) {
+		return { kind: 'saml', payload: { credentialToken: samlCredentialToken, saml: true } };
 	}
 	if (authType === 'cas' && (parsedUrl.pathname?.includes('validate') || parsedUrl.query?.ticket)) {
 		if (!ssoToken) {

--- a/app/lib/methods/helpers/parseSamlOrCasRedirect.ts
+++ b/app/lib/methods/helpers/parseSamlOrCasRedirect.ts
@@ -1,16 +1,25 @@
 import parse from 'url-parse';
 
-import { type ICredentials } from '../../../definitions';
+import { type ICredentialsCasAPI, type ICredentialsSamlAPI } from '../../../definitions';
 
-export type SamlOrCasRedirect = { kind: 'saml'; payload: ICredentials } | { kind: 'cas'; payload: ICredentials } | null;
+export type SamlOrCasRedirect =
+	| { kind: 'saml'; payload: ICredentialsSamlAPI }
+	| { kind: 'cas'; payload: ICredentialsCasAPI }
+	| null;
 
 export const parseSamlOrCasRedirect = (url: string, authType: string, ssoToken?: string): SamlOrCasRedirect => {
 	const parsedUrl = parse(url, true);
 	if (authType === 'saml' && parsedUrl.query?.saml_idp_credentialToken) {
-		const token = parsedUrl.query.saml_idp_credentialToken || ssoToken;
-		return { kind: 'saml', payload: { credentialToken: token, saml: true } };
+		const credentialToken = parsedUrl.query.saml_idp_credentialToken || ssoToken;
+		if (!credentialToken) {
+			return null;
+		}
+		return { kind: 'saml', payload: { credentialToken, saml: true } };
 	}
 	if (authType === 'cas' && (parsedUrl.pathname?.includes('validate') || parsedUrl.query?.ticket)) {
+		if (!ssoToken) {
+			return null;
+		}
 		return { kind: 'cas', payload: { cas: { credentialToken: ssoToken } } };
 	}
 	return null;

--- a/app/lib/methods/logout.ts
+++ b/app/lib/methods/logout.ts
@@ -8,7 +8,6 @@ import database, { getDatabase } from '../database';
 import log from './helpers/log';
 import { disconnect } from '../services/connect';
 import sdk from '../services/sdk';
-import { toSdkCredentials } from '../services/toSdkCredentials';
 import { CURRENT_SERVER, E2E_PRIVATE_KEY, E2E_PUBLIC_KEY, E2E_RANDOM_PASSWORD_KEY, TOKEN_KEY } from '../constants/keys';
 import UserPreferences from './userPreferences';
 import { removePushToken } from '../services/restApi';
@@ -67,18 +66,20 @@ export async function removeServer({ server }: { server: string }): Promise<void
 		if (userId) {
 			const resume = UserPreferences.getString(`${TOKEN_KEY}-${userId}`);
 
-			try {
-				const sdk = new RocketchatClient({ host: server, protocol: 'ddp', useSsl: isSsl(server) });
-				await sdk.login(toSdkCredentials({ resume: resume ?? undefined }));
+			if (resume) {
+				try {
+					const sdk = new RocketchatClient({ host: server, protocol: 'ddp', useSsl: isSsl(server) });
+					await sdk.login({ resume });
 
-				const token = getDeviceToken();
-				if (token) {
-					await sdk.del('push.token', { token });
+					const token = getDeviceToken();
+					if (token) {
+						await sdk.del('push.token', { token });
+					}
+
+					await sdk.logout();
+				} catch (e) {
+					log(e);
 				}
-
-				await sdk.logout();
-			} catch (e) {
-				log(e);
 			}
 		}
 

--- a/app/lib/methods/subscriptions/__tests__/roomSubscription.integration.test.ts
+++ b/app/lib/methods/subscriptions/__tests__/roomSubscription.integration.test.ts
@@ -1,31 +1,9 @@
-import type { Store } from 'redux';
-
 jest.unmock('@rocket.chat/sdk');
 
 jest.mock('universal-websocket-client', () =>
 	jest.fn().mockImplementation(() => {
-		const connection = {
-			send: jest.fn((data: string) => {
-				const message = JSON.parse(data) as { msg: string; id?: string; method?: string };
-				if (message.msg === 'connect') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'connected', session: 'session-id' }) }));
-				} else if (message.msg === 'ping') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'pong' }) }));
-				} else if (message.msg === 'sub') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'ready', subs: [message.id] }) }));
-				} else if (message.msg === 'unsub') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'nosub', id: message.id }) }));
-				}
-			}),
-			close: jest.fn(),
-			readyState: 1,
-			onopen: jest.fn(),
-			onmessage: jest.fn(),
-			onerror: jest.fn(),
-			onclose: jest.fn()
-		};
-		mockConnections.push(connection);
-		return connection;
+		const sdkIntegration = jest.requireActual<typeof SdkIntegration>('../../../testUtils/sdkIntegration');
+		return new sdkIntegration.MockConnection(mockConnections);
 	})
 );
 
@@ -95,83 +73,32 @@ import { getMessageById } from '../../../database/services/Message';
 import buildMessage from '../../helpers/buildMessage';
 import { subscribeRoom, unsubscribeRoom } from '../../../../actions/room';
 import { clearUserTyping } from '../../../../actions/usersTyping';
-import type { IApplicationState } from '../../../../definitions';
+import {
+	flush,
+	framesOn,
+	makeCollection as makeBaseCollection,
+	makeReduxStore,
+	receiveFrame
+} from '../../../testUtils/sdkIntegration';
+import type { MockConnection } from '../../../testUtils/sdkIntegration';
+import type * as SdkIntegration from '../../../testUtils/sdkIntegration';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const database = require('../../../database').default as {
 	active: { get: jest.Mock; write: jest.Mock; batch: jest.Mock };
 };
 
-interface MockConnection {
-	send: jest.Mock;
-	close: jest.Mock;
-	readyState: number;
-	onopen: () => void;
-	onmessage: (event: { data: string }) => void;
-	onerror: () => void;
-	onclose: () => void;
-}
-
-interface WireFrame {
-	msg: string;
-	id?: string;
-	name?: string;
-	params?: unknown[];
-}
-
 const mockConnections: MockConnection[] = [];
 
-function makeReduxStore() {
-	const listeners = new Set<() => void>();
-	const state = {
-		login: { user: null as Record<string, unknown> | null, isAuthenticated: false },
-		server: { version: '5.0.0' },
-		settings: {} as Record<string, unknown>,
-		room: { subscribedRoom: 'room-rid' as string | null }
-	};
-	return {
-		state,
-		store: {
-			getState: () => state,
-			dispatch: jest.fn(),
-			subscribe: (listener: () => void) => {
-				listeners.add(listener);
-				return () => listeners.delete(listener);
-			}
-		} as unknown as Store<IApplicationState>
-	};
-}
-
-async function flush(turns = 10) {
-	for (let i = 0; i < turns; i++) {
-		await Promise.resolve();
-		await jest.advanceTimersByTimeAsync(0);
-	}
-}
-
-function framesOn(connection: MockConnection, msg: string) {
-	return connection.send.mock.calls
-		.map(([data]: [string]) => JSON.parse(data) as WireFrame)
-		.filter(message => message.msg === msg);
-}
-
-function receiveFrame(connection: MockConnection, frame: Record<string, unknown>) {
-	connection.onmessage({ data: JSON.stringify(frame) });
-}
-
 function makeCollection(name: string) {
-	return {
-		name,
-		find: jest.fn(),
-		query: jest.fn(() => ({ fetch: jest.fn(() => Promise.resolve([])) })),
-		create: jest.fn(),
-		prepareCreate: jest.fn((fn: (record: Record<string, unknown>) => void) => {
-			const record = { _raw: { id: '' }, subscription: { id: '' } };
-			fn(record);
-			return record;
-		}),
-		schema: { columnArray: [] }
-	};
+	const collection = makeBaseCollection(name);
+	collection.prepareCreate.mockImplementation((fn: (record: Record<string, unknown>) => void) => {
+		const record = { _raw: { id: '' }, subscription: { id: '' } };
+		fn(record);
+		return record;
+	});
+	collection.schema = { columnArray: [] };
+	return collection;
 }
 
 const MESSAGE = {

--- a/app/lib/methods/subscriptions/__tests__/roomSubscription.integration.test.ts
+++ b/app/lib/methods/subscriptions/__tests__/roomSubscription.integration.test.ts
@@ -80,7 +80,7 @@ import {
 	makeReduxStore,
 	receiveFrame
 } from '../../../testUtils/sdkIntegration';
-import type { MockConnection } from '../../../testUtils/sdkIntegration';
+import type { IMockCollection, MockConnection } from '../../../testUtils/sdkIntegration';
 import type * as SdkIntegration from '../../../testUtils/sdkIntegration';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -90,7 +90,7 @@ const database = require('../../../database').default as {
 
 const mockConnections: MockConnection[] = [];
 
-function makeCollection(name: string) {
+function makeCollection(name: string): IMockCollection {
 	const collection = makeBaseCollection(name);
 	collection.prepareCreate.mockImplementation((fn: (record: Record<string, unknown>) => void) => {
 		const record = { _raw: { id: '' }, subscription: { id: '' } };

--- a/app/lib/services/__tests__/connect.integration.test.ts
+++ b/app/lib/services/__tests__/connect.integration.test.ts
@@ -1,5 +1,3 @@
-import type { Store } from 'redux';
-
 jest.unmock('@rocket.chat/sdk');
 
 import { connect, login, loginWithPassword } from '../connect';
@@ -11,56 +9,16 @@ import { setActiveUsers } from '../../../actions/activeUsers';
 import { updateSettings } from '../../../actions/settings';
 import { updatePermission } from '../../../actions/permissions';
 import { _activeUsers, _setUserTimer } from '../../methods/setUser';
-import type { IApplicationState } from '../../../definitions';
-
-interface MockConnection {
-	send: jest.Mock;
-	close: jest.Mock;
-	readyState: number;
-	onopen: () => void;
-	onmessage: (event: { data: string }) => void;
-	onerror: () => void;
-	onclose: (event?: { code?: number }) => void;
-}
-
-interface WireFrame {
-	msg: string;
-	id?: string;
-	name?: string;
-	method?: string;
-	params?: unknown[];
-}
+import { flush, framesOn, makeCollection, makeReduxStore, receiveFrame } from '../../testUtils/sdkIntegration';
+import type { MockConnection } from '../../testUtils/sdkIntegration';
+import type * as SdkIntegration from '../../testUtils/sdkIntegration';
 
 const mockConnections: MockConnection[] = [];
 
-const DDP_LOGIN_RESULT = { id: 'user-id', token: 'auth-token' };
-
 jest.mock('universal-websocket-client', () =>
 	jest.fn().mockImplementation(() => {
-		const connection = {
-			send: jest.fn((data: string) => {
-				const message = JSON.parse(data) as { msg: string; id?: string; method?: string };
-				if (message.msg === 'connect') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'connected', session: 'session-id' }) }));
-				} else if (message.msg === 'ping') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'pong' }) }));
-				} else if (message.msg === 'sub') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'ready', subs: [message.id] }) }));
-				} else if (message.msg === 'method' && message.method === 'login') {
-					setImmediate(() =>
-						connection.onmessage({ data: JSON.stringify({ msg: 'result', id: message.id, result: DDP_LOGIN_RESULT }) })
-					);
-				}
-			}),
-			close: jest.fn(),
-			readyState: 1,
-			onopen: jest.fn(),
-			onmessage: jest.fn(),
-			onerror: jest.fn(),
-			onclose: jest.fn()
-		};
-		mockConnections.push(connection);
-		return connection;
+		const sdkIntegration = jest.requireActual<typeof SdkIntegration>('../../testUtils/sdkIntegration');
+		return new sdkIntegration.MockConnection(mockConnections);
 	})
 );
 
@@ -125,56 +83,6 @@ const REST_LOGIN_ME = {
 	nickname: 'nick',
 	requirePasswordChange: false
 };
-
-function makeReduxStore() {
-	const listeners = new Set<() => void>();
-	const state = {
-		meteor: { connected: false },
-		login: { user: null as Record<string, unknown> | null, isAuthenticated: false },
-		server: { version: '5.0.0' },
-		settings: {} as Record<string, unknown>,
-		room: { subscribedRoom: null as string | null }
-	};
-	return {
-		state,
-		store: {
-			getState: () => state,
-			dispatch: jest.fn(),
-			subscribe: (listener: () => void) => {
-				listeners.add(listener);
-				return () => listeners.delete(listener);
-			}
-		} as unknown as Store<IApplicationState> & { dispatch: jest.Mock }
-	};
-}
-
-async function flush(turns = 10) {
-	for (let i = 0; i < turns; i++) {
-		await Promise.resolve();
-		await jest.advanceTimersByTimeAsync(0);
-	}
-}
-
-function framesOn(connection: MockConnection, msg: string) {
-	return connection.send.mock.calls
-		.map(([data]: [string]) => JSON.parse(data) as WireFrame)
-		.filter(message => message.msg === msg);
-}
-
-function receiveFrame(connection: MockConnection, frame: Record<string, unknown>) {
-	connection.onmessage({ data: JSON.stringify(frame) });
-}
-
-function makeCollection(name: string) {
-	return {
-		name,
-		find: jest.fn(),
-		query: jest.fn(() => ({ fetch: jest.fn(() => Promise.resolve([])) })),
-		create: jest.fn(),
-		prepareCreate: jest.fn(),
-		schema: {}
-	};
-}
 
 let redux: ReturnType<typeof makeReduxStore>;
 let collections: Record<string, ReturnType<typeof makeCollection>>;

--- a/app/lib/services/__tests__/socketHealth.integration.test.ts
+++ b/app/lib/services/__tests__/socketHealth.integration.test.ts
@@ -1,13 +1,14 @@
 import sdk from '../sdk';
 import { recoverSocket } from '../socketHealth';
-import { framesOn } from '../../testUtils/sdkIntegration';
-import type { MockConnection, SdkDriver } from '../../testUtils/sdkIntegration';
+import {
+	addMediaSubs,
+	backdateLastPing,
+	buildConnectedDriver,
+	framesOn,
+	stopAnsweringFrames
+} from '../../testUtils/sdkIntegration';
+import type { MockConnection, ISdkDriver } from '../../testUtils/sdkIntegration';
 import type * as SdkIntegration from '../../testUtils/sdkIntegration';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { Driver } = require('@rocket.chat/sdk/lib/drivers/driver') as {
-	Driver: new (options: { host: string; logger: unknown }) => SdkDriver;
-};
 
 const mockConnections: MockConnection[] = [];
 
@@ -27,47 +28,15 @@ const USER_ID = 'user-id';
 const PING_INTERVAL = 10000;
 const CLOSED = 3;
 
-const logger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
-
-async function buildConnectedDriver() {
-	const driver = new Driver({ host: 'localhost:3000', logger });
-	driver.userId = USER_ID;
-	const openPromise = driver.socket.open();
-	mockConnections[0].onopen();
-	await jest.advanceTimersByTimeAsync(0);
-	await openPromise;
-	return driver;
-}
-
-function addMediaSubs(driver: SdkDriver) {
-	['media-signal', 'media-calls'].forEach((name, index) => {
-		const id = `sub-${index}`;
-		driver.socket.subscriptions[id] = {
-			id,
-			name: 'stream-notify-user',
-			params: [`${USER_ID}/${name}`],
-			unsubscribe: jest.fn()
-		};
-	});
-}
-
-function backdateLastPing(driver: SdkDriver, ageMs: number) {
-	driver.socket.lastPing = Date.now() - ageMs;
-}
-
-function stopAnsweringFrames(connection: MockConnection) {
-	connection.send.mockImplementation(() => undefined);
-}
-
 describe('recoverSocket against the real SDK socket', () => {
-	let driver: SdkDriver;
+	let driver: ISdkDriver;
 
 	beforeEach(async () => {
 		jest.clearAllMocks();
 		jest.useFakeTimers();
 		mockConnections.length = 0;
-		driver = await buildConnectedDriver();
-		(sdk as unknown as { current: { driver: SdkDriver } }).current = { driver };
+		driver = await buildConnectedDriver(mockConnections, USER_ID);
+		(sdk as unknown as { current: { driver: ISdkDriver } }).current = { driver };
 	});
 
 	afterEach(() => {
@@ -177,7 +146,7 @@ describe('recoverSocket against the real SDK socket', () => {
 
 	it('re-sends the media subscriptions on the new socket reusing their ids', async () => {
 		backdateLastPing(driver, PING_INTERVAL * 3);
-		addMediaSubs(driver);
+		addMediaSubs(driver, USER_ID);
 
 		const recovery = recoverSocket();
 		await jest.advanceTimersByTimeAsync(0);
@@ -224,7 +193,7 @@ describe('recoverSocket against the real SDK socket', () => {
 		await jest.advanceTimersByTimeAsync(100);
 		expect(framesOn(mockConnections[1], 'sub')).toHaveLength(0);
 
-		addMediaSubs(driver);
+		addMediaSubs(driver, USER_ID);
 		await jest.advanceTimersByTimeAsync(200);
 
 		await expect(resubscribed).resolves.toBe(true);
@@ -236,7 +205,7 @@ describe('recoverSocket against the real SDK socket', () => {
 
 	it('resolves false when the reopened socket never acks the re-sub', async () => {
 		backdateLastPing(driver, PING_INTERVAL * 3);
-		addMediaSubs(driver);
+		addMediaSubs(driver, USER_ID);
 
 		const recovery = recoverSocket();
 		await jest.advanceTimersByTimeAsync(0);

--- a/app/lib/services/__tests__/socketHealth.integration.test.ts
+++ b/app/lib/services/__tests__/socketHealth.integration.test.ts
@@ -28,7 +28,7 @@ interface SdkDriver {
 	pingInterval: number;
 	reopenNow(): Promise<void>;
 	waitForNotifyUserMediaSubs(timeoutMs?: number): Promise<boolean>;
-	ddp: {
+	socket: {
 		lastPing: number;
 		pingTimeout?: ReturnType<typeof setTimeout>;
 		openTimeout?: ReturnType<typeof setTimeout>;
@@ -79,7 +79,7 @@ const logger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest
 async function buildConnectedDriver() {
 	const driver = new Driver({ host: 'localhost:3000', logger });
 	driver.userId = USER_ID;
-	const openPromise = driver.ddp.open();
+	const openPromise = driver.socket.open();
 	mockConnections[0].onopen();
 	await jest.advanceTimersByTimeAsync(0);
 	await openPromise;
@@ -89,7 +89,7 @@ async function buildConnectedDriver() {
 function addMediaSubs(driver: SdkDriver) {
 	['media-signal', 'media-calls'].forEach((name, index) => {
 		const id = `sub-${index}`;
-		driver.ddp.subscriptions[id] = {
+		driver.socket.subscriptions[id] = {
 			id,
 			name: 'stream-notify-user',
 			params: [`${USER_ID}/${name}`],
@@ -99,7 +99,7 @@ function addMediaSubs(driver: SdkDriver) {
 }
 
 function backdateLastPing(driver: SdkDriver, ageMs: number) {
-	driver.ddp.lastPing = Date.now() - ageMs;
+	driver.socket.lastPing = Date.now() - ageMs;
 }
 
 function stopAnsweringFrames(connection: MockConnection) {
@@ -120,12 +120,12 @@ describe('recoverSocket against the real SDK socket', () => {
 		jest.useFakeTimers();
 		mockConnections.length = 0;
 		driver = await buildConnectedDriver();
-		(sdk as unknown as { current: { ddp: SdkDriver } }).current = { ddp: driver };
+		(sdk as unknown as { current: { driver: SdkDriver } }).current = { driver };
 	});
 
 	afterEach(() => {
-		if (driver.ddp.pingTimeout) clearTimeout(driver.ddp.pingTimeout);
-		if (driver.ddp.openTimeout) clearTimeout(driver.ddp.openTimeout);
+		if (driver.socket.pingTimeout) clearTimeout(driver.socket.pingTimeout);
+		if (driver.socket.openTimeout) clearTimeout(driver.socket.openTimeout);
 		jest.useRealTimers();
 	});
 
@@ -209,7 +209,7 @@ describe('recoverSocket against the real SDK socket', () => {
 
 	it('rejects an in-flight DDP method call when recovery reopens the socket', async () => {
 		let rejected = false;
-		const inFlight = driver.ddp.send({ msg: 'method', method: 'getRoomByTypeAndName', params: [] }).catch(() => {
+		const inFlight = driver.socket.send({ msg: 'method', method: 'getRoomByTypeAndName', params: [] }).catch(() => {
 			rejected = true;
 		});
 		await jest.advanceTimersByTimeAsync(0);

--- a/app/lib/services/__tests__/socketHealth.integration.test.ts
+++ b/app/lib/services/__tests__/socketHealth.integration.test.ts
@@ -1,67 +1,20 @@
 import sdk from '../sdk';
 import { recoverSocket } from '../socketHealth';
+import { framesOn } from '../../testUtils/sdkIntegration';
+import type { MockConnection, SdkDriver } from '../../testUtils/sdkIntegration';
+import type * as SdkIntegration from '../../testUtils/sdkIntegration';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { Driver } = require('@rocket.chat/sdk/lib/drivers/driver') as {
 	Driver: new (options: { host: string; logger: unknown }) => SdkDriver;
 };
 
-interface MockConnection {
-	send: jest.Mock;
-	close: jest.Mock;
-	readyState: number;
-	onopen: () => void;
-	onmessage: (event: { data: string }) => void;
-	onerror: () => void;
-	onclose: () => void;
-}
-
-interface WireFrame {
-	msg: string;
-	id?: string;
-	name?: string;
-	params?: string[];
-}
-
-interface SdkDriver {
-	userId: string;
-	pingInterval: number;
-	reopenNow(): Promise<void>;
-	waitForNotifyUserMediaSubs(timeoutMs?: number): Promise<boolean>;
-	socket: {
-		lastPing: number;
-		pingTimeout?: ReturnType<typeof setTimeout>;
-		openTimeout?: ReturnType<typeof setTimeout>;
-		open(): Promise<void>;
-		send(message: Record<string, unknown>): Promise<unknown>;
-		subscriptions: Record<string, { id: string; name: string; params: string[]; unsubscribe: jest.Mock }>;
-	};
-}
-
 const mockConnections: MockConnection[] = [];
 
 jest.mock('universal-websocket-client', () =>
 	jest.fn().mockImplementation(() => {
-		const connection = {
-			send: jest.fn((data: string) => {
-				const message = JSON.parse(data) as { msg: string; id?: string };
-				if (message.msg === 'connect') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'connected', session: 'session-id' }) }));
-				} else if (message.msg === 'ping') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'pong' }) }));
-				} else if (message.msg === 'sub') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'ready', subs: [message.id] }) }));
-				}
-			}),
-			close: jest.fn(),
-			readyState: 1,
-			onopen: jest.fn(),
-			onmessage: jest.fn(),
-			onerror: jest.fn(),
-			onclose: jest.fn()
-		};
-		mockConnections.push(connection);
-		return connection;
+		const sdkIntegration = jest.requireActual<typeof SdkIntegration>('../../testUtils/sdkIntegration');
+		return new sdkIntegration.MockConnection(mockConnections);
 	})
 );
 
@@ -104,12 +57,6 @@ function backdateLastPing(driver: SdkDriver, ageMs: number) {
 
 function stopAnsweringFrames(connection: MockConnection) {
 	connection.send.mockImplementation(() => undefined);
-}
-
-function framesOn(connection: MockConnection, msg: string) {
-	return connection.send.mock.calls
-		.map(([data]: [string]) => JSON.parse(data) as WireFrame)
-		.filter(message => message.msg === msg);
 }
 
 describe('recoverSocket against the real SDK socket', () => {
@@ -238,7 +185,7 @@ describe('recoverSocket against the real SDK socket', () => {
 		await jest.advanceTimersByTimeAsync(0);
 		await expect(recovery).resolves.toBe('reopened');
 
-		const resubscribed = driver.waitForNotifyUserMediaSubs();
+		const resubscribed = driver.waitForNotifyUserMediaSubs!();
 		await jest.advanceTimersByTimeAsync(200);
 		await expect(resubscribed).resolves.toBe(true);
 
@@ -273,7 +220,7 @@ describe('recoverSocket against the real SDK socket', () => {
 		await jest.advanceTimersByTimeAsync(0);
 		await expect(recovery).resolves.toBe('reopened');
 
-		const resubscribed = driver.waitForNotifyUserMediaSubs(1000);
+		const resubscribed = driver.waitForNotifyUserMediaSubs!(1000);
 		await jest.advanceTimersByTimeAsync(100);
 		expect(framesOn(mockConnections[1], 'sub')).toHaveLength(0);
 
@@ -299,7 +246,7 @@ describe('recoverSocket against the real SDK socket', () => {
 
 		stopAnsweringFrames(mockConnections[1]);
 
-		const resubscribed = driver.waitForNotifyUserMediaSubs(500);
+		const resubscribed = driver.waitForNotifyUserMediaSubs!(500);
 		await jest.advanceTimersByTimeAsync(500);
 
 		await expect(resubscribed).resolves.toBe(false);

--- a/app/lib/services/__tests__/socketHealth.test.ts
+++ b/app/lib/services/__tests__/socketHealth.test.ts
@@ -1,7 +1,7 @@
 jest.mock('../sdk', () => ({
 	__esModule: true,
 	default: {
-		current: { ddp: undefined }
+		current: { driver: undefined }
 	}
 }));
 
@@ -12,9 +12,9 @@ import { classifySocketHealth, recoverSocket } from '../socketHealth';
 
 const now = 1_000_000;
 
-const sdkMock = sdk as unknown as { current: { ddp: unknown } | undefined };
+const sdkMock = sdk as unknown as { current: { driver: unknown } | undefined };
 
-interface MockDdp {
+interface MockDriver {
 	connected: boolean;
 	lastPing: number;
 	pingInterval: number;
@@ -22,7 +22,7 @@ interface MockDdp {
 	probe: jest.Mock<Promise<boolean>, [number]>;
 }
 
-function makeDdp(overrides: Partial<MockDdp> = {}): MockDdp {
+function makeDriver(overrides: Partial<MockDriver> = {}): MockDriver {
 	return {
 		connected: true,
 		lastPing: now,
@@ -43,52 +43,52 @@ describe('classifySocketHealth', () => {
 	});
 
 	it('returns round-trip-check for a connected socket rather than trusting it outright', () => {
-		const ddp = makeDdp({ connected: true });
-		expect(classifySocketHealth(ddp as unknown as Driver)).toBe('round-trip-check');
+		const driver = makeDriver({ connected: true });
+		expect(classifySocketHealth(driver as unknown as Driver)).toBe('round-trip-check');
 	});
 
 	it('returns reopen for a closed socket even when lastPing is fresh', () => {
-		const ddp = makeDdp({ connected: false, lastPing: now });
-		expect(classifySocketHealth(ddp as unknown as Driver)).toBe('reopen');
+		const driver = makeDriver({ connected: false, lastPing: now });
+		expect(classifySocketHealth(driver as unknown as Driver)).toBe('reopen');
 	});
 });
 
 describe('recoverSocket', () => {
-	let ddp: MockDdp;
+	let driver: MockDriver;
 
 	beforeEach(() => {
-		ddp = makeDdp({ lastPing: Date.now() });
-		sdkMock.current = { ddp };
+		driver = makeDriver({ lastPing: Date.now() });
+		sdkMock.current = { driver };
 	});
 
 	it('keeps a socket whose round trip answers', async () => {
 		await expect(recoverSocket()).resolves.toBe('confirmed-alive');
-		expect(ddp.reopenNow).not.toHaveBeenCalled();
+		expect(driver.reopenNow).not.toHaveBeenCalled();
 	});
 
 	it('runs the round trip with a 2s budget', async () => {
 		await recoverSocket();
-		expect(ddp.probe).toHaveBeenCalledWith(2000);
+		expect(driver.probe).toHaveBeenCalledWith(2000);
 	});
 
 	it('reopens when the round trip goes unanswered', async () => {
-		ddp.probe.mockResolvedValue(false);
+		driver.probe.mockResolvedValue(false);
 		await expect(recoverSocket()).resolves.toBe('reopened');
-		expect(ddp.reopenNow).toHaveBeenCalledTimes(1);
+		expect(driver.reopenNow).toHaveBeenCalledTimes(1);
 	});
 
 	it('reopens a known-dead socket without a round trip', async () => {
-		ddp.connected = false;
+		driver.connected = false;
 		await expect(recoverSocket()).resolves.toBe('reopened');
-		expect(ddp.probe).not.toHaveBeenCalled();
-		expect(ddp.reopenNow).toHaveBeenCalledTimes(1);
+		expect(driver.probe).not.toHaveBeenCalled();
+		expect(driver.reopenNow).toHaveBeenCalledTimes(1);
 	});
 
-	it('reports no-socket when the ddp handle is missing', async () => {
-		sdkMock.current = { ddp: undefined };
+	it('reports no-socket when the driver handle is missing', async () => {
+		sdkMock.current = { driver: undefined };
 		await expect(recoverSocket()).resolves.toBe('no-socket');
-		expect(ddp.probe).not.toHaveBeenCalled();
-		expect(ddp.reopenNow).not.toHaveBeenCalled();
+		expect(driver.probe).not.toHaveBeenCalled();
+		expect(driver.reopenNow).not.toHaveBeenCalled();
 	});
 
 	it('reports no-socket when there is no sdk instance', async () => {
@@ -97,31 +97,31 @@ describe('recoverSocket', () => {
 	});
 
 	it('rejects when the round trip throws', async () => {
-		ddp.probe.mockRejectedValue(new Error('round trip failed'));
+		driver.probe.mockRejectedValue(new Error('round trip failed'));
 		await expect(recoverSocket()).rejects.toThrow('round trip failed');
 	});
 
 	it('rejects when reopening throws', async () => {
-		ddp.connected = false;
-		ddp.reopenNow.mockRejectedValue(new Error('reopen failed'));
+		driver.connected = false;
+		driver.reopenNow.mockRejectedValue(new Error('reopen failed'));
 		await expect(recoverSocket()).rejects.toThrow('reopen failed');
 	});
 
 	it('shares one in-flight recovery between overlapping callers', async () => {
 		const outcomes = await Promise.all([recoverSocket(), recoverSocket()]);
 		expect(outcomes).toEqual(['confirmed-alive', 'confirmed-alive']);
-		expect(ddp.probe).toHaveBeenCalledTimes(1);
+		expect(driver.probe).toHaveBeenCalledTimes(1);
 	});
 
 	it('starts a fresh recovery after the shared one settles', async () => {
 		await recoverSocket();
 		await recoverSocket();
-		expect(ddp.probe).toHaveBeenCalledTimes(2);
+		expect(driver.probe).toHaveBeenCalledTimes(2);
 	});
 
 	it('abandons the aborted caller while the shared recovery runs on', async () => {
 		let answerRoundTrip: (alive: boolean) => void = () => {};
-		ddp.probe.mockImplementation(() => new Promise<boolean>(resolve => (answerRoundTrip = resolve)));
+		driver.probe.mockImplementation(() => new Promise<boolean>(resolve => (answerRoundTrip = resolve)));
 
 		const controller = new AbortController();
 		const aborted = recoverSocket({ abortSignal: controller.signal });
@@ -132,7 +132,7 @@ describe('recoverSocket', () => {
 
 		answerRoundTrip(true);
 		await expect(other).resolves.toBe('confirmed-alive');
-		expect(ddp.probe).toHaveBeenCalledTimes(1);
+		expect(driver.probe).toHaveBeenCalledTimes(1);
 	});
 
 	it('abandons a pre-aborted caller without touching the socket', async () => {
@@ -140,7 +140,7 @@ describe('recoverSocket', () => {
 		controller.abort();
 
 		await expect(recoverSocket({ abortSignal: controller.signal })).resolves.toBe('abandoned');
-		expect(ddp.probe).not.toHaveBeenCalled();
-		expect(ddp.reopenNow).not.toHaveBeenCalled();
+		expect(driver.probe).not.toHaveBeenCalled();
+		expect(driver.reopenNow).not.toHaveBeenCalled();
 	});
 });

--- a/app/lib/services/connect.ts
+++ b/app/lib/services/connect.ts
@@ -12,12 +12,10 @@ import { store } from '../store/auxStore';
 import { loginRequest, logout, setLoginServices, setUser } from '../../actions/login';
 import { waitForLoginReady } from './waitForLoginReady';
 import sdk from './sdk';
-import { toLoginResult } from './toLoginResult';
-import { toSdkCredentials } from './toSdkCredentials';
 import { mediaSessionInstance } from './voip/MediaSessionInstance';
 import { pendingHangups } from './voip/pendingHangups';
 import I18n from '../../i18n';
-import { type ICredentials, type ILoggedUser, STATUSES } from '../../definitions';
+import { type ICredentials, type ICredentialsPasswordAPI, type ILoggedUser, STATUSES, type TUserStatus } from '../../definitions';
 import { connectRequest, connectSuccess, disconnect as disconnectAction } from '../../actions/connect';
 import { updatePermission } from '../../actions/permissions';
 import EventEmitter from '../methods/helpers/events';
@@ -296,11 +294,15 @@ function stopListener(listener: any): void {
 	listener?.stop();
 }
 
+function toUserStatus(status?: string): TUserStatus {
+	return STATUSES.find(known => known === status) ?? 'offline';
+}
+
 async function login(credentials: ICredentials): Promise<ILoggedUser | undefined> {
 	// RC 0.64.0
-	await sdk.current.login(toSdkCredentials(credentials));
+	await sdk.current.login(credentials);
 	const serverVersion = store.getState().server.version;
-	const result = toLoginResult(sdk.current.currentLogin?.result);
+	const result = sdk.current.currentLogin?.result;
 
 	let enableMessageParserEarlyAdoption = true;
 	let showMessageInMainThread = false;
@@ -316,7 +318,7 @@ async function login(credentials: ICredentials): Promise<ILoggedUser | undefined
 			username: result.me.username,
 			name: result.me.name,
 			language: result.me.language,
-			status: result.me.status,
+			status: toUserStatus(result.me.status),
 			statusText: result.me.statusText,
 			customFields: result.me.customFields,
 			statusLivechat: result.me.statusLivechat,
@@ -331,6 +333,18 @@ async function login(credentials: ICredentials): Promise<ILoggedUser | undefined
 			requirePasswordChange: result.me.requirePasswordChange
 		};
 		return user;
+	}
+}
+
+function toPasswordLogin(params: ICredentials): ICredentialsPasswordAPI | undefined {
+	if ('ldap' in params) {
+		return { user: params.username, password: params.ldapPass };
+	}
+	if ('crowd' in params) {
+		return { user: params.username, password: params.crowdPassword };
+	}
+	if ('password' in params) {
+		return params;
 	}
 }
 
@@ -351,26 +365,17 @@ function loginTOTP(params: ICredentials, loginEmailPassword?: boolean): Promise<
 						invalid: (details.error || error) === 'totp-invalid'
 					});
 
-					if (loginEmailPassword) {
-						store.dispatch(setUser({ username: params.user || params.username }));
+					const passwordParams = loginEmailPassword ? toPasswordLogin(params) : undefined;
+					if (passwordParams) {
+						store.dispatch(setUser({ username: passwordParams.user || passwordParams.username }));
 
-						// Force normalized params for 2FA starting RC 3.9.0.
-						const serverVersion = store.getState().server.version;
-						if (compareServerVersion(serverVersion as string, 'greaterThanOrEqualTo', '3.9.0')) {
-							const user = params.user ?? params.username;
-							const password = params.password ?? params.ldapPass ?? params.crowdPassword;
-							params = { user, password };
-						}
-
-						return resolve(loginTOTP({ ...params, code: code?.twoFactorCode }, loginEmailPassword));
+						return resolve(loginTOTP({ ...passwordParams, code: code?.twoFactorCode }, loginEmailPassword));
 					}
 
 					return resolve(
 						loginTOTP({
 							totp: {
-								login: {
-									...params
-								},
+								login: params,
 								code: code?.twoFactorCode
 							}
 						})

--- a/app/lib/services/connect.ts
+++ b/app/lib/services/connect.ts
@@ -15,7 +15,13 @@ import sdk from './sdk';
 import { mediaSessionInstance } from './voip/MediaSessionInstance';
 import { pendingHangups } from './voip/pendingHangups';
 import I18n from '../../i18n';
-import { type ICredentials, type ICredentialsPasswordAPI, type ILoggedUser, STATUSES, type TUserStatus } from '../../definitions';
+import {
+	type ILoginCredentials,
+	type ICredentialsPasswordAPI,
+	type ILoggedUser,
+	STATUSES,
+	type TUserStatus
+} from '../../definitions';
 import { connectRequest, connectSuccess, disconnect as disconnectAction } from '../../actions/connect';
 import { updatePermission } from '../../actions/permissions';
 import EventEmitter from '../methods/helpers/events';
@@ -294,11 +300,7 @@ function stopListener(listener: any): void {
 	listener?.stop();
 }
 
-function toUserStatus(status?: string): TUserStatus {
-	return STATUSES.find(known => known === status) ?? 'offline';
-}
-
-async function login(credentials: ICredentials): Promise<ILoggedUser | undefined> {
+async function login(credentials: ILoginCredentials): Promise<ILoggedUser | undefined> {
 	// RC 0.64.0
 	await sdk.current.login(credentials);
 	const serverVersion = store.getState().server.version;
@@ -318,7 +320,7 @@ async function login(credentials: ICredentials): Promise<ILoggedUser | undefined
 			username: result.me.username,
 			name: result.me.name,
 			language: result.me.language,
-			status: toUserStatus(result.me.status),
+			status: result.me.status as TUserStatus,
 			statusText: result.me.statusText,
 			customFields: result.me.customFields,
 			statusLivechat: result.me.statusLivechat,
@@ -336,7 +338,7 @@ async function login(credentials: ICredentials): Promise<ILoggedUser | undefined
 	}
 }
 
-function toPasswordLogin(params: ICredentials): ICredentialsPasswordAPI | undefined {
+function toPasswordLogin(params: ILoginCredentials): ICredentialsPasswordAPI | undefined {
 	if ('ldap' in params) {
 		return { user: params.username, password: params.ldapPass };
 	}
@@ -348,7 +350,7 @@ function toPasswordLogin(params: ICredentials): ICredentialsPasswordAPI | undefi
 	}
 }
 
-function loginTOTP(params: ICredentials, loginEmailPassword?: boolean): Promise<ILoggedUser> {
+function loginTOTP(params: ILoginCredentials, loginEmailPassword?: boolean): Promise<ILoggedUser> {
 	return new Promise(async (resolve, reject) => {
 		try {
 			const result = await login(params);
@@ -392,7 +394,7 @@ function loginTOTP(params: ICredentials, loginEmailPassword?: boolean): Promise<
 }
 
 function loginWithPassword({ user, password }: { user: string; password: string }): Promise<ILoggedUser> {
-	let params: ICredentials = { user, password };
+	let params: ILoginCredentials = { user, password };
 	const state = store.getState();
 
 	if (state.settings.LDAP_Enable) {
@@ -413,7 +415,7 @@ function loginWithPassword({ user, password }: { user: string; password: string 
 	return loginTOTP(params, true);
 }
 
-async function loginOAuthOrSso(params: ICredentials) {
+async function loginOAuthOrSso(params: ILoginCredentials) {
 	const result = await loginTOTP(params, false);
 	store.dispatch(loginRequest({ resume: result.token }, false));
 }

--- a/app/lib/services/connect.ts
+++ b/app/lib/services/connect.ts
@@ -183,7 +183,7 @@ function connect({ server, logoutOnError = false }: { server: string; logoutOnEr
 		);
 
 		// RC 4.1
-		userPresenceListener = sdk.current.onStreamData('stream-user-presence', (ddpMessage: any) => {
+		userPresenceListener = sdk.onStreamData('stream-user-presence', (ddpMessage: { fields: { args?: any; uid?: any } }) => {
 			const userStatus = ddpMessage.fields.args[0];
 			const { uid } = ddpMessage.fields;
 			const [, status, statusText, statusSource, statusExpiresAtRaw] = userStatus;

--- a/app/lib/services/connect.ts
+++ b/app/lib/services/connect.ts
@@ -11,7 +11,7 @@ import { twoFactor } from './twoFactor';
 import { store } from '../store/auxStore';
 import { loginRequest, logout, setLoginServices, setUser } from '../../actions/login';
 import { waitForLoginReady } from './waitForLoginReady';
-import sdk from './sdk';
+import sdk, { type IStreamDataListener } from './sdk';
 import { mediaSessionInstance } from './voip/MediaSessionInstance';
 import { pendingHangups } from './voip/pendingHangups';
 import I18n from '../../i18n';
@@ -54,7 +54,7 @@ let pendingHangupsConnectedListener: any;
 let usersListener: any;
 let notifyAllListener: any;
 let rolesListener: any;
-let userPresenceListener: any;
+let userPresenceListener: Promise<IStreamDataListener> | undefined;
 let notifyLoggedListener: any;
 let logoutListener: any;
 

--- a/app/lib/services/restApi.ts
+++ b/app/lib/services/restApi.ts
@@ -562,10 +562,13 @@ export const deleteRoom = (roomId: string, t: RoomTypes) =>
 	// RC 0.49.0
 	sdk.post(`${roomTypeToApiType(t)}.delete`, { roomId });
 
-export const toggleMuteUserInRoom = (rid: string, username: string, userId: string, mute: boolean) => {
+export const toggleMuteUserInRoom = (rid: string, username: string | undefined, userId: string, mute: boolean) => {
 	const serverVersion = reduxStore.getState().server.version;
 	if (compareServerVersion(serverVersion, 'greaterThanOrEqualTo', '6.8.0')) {
 		return sdk.post(mute ? 'rooms.muteUser' : 'rooms.unmuteUser', { roomId: rid, userId });
+	}
+	if (!username) {
+		throw new Error('muteUserInRoom requires a username on servers older than 6.8.0');
 	}
 	// RC 0.51.0
 	return sdk.methodCallWrapper(mute ? 'muteUserInRoom' : 'unmuteUserInRoom', { rid, username });

--- a/app/lib/services/sdk.ts
+++ b/app/lib/services/sdk.ts
@@ -15,7 +15,7 @@ import {
 } from '../../definitions/rest/helpers';
 import { compareServerVersion, random } from '../methods/helpers';
 
-export type TDriver = Rocketchat['ddp'];
+export type TDriver = Rocketchat['driver'];
 
 export type TStreamDataCallback = (ddpMessage: any) => void;
 
@@ -161,8 +161,8 @@ class Sdk {
 		return this.methodCall(method, ...parsedParams);
 	}
 
-	subscribe(topic: string, ...args: any[]): Promise<ISubscription | undefined> {
-		return this.current.subscribe(topic, ...args);
+	subscribe(topic: string, eventname?: string, ...args: any[]): Promise<ISubscription | undefined> {
+		return this.current.subscribe(topic, eventname as string, ...args);
 	}
 
 	subscribeRaw(...args: any[]): Promise<ISubscription | undefined> {

--- a/app/lib/services/sdk.ts
+++ b/app/lib/services/sdk.ts
@@ -121,6 +121,7 @@ class Sdk {
 	methodCall(method: string, ...args: any[]): Promise<any> {
 		return new Promise(async (resolve, reject) => {
 			try {
+				// Clear the 2FA code after use — a stale trailing arg breaks typed method signatures
 				const { code } = this;
 				this.code = null;
 				const result = await this.current.methodCall(method, ...args, ...(code ? [code] : []));

--- a/app/lib/services/sdk.ts
+++ b/app/lib/services/sdk.ts
@@ -162,8 +162,8 @@ class Sdk {
 		return this.methodCall(method, ...parsedParams);
 	}
 
-	subscribe(topic: string, eventname?: string, ...args: any[]): Promise<ISubscription | undefined> {
-		return this.current.subscribe(topic, eventname as string, ...args);
+	subscribe(topic: string, eventName?: string, ...args: any[]): Promise<ISubscription | undefined> {
+		return this.current.subscribe(topic, eventName as string, ...args);
 	}
 
 	subscribeRaw(...args: any[]): Promise<ISubscription | undefined> {

--- a/app/lib/services/socketHealth.ts
+++ b/app/lib/services/socketHealth.ts
@@ -12,10 +12,10 @@ import sdk, { type TDriver } from './sdk';
  */
 export type SocketRecoveryPlan = 'reopen' | 'round-trip-check';
 
-export function classifySocketHealth(ddp: TDriver): SocketRecoveryPlan {
-	// `ddp.connected` already folds in the ping-age test (transportOpen && alive(),
+export function classifySocketHealth(driver: TDriver): SocketRecoveryPlan {
+	// `driver.connected` already folds in the ping-age test (transportOpen && alive(),
 	// where alive() is `now - lastPing <= config.ping * 2`), so a stale ping lands here.
-	if (!ddp.connected) {
+	if (!driver.connected) {
 		return 'reopen';
 	}
 	// A connected socket is still verified by a round trip, never trusted outright:
@@ -27,7 +27,7 @@ export function classifySocketHealth(ddp: TDriver): SocketRecoveryPlan {
  * What a recovery attempt reports.
  * - `'confirmed-alive'` — round trip succeeded; nothing was done.
  * - `'reopened'`        — socket reopened (stale ping, or round trip failed).
- * - `'no-socket'`       — `sdk.current?.ddp` undefined; nothing to recover.
+ * - `'no-socket'`       — `sdk.current?.driver` undefined; nothing to recover.
  * - `'abandoned'`       — caller's abort signal fired while waiting; the
  *                         underlying recovery (shared — see below) runs on.
  *
@@ -44,20 +44,20 @@ function shareRecovery(): Promise<SocketRecoveryOutcome> {
 	if (inFlightRecovery) {
 		return inFlightRecovery;
 	}
-	const ddp = sdk.current?.ddp;
-	if (!ddp) {
+	const driver = sdk.current?.driver;
+	if (!driver) {
 		return Promise.resolve('no-socket');
 	}
 	const recovery = (async (): Promise<SocketRecoveryOutcome> => {
-		if (classifySocketHealth(ddp) === 'reopen') {
-			await ddp.reopenNow();
+		if (classifySocketHealth(driver) === 'reopen') {
+			await driver.reopenNow();
 			return 'reopened';
 		}
-		const alive = await ddp.probe(2000);
+		const alive = await driver.probe(2000);
 		if (alive) {
 			return 'confirmed-alive';
 		}
-		await ddp.reopenNow();
+		await driver.reopenNow();
 		return 'reopened';
 	})();
 	inFlightRecovery = recovery;
@@ -111,7 +111,7 @@ export function recoverSocket(options?: { abortSignal?: AbortSignal }): Promise<
  * Vocabulary:
  * - socket health      — the classification concern (`classifySocketHealth`).
  * - recovery plan      — `SocketRecoveryPlan`, the decision.
- * - round trip         — the liveness check (`ddp.probe` stays as the SDK
+ * - round trip         — the liveness check (`driver.probe` stays as the SDK
  *                        method name; our terms say round trip).
  * - recovery outcome   — `SocketRecoveryOutcome`, what callers see.
  */

--- a/app/lib/services/socketHealth.ts
+++ b/app/lib/services/socketHealth.ts
@@ -105,12 +105,3 @@ export function recoverSocket(options?: { abortSignal?: AbortSignal }): Promise<
 	});
 	return Promise.race([recovery, abandoned]);
 }
-
-/**
- * Vocabulary:
- * - socket health      — the classification concern (`classifySocketHealth`).
- * - recovery plan      — `SocketRecoveryPlan`, the decision.
- * - round trip         — the liveness check (`driver.probe` stays as the SDK
- *                        method name; our terms say round trip).
- * - recovery outcome   — `SocketRecoveryOutcome`, what callers see.
- */

--- a/app/lib/services/socketHealth.ts
+++ b/app/lib/services/socketHealth.ts
@@ -13,8 +13,7 @@ import sdk, { type TDriver } from './sdk';
 export type SocketRecoveryPlan = 'reopen' | 'round-trip-check';
 
 export function classifySocketHealth(driver: TDriver): SocketRecoveryPlan {
-	// `driver.connected` already folds in the ping-age test (transportOpen && alive(),
-	// where alive() is `now - lastPing <= config.ping * 2`), so a stale ping lands here.
+	// `driver.connected` already folds in the ping-age test, so a stale ping lands here.
 	if (!driver.connected) {
 		return 'reopen';
 	}

--- a/app/lib/services/toLoginResult.ts
+++ b/app/lib/services/toLoginResult.ts
@@ -1,6 +1,0 @@
-import { type ILoginResultAPI } from '@rocket.chat/sdk/interfaces';
-
-import { type ILoginResultFromServer } from '../../definitions/ILoggedUser';
-
-export const toLoginResult = (result: ILoginResultAPI | null | undefined): ILoginResultFromServer | undefined =>
-	(result ?? undefined) as unknown as ILoginResultFromServer | undefined;

--- a/app/lib/services/toSdkCredentials.ts
+++ b/app/lib/services/toSdkCredentials.ts
@@ -1,5 +1,0 @@
-import { type ICredentials as ISdkCredentials } from '@rocket.chat/sdk/interfaces';
-
-import { type ICredentials } from '../../definitions/ICredentials';
-
-export const toSdkCredentials = (credentials: ICredentials): ISdkCredentials => credentials as ISdkCredentials;

--- a/app/lib/services/twoFactor.ts
+++ b/app/lib/services/twoFactor.ts
@@ -2,12 +2,12 @@ import { settings } from '@rocket.chat/sdk';
 
 import { TWO_FACTOR } from '../../containers/TwoFactor';
 import EventEmitter from '../methods/helpers/events';
-import { type ICredentials } from '../../definitions';
+import { type ILoginCredentials } from '../../definitions';
 
 interface ITwoFactor {
 	method: string;
 	invalid: boolean;
-	params?: ICredentials;
+	params?: ILoginCredentials;
 }
 
 export const twoFactor = ({ method, invalid, params }: ITwoFactor): Promise<{ twoFactorCode: string; twoFactorMethod: string }> =>

--- a/app/lib/services/voip/MediaSessionInstance.test.ts
+++ b/app/lib/services/voip/MediaSessionInstance.test.ts
@@ -70,7 +70,7 @@ jest.mock('../sdk', () => ({
 		},
 		get current() {
 			return {
-				ddp: {
+				driver: {
 					reopenNow: jest.fn(() => Promise.resolve()),
 					probe: jest.fn(() => Promise.resolve(true)),
 					lastPing: Date.now(),

--- a/app/lib/services/voip/acceptNativeCall.integration.test.ts
+++ b/app/lib/services/voip/acceptNativeCall.integration.test.ts
@@ -105,7 +105,7 @@ describe('acceptNativeCallWithReadiness against real login readiness', () => {
 		initStore(redux.store);
 		mockGetCallState.mockReturnValue({ call: null, resetNativeCallId: jest.fn() });
 		mockRecoverSocket.mockResolvedValue('reopened');
-		(sdk as any).current = { ddp: mediaSubsAckAfter(100) };
+		(sdk as any).current = { driver: mediaSubsAckAfter(100) };
 	});
 
 	afterEach(() => {
@@ -148,7 +148,7 @@ describe('acceptNativeCallWithReadiness against real login readiness', () => {
 	});
 
 	it('runs the failure ladder once and leaves nothing behind when readiness never lands', async () => {
-		(sdk as any).current = { ddp: mediaSubsNeverAck() };
+		(sdk as any).current = { driver: mediaSubsNeverAck() };
 		const resetNativeCallId = jest.fn();
 		mockGetCallState.mockReturnValue({ call: null, resetNativeCallId });
 		const mediaSession = makeMediaSession();

--- a/app/lib/services/voip/acceptNativeCall.sdk.integration.test.ts
+++ b/app/lib/services/voip/acceptNativeCall.sdk.integration.test.ts
@@ -45,7 +45,7 @@ interface SdkDriver {
 	userId: string;
 	pingInterval: number;
 	reopenNow(): Promise<void>;
-	ddp: {
+	socket: {
 		lastPing: number;
 		pingTimeout?: ReturnType<typeof setTimeout>;
 		openTimeout?: ReturnType<typeof setTimeout>;
@@ -113,7 +113,7 @@ function makeMediaSession(overrides: Partial<IMediaSession> = {}): IMediaSession
 async function buildConnectedDriver() {
 	const driver = new Driver({ host: 'localhost:3000', logger });
 	driver.userId = USER_ID;
-	const openPromise = driver.ddp.open();
+	const openPromise = driver.socket.open();
 	mockConnections[0].onopen();
 	await jest.advanceTimersByTimeAsync(0);
 	await openPromise;
@@ -123,7 +123,7 @@ async function buildConnectedDriver() {
 function addMediaSubs(driver: SdkDriver) {
 	['media-signal', 'media-calls'].forEach((name, index) => {
 		const id = `sub-${index}`;
-		driver.ddp.subscriptions[id] = {
+		driver.socket.subscriptions[id] = {
 			id,
 			name: 'stream-notify-user',
 			params: [`${USER_ID}/${name}`],
@@ -133,7 +133,7 @@ function addMediaSubs(driver: SdkDriver) {
 }
 
 function backdateLastPing(driver: SdkDriver, ageMs: number) {
-	driver.ddp.lastPing = Date.now() - ageMs;
+	driver.socket.lastPing = Date.now() - ageMs;
 }
 
 function stopAnsweringFrames(connection: MockConnection) {
@@ -147,14 +147,14 @@ beforeEach(async () => {
 	jest.useFakeTimers();
 	mockConnections.length = 0;
 	driver = await buildConnectedDriver();
-	(sdk as unknown as { current: { ddp: SdkDriver } }).current = { ddp: driver };
+	(sdk as unknown as { current: { driver: SdkDriver } }).current = { driver };
 	mockWaitForLoginReady.mockResolvedValue(true);
 	mockGetState.mockReturnValue({ call: null, resetNativeCallId: jest.fn() });
 });
 
 afterEach(() => {
-	if (driver.ddp.pingTimeout) clearTimeout(driver.ddp.pingTimeout);
-	if (driver.ddp.openTimeout) clearTimeout(driver.ddp.openTimeout);
+	if (driver.socket.pingTimeout) clearTimeout(driver.socket.pingTimeout);
+	if (driver.socket.openTimeout) clearTimeout(driver.socket.openTimeout);
 	jest.useRealTimers();
 });
 

--- a/app/lib/services/voip/acceptNativeCall.sdk.integration.test.ts
+++ b/app/lib/services/voip/acceptNativeCall.sdk.integration.test.ts
@@ -3,13 +3,9 @@ import { acceptNativeCallWithReadiness } from './acceptNativeCall';
 import { useCallStore } from './useCallStore';
 import { terminateNativeCall } from './terminateNativeCall';
 import { waitForLoginReady } from '../waitForLoginReady';
-import type { MockConnection, SdkDriver } from '../../testUtils/sdkIntegration';
+import { addMediaSubs, backdateLastPing, buildConnectedDriver, stopAnsweringFrames } from '../../testUtils/sdkIntegration';
+import type { MockConnection, ISdkDriver } from '../../testUtils/sdkIntegration';
 import type * as SdkIntegration from '../../testUtils/sdkIntegration';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { Driver } = require('@rocket.chat/sdk/lib/drivers/driver') as {
-	Driver: new (options: { host: string; logger: unknown }) => SdkDriver;
-};
 
 jest.mock('../sdk', () => ({
 	__esModule: true,
@@ -50,8 +46,6 @@ const CALL_ID = 'call-uuid';
 const USER_ID = 'user-id';
 const PING_INTERVAL = 10000;
 
-const logger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
-
 interface IMediaSession {
 	applyRestStateSignals: jest.Mock<Promise<void>>;
 	answerCall: jest.Mock<Promise<void>, [string]>;
@@ -69,44 +63,14 @@ function makeMediaSession(overrides: Partial<IMediaSession> = {}): IMediaSession
 	};
 }
 
-async function buildConnectedDriver() {
-	const driver = new Driver({ host: 'localhost:3000', logger });
-	driver.userId = USER_ID;
-	const openPromise = driver.socket.open();
-	mockConnections[0].onopen();
-	await jest.advanceTimersByTimeAsync(0);
-	await openPromise;
-	return driver;
-}
-
-function addMediaSubs(driver: SdkDriver) {
-	['media-signal', 'media-calls'].forEach((name, index) => {
-		const id = `sub-${index}`;
-		driver.socket.subscriptions[id] = {
-			id,
-			name: 'stream-notify-user',
-			params: [`${USER_ID}/${name}`],
-			unsubscribe: jest.fn()
-		};
-	});
-}
-
-function backdateLastPing(driver: SdkDriver, ageMs: number) {
-	driver.socket.lastPing = Date.now() - ageMs;
-}
-
-function stopAnsweringFrames(connection: MockConnection) {
-	connection.send.mockImplementation(() => undefined);
-}
-
-let driver: SdkDriver;
+let driver: ISdkDriver;
 
 beforeEach(async () => {
 	jest.clearAllMocks();
 	jest.useFakeTimers();
 	mockConnections.length = 0;
-	driver = await buildConnectedDriver();
-	(sdk as unknown as { current: { driver: SdkDriver } }).current = { driver };
+	driver = await buildConnectedDriver(mockConnections, USER_ID);
+	(sdk as unknown as { current: { driver: ISdkDriver } }).current = { driver };
 	mockWaitForLoginReady.mockResolvedValue(true);
 	mockGetState.mockReturnValue({ call: null, resetNativeCallId: jest.fn() });
 });
@@ -122,7 +86,7 @@ describe('acceptNativeCallWithReadiness against the real SDK socket', () => {
 		const mediaSession = makeMediaSession();
 
 		backdateLastPing(driver, PING_INTERVAL * 3);
-		addMediaSubs(driver);
+		addMediaSubs(driver, USER_ID);
 
 		const accept = acceptNativeCallWithReadiness(CALL_ID, mediaSession);
 		await jest.advanceTimersByTimeAsync(0);
@@ -144,7 +108,7 @@ describe('acceptNativeCallWithReadiness against the real SDK socket', () => {
 		mockGetState.mockReturnValue({ call: null, resetNativeCallId });
 
 		backdateLastPing(driver, PING_INTERVAL * 3);
-		addMediaSubs(driver);
+		addMediaSubs(driver, USER_ID);
 
 		const accept = acceptNativeCallWithReadiness(CALL_ID, mediaSession);
 		await jest.advanceTimersByTimeAsync(0);
@@ -174,7 +138,7 @@ describe('acceptNativeCallWithReadiness against the real SDK socket', () => {
 
 		await jest.advanceTimersByTimeAsync(100);
 
-		addMediaSubs(driver);
+		addMediaSubs(driver, USER_ID);
 		await jest.advanceTimersByTimeAsync(200);
 		await accept;
 

--- a/app/lib/services/voip/acceptNativeCall.sdk.integration.test.ts
+++ b/app/lib/services/voip/acceptNativeCall.sdk.integration.test.ts
@@ -3,6 +3,8 @@ import { acceptNativeCallWithReadiness } from './acceptNativeCall';
 import { useCallStore } from './useCallStore';
 import { terminateNativeCall } from './terminateNativeCall';
 import { waitForLoginReady } from '../waitForLoginReady';
+import type { MockConnection, SdkDriver } from '../../testUtils/sdkIntegration';
+import type * as SdkIntegration from '../../testUtils/sdkIntegration';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { Driver } = require('@rocket.chat/sdk/lib/drivers/driver') as {
@@ -31,55 +33,12 @@ jest.mock('../../methods/helpers/log', () => ({
 	default: jest.fn()
 }));
 
-interface MockConnection {
-	send: jest.Mock;
-	close: jest.Mock;
-	readyState: number;
-	onopen: () => void;
-	onmessage: (event: { data: string }) => void;
-	onerror: () => void;
-	onclose: () => void;
-}
-
-interface SdkDriver {
-	userId: string;
-	pingInterval: number;
-	reopenNow(): Promise<void>;
-	socket: {
-		lastPing: number;
-		pingTimeout?: ReturnType<typeof setTimeout>;
-		openTimeout?: ReturnType<typeof setTimeout>;
-		open(): Promise<void>;
-		subscriptions: Record<string, { id: string; name: string; params: string[]; unsubscribe: jest.Mock }>;
-	};
-}
-
 const mockConnections: MockConnection[] = [];
 
 jest.mock('universal-websocket-client', () =>
 	jest.fn().mockImplementation(() => {
-		const connection = {
-			send: jest.fn((data: string) => {
-				const message = JSON.parse(data) as { msg: string; id?: string };
-				if (message.msg === 'connect') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'connected', session: 'session-id' }) }));
-				} else if (message.msg === 'ping') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'pong' }) }));
-				} else if (message.msg === 'sub') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'ready', subs: [message.id] }) }));
-				} else if (message.msg === 'unsub') {
-					setImmediate(() => connection.onmessage({ data: JSON.stringify({ msg: 'nosub', id: message.id }) }));
-				}
-			}),
-			close: jest.fn(),
-			readyState: 1,
-			onopen: jest.fn(),
-			onmessage: jest.fn(),
-			onerror: jest.fn(),
-			onclose: jest.fn()
-		};
-		mockConnections.push(connection);
-		return connection;
+		const sdkIntegration = jest.requireActual<typeof SdkIntegration>('../../testUtils/sdkIntegration');
+		return new sdkIntegration.MockConnection(mockConnections);
 	})
 );
 

--- a/app/lib/services/voip/acceptNativeCall.test.ts
+++ b/app/lib/services/voip/acceptNativeCall.test.ts
@@ -9,7 +9,7 @@ const mockWaitForLoginReady = waitForLoginReady as jest.MockedFunction<typeof wa
 const mockRecoverSocket = recoverSocket as jest.MockedFunction<typeof recoverSocket>;
 const mockGetState = useCallStore.getState as jest.Mock;
 const mockTerminateNativeCall = terminateNativeCall as jest.Mock;
-const mockDdp = () => sdk.current?.ddp as any;
+const mockDriver = () => sdk.current?.driver as any;
 
 jest.mock('./useCallStore', () => ({
 	useCallStore: {
@@ -24,7 +24,7 @@ jest.mock('./terminateNativeCall', () => ({
 jest.mock('../sdk', () => ({
 	__esModule: true,
 	default: {
-		current: { ddp: {} }
+		current: { driver: {} }
 	}
 }));
 
@@ -59,7 +59,7 @@ function makeMediaSession(overrides: Partial<IMediaSession> = {}): IMediaSession
 	};
 }
 
-function makeDdp(overrides: Record<string, unknown> = {}) {
+function makeDriver(overrides: Record<string, unknown> = {}) {
 	return {
 		waitForNotifyUserMediaSubs: jest.fn(() => Promise.resolve(true)),
 		...overrides
@@ -80,7 +80,7 @@ describe('acceptNativeCallWithReadiness', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		jest.useFakeTimers();
-		(sdk as any).current = { ddp: makeDdp() };
+		(sdk as any).current = { driver: makeDriver() };
 		mockRecoverSocket.mockResolvedValue('confirmed-alive');
 		mockWaitForLoginReady.mockResolvedValue(true);
 		mockGetState.mockReturnValue(makeStoreState());
@@ -163,7 +163,7 @@ describe('acceptNativeCallWithReadiness', () => {
 	});
 
 	it('terminates and ends the call when media-subscription ack times out', async () => {
-		mockDdp().waitForNotifyUserMediaSubs = jest.fn(() => Promise.resolve(false));
+		mockDriver().waitForNotifyUserMediaSubs = jest.fn(() => Promise.resolve(false));
 		const mediaSession = makeMediaSession();
 		const resetNativeCallId = jest.fn();
 		mockGetState.mockReturnValue(makeStoreState({ resetNativeCallId }));

--- a/app/lib/services/voip/acceptNativeCall.ts
+++ b/app/lib/services/voip/acceptNativeCall.ts
@@ -15,7 +15,7 @@ export interface NativeCallMediaSession {
 
 const activeGates = new Map<string, AbortController>();
 
-async function waitForMediaSignalSubs(ddp: TDriver, timeoutMs: number, abortSignal?: AbortSignal): Promise<boolean> {
+async function waitForMediaSignalSubs(driver: TDriver, timeoutMs: number, abortSignal?: AbortSignal): Promise<boolean> {
 	if (abortSignal?.aborted) {
 		return false;
 	}
@@ -25,7 +25,7 @@ async function waitForMediaSignalSubs(ddp: TDriver, timeoutMs: number, abortSign
 	});
 
 	try {
-		return await Promise.race([ddp.waitForNotifyUserMediaSubs(timeoutMs), aborted]);
+		return await Promise.race([driver.waitForNotifyUserMediaSubs(timeoutMs), aborted]);
 	} catch (error) {
 		log(error);
 		return false;
@@ -65,14 +65,14 @@ export async function acceptNativeCallWithReadiness(callId: string, mediaSession
 			return;
 		}
 
-		const ddp = sdk.current?.ddp;
-		if (!ddp) {
+		const driver = sdk.current?.driver;
+		if (!driver) {
 			return handleFailure(callId, mediaSession);
 		}
 
 		const [loginReady, mediaSubsReady] = await Promise.all([
 			waitForLoginReady(8000, controller.signal),
-			waitForMediaSignalSubs(ddp, 8000, controller.signal)
+			waitForMediaSignalSubs(driver, 8000, controller.signal)
 		]);
 
 		if (controller.signal.aborted) {

--- a/app/lib/services/waitForLoginReady.ts
+++ b/app/lib/services/waitForLoginReady.ts
@@ -1,7 +1,7 @@
 import { onAbort } from '../methods/helpers/onAbort';
 import { store } from '../store/auxStore';
 
-// Reads redux rather than `ddp.loggedIn`: `close` clears `meteor.connected`, while `ddp.loggedIn` survives it.
+// Reads redux rather than `socket.loggedIn`: `close` clears `meteor.connected`, while `socket.loggedIn` survives it.
 // Neither survives a silent background death, so callers must bound their wait.
 export function isLoginReady(): boolean {
 	const state = store.getState();

--- a/app/lib/testUtils/sdkIntegration.ts
+++ b/app/lib/testUtils/sdkIntegration.ts
@@ -11,8 +11,8 @@ export interface IDdpMessage {
 }
 
 export class MockConnection {
-	send = jest.fn((data: string) => {
-		const message = JSON.parse(data) as IDdpMessage;
+	send = jest.fn((frame: string) => {
+		const message = JSON.parse(frame) as IDdpMessage;
 		if (message.msg === 'connect') {
 			setImmediate(() => this.onmessage({ data: JSON.stringify({ msg: 'connected', session: 'session-id' }) }));
 		} else if (message.msg === 'ping') {
@@ -59,7 +59,7 @@ export interface ISdkDriver {
 
 export function framesOn(connection: MockConnection, msg: string): IDdpMessage[] {
 	return connection.send.mock.calls
-		.map(([data]: [string]) => JSON.parse(data) as IDdpMessage)
+		.map(([frame]: [string]) => JSON.parse(frame) as IDdpMessage)
 		.filter(message => message.msg === msg);
 }
 

--- a/app/lib/testUtils/sdkIntegration.ts
+++ b/app/lib/testUtils/sdkIntegration.ts
@@ -2,7 +2,7 @@ import type { Store } from 'redux';
 
 import type { IApplicationState } from '../../definitions';
 
-export interface DdpMessage {
+export interface IDdpMessage {
 	msg: string;
 	id?: string;
 	name?: string;
@@ -12,7 +12,7 @@ export interface DdpMessage {
 
 export class MockConnection {
 	send = jest.fn((data: string) => {
-		const message = JSON.parse(data) as DdpMessage;
+		const message = JSON.parse(data) as IDdpMessage;
 		if (message.msg === 'connect') {
 			setImmediate(() => this.onmessage({ data: JSON.stringify({ msg: 'connected', session: 'session-id' }) }));
 		} else if (message.msg === 'ping') {
@@ -42,7 +42,7 @@ export class MockConnection {
 	}
 }
 
-export interface SdkDriver {
+export interface ISdkDriver {
 	userId: string;
 	pingInterval: number;
 	reopenNow(): Promise<void>;
@@ -57,14 +57,51 @@ export interface SdkDriver {
 	};
 }
 
-export function framesOn(connection: MockConnection, msg: string): DdpMessage[] {
+export function framesOn(connection: MockConnection, msg: string): IDdpMessage[] {
 	return connection.send.mock.calls
-		.map(([data]: [string]) => JSON.parse(data) as DdpMessage)
+		.map(([data]: [string]) => JSON.parse(data) as IDdpMessage)
 		.filter(message => message.msg === msg);
 }
 
 export function receiveFrame(connection: MockConnection, frame: Record<string, unknown>): void {
 	connection.onmessage({ data: JSON.stringify(frame) });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { Driver } = require('@rocket.chat/sdk/lib/drivers/driver') as {
+	Driver: new (options: { host: string; logger: unknown }) => ISdkDriver;
+};
+
+const driverLogger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
+
+export async function buildConnectedDriver(connections: MockConnection[], userId: string): Promise<ISdkDriver> {
+	const driver = new Driver({ host: 'localhost:3000', logger: driverLogger });
+	driver.userId = userId;
+	const openPromise = driver.socket.open();
+	connections[0].onopen();
+	await jest.advanceTimersByTimeAsync(0);
+	await openPromise;
+	return driver;
+}
+
+export function addMediaSubs(driver: ISdkDriver, userId: string): void {
+	['media-signal', 'media-calls'].forEach((name, index) => {
+		const id = `sub-${index}`;
+		driver.socket.subscriptions[id] = {
+			id,
+			name: 'stream-notify-user',
+			params: [`${userId}/${name}`],
+			unsubscribe: jest.fn()
+		};
+	});
+}
+
+export function backdateLastPing(driver: ISdkDriver, ageMs: number): void {
+	driver.socket.lastPing = Date.now() - ageMs;
+}
+
+export function stopAnsweringFrames(connection: MockConnection): void {
+	connection.send.mockImplementation(() => undefined);
 }
 
 export function makeCollection(name: string) {

--- a/app/lib/testUtils/sdkIntegration.ts
+++ b/app/lib/testUtils/sdkIntegration.ts
@@ -1,0 +1,108 @@
+import type { Store } from 'redux';
+
+import type { IApplicationState } from '../../definitions';
+
+export interface DdpMessage {
+	msg: string;
+	id?: string;
+	name?: string;
+	method?: string;
+	params?: unknown[];
+}
+
+export class MockConnection {
+	send = jest.fn((data: string) => {
+		const message = JSON.parse(data) as DdpMessage;
+		if (message.msg === 'connect') {
+			setImmediate(() => this.onmessage({ data: JSON.stringify({ msg: 'connected', session: 'session-id' }) }));
+		} else if (message.msg === 'ping') {
+			setImmediate(() => this.onmessage({ data: JSON.stringify({ msg: 'pong' }) }));
+		} else if (message.msg === 'sub') {
+			setImmediate(() => this.onmessage({ data: JSON.stringify({ msg: 'ready', subs: [message.id] }) }));
+		} else if (message.msg === 'unsub') {
+			setImmediate(() => this.onmessage({ data: JSON.stringify({ msg: 'nosub', id: message.id }) }));
+		} else if (message.msg === 'method' && message.method === 'login') {
+			setImmediate(() =>
+				this.onmessage({
+					data: JSON.stringify({ msg: 'result', id: message.id, result: { id: 'user-id', token: 'auth-token' } })
+				})
+			);
+		}
+	});
+
+	close = jest.fn();
+	readyState = 1;
+	onopen = () => {};
+	onmessage = (_event: { data: string }) => {};
+	onerror = () => {};
+	onclose = (_event?: { code?: number }) => {};
+
+	constructor(registry: MockConnection[]) {
+		registry.push(this);
+	}
+}
+
+export interface SdkDriver {
+	userId: string;
+	pingInterval: number;
+	reopenNow(): Promise<void>;
+	waitForNotifyUserMediaSubs?(timeoutMs?: number): Promise<boolean>;
+	socket: {
+		lastPing: number;
+		pingTimeout?: ReturnType<typeof setTimeout>;
+		openTimeout?: ReturnType<typeof setTimeout>;
+		open(): Promise<void>;
+		send(message: Record<string, unknown>): Promise<unknown>;
+		subscriptions: Record<string, { id: string; name: string; params: string[]; unsubscribe: jest.Mock }>;
+	};
+}
+
+export function framesOn(connection: MockConnection, msg: string): DdpMessage[] {
+	return connection.send.mock.calls
+		.map(([data]: [string]) => JSON.parse(data) as DdpMessage)
+		.filter(message => message.msg === msg);
+}
+
+export function receiveFrame(connection: MockConnection, frame: Record<string, unknown>): void {
+	connection.onmessage({ data: JSON.stringify(frame) });
+}
+
+export function makeCollection(name: string) {
+	return {
+		name,
+		find: jest.fn(),
+		query: jest.fn(() => ({ fetch: jest.fn(() => Promise.resolve([])) })),
+		create: jest.fn(),
+		prepareCreate: jest.fn(),
+		schema: {}
+	};
+}
+
+export async function flush(turns = 10): Promise<void> {
+	for (let i = 0; i < turns; i++) {
+		await Promise.resolve();
+		await jest.advanceTimersByTimeAsync(0);
+	}
+}
+
+export function makeReduxStore() {
+	const listeners = new Set<() => void>();
+	const state = {
+		meteor: { connected: false },
+		login: { user: null as Record<string, unknown> | null, isAuthenticated: false },
+		server: { version: '5.0.0' },
+		settings: {} as Record<string, unknown>,
+		room: { subscribedRoom: null as string | null }
+	};
+	return {
+		state,
+		store: {
+			getState: () => state,
+			dispatch: jest.fn(),
+			subscribe: (listener: () => void) => {
+				listeners.add(listener);
+				return () => listeners.delete(listener);
+			}
+		} as unknown as Store<IApplicationState> & { dispatch: jest.Mock }
+	};
+}

--- a/app/lib/testUtils/sdkIntegration.ts
+++ b/app/lib/testUtils/sdkIntegration.ts
@@ -104,7 +104,16 @@ export function stopAnsweringFrames(connection: MockConnection): void {
 	connection.send.mockImplementation(() => undefined);
 }
 
-export function makeCollection(name: string) {
+export interface IMockCollection {
+	name: string;
+	find: jest.Mock;
+	query: jest.Mock;
+	create: jest.Mock;
+	prepareCreate: jest.Mock;
+	schema: Record<string, unknown>;
+}
+
+export function makeCollection(name: string): IMockCollection {
 	return {
 		name,
 		find: jest.fn(),
@@ -122,14 +131,27 @@ export async function flush(turns = 10): Promise<void> {
 	}
 }
 
-export function makeReduxStore() {
+export interface IMockReduxState {
+	meteor: { connected: boolean };
+	login: { user: Record<string, unknown> | null; isAuthenticated: boolean };
+	server: { version: string };
+	settings: Record<string, unknown>;
+	room: { subscribedRoom: string | null };
+}
+
+export interface IMockReduxStore {
+	state: IMockReduxState;
+	store: Store<IApplicationState> & { dispatch: jest.Mock };
+}
+
+export function makeReduxStore(): IMockReduxStore {
 	const listeners = new Set<() => void>();
-	const state = {
+	const state: IMockReduxState = {
 		meteor: { connected: false },
-		login: { user: null as Record<string, unknown> | null, isAuthenticated: false },
+		login: { user: null, isAuthenticated: false },
 		server: { version: '5.0.0' },
-		settings: {} as Record<string, unknown>,
-		room: { subscribedRoom: null as string | null }
+		settings: {},
+		room: { subscribedRoom: null }
 	};
 	return {
 		state,

--- a/app/views/AuthenticationWebView.tsx
+++ b/app/views/AuthenticationWebView.tsx
@@ -7,7 +7,7 @@ import parse from 'url-parse';
 
 import ActivityIndicator from '../containers/ActivityIndicator';
 import * as HeaderButton from '../containers/Header/components/HeaderButton';
-import { type ICredentials } from '../definitions';
+import { type ILoginCredentials } from '../definitions';
 import { userAgent } from '../lib/constants/userAgent';
 import { useAppSelector } from '../lib/hooks/useAppSelector';
 import { useDebounce } from '../lib/methods/helpers';
@@ -70,9 +70,9 @@ const AuthenticationWebView = ({ route }: AuthenticationWebViewProps) => {
 	const iframeRedirectRegex = new RegExp(`(?=.*(${server}))(?=.*(event|loginToken|token))`, 'g');
 
 	// Force 3s delay so the server has time to evaluate the token
-	const debouncedLogin = useDebounce((params: ICredentials) => login(params), 3000);
+	const debouncedLogin = useDebounce((params: ILoginCredentials) => login(params), 3000);
 
-	const login = async (params: ICredentials) => {
+	const login = async (params: ILoginCredentials) => {
 		if (loggingRef.current) {
 			return;
 		}

--- a/app/views/ForwardLivechatView.tsx
+++ b/app/views/ForwardLivechatView.tsx
@@ -65,7 +65,7 @@ const ForwardLivechatView = (): ReactElement => {
 				term
 			});
 			if (result.success) {
-				const parsedUsers = result.items.map(user => ({ label: user.username, value: user._id }));
+				const parsedUsers = result.items.flatMap(user => (user.username ? [{ label: user.username, value: user._id }] : []));
 				if (!term) {
 					setUsers(parsedUsers);
 				}

--- a/app/views/ProfileView/methods/buildProfileParams.ts
+++ b/app/views/ProfileView/methods/buildProfileParams.ts
@@ -4,7 +4,7 @@ import { type IProfileParams, type IUser } from '../../../definitions';
 
 interface IProfileFormValues {
 	name: string;
-	username: string;
+	username?: string;
 	email: string | null;
 	currentPassword: string | null;
 	bio?: string;

--- a/app/views/RoomMembersView/helpers.ts
+++ b/app/views/RoomMembersView/helpers.ts
@@ -48,8 +48,11 @@ export const fetchRoomMembersRoles = async (roomType: TRoomType, rid: string, up
 };
 
 export const handleMute = async (user: TUserModel, rid: string) => {
+	if (!user?.username) {
+		return;
+	}
 	try {
-		await toggleMuteUserInRoom(rid, user?.username, user?._id, !user.muted);
+		await toggleMuteUserInRoom(rid, user.username, user._id, !user.muted);
 		EventEmitter.emit(LISTENER, {
 			message: I18n.t('User_has_been_key', { key: user?.muted ? I18n.t('unmuted') : I18n.t('muted') })
 		});
@@ -88,6 +91,9 @@ export const handleModerator = async (
 };
 
 export const navToDirectMessage = async (item: IUser, isMasterDetail: boolean): Promise<void> => {
+	if (!item.username) {
+		return;
+	}
 	try {
 		const db = database.active;
 		const subsCollection = db.get('subscriptions');

--- a/app/views/RoomMembersView/helpers.ts
+++ b/app/views/RoomMembersView/helpers.ts
@@ -48,9 +48,6 @@ export const fetchRoomMembersRoles = async (roomType: TRoomType, rid: string, up
 };
 
 export const handleMute = async (user: TUserModel, rid: string) => {
-	if (!user?.username) {
-		return;
-	}
 	try {
 		await toggleMuteUserInRoom(rid, user.username, user._id, !user.muted);
 		EventEmitter.emit(LISTENER, {

--- a/app/views/RoomMembersView/index.tsx
+++ b/app/views/RoomMembersView/index.tsx
@@ -282,7 +282,8 @@ const RoomMembersView = (): ReactElement => {
 		});
 	};
 
-	const getUserDisplayName = (user: TUserModel) => (useRealName ? user.name : user.username) || user.username;
+	const getUserDisplayName = (user: TUserModel) =>
+		(useRealName ? user.name || user.username : user.username || user.name) || user._id;
 
 	const onPressUser = (selectedUser: TUserModel) => {
 		const { room, roomRoles, members } = state;

--- a/app/views/RoomMembersView/index.tsx
+++ b/app/views/RoomMembersView/index.tsx
@@ -282,8 +282,11 @@ const RoomMembersView = (): ReactElement => {
 		});
 	};
 
-	const getUserDisplayName = (user: TUserModel) =>
-		(useRealName ? user.name || user.username : user.username || user.name) || user._id;
+	const getUserDisplayName = (user: TUserModel) => {
+		const preferred = useRealName ? user.name : user.username;
+		const fallback = useRealName ? user.username : user.name;
+		return preferred || fallback || user._id;
+	};
 
 	const onPressUser = (selectedUser: TUserModel) => {
 		const { room, roomRoles, members } = state;

--- a/app/views/SelectedUsersView/index.tsx
+++ b/app/views/SelectedUsersView/index.tsx
@@ -94,7 +94,7 @@ const SelectedUsersView = () => {
 	}, [navigation, users.length, maxUsers, buttonText, nextAction]);
 
 	useEffect(() => {
-		if (isGroupChat()) {
+		if (isGroupChat() && user.username) {
 			dispatch(addUser({ _id: user.id, name: user.username, fname: user.name as string }));
 		}
 	}, []);

--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -57,11 +57,7 @@ interface IShareViewProps {
 	navigation: NativeStackNavigationProp<InsideStackParamList, 'ShareView'>;
 	route: RouteProp<InsideStackParamList, 'ShareView'>;
 	theme: TSupportedThemes;
-	user: {
-		id: string;
-		username: string;
-		token: string;
-	};
+	user: IUser;
 	server: string;
 	serverVersion?: string;
 	FileUpload_MediaTypeWhiteList?: string;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@rocket.chat/media-signaling": "1.0.0-rc.1",
 		"@rocket.chat/message-parser": "0.31.36",
 		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#main",
-		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#383e457b3bb31598daacf2572d20644c795f58d2",
+		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#176bdfe4b5cd2f47370266572cbcb94a5eee7322",
 		"@rocket.chat/ui-kit": "^0.39.0",
 		"@zoontek/react-native-navigation-bar": "^1.1.1",
 		"axios": "0.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: RocketChat/rocket.chat-mobile-crypto#main
         version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/69a0a250dd7c6ff0808eb659d7202be1cae7fa1c(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@7.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@rocket.chat/sdk':
-        specifier: RocketChat/Rocket.Chat.js.SDK#383e457b3bb31598daacf2572d20644c795f58d2
-        version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/383e457b3bb31598daacf2572d20644c795f58d2
+        specifier: RocketChat/Rocket.Chat.js.SDK#176bdfe4b5cd2f47370266572cbcb94a5eee7322
+        version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/176bdfe4b5cd2f47370266572cbcb94a5eee7322
       '@rocket.chat/ui-kit':
         specifier: ^0.39.0
         version: 0.39.0(@rocket.chat/icons@0.47.0)(@types/node@25.0.3)(typescript@7.0.2)
@@ -2633,8 +2633,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/383e457b3bb31598daacf2572d20644c795f58d2':
-    resolution: {gitHosted: true, integrity: sha512-in4lCtRYlY6PcCN3JfEtO3zVqyVjdic9BXxScWiD2y/BwwBqijgRFKckYm44v9GOwMllav92e9Dsfz8GyuBfhw==, tarball: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/383e457b3bb31598daacf2572d20644c795f58d2}
+  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/176bdfe4b5cd2f47370266572cbcb94a5eee7322':
+    resolution: {gitHosted: true, integrity: sha512-SAkGojmE6QbNMVNqz6Sgq2QDwcZ0S3kMLyJDNrCbTvcE18PJ9INoanXztzek65J9cZuq5Z2faeENVft8wlqZ+A==, tarball: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/176bdfe4b5cd2f47370266572cbcb94a5eee7322}
     version: 1.3.3-mobile
 
   '@rocket.chat/ui-kit@0.39.0':
@@ -10517,7 +10517,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@7.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0)
 
-  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/383e457b3bb31598daacf2572d20644c795f58d2':
+  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/176bdfe4b5cd2f47370266572cbcb94a5eee7322':
     dependencies:
       js-sha256: 0.9.0
       tiny-events: 1.0.1


### PR DESCRIPTION
## Proposed changes

Stacked on #7574, which bumps `@rocket.chat/sdk` to the mobile branch. This PR makes the app actually consume it:

- Adopts the SDK's `ILoginCredentials` union as the app's `ICredentials` and deletes the `toLoginResult`/`toSdkCredentials` casts that stood in for real types. The old flat type declared `password` and `username` required, so every login — saml, cas, apple, oauth, resume — was typed as if it carried both.
- `ILoggedUser.username` is now optional: a user who registered without choosing one has none, which `isRegisterUser` already assumed.
- Apple login: send `{}` rather than `null` for `fullName`. Apple returns null on every sign-in after the first and the server destructures it unguarded, so repeat Apple logins failed with a generic error. A missing identity token is now reported through the failure path instead of throwing inside a catch that read as user dismissal.
- `parseSamlOrCasRedirect` returns null instead of a payload with no credential token — a login the server cannot complete.
- The 2FA retry always normalizes to `{ user, password, code }`. It used to keep the ldap/crowd shape when the server predated 3.9.0, and that branch also ran whenever the server version was not yet known, sending a top-level `code` the server's 2FA gate ignores.
- `classifySocketHealth`: drops the unreachable stale-ping branch — `Socket.connected` already folds in the ping-age test, so a connected socket never has a stale ping.
- Integration tests run the app's connect/recover/voip-accept/room-subscription paths against the real SDK classes over a mocked websocket transport, replacing the mock-based `ddpSocket.test.ts`. The shared scaffolding lives in `app/lib/testUtils/sdkIntegration.ts`.

## Issue(s)

None.

## How to test or reproduce

- `TZ=UTC pnpm test` — unit and integration suites cover the login payload shapes, socket health classification, and the reconnect paths.
- Manually: log in with Apple twice (second sign-in is the one that used to fail), log in via SAML/CAS, and log in with 2FA on a pre-3.9 server.

## Screenshots

N/A — no visual changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Depends on #7574 — the SDK bump lands there; this PR contains only the app-side adoption on top of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple sign-in handling when required identity information is unavailable.
  * Prevented invalid autocomplete results and user actions when usernames are missing.
  * Added safer fallback names using real name, username, or user ID.
  * Preserved user state when profile responses lack a username.
  * Improved two-factor cancellation, resending, and authentication error handling.
  * Strengthened SAML and CAS sign-in validation when tokens are missing.
  * Improved logout, socket recovery, and media connection error reporting.

* **Refactor**
  * Updated authentication and connection handling for more consistent reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->