### PR TITLE
chore: narrow subscribeSettings and drop its unused SDK type import

### DIFF
--- a/app/lib/methods/getSettings.ts
+++ b/app/lib/methods/getSettings.ts
@@ -1,5 +1,4 @@
 import { Q } from '@nozbe/watermelondb';
-import { type ISubscription } from '@rocket.chat/sdk/interfaces';
 import { sanitizedRaw } from '@nozbe/watermelondb/RawRecord';
 
 import { addSettings, clearSettings } from '../../actions/settings';
@@ -144,8 +143,8 @@ export async function setSettings(): Promise<void> {
 	reduxStore.dispatch(addSettings(parseSettings(parsed.slice(0, parsed.length))));
 }
 
-export function subscribeSettings(): Promise<ISubscription | undefined> {
-	return sdk.subscribe('stream-notify-all', 'public-settings-changed');
+export async function subscribeSettings(): Promise<void> {
+	await sdk.subscribe('stream-notify-all', 'public-settings-changed');
 }
 
 type IData = ISettingsIcon | IPreparedSettings;


### PR DESCRIPTION
## Proposed changes

`subscribeSettings` was typed as returning the DDP subscription handle from the SDK, which forced the
settings module to import `ISubscription` from `@rocket.chat/sdk/interfaces`. Its only caller — the
login saga's `subscribeSettingsFork` — discards the value, so the type bought nothing and the module
carried a compile-time dependency on the SDK's vocabulary for no gain.

The return type is now `Promise<void>` and the SDK import is gone. This is not a signature-only edit:
the body awaits the subscribe instead of returning its promise, which is what lets the handle be
dropped.

Behaviour is unchanged. Rejections still reach the saga's `try/catch`, because `await` inside an
`async` function re-propagates them through the returned promise.

The equivalent `ISubscription` usage in the SDK service wrapper is left alone — that one genuinely
consumes the handle.

## Issue(s)

Cleanup found while reviewing #7574; targets that branch.

## How to test or reproduce

No user-visible surface. The change is a compile-time coupling removal, verified by:

- `pnpm lint` — `tsc` clean, so no call site depended on the old return type
- `TZ=UTC pnpm test app/lib/services/sdk.test.ts app/lib/methods/subscriptions app/sagas` — 8 suites, 40 tests pass
- `grep '@rocket.chat/sdk' app/lib/methods/getSettings.ts` — no longer matches
- Log in and confirm settings still sync live: change a public setting server-side and see it apply without a restart

## Screenshots

N/A — no visual change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

No regression test is included, and that is deliberate rather than an omission. The defect is the
*absence* of a type import, which no runtime assertion can observe: `subscribeSettings()` resolved to
a discarded value before and resolves to `undefined` now, so any behavioural test passes either way.
The meaningful guard — "this module must not import from `@rocket.chat/sdk`" — is a lint concern, and
adding such a rule is a larger change than this cleanup warrants.

Keeping the handle and unsubscribing on logout was considered and rejected as out of scope: that is a
new teardown path, i.e. a feature, not a cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated settings subscription handling to complete asynchronously without returning an internal subscription object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->