### PR TITLE
test: use the app's own TDriver instead of reaching into SDK internals

### DIFF
--- a/app/lib/services/__tests__/socketHealth.test.ts
+++ b/app/lib/services/__tests__/socketHealth.test.ts
@@ -5,9 +5,7 @@ jest.mock('../sdk', () => ({
 	}
 }));
 
-import type { Driver } from '@rocket.chat/sdk/lib/drivers/driver';
-
-import sdk from '../sdk';
+import sdk, { type TDriver } from '../sdk';
 import { classifySocketHealth, recoverSocket } from '../socketHealth';
 
 const now = 1_000_000;
@@ -44,12 +42,12 @@ describe('classifySocketHealth', () => {
 
 	it('returns round-trip-check for a connected socket rather than trusting it outright', () => {
 		const driver = makeDriver({ connected: true });
-		expect(classifySocketHealth(driver as unknown as Driver)).toBe('round-trip-check');
+		expect(classifySocketHealth(driver as unknown as TDriver)).toBe('round-trip-check');
 	});
 
 	it('returns reopen for a closed socket even when lastPing is fresh', () => {
 		const driver = makeDriver({ connected: false, lastPing: now });
-		expect(classifySocketHealth(driver as unknown as Driver)).toBe('reopen');
+		expect(classifySocketHealth(driver as unknown as TDriver)).toBe('reopen');
 	});
 });
 


### PR DESCRIPTION
## Proposed changes

`socketHealth.test.ts` imported the `Driver` type from a deep path inside `@rocket.chat/sdk` to describe a value whose type the app already exports. `TDriver` (in `app/lib/services/sdk.ts`) is derived from the public client and is the exact parameter type of the function under test, so the deep import bought nothing.

This swaps it, and folds the type import into the `sdk` import already present in the file — matching how `socketHealth.ts` itself imports the pair.

The two remaining deep reaches into the SDK are deliberately left alone. They need the `Driver` **class** at runtime, and the SDK root exports only `settings` and `Rocketchat`, so no public route exists for them.

## Issue(s)

N/A — review cleanup on #7574.

## How to test or reproduce

```
TZ=UTC npx jest app/lib/services/__tests__/ app/lib/services/voip/
```

267 tests pass across 21 suites.

The change is type-only and erased at compile time, so the tests cannot detect it either way. What was verified instead is that the two types are genuinely interchangeable — under `tsc`, `Driver`, `TDriver` and the function's parameter type are mutually identical, checked with a deliberately falsified control to confirm the check was capable of failing.

## Screenshots

N/A — no user-visible change.

## Types of changes

- [x] Chore (refactoring, dependencies, etc.)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/CONTRIBUTING.md)
- [x] My changes do not require a change to the documentation
- [x] I have added tests to cover my changes (existing suites cover this; no behaviour changed)
- [x] All new and existing tests passed

## Further comments

Targets `new-sdk` rather than `develop` so it lands with the bump under review.

Worth flagging for anyone else working on this branch: the SDK field was renamed `ddp` → `driver` in the latest pin. A stale `node_modules` produces 15 confusing test failures and a bogus typecheck error in `socketHealth.ts`. Run `pnpm install` before trusting any result here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated socket health test type references to align with the current SDK interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->