### PR TITLE
chore: remove lint suppressions for a disabled rule

### DIFF
--- a/app/lib/methods/subscriptions/__tests__/roomSubscription.integration.test.ts
+++ b/app/lib/methods/subscriptions/__tests__/roomSubscription.integration.test.ts
@@ -83,7 +83,6 @@ import {
 import type { IMockCollection, MockConnection } from '../../../testUtils/sdkIntegration';
 import type * as SdkIntegration from '../../../testUtils/sdkIntegration';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const database = require('../../../database').default as {
 	active: { get: jest.Mock; write: jest.Mock; batch: jest.Mock };
 };

--- a/app/lib/services/__tests__/connect.integration.test.ts
+++ b/app/lib/services/__tests__/connect.integration.test.ts
@@ -61,7 +61,6 @@ jest.mock('../../database', () => ({
 	}
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const database = require('../../database').default as {
 	setActiveDB: jest.Mock;
 	active: { get: jest.Mock; write: jest.Mock; batch: jest.Mock };

--- a/app/lib/testUtils/sdkIntegration.ts
+++ b/app/lib/testUtils/sdkIntegration.ts
@@ -1,3 +1,4 @@
+import type * as RocketChatSdk from '@rocket.chat/sdk';
 import type { Store } from 'redux';
 
 import type { IApplicationState } from '../../definitions';
@@ -67,14 +68,12 @@ export function receiveFrame(connection: MockConnection, frame: Record<string, u
 	connection.onmessage({ data: JSON.stringify(frame) });
 }
 
-const { Driver } = require('@rocket.chat/sdk/lib/drivers/driver') as {
-	Driver: new (options: { host: string; logger: unknown }) => ISdkDriver;
-};
+const { Rocketchat } = jest.requireActual<typeof RocketChatSdk>('@rocket.chat/sdk');
 
 const driverLogger = { debug: jest.fn(), info: jest.fn(), error: jest.fn(), warn: jest.fn() };
 
 export async function buildConnectedDriver(connections: MockConnection[], userId: string): Promise<ISdkDriver> {
-	const driver = new Driver({ host: 'localhost:3000', logger: driverLogger });
+	const driver = new Rocketchat({ host: 'localhost:3000', logger: driverLogger }).driver as unknown as ISdkDriver;
 	driver.userId = userId;
 	const openPromise = driver.socket.open();
 	connections[0].onopen();

--- a/app/lib/testUtils/sdkIntegration.ts
+++ b/app/lib/testUtils/sdkIntegration.ts
@@ -67,7 +67,6 @@ export function receiveFrame(connection: MockConnection, frame: Record<string, u
 	connection.onmessage({ data: JSON.stringify(frame) });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { Driver } = require('@rocket.chat/sdk/lib/drivers/driver') as {
 	Driver: new (options: { host: string; logger: unknown }) => ISdkDriver;
 };


### PR DESCRIPTION
## Proposed changes

Two cleanups in the test helpers this branch added.

**1. Remove three `eslint-disable-next-line @typescript-eslint/no-var-requires` comments that suppress nothing.**

The rule is disabled two ways over: `typescript/no-var-requires` is `"off"` in the `**/*.ts`/`**/*.tsx` override in
`.oxlintrc.json`, and `**/__tests__` is in `ignorePatterns`, so two of the three files are not linted at all.

**2. Reach the SDK driver through the package root instead of an internal module path.**

`sdkIntegration.ts` reached into `@rocket.chat/sdk/lib/drivers/driver` and re-declared the constructor signature by
hand. It now goes through the package's public export:

```ts
const { Rocketchat } = jest.requireActual<typeof RocketChatSdk>('@rocket.chat/sdk');
```

`jest.requireActual` is needed because `__mocks__/@rocket.chat/sdk.js` is a manual mock for a node_modules package,
so Jest applies it to every suite automatically and a plain import of the root yields an empty `Rocketchat` class.
The type-only `import type * as RocketChatSdk` is erased at runtime, so it does not pull the mock in.

The `as unknown as ISdkDriver` cast stays: `socket` is `private` on `Driver`, so any route to it needs a cast.

Net effect: no dependency on an internal SDK file path, and the hand-written constructor signature is gone in
favour of the package's own types.

## Issue(s)

Follow-up cleanup on #7574.

## How to test or reproduce

- `npx oxlint --report-unused-disable-directives app/lib/testUtils/sdkIntegration.ts` reports an unused directive
  before this change and nothing after it.
- `npx oxlint`, `npx oxfmt --check .` and `npx tsc --noEmit` are clean.
- `TZ=UTC npx jest app/lib/services/__tests__ app/lib/methods/subscriptions/__tests__ app/lib/services/voip` → 270 passed.

## Screenshots

n/a — no user-facing change.

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Test-only change. No production code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete linting comments and streamlined integration test setup.
  * Updated test utilities to use the SDK’s supported connection flow.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->