### PR TITLE
test: cover multi-workspace switching

### DIFF
--- a/.sniffler/test-map.json
+++ b/.sniffler/test-map.json
@@ -40,7 +40,9 @@
 			"app/views/RegisterView/**",
 			"app/views/RoomsListView/**",
 			"app/sagas/login.js",
-			"app/sagas/rooms.js"
+			"app/sagas/rooms.js",
+			"app/sagas/selectServer.ts",
+			"app/lib/services/connect.ts"
 		]
 	},
 	{
@@ -66,7 +68,9 @@
 			"app/views/RegisterView/**",
 			"app/views/RoomsListView/**",
 			"app/sagas/login.js",
-			"app/sagas/rooms.js"
+			"app/sagas/rooms.js",
+			"app/sagas/selectServer.ts",
+			"app/lib/services/connect.ts"
 		]
 	},
 	{

--- a/app/lib/methods/logout.test.ts
+++ b/app/lib/methods/logout.test.ts
@@ -39,6 +39,8 @@ const OTHER_SERVER = 'https://b.rocket.chat';
 const USER_ID = 'user-a';
 const OTHER_USER_ID = 'user-b';
 
+const tokenKey = (suffix: string) => `${TOKEN_KEY}-${suffix}`;
+
 const serverKeys = (server: string) => [
 	`${BASIC_AUTH_KEY}-${server}`,
 	`${server}-${E2E_PUBLIC_KEY}`,
@@ -49,22 +51,22 @@ const serverKeys = (server: string) => [
 const keysToClear = [
 	...serverKeys(SERVER),
 	...serverKeys(OTHER_SERVER),
-	`${TOKEN_KEY}-${SERVER}`,
-	`${TOKEN_KEY}-${OTHER_SERVER}`,
-	`${TOKEN_KEY}-${USER_ID}`,
-	`${TOKEN_KEY}-${OTHER_USER_ID}`,
+	tokenKey(SERVER),
+	tokenKey(OTHER_SERVER),
+	tokenKey(USER_ID),
+	tokenKey(OTHER_USER_ID),
 	CURRENT_SERVER
 ];
 
 function seedServer(server: string, userId?: string) {
 	if (userId) {
-		UserPreferences.setString(`${TOKEN_KEY}-${server}`, userId);
-		UserPreferences.setString(`${TOKEN_KEY}-${userId}`, `token-${userId}`);
+		UserPreferences.setString(tokenKey(server), userId);
+		UserPreferences.setString(tokenKey(userId), `token-${userId}`);
 	}
 	serverKeys(server).forEach(key => UserPreferences.setString(key, `value-for-${key}`));
 }
 
-function seedServersDBWithServer() {
+function mockServersDBFind() {
 	const serverRecord = { prepareDestroyPermanently: jest.fn(() => ({})) };
 	jest.mocked(database.servers.get).mockReturnValue({ find: jest.fn(() => Promise.resolve(serverRecord)) } as any);
 }
@@ -73,7 +75,7 @@ describe('removeServerData', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		keysToClear.forEach(key => UserPreferences.removeItem(key));
-		seedServersDBWithServer();
+		mockServersDBFind();
 	});
 
 	it('clears every per-server key for the removed server', async () => {
@@ -81,8 +83,8 @@ describe('removeServerData', () => {
 
 		await removeServerData({ server: SERVER });
 
-		expect(UserPreferences.getString(`${TOKEN_KEY}-${SERVER}`)).toBeNull();
-		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_ID}`)).toBeNull();
+		expect(UserPreferences.getString(tokenKey(SERVER))).toBeNull();
+		expect(UserPreferences.getString(tokenKey(USER_ID))).toBeNull();
 		serverKeys(SERVER).forEach(key => expect(UserPreferences.getString(key)).toBeNull());
 	});
 
@@ -92,8 +94,8 @@ describe('removeServerData', () => {
 
 		await removeServerData({ server: SERVER });
 
-		expect(UserPreferences.getString(`${TOKEN_KEY}-${OTHER_SERVER}`)).toBe(OTHER_USER_ID);
-		expect(UserPreferences.getString(`${TOKEN_KEY}-${OTHER_USER_ID}`)).toBe(`token-${OTHER_USER_ID}`);
+		expect(UserPreferences.getString(tokenKey(OTHER_SERVER))).toBe(OTHER_USER_ID);
+		expect(UserPreferences.getString(tokenKey(OTHER_USER_ID))).toBe(`token-${OTHER_USER_ID}`);
 		serverKeys(OTHER_SERVER).forEach(key => expect(UserPreferences.getString(key)).toBe(`value-for-${key}`));
 	});
 
@@ -108,11 +110,11 @@ describe('removeServerData', () => {
 
 	it('skips the user token key when the server has no stored userId', async () => {
 		seedServer(SERVER);
-		UserPreferences.setString(`${TOKEN_KEY}-${USER_ID}`, `token-${USER_ID}`);
+		UserPreferences.setString(tokenKey(USER_ID), `token-${USER_ID}`);
 
 		await removeServerData({ server: SERVER });
 
-		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_ID}`)).toBe(`token-${USER_ID}`);
+		expect(UserPreferences.getString(tokenKey(USER_ID))).toBe(`token-${USER_ID}`);
 		serverKeys(SERVER).forEach(key => expect(UserPreferences.getString(key)).toBeNull());
 	});
 });

--- a/app/lib/methods/logout.test.ts
+++ b/app/lib/methods/logout.test.ts
@@ -1,0 +1,122 @@
+// Do not mock './userPreferences' here: this test asserts against the real MMKV-backed store
+// (__mocks__/react-native-mmkv.js). Mocking it replaces the state transitions this test exists
+// to prove with spy calls, and the negative columns stop meaning anything.
+
+jest.mock('../database', () => ({
+	__esModule: true,
+	default: {
+		servers: {
+			get: jest.fn(),
+			write: jest.fn((block: () => unknown) => Promise.resolve(block())),
+			batch: jest.fn()
+		}
+	},
+	getDatabase: jest.fn()
+}));
+
+jest.mock('./helpers/log', () => ({
+	...jest.requireActual('./helpers/log'),
+	__esModule: true,
+	default: jest.fn()
+}));
+
+jest.mock('../notifications', () => ({
+	getDeviceToken: jest.fn(() => '')
+}));
+
+jest.mock('../services/connect', () => ({
+	disconnect: jest.fn()
+}));
+
+jest.mock('../services/restApi', () => ({
+	removePushToken: jest.fn()
+}));
+
+import { removeServerData } from './logout';
+import database from '../database';
+import UserPreferences from './userPreferences';
+import { BASIC_AUTH_KEY } from './helpers/fetch';
+import { CURRENT_SERVER, E2E_PRIVATE_KEY, E2E_PUBLIC_KEY, E2E_RANDOM_PASSWORD_KEY, TOKEN_KEY } from '../constants/keys';
+
+const SERVER = 'https://a.rocket.chat';
+const OTHER_SERVER = 'https://b.rocket.chat';
+const USER_ID = 'user-a';
+const OTHER_USER_ID = 'user-b';
+
+const serverKeys = (server: string) => [
+	`${BASIC_AUTH_KEY}-${server}`,
+	`${server}-${E2E_PUBLIC_KEY}`,
+	`${server}-${E2E_PRIVATE_KEY}`,
+	`${server}-${E2E_RANDOM_PASSWORD_KEY}`
+];
+
+const allKeys = [
+	...serverKeys(SERVER),
+	...serverKeys(OTHER_SERVER),
+	`${TOKEN_KEY}-${SERVER}`,
+	`${TOKEN_KEY}-${OTHER_SERVER}`,
+	`${TOKEN_KEY}-${USER_ID}`,
+	`${TOKEN_KEY}-${OTHER_USER_ID}`,
+	CURRENT_SERVER
+];
+
+function seedServer(server: string, userId?: string) {
+	if (userId) {
+		UserPreferences.setString(`${TOKEN_KEY}-${server}`, userId);
+		UserPreferences.setString(`${TOKEN_KEY}-${userId}`, `token-${userId}`);
+	}
+	serverKeys(server).forEach(key => UserPreferences.setString(key, `value-for-${key}`));
+}
+
+function stubServersDB() {
+	const record = { prepareDestroyPermanently: jest.fn(() => ({})) };
+	jest.mocked(database.servers.get).mockReturnValue({ find: jest.fn(() => Promise.resolve(record)) } as any);
+}
+
+describe('removeServerData', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		allKeys.forEach(key => UserPreferences.removeItem(key));
+		stubServersDB();
+	});
+
+	it('clears every per-server key for the removed server', async () => {
+		seedServer(SERVER, USER_ID);
+
+		await removeServerData({ server: SERVER });
+
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${SERVER}`)).toBeNull();
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_ID}`)).toBeNull();
+		serverKeys(SERVER).forEach(key => expect(UserPreferences.getString(key)).toBeNull());
+	});
+
+	it('leaves another workspace keys untouched', async () => {
+		seedServer(SERVER, USER_ID);
+		seedServer(OTHER_SERVER, OTHER_USER_ID);
+
+		await removeServerData({ server: SERVER });
+
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${OTHER_SERVER}`)).toBe(OTHER_USER_ID);
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${OTHER_USER_ID}`)).toBe(`token-${OTHER_USER_ID}`);
+		serverKeys(OTHER_SERVER).forEach(key => expect(UserPreferences.getString(key)).toBe(`value-for-${key}`));
+	});
+
+	it('leaves CURRENT_SERVER in place', async () => {
+		seedServer(SERVER, USER_ID);
+		UserPreferences.setString(CURRENT_SERVER, SERVER);
+
+		await removeServerData({ server: SERVER });
+
+		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(SERVER);
+	});
+
+	it('skips the user token key when the server has no stored userId', async () => {
+		seedServer(SERVER);
+		UserPreferences.setString(`${TOKEN_KEY}-${USER_ID}`, `token-${USER_ID}`);
+
+		await removeServerData({ server: SERVER });
+
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_ID}`)).toBe(`token-${USER_ID}`);
+		serverKeys(SERVER).forEach(key => expect(UserPreferences.getString(key)).toBeNull());
+	});
+});

--- a/app/lib/methods/logout.test.ts
+++ b/app/lib/methods/logout.test.ts
@@ -1,7 +1,3 @@
-// Do not mock './userPreferences' here: this test asserts against the real MMKV-backed store
-// (__mocks__/react-native-mmkv.js). Mocking it replaces the state transitions this test exists
-// to prove with spy calls, and the negative columns stop meaning anything.
-
 jest.mock('../database', () => ({
 	__esModule: true,
 	default: {
@@ -68,16 +64,16 @@ function seedServer(server: string, userId?: string) {
 	serverKeys(server).forEach(key => UserPreferences.setString(key, `value-for-${key}`));
 }
 
-function stubServersDB() {
-	const record = { prepareDestroyPermanently: jest.fn(() => ({})) };
-	jest.mocked(database.servers.get).mockReturnValue({ find: jest.fn(() => Promise.resolve(record)) } as any);
+function seedServersDBWithServer() {
+	const serverRecord = { prepareDestroyPermanently: jest.fn(() => ({})) };
+	jest.mocked(database.servers.get).mockReturnValue({ find: jest.fn(() => Promise.resolve(serverRecord)) } as any);
 }
 
 describe('removeServerData', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		allKeys.forEach(key => UserPreferences.removeItem(key));
-		stubServersDB();
+		seedServersDBWithServer();
 	});
 
 	it('clears every per-server key for the removed server', async () => {

--- a/app/lib/methods/logout.test.ts
+++ b/app/lib/methods/logout.test.ts
@@ -46,7 +46,7 @@ const serverKeys = (server: string) => [
 	`${server}-${E2E_RANDOM_PASSWORD_KEY}`
 ];
 
-const allKeys = [
+const keysToClear = [
 	...serverKeys(SERVER),
 	...serverKeys(OTHER_SERVER),
 	`${TOKEN_KEY}-${SERVER}`,
@@ -72,7 +72,7 @@ function seedServersDBWithServer() {
 describe('removeServerData', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
-		allKeys.forEach(key => UserPreferences.removeItem(key));
+		keysToClear.forEach(key => UserPreferences.removeItem(key));
 		seedServersDBWithServer();
 	});
 

--- a/app/lib/methods/logout.test.ts
+++ b/app/lib/methods/logout.test.ts
@@ -46,10 +46,10 @@ const OTHER_SERVER = 'https://b.rocket.chat';
 const USER_ID = 'user-a';
 const OTHER_USER_ID = 'user-b';
 
-const tokenKey = (suffix: string) => `${TOKEN_KEY}-${suffix}`;
-const certificateKey = (server: string) => `${CERTIFICATE_KEY}-${server}`;
+const tokenKey = (suffix: string): string => `${TOKEN_KEY}-${suffix}`;
+const certificateKey = (server: string): string => `${CERTIFICATE_KEY}-${server}`;
 
-const serverKeys = (server: string) => [
+const serverKeys = (server: string): string[] => [
 	`${BASIC_AUTH_KEY}-${server}`,
 	`${server}-${E2E_PUBLIC_KEY}`,
 	`${server}-${E2E_PRIVATE_KEY}`,
@@ -67,7 +67,7 @@ const keysToClear = [
 	CURRENT_SERVER
 ];
 
-function seedServer(server: string, userId?: string) {
+function seedServer(server: string, userId?: string): void {
 	if (userId) {
 		UserPreferences.setString(tokenKey(server), userId);
 		UserPreferences.setString(tokenKey(userId), `token-${userId}`);
@@ -75,7 +75,7 @@ function seedServer(server: string, userId?: string) {
 	serverKeys(server).forEach(key => UserPreferences.setString(key, `value-for-${key}`));
 }
 
-function mockDestroyableServerRecord() {
+function mockDestroyableServerRecord(): void {
 	const serverRecord = { prepareDestroyPermanently: jest.fn(() => ({})) };
 	jest.mocked(database.servers.get).mockReturnValue({ find: jest.fn(() => Promise.resolve(serverRecord)) } as any);
 }

--- a/app/lib/methods/logout.test.ts
+++ b/app/lib/methods/logout.test.ts
@@ -75,7 +75,7 @@ function seedServer(server: string, userId?: string) {
 	serverKeys(server).forEach(key => UserPreferences.setString(key, `value-for-${key}`));
 }
 
-function mockServersDBFind() {
+function mockDestroyableServerRecord() {
 	const serverRecord = { prepareDestroyPermanently: jest.fn(() => ({})) };
 	jest.mocked(database.servers.get).mockReturnValue({ find: jest.fn(() => Promise.resolve(serverRecord)) } as any);
 }
@@ -84,7 +84,7 @@ describe('removeServerData', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		keysToClear.forEach(key => UserPreferences.removeItem(key));
-		mockServersDBFind();
+		mockDestroyableServerRecord();
 	});
 
 	it('clears every per-server key for the removed server', async () => {

--- a/app/lib/methods/logout.test.ts
+++ b/app/lib/methods/logout.test.ts
@@ -32,7 +32,14 @@ import { removeServerData } from './logout';
 import database from '../database';
 import UserPreferences from './userPreferences';
 import { BASIC_AUTH_KEY } from './helpers/fetch';
-import { CURRENT_SERVER, E2E_PRIVATE_KEY, E2E_PUBLIC_KEY, E2E_RANDOM_PASSWORD_KEY, TOKEN_KEY } from '../constants/keys';
+import {
+	CERTIFICATE_KEY,
+	CURRENT_SERVER,
+	E2E_PRIVATE_KEY,
+	E2E_PUBLIC_KEY,
+	E2E_RANDOM_PASSWORD_KEY,
+	TOKEN_KEY
+} from '../constants/keys';
 
 const SERVER = 'https://a.rocket.chat';
 const OTHER_SERVER = 'https://b.rocket.chat';
@@ -40,6 +47,7 @@ const USER_ID = 'user-a';
 const OTHER_USER_ID = 'user-b';
 
 const tokenKey = (suffix: string) => `${TOKEN_KEY}-${suffix}`;
+const certificateKey = (server: string) => `${CERTIFICATE_KEY}-${server}`;
 
 const serverKeys = (server: string) => [
 	`${BASIC_AUTH_KEY}-${server}`,
@@ -55,6 +63,7 @@ const keysToClear = [
 	tokenKey(OTHER_SERVER),
 	tokenKey(USER_ID),
 	tokenKey(OTHER_USER_ID),
+	certificateKey(SERVER),
 	CURRENT_SERVER
 ];
 
@@ -106,6 +115,15 @@ describe('removeServerData', () => {
 		await removeServerData({ server: SERVER });
 
 		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(SERVER);
+	});
+
+	it('keeps the pinned certificate so the user does not have to re-enter its password', async () => {
+		seedServer(SERVER, USER_ID);
+		UserPreferences.setString(certificateKey(SERVER), 'client-certificate');
+
+		await removeServerData({ server: SERVER });
+
+		expect(UserPreferences.getString(certificateKey(SERVER))).toBe('client-certificate');
 	});
 
 	it('skips the user token key when the server has no stored userId', async () => {

--- a/app/lib/testUtils/sagaStore.ts
+++ b/app/lib/testUtils/sagaStore.ts
@@ -6,12 +6,18 @@ import reducers from '../../reducers';
 
 const MICROTASK_DRAIN_PASSES = 20;
 
-type PreloadedState = Parameters<typeof createStore>[1];
+export type PreloadedState = Parameters<typeof createStore>[1];
 
 export async function flushSagaMicrotasks(): Promise<void> {
 	for (let i = 0; i < MICROTASK_DRAIN_PASSES; i += 1) {
 		await Promise.resolve();
 	}
+}
+
+const runningTasks: Task[] = [];
+
+export function cancelSagaTasks(): void {
+	runningTasks.splice(0).forEach(task => task.cancel());
 }
 
 export function createRecordingStore(rootSaga: Saga, preloadedState?: PreloadedState) {
@@ -29,5 +35,6 @@ export function createRecordingStore(rootSaga: Saga, preloadedState?: PreloadedS
 		)
 	);
 	const task: Task = sagaMiddleware.run(rootSaga);
+	runningTasks.push(task);
 	return { store, dispatched, task };
 }

--- a/app/lib/testUtils/sagaStore.ts
+++ b/app/lib/testUtils/sagaStore.ts
@@ -1,0 +1,29 @@
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import type { Saga, Task } from 'redux-saga';
+
+import reducers from '../../reducers';
+
+export async function flushSagaMicrotasks(): Promise<void> {
+	for (let i = 0; i < 20; i += 1) {
+		await new Promise(resolve => setImmediate(resolve));
+	}
+}
+
+export function createRecordingStore(rootSaga: Saga, preloadedState?: Parameters<typeof createStore>[1]) {
+	const dispatched: Record<string, any>[] = [];
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(
+		reducers,
+		preloadedState,
+		applyMiddleware(
+			() => next => action => {
+				dispatched.push(action);
+				return next(action);
+			},
+			sagaMiddleware
+		)
+	);
+	const task: Task = sagaMiddleware.run(rootSaga);
+	return { store, dispatched, task };
+}

--- a/app/lib/testUtils/sagaStore.ts
+++ b/app/lib/testUtils/sagaStore.ts
@@ -4,13 +4,17 @@ import type { Saga, Task } from 'redux-saga';
 
 import reducers from '../../reducers';
 
+const MICROTASK_DRAIN_PASSES = 20;
+
+type PreloadedState = Parameters<typeof createStore>[1];
+
 export async function flushSagaMicrotasks(): Promise<void> {
-	for (let i = 0; i < 20; i += 1) {
-		await new Promise(resolve => setImmediate(resolve));
+	for (let i = 0; i < MICROTASK_DRAIN_PASSES; i += 1) {
+		await Promise.resolve();
 	}
 }
 
-export function createRecordingStore(rootSaga: Saga, preloadedState?: Parameters<typeof createStore>[1]) {
+export function createRecordingStore(rootSaga: Saga, preloadedState?: PreloadedState) {
 	const dispatched: Record<string, any>[] = [];
 	const sagaMiddleware = createSagaMiddleware();
 	const store = createStore(

--- a/app/lib/testUtils/sagaStore.ts
+++ b/app/lib/testUtils/sagaStore.ts
@@ -20,13 +20,13 @@ export function cancelSagaTasks(): void {
 }
 
 export function createRecordingStore(rootSaga: Saga) {
-	const dispatched: AnyAction[] = [];
+	const dispatchedActions: AnyAction[] = [];
 	const sagaMiddleware = createSagaMiddleware();
 	const store = createStore(
 		reducers,
 		applyMiddleware(
 			() => next => action => {
-				dispatched.push(action);
+				dispatchedActions.push(action);
 				return next(action);
 			},
 			sagaMiddleware
@@ -34,5 +34,5 @@ export function createRecordingStore(rootSaga: Saga) {
 	);
 	const task: Task = sagaMiddleware.run(rootSaga);
 	runningTasks.push(task);
-	return { store, dispatched };
+	return { store, dispatchedActions };
 }

--- a/app/lib/testUtils/sagaStore.ts
+++ b/app/lib/testUtils/sagaStore.ts
@@ -7,8 +7,6 @@ import reducers from '../../reducers';
 
 const MICROTASK_DRAIN_PASSES = 20;
 
-export type PreloadedState = Parameters<typeof createStore>[1];
-
 export async function flushSagaMicrotasks(): Promise<void> {
 	for (let i = 0; i < MICROTASK_DRAIN_PASSES; i += 1) {
 		await Promise.resolve();
@@ -21,12 +19,11 @@ export function cancelSagaTasks(): void {
 	runningTasks.splice(0).forEach(task => task.cancel());
 }
 
-export function createRecordingStore(rootSaga: Saga, preloadedState?: PreloadedState) {
+export function createRecordingStore(rootSaga: Saga) {
 	const dispatched: AnyAction[] = [];
 	const sagaMiddleware = createSagaMiddleware();
 	const store = createStore(
 		reducers,
-		preloadedState,
 		applyMiddleware(
 			() => next => action => {
 				dispatched.push(action);

--- a/app/lib/testUtils/sagaStore.ts
+++ b/app/lib/testUtils/sagaStore.ts
@@ -1,4 +1,5 @@
 import { applyMiddleware, createStore } from 'redux';
+import type { AnyAction } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import type { Saga, Task } from 'redux-saga';
 
@@ -21,7 +22,7 @@ export function cancelSagaTasks(): void {
 }
 
 export function createRecordingStore(rootSaga: Saga, preloadedState?: PreloadedState) {
-	const dispatched: Record<string, any>[] = [];
+	const dispatched: AnyAction[] = [];
 	const sagaMiddleware = createSagaMiddleware();
 	const store = createStore(
 		reducers,
@@ -36,5 +37,5 @@ export function createRecordingStore(rootSaga: Saga, preloadedState?: PreloadedS
 	);
 	const task: Task = sagaMiddleware.run(rootSaga);
 	runningTasks.push(task);
-	return { store, dispatched, task };
+	return { store, dispatched };
 }

--- a/app/lib/testUtils/sagaStore.ts
+++ b/app/lib/testUtils/sagaStore.ts
@@ -1,5 +1,5 @@
 import { applyMiddleware, createStore } from 'redux';
-import type { AnyAction } from 'redux';
+import type { AnyAction, Store } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import type { Saga, Task } from 'redux-saga';
 
@@ -19,7 +19,12 @@ export function cancelSagaTasks(): void {
 	runningTasks.splice(0).forEach(task => task.cancel());
 }
 
-export function createRecordingStore(rootSaga: Saga) {
+export interface RecordingStore {
+	store: Store;
+	dispatchedActions: AnyAction[];
+}
+
+export function createRecordingStore(rootSaga: Saga): RecordingStore {
 	const dispatchedActions: AnyAction[] = [];
 	const sagaMiddleware = createSagaMiddleware();
 	const store = createStore(

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -111,8 +111,6 @@ import database from '../../lib/database';
 import EventEmitter from '../../lib/methods/helpers/events';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
 const setupStore = () => createRecordingStore(deepLinkingRoot);
 
 afterEach(cancelSagaTasks);
@@ -593,6 +591,7 @@ describe('deepLinking saga — unknown host hands off to the add-server flow', (
 
 	afterEach(() => {
 		jest.useRealTimers();
+		jest.restoreAllMocks();
 	});
 
 	it('starts the outside stack, seeds the previous server, then emits NewServer for the host', async () => {

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -113,6 +113,7 @@ import { loginOAuthOrSso } from '../../lib/services/connect';
 import sdk from '../../lib/services/sdk';
 import database from '../../lib/database';
 import EventEmitter from '../../lib/methods/helpers/events';
+import { createRecordingStore } from '../../lib/testUtils/sagaStore';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -587,34 +588,14 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 	});
 });
 
-// ─── Unknown host without a token → add-server flow ───────────────────────────
-
 describe('deepLinking saga — unknown host hands off to the add-server flow', () => {
 	const PREVIOUS_SERVER = 'https://previous.rocket.chat';
-
-	function setupRecordingStore() {
-		const dispatched: Record<string, any>[] = [];
-		const sagaMiddleware = createSagaMiddleware();
-		const store = createStore(
-			reducers,
-			applyMiddleware(
-				() => next => action => {
-					dispatched.push(action);
-					return next(action);
-				},
-				sagaMiddleware
-			)
-		);
-		sagaMiddleware.run(deepLinkingRoot);
-		return { store, dispatched };
-	}
 
 	beforeEach(() => {
 		jest.useFakeTimers();
 		jest.mocked(UserPreferences.getString).mockReset();
 		jest.mocked(getServerById).mockReset();
 		jest.mocked(getServerInfo).mockReset();
-		jest.mocked(EventEmitter.emit as jest.Mock)?.mockReset?.();
 
 		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
 			if (key === 'currentServer') return PREVIOUS_SERVER;
@@ -631,7 +612,7 @@ describe('deepLinking saga — unknown host hands off to the add-server flow', (
 
 	it('starts the outside stack, seeds the previous server, then emits NewServer for the host', async () => {
 		const emit = jest.spyOn(EventEmitter, 'emit').mockImplementation(() => {});
-		const { store, dispatched } = setupRecordingStore();
+		const { store, dispatched } = createRecordingStore(deepLinkingRoot);
 
 		store.dispatch(deepLinkingOpen(makeParams() as any));
 		await flushSagaMicrotasks();

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -92,16 +92,12 @@ jest.mock('../../lib/methods/helpers', () => ({
 
 // ─── Real imports (after mocks) ───────────────────────────────────────────────
 
-import { applyMiddleware, createStore } from 'redux';
-import createSagaMiddleware from 'redux-saga';
-
 import { deepLinkingOpen, deepLinkingClickCallPush } from '../../actions/deepLinking';
 import { loginSuccess } from '../../actions/login';
 import { selectServerSuccess } from '../../actions/server';
 import { appStart } from '../../actions/app';
 import { APP, SERVER } from '../../actions/actionsTypes';
 import { RootEnum } from '../../definitions';
-import reducers from '../../reducers';
 import deepLinkingRoot from '../deepLinking';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { getServerById } from '../../lib/database/services/Server';
@@ -113,23 +109,12 @@ import { loginOAuthOrSso } from '../../lib/services/connect';
 import sdk from '../../lib/services/sdk';
 import database from '../../lib/database';
 import EventEmitter from '../../lib/methods/helpers/events';
-import { createRecordingStore } from '../../lib/testUtils/sagaStore';
+import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Drains pending saga microtasks so all synchronous saga steps complete. */
-async function flushSagaMicrotasks(): Promise<void> {
-	await Promise.resolve();
-	await Promise.resolve();
-}
-
-type PreloadedState = Parameters<typeof createStore>[1];
-
-function setupStore(preloadedState?: PreloadedState) {
-	const sagaMiddleware = createSagaMiddleware();
-	const store = createStore(reducers, preloadedState, applyMiddleware(sagaMiddleware));
-	sagaMiddleware.run(deepLinkingRoot);
-	return store;
+function setupStore(preloadedState?: Parameters<typeof createRecordingStore>[1]) {
+	return createRecordingStore(deepLinkingRoot, preloadedState).store;
 }
 
 // ─── Factories ────────────────────────────────────────────────────────────────

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -216,7 +216,6 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		// Now dispatch APP.START(ROOT_INSIDE) — this satisfies the take.
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
 	});
@@ -247,7 +246,6 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		// Now release the saga by dispatching APP.START(ROOT_INSIDE)
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
 	});
@@ -275,7 +273,6 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		// so the select sees ROOT_INSIDE and skips the take.
 		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
-		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
 		// goRoom should fire immediately — the take was skipped by the select short-circuit
@@ -312,7 +309,6 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		// Now dispatch correct root — satisfies the take
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
 	});
@@ -340,13 +336,11 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		// First APP.START(ROOT_INSIDE) — fires the take
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
 
 		// Second APP.START(ROOT_INSIDE) — saga is done, no re-trigger
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
-		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
 		// Still exactly once
@@ -402,10 +396,8 @@ describe('deepLinking saga — server already connected, should skip changing se
 		const { store } = setupStore();
 
 		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
-		// Two flushes drain the getServerById and getServerInfo promise microtasks.
 		// No jest.advanceTimersByTimeAsync needed — delay(1000) is skipped when
 		// hostAlreadyConnected is true.
-		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
 		// Saga must be parked at take(LOGIN.SUCCESS), not take(SERVER.SELECT_SUCCESS)
@@ -418,7 +410,6 @@ describe('deepLinking saga — server already connected, should skip changing se
 		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
 
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
-		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
@@ -435,14 +426,12 @@ describe('deepLinking saga — server already connected, should skip changing se
 		const { store } = setupStore();
 		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(emitSpy).not.toHaveBeenCalledWith('NewServer', expect.anything());
 
 		// Complete the flow to confirm the saga finishes correctly
 		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
 		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
-		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
@@ -498,7 +487,6 @@ describe('deepLinking saga — handleClickCallPush (new server + token + call ro
 
 		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(jest.mocked(navigateToRoom)).toHaveBeenCalledTimes(1);
 	});
@@ -519,7 +507,6 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-fresh-A', credentialSecret: 'secret-A' } as any));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledTimes(1);
 		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledWith({
@@ -532,7 +519,6 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-no-secret-D' } as any));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		expect(jest.mocked(loginOAuthOrSso)).not.toHaveBeenCalled();
 	});
@@ -542,11 +528,9 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-dup-B', credentialSecret: 'secret-B' } as any));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		// Second dispatch with the identical token — guard must suppress it.
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-dup-B', credentialSecret: 'secret-B' } as any));
-		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
 		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledTimes(1);
@@ -557,11 +541,9 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-first-C', credentialSecret: 'secret-C' } as any));
 		await flushSagaMicrotasks();
-		await flushSagaMicrotasks();
 
 		// A distinct token must not be blocked by the guard.
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-second-C', credentialSecret: 'secret-C2' } as any));
-		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
 		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenCalledTimes(2);
@@ -596,7 +578,7 @@ describe('deepLinking saga — unknown host hands off to the add-server flow', (
 
 	it('starts the outside stack, seeds the previous server, then emits NewServer for the host', async () => {
 		const emit = jest.spyOn(EventEmitter, 'emit').mockImplementation(() => {});
-		const { store, dispatched } = createRecordingStore(deepLinkingRoot);
+		const { store, dispatched } = setupStore();
 
 		store.dispatch(deepLinkingOpen(makeParams() as any));
 		await flushSagaMicrotasks();

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -110,8 +110,9 @@ import sdk from '../../lib/services/sdk';
 import database from '../../lib/database';
 import EventEmitter from '../../lib/methods/helpers/events';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import type { RecordingStore } from '../../lib/testUtils/sagaStore';
 
-const setupStore = () => createRecordingStore(deepLinkingRoot);
+const setupStore = (): RecordingStore => createRecordingStore(deepLinkingRoot);
 
 afterEach(cancelSagaTasks);
 

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -99,6 +99,7 @@ import { deepLinkingOpen, deepLinkingClickCallPush } from '../../actions/deepLin
 import { loginSuccess } from '../../actions/login';
 import { selectServerSuccess } from '../../actions/server';
 import { appStart } from '../../actions/app';
+import { APP, SERVER } from '../../actions/actionsTypes';
 import { RootEnum } from '../../definitions';
 import reducers from '../../reducers';
 import deepLinkingRoot from '../deepLinking';
@@ -583,5 +584,70 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenNthCalledWith(2, {
 			oauth: { credentialToken: 'token-second-C', credentialSecret: 'secret-C2' }
 		});
+	});
+});
+
+// ─── Unknown host without a token → add-server flow ───────────────────────────
+
+describe('deepLinking saga — unknown host hands off to the add-server flow', () => {
+	const PREVIOUS_SERVER = 'https://previous.rocket.chat';
+
+	function setupRecordingStore() {
+		const dispatched: Record<string, any>[] = [];
+		const sagaMiddleware = createSagaMiddleware();
+		const store = createStore(
+			reducers,
+			applyMiddleware(
+				() => next => action => {
+					dispatched.push(action);
+					return next(action);
+				},
+				sagaMiddleware
+			)
+		);
+		sagaMiddleware.run(deepLinkingRoot);
+		return { store, dispatched };
+	}
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(getServerInfo).mockReset();
+		jest.mocked(EventEmitter.emit as jest.Mock)?.mockReset?.();
+
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return PREVIOUS_SERVER;
+			return null;
+		});
+		jest.mocked(getServerById).mockResolvedValue(undefined as any);
+		jest.mocked(getServerInfo).mockResolvedValue({ success: true } as any);
+		jest.mocked(sdk).current.client.host = PREVIOUS_SERVER;
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('starts the outside stack, seeds the previous server, then emits NewServer for the host', async () => {
+		const emit = jest.spyOn(EventEmitter, 'emit').mockImplementation(() => {});
+		const { store, dispatched } = setupRecordingStore();
+
+		store.dispatch(deepLinkingOpen(makeParams() as any));
+		await flushSagaMicrotasks();
+
+		const outsideIndex = dispatched.findIndex(action => action.type === APP.START && action.root === RootEnum.ROOT_OUTSIDE);
+		const initAddIndex = dispatched.findIndex(action => action.type === SERVER.INIT_ADD);
+
+		expect(outsideIndex).toBeGreaterThanOrEqual(0);
+		expect(initAddIndex).toBeGreaterThan(outsideIndex);
+		expect(dispatched[initAddIndex].previousServer).toBe(PREVIOUS_SERVER);
+		expect(emit).not.toHaveBeenCalledWith('NewServer', { server: HOST });
+
+		jest.advanceTimersByTime(1000);
+		await flushSagaMicrotasks();
+
+		expect(emit).toHaveBeenCalledWith('NewServer', { server: HOST });
+		emit.mockRestore();
 	});
 });

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -109,13 +109,13 @@ import { loginOAuthOrSso } from '../../lib/services/connect';
 import sdk from '../../lib/services/sdk';
 import database from '../../lib/database';
 import EventEmitter from '../../lib/methods/helpers/events';
-import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function setupStore(preloadedState?: Parameters<typeof createRecordingStore>[1]) {
-	return createRecordingStore(deepLinkingRoot, preloadedState).store;
-}
+const setupStore = () => createRecordingStore(deepLinkingRoot).store;
+
+afterEach(cancelSagaTasks);
 
 // ─── Factories ────────────────────────────────────────────────────────────────
 

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -208,7 +208,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
 		await flushSagaMicrotasks();
 
-		// Saga has dispatched appReady and selected state.app.root.
+		// Saga has dispatchedActions appReady and selected state.app.root.
 		// Root is NOT yet ROOT_INSIDE (reducer hasn't seen ROOT_INSIDE yet),
 		// so saga is waiting for APP.START(ROOT_INSIDE).
 		expect(jest.mocked(goRoom)).not.toHaveBeenCalled();
@@ -578,17 +578,19 @@ describe('deepLinking saga — unknown host hands off to the add-server flow', (
 
 	it('starts the outside stack, seeds the previous server, then emits NewServer for the host', async () => {
 		const emit = jest.spyOn(EventEmitter, 'emit').mockImplementation(() => {});
-		const { store, dispatched } = setupStore();
+		const { store, dispatchedActions } = setupStore();
 
 		store.dispatch(deepLinkingOpen(makeParams() as any));
 		await flushSagaMicrotasks();
 
-		const outsideIndex = dispatched.findIndex(action => action.type === APP.START && action.root === RootEnum.ROOT_OUTSIDE);
-		const initAddIndex = dispatched.findIndex(action => action.type === SERVER.INIT_ADD);
+		const outsideIndex = dispatchedActions.findIndex(
+			action => action.type === APP.START && action.root === RootEnum.ROOT_OUTSIDE
+		);
+		const initAddIndex = dispatchedActions.findIndex(action => action.type === SERVER.INIT_ADD);
 
 		expect(outsideIndex).toBeGreaterThanOrEqual(0);
 		expect(initAddIndex).toBeGreaterThan(outsideIndex);
-		expect(dispatched[initAddIndex].previousServer).toBe(PREVIOUS_SERVER);
+		expect(dispatchedActions[initAddIndex].previousServer).toBe(PREVIOUS_SERVER);
 		expect(emit).not.toHaveBeenCalledWith('NewServer', { server: HOST });
 
 		jest.advanceTimersByTime(1000);

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -113,7 +113,7 @@ import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../.
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const setupStore = () => createRecordingStore(deepLinkingRoot).store;
+const setupStore = () => createRecordingStore(deepLinkingRoot);
 
 afterEach(cancelSagaTasks);
 
@@ -188,7 +188,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 	 * once, sequenced after the APP.START dispatch.
 	 */
 	it('calls goRoom exactly once after APP.START(ROOT_INSIDE) completes the chain', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 		const params = makeParamsWithToken();
 
 		store.dispatch(deepLinkingOpen(params));
@@ -229,7 +229,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 	 * Then dispatch APP.START(ROOT_INSIDE). Flush. Assert goRoom called once.
 	 */
 	it('goRoom is NOT called between LOGIN.SUCCESS and APP.START(ROOT_INSIDE)', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 		const params = makeParamsWithToken();
 
 		store.dispatch(deepLinkingOpen(params));
@@ -261,7 +261,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 	 * before flushing, so the reducer updates the root before the saga's select runs.
 	 */
 	it('skips the APP.START take when state.app.root is already ROOT_INSIDE at select time', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 		const params = makeParamsWithToken();
 
 		store.dispatch(deepLinkingOpen(params));
@@ -290,7 +290,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 	 * called once.
 	 */
 	it('APP.START(ROOT_OUTSIDE) does not satisfy the take; APP.START(ROOT_INSIDE) does', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 		const params = makeParamsWithToken();
 
 		store.dispatch(deepLinkingOpen(params));
@@ -325,7 +325,7 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 	 * the take, takeLatest has not been retriggered).
 	 */
 	it('a second APP.START(ROOT_INSIDE) after navigation does not re-trigger goRoom', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 		const params = makeParamsWithToken();
 
 		store.dispatch(deepLinkingOpen(params));
@@ -401,7 +401,7 @@ describe('deepLinking saga — server already connected, should skip changing se
 	 * (not SELECT_SUCCESS) when the server is already connected.
 	 */
 	it('calls goRoom after LOGIN.SUCCESS + APP.START(ROOT_INSIDE) without needing SERVER.SELECT_SUCCESS', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 
 		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
 		// Two flushes drain the getServerById and getServerInfo promise microtasks.
@@ -434,7 +434,7 @@ describe('deepLinking saga — server already connected, should skip changing se
 	it('does not emit NewServer when the SDK is already connected to the deeplink host', async () => {
 		const emitSpy = jest.spyOn(EventEmitter, 'emit');
 
-		const store = setupStore();
+		const { store } = setupStore();
 		store.dispatch(deepLinkingOpen(makeParamsWithToken()));
 		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
@@ -486,7 +486,7 @@ describe('deepLinking saga — handleClickCallPush (new server + token + call ro
 	});
 
 	it('navigates to the call room once after SELECT_SUCCESS and LOGIN.SUCCESS', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 
 		store.dispatch(deepLinkingClickCallPush(makeCallParams()));
 		await flushSagaMicrotasks();
@@ -517,7 +517,7 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 	});
 
 	it('calls loginOAuthOrSso with the oauth credentials on a fresh token', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-fresh-A', credentialSecret: 'secret-A' } as any));
 		await flushSagaMicrotasks();
@@ -530,7 +530,7 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 	});
 
 	it('does not call loginOAuthOrSso when the credentialSecret is missing', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-no-secret-D' } as any));
 		await flushSagaMicrotasks();
@@ -540,7 +540,7 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 	});
 
 	it('does not call loginOAuthOrSso a second time for the same credentialToken', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-dup-B', credentialSecret: 'secret-B' } as any));
 		await flushSagaMicrotasks();
@@ -555,7 +555,7 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 	});
 
 	it('calls loginOAuthOrSso again for a different credentialToken after a previous one was consumed', async () => {
-		const store = setupStore();
+		const { store } = setupStore();
 
 		store.dispatch(deepLinkingOpen({ type: 'oauth', credentialToken: 'token-first-C', credentialSecret: 'secret-C' } as any));
 		await flushSagaMicrotasks();

--- a/app/sagas/__tests__/login.switchCancel.test.ts
+++ b/app/sagas/__tests__/login.switchCancel.test.ts
@@ -101,15 +101,9 @@ import { selectServerRequest, selectServerSuccess } from '../../actions/server';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import { getPermissions } from '../../lib/methods/getPermissions';
-import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
-const runningTasks: { cancel: () => void }[] = [];
-
-function setupStore() {
-	const { store, task } = createRecordingStore(loginRoot);
-	runningTasks.push(task);
-	return store;
-}
+const setupStore = () => createRecordingStore(loginRoot).store;
 
 const SERVER_A = 'https://a.rocket.chat';
 const SERVER_B = 'https://b.rocket.chat';
@@ -123,9 +117,7 @@ describe('login saga — a workspace switch cancels the login bootstrap', () => 
 		jest.clearAllMocks();
 	});
 
-	afterEach(() => {
-		runningTasks.splice(0).forEach(task => task.cancel());
-	});
+	afterEach(cancelSagaTasks);
 
 	it('does not persist the credentials when SELECT_REQUEST arrives before the token write', async () => {
 		let releasePermissions = () => {};

--- a/app/sagas/__tests__/login.switchCancel.test.ts
+++ b/app/sagas/__tests__/login.switchCancel.test.ts
@@ -1,0 +1,179 @@
+// Do not mock '../../lib/methods/userPreferences' here: this test asserts against the real
+// MMKV-backed store (__mocks__/react-native-mmkv.js). Mocking it turns the assertions into
+// spy checks and the test stops proving that no credential was persisted.
+
+jest.mock('../../lib/methods/getPermissions', () => ({
+	getPermissions: jest.fn()
+}));
+
+jest.mock('../../lib/methods/enterpriseModules', () => ({
+	getEnterpriseModules: jest.fn(),
+	isOmnichannelModuleAvailable: jest.fn(() => false),
+	isOmnichannelStatusAvailable: jest.fn(() => false),
+	isVoipModuleAvailable: jest.fn(() => false)
+}));
+
+jest.mock('../../lib/methods/getCustomEmojis', () => ({
+	getCustomEmojis: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getRoles', () => ({
+	getRoles: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getSlashCommands', () => ({
+	getSlashCommands: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getSettings', () => ({
+	subscribeSettings: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getUsersPresence', () => ({
+	getUserPresence: jest.fn(),
+	refreshDmUsersPresence: jest.fn(),
+	subscribeUsersPresence: jest.fn()
+}));
+
+jest.mock('../../lib/services/restApi', () => ({
+	getUsersRoles: jest.fn(() => []),
+	registerPushToken: jest.fn(),
+	saveUserProfile: jest.fn(),
+	setUserPresenceAway: jest.fn()
+}));
+
+jest.mock('../../lib/services/connect', () => ({
+	disconnect: jest.fn(),
+	login: jest.fn(),
+	loginWithPassword: jest.fn()
+}));
+
+jest.mock('../../lib/methods/logout', () => ({
+	logout: jest.fn(),
+	removeServerData: jest.fn(),
+	removeServerDatabase: jest.fn()
+}));
+
+jest.mock('../../lib/services/voip/MediaSessionInstance', () => ({
+	mediaSessionInstance: { init: jest.fn(), reset: jest.fn() }
+}));
+
+jest.mock('../../lib/services/voip/MediaSessionStore', () => ({
+	mediaSessionStore: { getCurrentInstance: jest.fn(() => null) }
+}));
+
+jest.mock('../../lib/services/voip/isInActiveVoipCall', () => ({
+	isInActiveVoipCall: jest.fn(() => false)
+}));
+
+jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
+	localAuthenticate: jest.fn()
+}));
+
+jest.mock('../../lib/services/sdk', () => ({
+	__esModule: true,
+	default: {
+		current: { client: { host: '' } },
+		subscribe: jest.fn()
+	}
+}));
+
+jest.mock('../../lib/methods/helpers/log', () => ({
+	...jest.requireActual('../../lib/methods/helpers/log'),
+	__esModule: true,
+	default: jest.fn()
+}));
+
+jest.mock('../../lib/database', () => ({
+	__esModule: true,
+	default: {
+		active: { get: jest.fn() },
+		servers: {
+			get: jest.fn(() => ({
+				find: jest.fn(() => Promise.reject(new Error('not found'))),
+				create: jest.fn(),
+				schema: {}
+			})),
+			write: jest.fn(async (block: () => Promise<void>) => block())
+		}
+	}
+}));
+
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import reducers from '../../reducers';
+import loginRoot from '../login';
+import { loginSuccess } from '../../actions/login';
+import { selectServerRequest, selectServerSuccess } from '../../actions/server';
+import UserPreferences from '../../lib/methods/userPreferences';
+import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
+import { getPermissions } from '../../lib/methods/getPermissions';
+
+async function flushSagaMicrotasks(): Promise<void> {
+	for (let i = 0; i < 20; i += 1) {
+		await new Promise(resolve => setImmediate(resolve));
+	}
+}
+
+type PreloadedState = Parameters<typeof createStore>[1];
+
+function setupStore(preloadedState?: PreloadedState) {
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(reducers, preloadedState, applyMiddleware(sagaMiddleware));
+	sagaMiddleware.run(loginRoot);
+	return store;
+}
+
+const SERVER_A = 'https://a.rocket.chat';
+const SERVER_B = 'https://b.rocket.chat';
+const USER_B = { id: 'user-b', token: 'token-b', username: 'userb', name: 'User B' };
+
+describe('login saga — a workspace switch cancels the login bootstrap', () => {
+	beforeEach(() => {
+		UserPreferences.removeItem(`${TOKEN_KEY}-${SERVER_A}`);
+		UserPreferences.removeItem(`${TOKEN_KEY}-${USER_B.id}`);
+		UserPreferences.removeItem(CURRENT_SERVER);
+		jest.clearAllMocks();
+	});
+
+	it('does not persist the credentials when SELECT_REQUEST arrives before the token write', async () => {
+		let releasePermissions = () => {};
+		jest.mocked(getPermissions).mockImplementation(
+			() =>
+				new Promise<void>(resolve => {
+					releasePermissions = resolve;
+				}) as any
+		);
+
+		const store = setupStore();
+		store.dispatch(selectServerSuccess({ server: SERVER_A, version: '7.0.0', name: 'A' }));
+
+		store.dispatch(loginSuccess(USER_B));
+		await flushSagaMicrotasks();
+
+		expect(getPermissions).toHaveBeenCalled();
+
+		store.dispatch(selectServerRequest(SERVER_B, '7.0.0'));
+		await flushSagaMicrotasks();
+
+		releasePermissions();
+		await flushSagaMicrotasks();
+
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${SERVER_A}`)).toBeNull();
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_B.id}`)).toBeNull();
+	});
+
+	it('persists the credentials when no switch interrupts the bootstrap', async () => {
+		jest.mocked(getPermissions).mockResolvedValue(undefined as any);
+
+		const store = setupStore();
+		store.dispatch(selectServerSuccess({ server: SERVER_A, version: '7.0.0', name: 'A' }));
+
+		store.dispatch(loginSuccess(USER_B));
+		await flushSagaMicrotasks();
+
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${SERVER_A}`)).toBe(USER_B.id);
+		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_B.id}`)).toBe(USER_B.token);
+	});
+});

--- a/app/sagas/__tests__/login.switchCancel.test.ts
+++ b/app/sagas/__tests__/login.switchCancel.test.ts
@@ -103,7 +103,9 @@ import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import { getPermissions } from '../../lib/methods/getPermissions';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
-const setupStore = () => createRecordingStore(loginRoot).store;
+const setupStore = () => createRecordingStore(loginRoot);
+
+afterEach(cancelSagaTasks);
 
 const SERVER_A = 'https://a.rocket.chat';
 const SERVER_B = 'https://b.rocket.chat';
@@ -117,8 +119,6 @@ describe('login saga — a workspace switch cancels the login bootstrap', () => 
 		jest.clearAllMocks();
 	});
 
-	afterEach(cancelSagaTasks);
-
 	it('does not persist the credentials when SELECT_REQUEST arrives before the token write', async () => {
 		let releasePermissions = () => {};
 		jest.mocked(getPermissions).mockImplementation(
@@ -128,7 +128,7 @@ describe('login saga — a workspace switch cancels the login bootstrap', () => 
 				}) as any
 		);
 
-		const store = setupStore();
+		const { store } = setupStore();
 		store.dispatch(selectServerSuccess({ server: SERVER_A, version: '7.0.0', name: 'A' }));
 
 		store.dispatch(loginSuccess(USER_B));
@@ -150,7 +150,7 @@ describe('login saga — a workspace switch cancels the login bootstrap', () => 
 	it('persists the credentials when no switch interrupts the bootstrap', async () => {
 		jest.mocked(getPermissions).mockResolvedValue(undefined as any);
 
-		const store = setupStore();
+		const { store } = setupStore();
 		store.dispatch(selectServerSuccess({ server: SERVER_A, version: '7.0.0', name: 'A' }));
 
 		store.dispatch(loginSuccess(USER_B));

--- a/app/sagas/__tests__/login.switchCancel.test.ts
+++ b/app/sagas/__tests__/login.switchCancel.test.ts
@@ -118,10 +118,12 @@ async function flushSagaMicrotasks(): Promise<void> {
 
 type PreloadedState = Parameters<typeof createStore>[1];
 
+const runningTasks: { cancel: () => void }[] = [];
+
 function setupStore(preloadedState?: PreloadedState) {
 	const sagaMiddleware = createSagaMiddleware();
 	const store = createStore(reducers, preloadedState, applyMiddleware(sagaMiddleware));
-	sagaMiddleware.run(loginRoot);
+	runningTasks.push(sagaMiddleware.run(loginRoot));
 	return store;
 }
 
@@ -135,6 +137,10 @@ describe('login saga — a workspace switch cancels the login bootstrap', () => 
 		UserPreferences.removeItem(`${TOKEN_KEY}-${USER_B.id}`);
 		UserPreferences.removeItem(CURRENT_SERVER);
 		jest.clearAllMocks();
+	});
+
+	afterEach(() => {
+		runningTasks.splice(0).forEach(task => task.cancel());
 	});
 
 	it('does not persist the credentials when SELECT_REQUEST arrives before the token write', async () => {

--- a/app/sagas/__tests__/login.switchCancel.test.ts
+++ b/app/sagas/__tests__/login.switchCancel.test.ts
@@ -102,8 +102,9 @@ import UserPreferences from '../../lib/methods/userPreferences';
 import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import { getPermissions } from '../../lib/methods/getPermissions';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import type { RecordingStore } from '../../lib/testUtils/sagaStore';
 
-const setupStore = () => createRecordingStore(loginRoot);
+const setupStore = (): RecordingStore => createRecordingStore(loginRoot);
 
 afterEach(cancelSagaTasks);
 

--- a/app/sagas/__tests__/login.switchCancel.test.ts
+++ b/app/sagas/__tests__/login.switchCancel.test.ts
@@ -1,7 +1,3 @@
-// Do not mock '../../lib/methods/userPreferences' here: this test asserts against the real
-// MMKV-backed store (__mocks__/react-native-mmkv.js). Mocking it turns the assertions into
-// spy checks and the test stops proving that no credential was persisted.
-
 jest.mock('../../lib/methods/getPermissions', () => ({
 	getPermissions: jest.fn()
 }));
@@ -99,31 +95,19 @@ jest.mock('../../lib/database', () => ({
 	}
 }));
 
-import { applyMiddleware, createStore } from 'redux';
-import createSagaMiddleware from 'redux-saga';
-
-import reducers from '../../reducers';
 import loginRoot from '../login';
 import { loginSuccess } from '../../actions/login';
 import { selectServerRequest, selectServerSuccess } from '../../actions/server';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import { getPermissions } from '../../lib/methods/getPermissions';
-
-async function flushSagaMicrotasks(): Promise<void> {
-	for (let i = 0; i < 20; i += 1) {
-		await new Promise(resolve => setImmediate(resolve));
-	}
-}
-
-type PreloadedState = Parameters<typeof createStore>[1];
+import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 const runningTasks: { cancel: () => void }[] = [];
 
-function setupStore(preloadedState?: PreloadedState) {
-	const sagaMiddleware = createSagaMiddleware();
-	const store = createStore(reducers, preloadedState, applyMiddleware(sagaMiddleware));
-	runningTasks.push(sagaMiddleware.run(loginRoot));
+function setupStore() {
+	const { store, task } = createRecordingStore(loginRoot);
+	runningTasks.push(task);
 	return store;
 }
 
@@ -168,6 +152,7 @@ describe('login saga — a workspace switch cancels the login bootstrap', () => 
 
 		expect(UserPreferences.getString(`${TOKEN_KEY}-${SERVER_A}`)).toBeNull();
 		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_B.id}`)).toBeNull();
+		expect(UserPreferences.getString(CURRENT_SERVER)).toBeNull();
 	});
 
 	it('persists the credentials when no switch interrupts the bootstrap', async () => {
@@ -181,5 +166,6 @@ describe('login saga — a workspace switch cancels the login bootstrap', () => 
 
 		expect(UserPreferences.getString(`${TOKEN_KEY}-${SERVER_A}`)).toBe(USER_B.id);
 		expect(UserPreferences.getString(`${TOKEN_KEY}-${USER_B.id}`)).toBe(USER_B.token);
+		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(SERVER_A);
 	});
 });

--- a/app/sagas/__tests__/selectServer.sdkHost.test.ts
+++ b/app/sagas/__tests__/selectServer.sdkHost.test.ts
@@ -32,22 +32,13 @@ jest.mock('../../lib/services/twoFactor', () => ({
 	twoFactor: jest.fn()
 }));
 
-import { applyMiddleware, createStore } from 'redux';
-import createSagaMiddleware from 'redux-saga';
-
-import reducers from '../../reducers';
 import selectServerRoot from '../selectServer';
 import { selectServerRequest } from '../../actions/server';
 import { APP, SERVER } from '../../actions/actionsTypes';
 import { RootEnum } from '../../definitions';
 import sdk from '../../lib/services/sdk';
 import { connect } from '../../lib/services/connect';
-
-async function flushSagaMicrotasks(): Promise<void> {
-	for (let i = 0; i < 20; i += 1) {
-		await new Promise(resolve => setImmediate(resolve));
-	}
-}
+import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 const HOST = 'https://open.rocket.chat';
 
@@ -60,19 +51,7 @@ describe('selectServer saga — redundant select for the live SDK host', () => {
 		sdk.initialize(HOST);
 		expect(sdk.current.client.host).toBe(HOST);
 
-		const dispatched: Record<string, any>[] = [];
-		const sagaMiddleware = createSagaMiddleware();
-		const store = createStore(
-			reducers,
-			applyMiddleware(
-				() => next => action => {
-					dispatched.push(action);
-					return next(action);
-				},
-				sagaMiddleware
-			)
-		);
-		sagaMiddleware.run(selectServerRoot);
+		const { store, dispatched } = createRecordingStore(selectServerRoot);
 
 		store.dispatch(selectServerRequest(HOST, '7.0.0', false));
 		await flushSagaMicrotasks();

--- a/app/sagas/__tests__/selectServer.sdkHost.test.ts
+++ b/app/sagas/__tests__/selectServer.sdkHost.test.ts
@@ -1,10 +1,10 @@
 jest.unmock('@rocket.chat/sdk');
 
-const mockConnections: any[] = [];
+const mockConnections: MockConnection[] = [];
 
 jest.mock('universal-websocket-client', () =>
 	jest.fn().mockImplementation(() => {
-		const sdkIntegration = jest.requireActual('../../lib/testUtils/sdkIntegration');
+		const sdkIntegration = jest.requireActual<typeof SdkIntegration>('../../lib/testUtils/sdkIntegration');
 		return new sdkIntegration.MockConnection(mockConnections);
 	})
 );
@@ -38,11 +38,17 @@ import { APP, SERVER } from '../../actions/actionsTypes';
 import { RootEnum } from '../../definitions';
 import sdk from '../../lib/services/sdk';
 import { connect } from '../../lib/services/connect';
+import type { MockConnection } from '../../lib/testUtils/sdkIntegration';
+import type * as SdkIntegration from '../../lib/testUtils/sdkIntegration';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 const HOST = 'https://open.rocket.chat';
 
 describe('selectServer saga — redundant select for the live SDK host', () => {
+	beforeEach(() => {
+		mockConnections.length = 0;
+	});
+
 	afterEach(() => {
 		cancelSagaTasks();
 		sdk.disconnect();

--- a/app/sagas/__tests__/selectServer.sdkHost.test.ts
+++ b/app/sagas/__tests__/selectServer.sdkHost.test.ts
@@ -1,0 +1,87 @@
+jest.unmock('@rocket.chat/sdk');
+
+const mockConnections: any[] = [];
+
+jest.mock('universal-websocket-client', () =>
+	jest.fn().mockImplementation(() => {
+		const sdkIntegration = jest.requireActual('../../lib/testUtils/sdkIntegration');
+		return new sdkIntegration.MockConnection(mockConnections);
+	})
+);
+
+jest.mock('../../lib/methods/helpers/sslPinning', () => ({
+	__esModule: true,
+	default: undefined
+}));
+
+jest.mock('../../lib/services/connect', () => ({
+	connect: jest.fn(() => Promise.resolve()),
+	disconnect: jest.fn(),
+	getLoginServices: jest.fn(),
+	getWebsocketInfo: jest.fn(() => Promise.resolve({ success: true }))
+}));
+
+jest.mock('../../lib/methods/helpers/log', () => ({
+	...jest.requireActual('../../lib/methods/helpers/log'),
+	__esModule: true,
+	default: jest.fn(),
+	logServerVersion: jest.fn()
+}));
+
+jest.mock('../../lib/services/twoFactor', () => ({
+	twoFactor: jest.fn()
+}));
+
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import reducers from '../../reducers';
+import selectServerRoot from '../selectServer';
+import { selectServerRequest } from '../../actions/server';
+import { APP, SERVER } from '../../actions/actionsTypes';
+import { RootEnum } from '../../definitions';
+import sdk from '../../lib/services/sdk';
+import { connect } from '../../lib/services/connect';
+
+async function flushSagaMicrotasks(): Promise<void> {
+	for (let i = 0; i < 20; i += 1) {
+		await new Promise(resolve => setImmediate(resolve));
+	}
+}
+
+const HOST = 'https://open.rocket.chat';
+
+describe('selectServer saga — redundant select for the live SDK host', () => {
+	afterEach(() => {
+		sdk.disconnect();
+	});
+
+	it('reads the live host off the real SDK client and cancels the select without reconnecting', async () => {
+		sdk.initialize(HOST);
+		expect(sdk.current.client.host).toBe(HOST);
+
+		const dispatched: Record<string, any>[] = [];
+		const sagaMiddleware = createSagaMiddleware();
+		const store = createStore(
+			reducers,
+			applyMiddleware(
+				() => next => action => {
+					dispatched.push(action);
+					return next(action);
+				},
+				sagaMiddleware
+			)
+		);
+		sagaMiddleware.run(selectServerRoot);
+
+		store.dispatch(selectServerRequest(HOST, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		const insideIndex = dispatched.findIndex(action => action.type === APP.START && action.root === RootEnum.ROOT_INSIDE);
+		const cancelIndex = dispatched.findIndex(action => action.type === SERVER.SELECT_CANCEL);
+
+		expect(insideIndex).toBeGreaterThanOrEqual(0);
+		expect(cancelIndex).toBeGreaterThan(insideIndex);
+		expect(connect).not.toHaveBeenCalled();
+	});
+});

--- a/app/sagas/__tests__/selectServer.sdkHost.test.ts
+++ b/app/sagas/__tests__/selectServer.sdkHost.test.ts
@@ -43,7 +43,10 @@ import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/s
 const HOST = 'https://open.rocket.chat';
 
 describe('selectServer saga — redundant select for the live SDK host', () => {
+	const runningTasks: { cancel: () => void }[] = [];
+
 	afterEach(() => {
+		runningTasks.splice(0).forEach(task => task.cancel());
 		sdk.disconnect();
 	});
 
@@ -51,7 +54,8 @@ describe('selectServer saga — redundant select for the live SDK host', () => {
 		sdk.initialize(HOST);
 		expect(sdk.current.client.host).toBe(HOST);
 
-		const { store, dispatched } = createRecordingStore(selectServerRoot);
+		const { store, dispatched, task } = createRecordingStore(selectServerRoot);
+		runningTasks.push(task);
 
 		store.dispatch(selectServerRequest(HOST, '7.0.0', false));
 		await flushSagaMicrotasks();

--- a/app/sagas/__tests__/selectServer.sdkHost.test.ts
+++ b/app/sagas/__tests__/selectServer.sdkHost.test.ts
@@ -38,15 +38,13 @@ import { APP, SERVER } from '../../actions/actionsTypes';
 import { RootEnum } from '../../definitions';
 import sdk from '../../lib/services/sdk';
 import { connect } from '../../lib/services/connect';
-import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 const HOST = 'https://open.rocket.chat';
 
 describe('selectServer saga — redundant select for the live SDK host', () => {
-	const runningTasks: { cancel: () => void }[] = [];
-
 	afterEach(() => {
-		runningTasks.splice(0).forEach(task => task.cancel());
+		cancelSagaTasks();
 		sdk.disconnect();
 	});
 
@@ -54,8 +52,7 @@ describe('selectServer saga — redundant select for the live SDK host', () => {
 		sdk.initialize(HOST);
 		expect(sdk.current.client.host).toBe(HOST);
 
-		const { store, dispatched, task } = createRecordingStore(selectServerRoot);
-		runningTasks.push(task);
+		const { store, dispatched } = createRecordingStore(selectServerRoot);
 
 		store.dispatch(selectServerRequest(HOST, '7.0.0', false));
 		await flushSagaMicrotasks();

--- a/app/sagas/__tests__/selectServer.sdkHost.test.ts
+++ b/app/sagas/__tests__/selectServer.sdkHost.test.ts
@@ -58,13 +58,13 @@ describe('selectServer saga — redundant select for the live SDK host', () => {
 		sdk.initialize(HOST);
 		expect(sdk.current.client.host).toBe(HOST);
 
-		const { store, dispatched } = createRecordingStore(selectServerRoot);
+		const { store, dispatchedActions } = createRecordingStore(selectServerRoot);
 
 		store.dispatch(selectServerRequest(HOST, '7.0.0', false));
 		await flushSagaMicrotasks();
 
-		const insideIndex = dispatched.findIndex(action => action.type === APP.START && action.root === RootEnum.ROOT_INSIDE);
-		const cancelIndex = dispatched.findIndex(action => action.type === SERVER.SELECT_CANCEL);
+		const insideIndex = dispatchedActions.findIndex(action => action.type === APP.START && action.root === RootEnum.ROOT_INSIDE);
+		const cancelIndex = dispatchedActions.findIndex(action => action.type === SERVER.SELECT_CANCEL);
 
 		expect(insideIndex).toBeGreaterThanOrEqual(0);
 		expect(cancelIndex).toBeGreaterThan(insideIndex);

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -1,7 +1,3 @@
-// Do not mock '../../lib/methods/userPreferences' here: this test asserts against the real
-// MMKV-backed store (__mocks__/react-native-mmkv.js). Mocking it lets the test wire up whichever
-// key the code happens to ask for, which is exactly the asymmetry these cases exist to catch.
-
 jest.mock('../../lib/methods/helpers/sslPinning', () => ({
 	__esModule: true,
 	default: undefined
@@ -66,10 +62,7 @@ jest.mock('../../lib/methods/helpers/log', () => ({
 }));
 
 import { settings as RocketChatSettings } from '@rocket.chat/sdk';
-import { applyMiddleware, createStore } from 'redux';
-import createSagaMiddleware from 'redux-saga';
 
-import reducers from '../../reducers';
 import selectServerRoot from '../selectServer';
 import { selectServerRequest } from '../../actions/server';
 import { SERVER } from '../../actions/actionsTypes';
@@ -79,34 +72,15 @@ import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import { getLoggedUserById } from '../../lib/database/services/LoggedUser';
 import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { connect } from '../../lib/services/connect';
-
-async function flushSagaMicrotasks(): Promise<void> {
-	for (let i = 0; i < 20; i += 1) {
-		await new Promise(resolve => setImmediate(resolve));
-	}
-}
+import { getServerById } from '../../lib/database/services/Server';
+import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 const OLD_SERVER = 'https://old.rocket.chat';
 const SERVER_URL = 'https://new.rocket.chat';
 const USER_ID = 'user-new';
 const TOKEN = 'token-new';
 
-function setupStore() {
-	const dispatched: Record<string, any>[] = [];
-	const sagaMiddleware = createSagaMiddleware();
-	const store = createStore(
-		reducers,
-		applyMiddleware(
-			() => next => action => {
-				dispatched.push(action);
-				return next(action);
-			},
-			sagaMiddleware
-		)
-	);
-	sagaMiddleware.run(selectServerRoot);
-	return { store, dispatched };
-}
+const setupStore = () => createRecordingStore(selectServerRoot);
 
 const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
 
@@ -140,7 +114,7 @@ describe('selectServer saga — resolving the target workspace user', () => {
 		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
 		await flushSagaMicrotasks();
 
-		expect(store.getState().login.user).toMatchObject({ token: TOKEN });
+		expect(store.getState().login.user).toEqual({ token: TOKEN });
 		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(SERVER_URL);
 	});
 
@@ -184,7 +158,7 @@ describe('selectServer saga — resolving the target workspace user', () => {
 	});
 });
 
-describe('selectServer saga — version fallback when server info is not fetched', () => {
+describe('selectServer saga — version and name fallback', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		keysToClear.forEach(key => UserPreferences.removeItem(key));
@@ -204,7 +178,7 @@ describe('selectServer saga — version fallback when server info is not fetched
 		expect(getServerInfo).not.toHaveBeenCalled();
 	});
 
-	it('reports a server failure, not a select failure, when the server info fetch throws', async () => {
+	it('reports a server failure and the caller-supplied version when the server info fetch throws', async () => {
 		jest.mocked(getServerInfo).mockRejectedValue(new Error('offline'));
 
 		const { store, dispatched } = setupStore();
@@ -214,5 +188,20 @@ describe('selectServer saga — version fallback when server info is not fetched
 		const types = dispatched.map(action => action.type);
 		expect(types).toContain(SERVER.FAILURE);
 		expect(types).not.toContain(SERVER.SELECT_FAILURE);
+
+		const success = dispatched.find(action => action.type === SERVER.SELECT_SUCCESS);
+		expect(success).toMatchObject({ server: SERVER_URL, version: '7.4.0', name: 'Rocket.Chat' });
+	});
+
+	it('reports the stored record version when the server info fetch is unsuccessful', async () => {
+		jest.mocked(getServerInfo).mockResolvedValue({ success: false } as any);
+		jest.mocked(getServerById).mockResolvedValue({ version: '6.9.0', name: 'Stored A' } as any);
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.4.0', true));
+		await flushSagaMicrotasks();
+
+		const success = dispatched.find(action => action.type === SERVER.SELECT_SUCCESS);
+		expect(success).toMatchObject({ server: SERVER_URL, version: '6.9.0', name: 'Stored A' });
 	});
 });

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -84,16 +84,16 @@ const setupStore = () => createRecordingStore(selectServerRoot);
 
 afterEach(cancelSagaTasks);
 
+beforeEach(() => {
+	jest.clearAllMocks();
+	keysToClear.forEach(key => UserPreferences.removeItem(key));
+	UserPreferences.setString(CURRENT_SERVER, OLD_SERVER);
+	setBasicAuth(null);
+});
+
 const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
 
 describe('selectServer saga — resolving the target workspace user', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-		keysToClear.forEach(key => UserPreferences.removeItem(key));
-		UserPreferences.setString(CURRENT_SERVER, OLD_SERVER);
-		setBasicAuth(null);
-	});
-
 	it('sets the full user from the logged-user record and stamps CURRENT_SERVER', async () => {
 		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
 		jest.mocked(getLoggedUserById).mockResolvedValue({ id: USER_ID, token: TOKEN, username: 'new' } as any);
@@ -160,12 +160,8 @@ describe('selectServer saga — resolving the target workspace user', () => {
 
 describe('selectServer saga — version and name fallback', () => {
 	beforeEach(() => {
-		jest.clearAllMocks();
-		keysToClear.forEach(key => UserPreferences.removeItem(key));
-		UserPreferences.setString(CURRENT_SERVER, OLD_SERVER);
 		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
 		jest.mocked(getLoggedUserById).mockResolvedValue({ id: USER_ID, token: TOKEN } as any);
-		setBasicAuth(null);
 	});
 
 	it('reports the caller-supplied version and the default name', async () => {

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -1,0 +1,184 @@
+// Do not mock '../../lib/methods/userPreferences' here: this test asserts against the real
+// MMKV-backed store (__mocks__/react-native-mmkv.js). Mocking it lets the test wire up whichever
+// key the code happens to ask for, which is exactly the asymmetry these cases exist to catch.
+
+jest.mock('../../lib/methods/helpers/sslPinning', () => ({
+	__esModule: true,
+	default: undefined
+}));
+
+jest.mock('../../lib/database/services/LoggedUser', () => ({
+	getLoggedUserById: jest.fn()
+}));
+
+jest.mock('../../lib/database/services/Server', () => ({
+	getServerById: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getServerInfo', () => ({
+	getServerInfo: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getSettings', () => ({
+	getLoginSettings: jest.fn(),
+	setSettings: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getCustomEmojis', () => ({
+	setCustomEmojis: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getPermissions', () => ({
+	setPermissions: jest.fn()
+}));
+
+jest.mock('../../lib/methods/getRoles', () => ({
+	setRoles: jest.fn()
+}));
+
+jest.mock('../../lib/methods/enterpriseModules', () => ({
+	setEnterpriseModules: jest.fn()
+}));
+
+jest.mock('../../lib/methods/checkSupportedVersions', () => ({
+	checkSupportedVersions: jest.fn(() => Promise.resolve({ status: 'supported' }))
+}));
+
+jest.mock('../../lib/services/connect', () => ({
+	connect: jest.fn(() => Promise.resolve()),
+	disconnect: jest.fn(),
+	getLoginServices: jest.fn(),
+	getWebsocketInfo: jest.fn(() => Promise.resolve({ success: true }))
+}));
+
+jest.mock('../../lib/services/sdk', () => ({
+	__esModule: true,
+	default: {
+		current: { client: { host: '' } }
+	}
+}));
+
+jest.mock('../../lib/methods/helpers/log', () => ({
+	...jest.requireActual('../../lib/methods/helpers/log'),
+	__esModule: true,
+	default: jest.fn(),
+	logServerVersion: jest.fn()
+}));
+
+import { settings as RocketChatSettings } from '@rocket.chat/sdk';
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import reducers from '../../reducers';
+import selectServerRoot from '../selectServer';
+import { selectServerRequest } from '../../actions/server';
+import { SERVER } from '../../actions/actionsTypes';
+import UserPreferences from '../../lib/methods/userPreferences';
+import { BASIC_AUTH_KEY, setBasicAuth } from '../../lib/methods/helpers/fetch';
+import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
+import { getLoggedUserById } from '../../lib/database/services/LoggedUser';
+import { connect } from '../../lib/services/connect';
+
+async function flushSagaMicrotasks(): Promise<void> {
+	for (let i = 0; i < 20; i += 1) {
+		await new Promise(resolve => setImmediate(resolve));
+	}
+}
+
+const OLD_SERVER = 'https://old.rocket.chat';
+const SERVER_URL = 'https://new.rocket.chat';
+const USER_ID = 'user-new';
+const TOKEN = 'token-new';
+
+function setupStore() {
+	const dispatched: { type: string }[] = [];
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(
+		reducers,
+		applyMiddleware(
+			() => next => action => {
+				dispatched.push(action);
+				return next(action);
+			},
+			sagaMiddleware
+		)
+	);
+	sagaMiddleware.run(selectServerRoot);
+	return { store, dispatched };
+}
+
+const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
+
+describe('selectServer saga — resolving the target workspace user', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		keysToClear.forEach(key => UserPreferences.removeItem(key));
+		UserPreferences.setString(CURRENT_SERVER, OLD_SERVER);
+		setBasicAuth(null);
+	});
+
+	it('sets the full user from the logged-user record and stamps CURRENT_SERVER', async () => {
+		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
+		jest.mocked(getLoggedUserById).mockResolvedValue({ id: USER_ID, token: TOKEN, username: 'new' } as any);
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(store.getState().login.user).toMatchObject({ id: USER_ID, token: TOKEN });
+		expect(dispatched.map(action => action.type)).not.toContain(SERVER.SELECT_FAILURE);
+		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(SERVER_URL);
+	});
+
+	it('falls back to the token stored under the userId key when there is no record', async () => {
+		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
+		UserPreferences.setString(`${TOKEN_KEY}-${USER_ID}`, TOKEN);
+		jest.mocked(getLoggedUserById).mockResolvedValue(null as any);
+
+		const { store } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(store.getState().login.user).toMatchObject({ token: TOKEN });
+		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(SERVER_URL);
+	});
+
+	it('does not stamp CURRENT_SERVER when the target workspace has no credentials', async () => {
+		jest.mocked(getLoggedUserById).mockResolvedValue(null as any);
+
+		const { store } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(getLoggedUserById).not.toHaveBeenCalled();
+		expect(store.getState().login.user).toEqual({});
+		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(OLD_SERVER);
+	});
+
+	it('leaves CURRENT_SERVER on the previous workspace when the switch fails', async () => {
+		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
+		jest.mocked(getLoggedUserById).mockRejectedValue(new Error('database unavailable'));
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(dispatched.map(action => action.type)).toContain(SERVER.SELECT_FAILURE);
+		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(OLD_SERVER);
+		expect(connect).not.toHaveBeenCalled();
+	});
+
+	it('drops the previous workspace basic-auth header when the target has none', async () => {
+		setBasicAuth('old-workspace-credentials');
+		expect(RocketChatSettings.customHeaders).toHaveProperty('Authorization');
+
+		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
+		jest.mocked(getLoggedUserById).mockResolvedValue({ id: USER_ID, token: TOKEN } as any);
+
+		const { store } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(RocketChatSettings.customHeaders).not.toHaveProperty('Authorization');
+	});
+});

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -80,6 +80,8 @@ const SERVER_URL = 'https://new.rocket.chat';
 const USER_ID = 'user-new';
 const TOKEN = 'token-new';
 
+const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
+
 const setupStore = () => createRecordingStore(selectServerRoot);
 
 afterEach(cancelSagaTasks);
@@ -90,8 +92,6 @@ beforeEach(() => {
 	UserPreferences.setString(CURRENT_SERVER, OLD_SERVER);
 	setBasicAuth(null);
 });
-
-const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
 
 describe('selectServer saga — resolving the target workspace user', () => {
 	it('sets the full user from the logged-user record and stamps CURRENT_SERVER', async () => {

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -98,12 +98,12 @@ describe('selectServer saga — resolving the target workspace user', () => {
 		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
 		jest.mocked(getLoggedUserById).mockResolvedValue({ id: USER_ID, token: TOKEN, username: 'new' } as any);
 
-		const { store, dispatched } = setupStore();
+		const { store, dispatchedActions } = setupStore();
 		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
 		await flushSagaMicrotasks();
 
 		expect(store.getState().login.user).toMatchObject({ id: USER_ID, token: TOKEN });
-		expect(dispatched.map(action => action.type)).not.toContain(SERVER.SELECT_FAILURE);
+		expect(dispatchedActions.map(action => action.type)).not.toContain(SERVER.SELECT_FAILURE);
 		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(SERVER_URL);
 	});
 
@@ -134,11 +134,11 @@ describe('selectServer saga — resolving the target workspace user', () => {
 		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
 		jest.mocked(getLoggedUserById).mockRejectedValue(new Error('database unavailable'));
 
-		const { store, dispatched } = setupStore();
+		const { store, dispatchedActions } = setupStore();
 		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
 		await flushSagaMicrotasks();
 
-		expect(dispatched.map(action => action.type)).toContain(SERVER.SELECT_FAILURE);
+		expect(dispatchedActions.map(action => action.type)).toContain(SERVER.SELECT_FAILURE);
 		expect(UserPreferences.getString(CURRENT_SERVER)).toBe(OLD_SERVER);
 		expect(connect).not.toHaveBeenCalled();
 	});
@@ -165,11 +165,11 @@ describe('selectServer saga — version and name fallback', () => {
 	});
 
 	it('reports the caller-supplied version and the default name', async () => {
-		const { store, dispatched } = setupStore();
+		const { store, dispatchedActions } = setupStore();
 		store.dispatch(selectServerRequest(SERVER_URL, '7.4.0', false));
 		await flushSagaMicrotasks();
 
-		const success = dispatched.find(action => action.type === SERVER.SELECT_SUCCESS);
+		const success = dispatchedActions.find(action => action.type === SERVER.SELECT_SUCCESS);
 		expect(success).toMatchObject({ server: SERVER_URL, version: '7.4.0', name: 'Rocket.Chat' });
 		expect(getServerInfo).not.toHaveBeenCalled();
 	});
@@ -177,15 +177,15 @@ describe('selectServer saga — version and name fallback', () => {
 	it('reports a server failure and the caller-supplied version when the server info fetch throws', async () => {
 		jest.mocked(getServerInfo).mockRejectedValue(new Error('offline'));
 
-		const { store, dispatched } = setupStore();
+		const { store, dispatchedActions } = setupStore();
 		store.dispatch(selectServerRequest(SERVER_URL, '7.4.0', true));
 		await flushSagaMicrotasks();
 
-		const types = dispatched.map(action => action.type);
+		const types = dispatchedActions.map(action => action.type);
 		expect(types).toContain(SERVER.FAILURE);
 		expect(types).not.toContain(SERVER.SELECT_FAILURE);
 
-		const success = dispatched.find(action => action.type === SERVER.SELECT_SUCCESS);
+		const success = dispatchedActions.find(action => action.type === SERVER.SELECT_SUCCESS);
 		expect(success).toMatchObject({ server: SERVER_URL, version: '7.4.0', name: 'Rocket.Chat' });
 	});
 
@@ -193,11 +193,11 @@ describe('selectServer saga — version and name fallback', () => {
 		jest.mocked(getServerInfo).mockResolvedValue({ success: false } as any);
 		jest.mocked(getServerById).mockResolvedValue({ version: '6.9.0', name: 'Stored A' } as any);
 
-		const { store, dispatched } = setupStore();
+		const { store, dispatchedActions } = setupStore();
 		store.dispatch(selectServerRequest(SERVER_URL, '7.4.0', true));
 		await flushSagaMicrotasks();
 
-		const success = dispatched.find(action => action.type === SERVER.SELECT_SUCCESS);
+		const success = dispatchedActions.find(action => action.type === SERVER.SELECT_SUCCESS);
 		expect(success).toMatchObject({ server: SERVER_URL, version: '6.9.0', name: 'Stored A' });
 	});
 });

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -77,6 +77,7 @@ import UserPreferences from '../../lib/methods/userPreferences';
 import { BASIC_AUTH_KEY, setBasicAuth } from '../../lib/methods/helpers/fetch';
 import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import { getLoggedUserById } from '../../lib/database/services/LoggedUser';
+import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { connect } from '../../lib/services/connect';
 
 async function flushSagaMicrotasks(): Promise<void> {
@@ -91,7 +92,7 @@ const USER_ID = 'user-new';
 const TOKEN = 'token-new';
 
 function setupStore() {
-	const dispatched: { type: string }[] = [];
+	const dispatched: Record<string, any>[] = [];
 	const sagaMiddleware = createSagaMiddleware();
 	const store = createStore(
 		reducers,
@@ -180,5 +181,38 @@ describe('selectServer saga — resolving the target workspace user', () => {
 		await flushSagaMicrotasks();
 
 		expect(RocketChatSettings.customHeaders).not.toHaveProperty('Authorization');
+	});
+});
+
+describe('selectServer saga — version fallback when server info is not fetched', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		keysToClear.forEach(key => UserPreferences.removeItem(key));
+		UserPreferences.setString(CURRENT_SERVER, OLD_SERVER);
+		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
+		jest.mocked(getLoggedUserById).mockResolvedValue({ id: USER_ID, token: TOKEN } as any);
+		setBasicAuth(null);
+	});
+
+	it('reports the caller-supplied version and the default name', async () => {
+		const { store, dispatched } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.4.0', false));
+		await flushSagaMicrotasks();
+
+		const success = dispatched.find(action => action.type === SERVER.SELECT_SUCCESS);
+		expect(success).toMatchObject({ server: SERVER_URL, version: '7.4.0', name: 'Rocket.Chat' });
+		expect(getServerInfo).not.toHaveBeenCalled();
+	});
+
+	it('reports a server failure, not a select failure, when the server info fetch throws', async () => {
+		jest.mocked(getServerInfo).mockRejectedValue(new Error('offline'));
+
+		const { store, dispatched } = setupStore();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.4.0', true));
+		await flushSagaMicrotasks();
+
+		const types = dispatched.map(action => action.type);
+		expect(types).toContain(SERVER.FAILURE);
+		expect(types).not.toContain(SERVER.SELECT_FAILURE);
 	});
 });

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -74,6 +74,7 @@ import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { connect } from '../../lib/services/connect';
 import { getServerById } from '../../lib/database/services/Server';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import type { RecordingStore } from '../../lib/testUtils/sagaStore';
 
 const OLD_SERVER = 'https://old.rocket.chat';
 const SERVER_URL = 'https://new.rocket.chat';
@@ -82,7 +83,7 @@ const TOKEN = 'token-new';
 
 const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
 
-const setupStore = () => createRecordingStore(selectServerRoot);
+const setupStore = (): RecordingStore => createRecordingStore(selectServerRoot);
 
 afterEach(cancelSagaTasks);
 

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -80,7 +80,17 @@ const SERVER_URL = 'https://new.rocket.chat';
 const USER_ID = 'user-new';
 const TOKEN = 'token-new';
 
-const setupStore = () => createRecordingStore(selectServerRoot);
+const runningTasks: { cancel: () => void }[] = [];
+
+function setupStore() {
+	const { store, dispatched, task } = createRecordingStore(selectServerRoot);
+	runningTasks.push(task);
+	return { store, dispatched };
+}
+
+afterEach(() => {
+	runningTasks.splice(0).forEach(task => task.cancel());
+});
 
 const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
 

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -73,24 +73,16 @@ import { getLoggedUserById } from '../../lib/database/services/LoggedUser';
 import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { connect } from '../../lib/services/connect';
 import { getServerById } from '../../lib/database/services/Server';
-import { createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 
 const OLD_SERVER = 'https://old.rocket.chat';
 const SERVER_URL = 'https://new.rocket.chat';
 const USER_ID = 'user-new';
 const TOKEN = 'token-new';
 
-const runningTasks: { cancel: () => void }[] = [];
+const setupStore = () => createRecordingStore(selectServerRoot);
 
-function setupStore() {
-	const { store, dispatched, task } = createRecordingStore(selectServerRoot);
-	runningTasks.push(task);
-	return { store, dispatched };
-}
-
-afterEach(() => {
-	runningTasks.splice(0).forEach(task => task.cancel());
-});
+afterEach(cancelSagaTasks);
 
 const keysToClear = [`${TOKEN_KEY}-${SERVER_URL}`, `${TOKEN_KEY}-${USER_ID}`, `${BASIC_AUTH_KEY}-${SERVER_URL}`, CURRENT_SERVER];
 
@@ -129,8 +121,6 @@ describe('selectServer saga — resolving the target workspace user', () => {
 	});
 
 	it('does not stamp CURRENT_SERVER when the target workspace has no credentials', async () => {
-		jest.mocked(getLoggedUserById).mockResolvedValue(null as any);
-
 		const { store } = setupStore();
 		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
 		await flushSagaMicrotasks();


### PR DESCRIPTION
## Proposed changes

Adds unit coverage for multi-workspace (server) switching, which was previously untested at the saga level.

- `selectServer`: how the target workspace's user is resolved (logged-user record, token-only fallback, no credentials at all), that a failed switch leaves `currentServer` naming the previous workspace, that the previous workspace's basic-auth header is dropped, and the offline version/name fallback.
- `selectServer` redundant-select guard: driven against the real `@rocket.chat/sdk` (with a mocked websocket client) so `client.host` comes from the real constructor and an SDK-shape change can actually fail it.
- `login`: a workspace switch cancels the login bootstrap before it persists credentials, so workspace A never gets stamped with workspace B's identity.
- `logout`: `removeServerData` clears the per-server keys `removeServerKeys` owns (token, basic-auth, the three E2E keys) while leaving the other workspace's keys and `currentServer` untouched. It also keeps `${CERTIFICATE_KEY}-${server}` on purpose, so a user with a pinned client certificate does not have to re-enter its password after removing the server; there is a case pinning that against a future over-broad "clear everything" refactor.
- `deepLinking`: an unknown host hands off to the add-server flow, and `serverInitAdd` carries the previous server (not the deeplink host) so the add-server screen keeps a route back.

Also extracts `app/lib/testUtils/sagaStore.ts` — a recording store plus microtask-drain and saga-task-cancellation helpers — and moves the existing `deepLinking` suite onto it, so the new suites do not each re-declare a saga store.

Also adds `app/sagas/selectServer.ts` and `app/lib/services/connect.ts` to the `dependsOn` of the `changeserver` and `delete-server` e2e entries — neither path was listed anywhere, so editing the switch saga triggered no server-switch e2e on any PR.

The credential assertions run against the real MMKV-backed `UserPreferences`. Mocking it in these files would keep every case green while removing what they prove.

## Issue(s)

## How to test or reproduce

`TZ=UTC pnpm test`

## Screenshots

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

## Further comments

Every case was checked by breaking the production line it targets and confirming the test goes red, with these exceptions:

- `removeServerData` "skips the user token key when there is no userId" has no falsifying mutation — removing the guard only deletes a nonsense key.
- The `selectServer` failure-path case detects an early `currentServer` stamp but not a reordering inside the `if (user)` branch, since `connect()` cannot reject.
- The `removeServerData` "leaves another workspace keys untouched", "leaves `CURRENT_SERVER` in place" and "keeps the pinned certificate" cases stay green even with the whole `removeServerKeys` call deleted. They target no production line; they pin the scoping invariant against a future over-broad clear.

Stacked on #7574.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for workspace switching, login cancellation, deep-link handling, and SDK host selection.
  * Added validation for credential cleanup, token handling, server data removal, database failures, and reconnect behavior.
  * Verified preservation of unrelated workspace data and correct handling of missing credentials or server information.
  * Standardized test setup and cleanup to improve reliability and reduce test-related inconsistencies.
  * Added checks for action ordering during server setup and switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



