### PR TITLE
fix: give every saga exit a user-facing root

### DIFF
--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -603,8 +603,6 @@ describe('deepLinking saga — unknown host hands off to the add-server flow', (
 	});
 });
 
-// ─── handleShareExtension — every exit must land on a user-facing root ──────────
-
 describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 	beforeEach(() => {
 		jest.mocked(UserPreferences.getString).mockReset();

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -602,9 +602,9 @@ describe('deepLinking saga — unknown host hands off to the add-server flow', (
 	});
 });
 
-// ─── handleShareExtension — every exit must land on a terminal root ──────────
+// ─── handleShareExtension — every exit must land on a user-facing root ──────────
 
-describe('deepLinking saga — handleShareExtension terminal roots', () => {
+describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 	beforeEach(() => {
 		jest.mocked(UserPreferences.getString).mockReset();
 		jest.mocked(getServerById).mockReset();

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -621,7 +621,7 @@ describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 		jest.mocked(sdk).current.client.host = '';
 	});
 
-	it('leaves ROOT_OUTSIDE, not the loading root, when the server record is missing', async () => {
+	it('lands on ROOT_OUTSIDE, not the loading root, when the server record is missing', async () => {
 		jest.mocked(getServerById).mockResolvedValue(null as any);
 		const { store } = setupStore();
 
@@ -631,7 +631,7 @@ describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
 	});
 
-	it('leaves ROOT_OUTSIDE when the login that the share sheet waits on fails', async () => {
+	it('lands on ROOT_OUTSIDE when the login that the share sheet waits on fails', async () => {
 		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
 		const { store } = setupStore();
 
@@ -645,7 +645,7 @@ describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
 	});
 
-	it('leaves ROOT_OUTSIDE when selecting the server fails while the share sheet waits', async () => {
+	it('lands on ROOT_OUTSIDE when selecting the server fails while the share sheet waits', async () => {
 		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
 		const { store } = setupStore();
 
@@ -658,7 +658,7 @@ describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
 	});
 
-	it('leaves ROOT_OUTSIDE when the server logs the share sheet out instead of failing the login', async () => {
+	it('lands on ROOT_OUTSIDE when the server logs the share sheet out instead of failing the login', async () => {
 		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
 		const { store } = setupStore();
 
@@ -671,7 +671,7 @@ describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
 	});
 
-	it('leaves ROOT_OUTSIDE when local authentication throws', async () => {
+	it('lands on ROOT_OUTSIDE when local authentication throws', async () => {
 		jest.mocked(localAuthenticate).mockRejectedValueOnce(new Error('biometrics unavailable'));
 		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
 		const { store } = setupStore();

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -96,11 +96,12 @@ import { deepLinkingOpen, deepLinkingClickCallPush } from '../../actions/deepLin
 import { loginFailure, loginSuccess } from '../../actions/login';
 import { selectServerFailure, selectServerSuccess } from '../../actions/server';
 import { appStart } from '../../actions/app';
-import { APP, SERVER } from '../../actions/actionsTypes';
+import { APP, LOGOUT, SERVER } from '../../actions/actionsTypes';
 import { RootEnum } from '../../definitions';
 import deepLinkingRoot from '../deepLinking';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { getServerById } from '../../lib/database/services/Server';
+import { localAuthenticate } from '../../lib/methods/helpers/localAuthentication';
 import { canOpenRoom } from '../../lib/methods/canOpenRoom';
 import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { goRoom, navigateToRoom } from '../../lib/methods/helpers/goRoom';
@@ -652,6 +653,30 @@ describe('deepLinking saga — handleShareExtension user-facing roots', () => {
 		await flushSagaMicrotasks();
 
 		store.dispatch(selectServerFailure());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
+	it('leaves ROOT_OUTSIDE when the server logs the share sheet out instead of failing the login', async () => {
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		const { store } = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'shareextension' } as any));
+		await flushSagaMicrotasks();
+
+		store.dispatch({ type: LOGOUT });
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
+	it('leaves ROOT_OUTSIDE when local authentication throws', async () => {
+		jest.mocked(localAuthenticate).mockRejectedValueOnce(new Error('biometrics unavailable'));
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		const { store } = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'shareextension' } as any));
 		await flushSagaMicrotasks();
 
 		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -96,8 +96,8 @@ import { applyMiddleware, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
 import { deepLinkingOpen, deepLinkingClickCallPush } from '../../actions/deepLinking';
-import { loginSuccess } from '../../actions/login';
-import { selectServerSuccess } from '../../actions/server';
+import { loginFailure, loginSuccess } from '../../actions/login';
+import { selectServerFailure, selectServerSuccess } from '../../actions/server';
 import { appStart } from '../../actions/app';
 import { RootEnum } from '../../definitions';
 import reducers from '../../reducers';
@@ -583,5 +583,80 @@ describe('deepLinking saga — handleOAuth dedup guard', () => {
 		expect(jest.mocked(loginOAuthOrSso)).toHaveBeenNthCalledWith(2, {
 			oauth: { credentialToken: 'token-second-C', credentialSecret: 'secret-C2' }
 		});
+	});
+});
+
+// ─── handleShareExtension — every exit must land on a terminal root ──────────
+
+describe('deepLinking saga — handleShareExtension terminal roots', () => {
+	beforeEach(() => {
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(UserPreferences.getString).mockImplementation((key: string) => {
+			if (key === 'currentServer') return HOST;
+			return makeStoredUser();
+		});
+		sdk.current.client.host = '';
+	});
+
+	afterEach(() => {
+		sdk.current.client.host = '';
+	});
+
+	it('leaves ROOT_OUTSIDE, not the loading root, when the server record is missing', async () => {
+		jest.mocked(getServerById).mockResolvedValue(null);
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'shareextension' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
+	it('leaves ROOT_OUTSIDE when the login that the share sheet waits on fails', async () => {
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'shareextension' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_LOADING_SHARE_EXTENSION);
+
+		store.dispatch(loginFailure({ message: 'connect failed' }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
+	it('leaves ROOT_OUTSIDE when selecting the server fails while the share sheet waits', async () => {
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'shareextension' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerFailure());
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
+	it('still reaches ROOT_SHARE_EXTENSION when the login succeeds', async () => {
+		jest.mocked(getServerById).mockResolvedValue(makeServerRecord() as any);
+		const store = setupStore();
+
+		store.dispatch(deepLinkingOpen({ type: 'shareextension' } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: TOKEN } as any));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_SHARE_EXTENSION);
 	});
 });

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -54,6 +54,8 @@ import { RootEnum } from '../../definitions';
 import initRoot from '../init';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { getServerById } from '../../lib/database/services/Server';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { deepLinkingClickCallPush } from '../../actions/deepLinking';
 import { TOKEN_KEY } from '../../lib/constants/keys';
 import database from '../../lib/database';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
@@ -69,6 +71,8 @@ describe('init saga — restore user-facing roots', () => {
 		jest.mocked(UserPreferences.getString).mockReset();
 		jest.mocked(getServerById).mockReset();
 		jest.mocked(RNBootSplash.hide).mockClear();
+		jest.mocked(deepLinkingClickCallPush).mockClear();
+		jest.mocked(AsyncStorage.getItem).mockResolvedValue(null as any);
 		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
 	});
 
@@ -114,6 +118,18 @@ describe('init saga — restore user-facing roots', () => {
 		expect(store.getState().server.server).toBe(OTHER_HOST);
 		expect(store.getState().server.version).toBe('7.0.0');
 		expect(store.getState().app.ready).toBe(true);
+	});
+
+	it('delivers the pending push notification without stranding the boot', async () => {
+		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
+		jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({ rid: 'room-1' }) as any);
+		const { store } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(deepLinkingClickCallPush)).toHaveBeenCalledWith({ rid: 'room-1' });
+		expect(store.getState().server.server).toBe(HOST);
 	});
 
 	it('selects the stored server and marks the app ready when the record exists', async () => {

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -1,5 +1,3 @@
-// ─── Boundary mocks — must appear before any import that triggers the module ───
-
 jest.mock('../../lib/methods/userPreferences', () => ({
 	__esModule: true,
 	default: {
@@ -40,8 +38,6 @@ jest.mock('../../lib/database', () => ({
 		}
 	}
 }));
-
-// ─── Real imports (after mocks) ───────────────────────────────────────────────
 
 import RNBootSplash from 'react-native-bootsplash';
 

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -1,0 +1,117 @@
+// ─── Boundary mocks — must appear before any import that triggers the module ───
+
+jest.mock('../../lib/methods/userPreferences', () => ({
+	__esModule: true,
+	default: {
+		getString: jest.fn()
+	}
+}));
+
+jest.mock('../../lib/database/services/Server', () => ({
+	getServerById: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
+	localAuthenticate: jest.fn()
+}));
+
+jest.mock('../../lib/methods/userPreferencesMethods', () => ({
+	getSortPreferences: jest.fn(() => ({}))
+}));
+
+jest.mock('../../actions/deepLinking', () => ({
+	deepLinkingClickCallPush: jest.fn()
+}));
+
+jest.mock('react-native-bootsplash', () => ({
+	__esModule: true,
+	default: { hide: jest.fn(() => Promise.resolve()) }
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+	__esModule: true,
+	default: {
+		getItem: jest.fn(() => Promise.resolve(null)),
+		removeItem: jest.fn(() => Promise.resolve(null))
+	}
+}));
+
+jest.mock('../../lib/database', () => ({
+	__esModule: true,
+	default: {
+		servers: {
+			get: jest.fn()
+		}
+	}
+}));
+
+// ─── Real imports (after mocks) ───────────────────────────────────────────────
+
+import { applyMiddleware, createStore } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+import RNBootSplash from 'react-native-bootsplash';
+
+import { appInit } from '../../actions/app';
+import { RootEnum } from '../../definitions';
+import reducers from '../../reducers';
+import initRoot from '../init';
+import UserPreferences from '../../lib/methods/userPreferences';
+import { getServerById } from '../../lib/database/services/Server';
+
+/** Drains pending saga microtasks so all synchronous saga steps complete. */
+async function flushSagaMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function setupStore() {
+	const sagaMiddleware = createSagaMiddleware();
+	const store = createStore(reducers, undefined, applyMiddleware(sagaMiddleware));
+	sagaMiddleware.run(initRoot);
+	return store;
+}
+
+const HOST = 'https://open.rocket.chat';
+
+describe('init saga — restore terminal roots', () => {
+	beforeEach(() => {
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(RNBootSplash.hide).mockClear();
+		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
+	});
+
+	it('lands on ROOT_OUTSIDE and hides the splash when the stored server has no database record', async () => {
+		jest.mocked(getServerById).mockResolvedValue(null);
+		const store = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+		expect(jest.mocked(RNBootSplash.hide)).toHaveBeenCalled();
+	});
+
+	it('marks the app ready when the stored server has no database record', async () => {
+		jest.mocked(getServerById).mockResolvedValue(null);
+		const store = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.ready).toBe(true);
+	});
+
+	it('selects the stored server and marks the app ready when the record exists', async () => {
+		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
+		const store = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.ready).toBe(true);
+		expect(store.getState().server.server).toBe(HOST);
+	});
+});

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -97,6 +97,17 @@ describe('init saga — restore user-facing roots', () => {
 		expect(store.getState().app.ready).toBe(true);
 	});
 
+	it('lands on ROOT_OUTSIDE when no server is stored at all', async () => {
+		jest.mocked(UserPreferences.getString).mockImplementation(() => null);
+		const { store } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+		expect(store.getState().app.ready).toBe(true);
+	});
+
 	it('selects another logged in server with its own version when the stored server has no token', async () => {
 		jest.mocked(UserPreferences.getString).mockImplementation(key => {
 			if (key === `${TOKEN_KEY}-${OTHER_HOST}`) return 'token';
@@ -141,7 +152,7 @@ describe('init saga — restore user-facing roots', () => {
 		expect(dispatchedActions).not.toContainEqual(expect.objectContaining({ type: DEEP_LINKING.OPEN_VIDEO_CONF }));
 	});
 
-	it('delivers the pending push notification even when the connect fails after the server is restored', async () => {
+	it('delivers the pending push notification even when the root has already moved outside', async () => {
 		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
 		jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({ rid: 'room-1' }) as any);
 		const { store, dispatchedActions } = setupStore();

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -61,7 +61,7 @@ const setupStore = (): RecordingStore => createRecordingStore(initRoot);
 
 const HOST = 'https://open.rocket.chat';
 
-describe('init saga — restore terminal roots', () => {
+describe('init saga — restore user-facing roots', () => {
 	beforeEach(() => {
 		jest.mocked(UserPreferences.getString).mockReset();
 		jest.mocked(getServerById).mockReset();

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -68,6 +68,7 @@ describe('init saga — restore user-facing roots', () => {
 		jest.mocked(getServerById).mockReset();
 		jest.mocked(RNBootSplash.hide).mockClear();
 		jest.mocked(AsyncStorage.getItem).mockResolvedValue(null as any);
+		jest.mocked(AsyncStorage.removeItem).mockClear();
 		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
 	});
 
@@ -125,6 +126,32 @@ describe('init saga — restore user-facing roots', () => {
 
 		expect(dispatchedActions).toContainEqual({ type: DEEP_LINKING.OPEN_VIDEO_CONF, params: { rid: 'room-1' } });
 		expect(store.getState().server.server).toBe(HOST);
+	});
+
+	it('keeps the selected server when the stored push notification payload is malformed', async () => {
+		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
+		jest.mocked(AsyncStorage.getItem).mockResolvedValue('not json' as any);
+		const { store, dispatchedActions } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().server.server).toBe(HOST);
+		expect(store.getState().app.root).not.toBe(RootEnum.ROOT_OUTSIDE);
+		expect(dispatchedActions).not.toContainEqual(expect.objectContaining({ type: DEEP_LINKING.OPEN_VIDEO_CONF }));
+	});
+
+	it('drops the pending push notification when the boot lands on ROOT_OUTSIDE', async () => {
+		jest.mocked(getServerById).mockResolvedValue(null);
+		jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({ rid: 'room-1' }) as any);
+		const { store, dispatchedActions } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+		expect(jest.mocked(AsyncStorage.removeItem)).toHaveBeenCalledWith('pushNotification');
+		expect(dispatchedActions).not.toContainEqual(expect.objectContaining({ type: DEEP_LINKING.OPEN_VIDEO_CONF }));
 	});
 
 	it('selects the stored server and marks the app ready when the record exists', async () => {

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -19,10 +19,6 @@ jest.mock('../../lib/methods/userPreferencesMethods', () => ({
 	getSortPreferences: jest.fn(() => ({}))
 }));
 
-jest.mock('../../actions/deepLinking', () => ({
-	deepLinkingClickCallPush: jest.fn()
-}));
-
 jest.mock('react-native-bootsplash', () => ({
 	__esModule: true,
 	default: { hide: jest.fn(() => Promise.resolve()) }
@@ -55,7 +51,7 @@ import initRoot from '../init';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { getServerById } from '../../lib/database/services/Server';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { deepLinkingClickCallPush } from '../../actions/deepLinking';
+import { DEEP_LINKING } from '../../actions/actionsTypes';
 import { TOKEN_KEY } from '../../lib/constants/keys';
 import database from '../../lib/database';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
@@ -71,7 +67,6 @@ describe('init saga — restore user-facing roots', () => {
 		jest.mocked(UserPreferences.getString).mockReset();
 		jest.mocked(getServerById).mockReset();
 		jest.mocked(RNBootSplash.hide).mockClear();
-		jest.mocked(deepLinkingClickCallPush).mockClear();
 		jest.mocked(AsyncStorage.getItem).mockResolvedValue(null as any);
 		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
 	});
@@ -123,12 +118,12 @@ describe('init saga — restore user-facing roots', () => {
 	it('delivers the pending push notification without stranding the boot', async () => {
 		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
 		jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({ rid: 'room-1' }) as any);
-		const { store } = setupStore();
+		const { store, dispatchedActions } = setupStore();
 
 		store.dispatch(appInit());
 		await flushSagaMicrotasks();
 
-		expect(jest.mocked(deepLinkingClickCallPush)).toHaveBeenCalledWith({ rid: 'room-1' });
+		expect(dispatchedActions).toContainEqual({ type: DEEP_LINKING.OPEN_VIDEO_CONF, params: { rid: 'room-1' } });
 		expect(store.getState().server.server).toBe(HOST);
 	});
 

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -45,7 +45,7 @@ jest.mock('../../lib/database', () => ({
 
 import RNBootSplash from 'react-native-bootsplash';
 
-import { appInit } from '../../actions/app';
+import { appInit, appStart } from '../../actions/app';
 import { RootEnum } from '../../definitions';
 import initRoot from '../init';
 import UserPreferences from '../../lib/methods/userPreferences';
@@ -139,6 +139,18 @@ describe('init saga — restore user-facing roots', () => {
 		expect(store.getState().server.server).toBe(HOST);
 		expect(store.getState().app.root).not.toBe(RootEnum.ROOT_OUTSIDE);
 		expect(dispatchedActions).not.toContainEqual(expect.objectContaining({ type: DEEP_LINKING.OPEN_VIDEO_CONF }));
+	});
+
+	it('delivers the pending push notification even when the connect fails after the server is restored', async () => {
+		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
+		jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({ rid: 'room-1' }) as any);
+		const { store, dispatchedActions } = setupStore();
+
+		store.dispatch(appInit());
+		store.dispatch(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+		await flushSagaMicrotasks();
+
+		expect(dispatchedActions).toContainEqual({ type: DEEP_LINKING.OPEN_VIDEO_CONF, params: { rid: 'room-1' } });
 	});
 
 	it('drops the pending push notification when the boot lands on ROOT_OUTSIDE', async () => {

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -54,6 +54,7 @@ import { RootEnum } from '../../definitions';
 import initRoot from '../init';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { getServerById } from '../../lib/database/services/Server';
+import { TOKEN_KEY } from '../../lib/constants/keys';
 import database from '../../lib/database';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 import type { RecordingStore } from '../../lib/testUtils/sagaStore';
@@ -97,15 +98,11 @@ describe('init saga — restore user-facing roots', () => {
 	});
 
 	it('selects another logged in server with its own version when the stored server has no token', async () => {
-		jest
-			.mocked(UserPreferences.getString)
-			.mockImplementation(key =>
-				key === `reactnativemeteor_usertoken-${OTHER_HOST}`
-					? 'token'
-					: key.startsWith('reactnativemeteor_usertoken-')
-						? null
-						: HOST
-			);
+		jest.mocked(UserPreferences.getString).mockImplementation(key => {
+			if (key === `${TOKEN_KEY}-${OTHER_HOST}`) return 'token';
+			if (key.startsWith(`${TOKEN_KEY}-`)) return null;
+			return HOST;
+		});
 		jest.mocked(database.servers.get).mockReturnValue({
 			query: () => ({ fetch: () => Promise.resolve([{ id: OTHER_HOST, version: '7.0.0' }]) })
 		} as any);

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -54,12 +54,14 @@ import { RootEnum } from '../../definitions';
 import initRoot from '../init';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { getServerById } from '../../lib/database/services/Server';
+import database from '../../lib/database';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 import type { RecordingStore } from '../../lib/testUtils/sagaStore';
 
 const setupStore = (): RecordingStore => createRecordingStore(initRoot);
 
 const HOST = 'https://open.rocket.chat';
+const OTHER_HOST = 'https://other.rocket.chat';
 
 describe('init saga — restore user-facing roots', () => {
 	beforeEach(() => {
@@ -91,6 +93,29 @@ describe('init saga — restore user-facing roots', () => {
 		store.dispatch(appInit());
 		await flushSagaMicrotasks();
 
+		expect(store.getState().app.ready).toBe(true);
+	});
+
+	it('selects another logged in server with its own version when the stored server has no token', async () => {
+		jest
+			.mocked(UserPreferences.getString)
+			.mockImplementation(key =>
+				key === `reactnativemeteor_usertoken-${OTHER_HOST}`
+					? 'token'
+					: key.startsWith('reactnativemeteor_usertoken-')
+						? null
+						: HOST
+			);
+		jest.mocked(database.servers.get).mockReturnValue({
+			query: () => ({ fetch: () => Promise.resolve([{ id: OTHER_HOST, version: '7.0.0' }]) })
+		} as any);
+		const { store } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().server.server).toBe(OTHER_HOST);
+		expect(store.getState().server.version).toBe('7.0.0');
 		expect(store.getState().app.ready).toBe(true);
 	});
 

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -69,6 +69,7 @@ describe('init saga — restore user-facing roots', () => {
 		jest.mocked(RNBootSplash.hide).mockClear();
 		jest.mocked(AsyncStorage.getItem).mockResolvedValue(null as any);
 		jest.mocked(AsyncStorage.removeItem).mockClear();
+		jest.mocked(database.servers.get).mockReset();
 		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
 	});
 
@@ -99,6 +100,20 @@ describe('init saga — restore user-facing roots', () => {
 
 	it('lands on ROOT_OUTSIDE when no server is stored at all', async () => {
 		jest.mocked(UserPreferences.getString).mockImplementation(() => null);
+		const { store } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+		expect(store.getState().app.ready).toBe(true);
+	});
+
+	it('lands on ROOT_OUTSIDE when neither the stored server nor any other has a token', async () => {
+		jest.mocked(UserPreferences.getString).mockImplementation(key => (key.startsWith(`${TOKEN_KEY}-`) ? null : HOST));
+		jest.mocked(database.servers.get).mockReturnValue({
+			query: () => ({ fetch: () => Promise.resolve([{ id: OTHER_HOST, version: '7.0.0' }]) })
+		} as any);
 		const { store } = setupStore();
 
 		store.dispatch(appInit());

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -211,6 +211,15 @@ describe('selectServer saga — user-facing root after a failed switch', () => {
 		jest.mocked(getLoggedUserById).mockRejectedValue(new Error('database unavailable'));
 	});
 
+	it('lands on ROOT_OUTSIDE when the switch fails during boot, before any root is set', async () => {
+		const { store } = setupStore();
+		expect(store.getState().app.root).toBeUndefined();
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
 	it('lands on ROOT_OUTSIDE when the switch fails while the app is on the loading root', async () => {
 		const { store } = setupStore();
 		store.dispatch(appStart({ root: RootEnum.ROOT_LOADING }));
@@ -236,5 +245,14 @@ describe('selectServer saga — user-facing root after a failed switch', () => {
 		await flushSagaMicrotasks();
 
 		expect(store.getState().app.root).toBe(RootEnum.ROOT_INSIDE);
+	});
+
+	it('keeps the current root when the switch fails while the share sheet is up', async () => {
+		const { store } = setupStore();
+		store.dispatch(appStart({ root: RootEnum.ROOT_SHARE_EXTENSION }));
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_SHARE_EXTENSION);
 	});
 });

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -65,6 +65,8 @@ import { settings as RocketChatSettings } from '@rocket.chat/sdk';
 
 import selectServerRoot from '../selectServer';
 import { selectServerRequest } from '../../actions/server';
+import { appStart } from '../../actions/app';
+import { RootEnum } from '../../definitions';
 import { SERVER } from '../../actions/actionsTypes';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { BASIC_AUTH_KEY, setBasicAuth } from '../../lib/methods/helpers/fetch';
@@ -200,5 +202,39 @@ describe('selectServer saga — version and name fallback', () => {
 
 		const success = dispatchedActions.find(action => action.type === SERVER.SELECT_SUCCESS);
 		expect(success).toMatchObject({ server: SERVER_URL, version: '6.9.0', name: 'Stored A' });
+	});
+});
+
+describe('selectServer saga — user-facing root after a failed switch', () => {
+	beforeEach(() => {
+		UserPreferences.setString(`${TOKEN_KEY}-${SERVER_URL}`, USER_ID);
+		jest.mocked(getLoggedUserById).mockRejectedValue(new Error('database unavailable'));
+	});
+
+	it('leaves ROOT_OUTSIDE when the switch fails while the app is on the loading root', async () => {
+		const { store } = setupStore();
+		store.dispatch(appStart({ root: RootEnum.ROOT_LOADING }));
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
+	it('leaves ROOT_OUTSIDE when the switch fails while the share sheet is on its loading root', async () => {
+		const { store } = setupStore();
+		store.dispatch(appStart({ root: RootEnum.ROOT_LOADING_SHARE_EXTENSION }));
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+	});
+
+	it('keeps the current root when the switch fails while the app is already inside', async () => {
+		const { store } = setupStore();
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_INSIDE);
 	});
 });

--- a/app/sagas/__tests__/selectServer.test.ts
+++ b/app/sagas/__tests__/selectServer.test.ts
@@ -211,7 +211,7 @@ describe('selectServer saga — user-facing root after a failed switch', () => {
 		jest.mocked(getLoggedUserById).mockRejectedValue(new Error('database unavailable'));
 	});
 
-	it('leaves ROOT_OUTSIDE when the switch fails while the app is on the loading root', async () => {
+	it('lands on ROOT_OUTSIDE when the switch fails while the app is on the loading root', async () => {
 		const { store } = setupStore();
 		store.dispatch(appStart({ root: RootEnum.ROOT_LOADING }));
 		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));
@@ -220,7 +220,7 @@ describe('selectServer saga — user-facing root after a failed switch', () => {
 		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
 	});
 
-	it('leaves ROOT_OUTSIDE when the switch fails while the share sheet is on its loading root', async () => {
+	it('lands on ROOT_OUTSIDE when the switch fails while the share sheet is on its loading root', async () => {
 		const { store } = setupStore();
 		store.dispatch(appStart({ root: RootEnum.ROOT_LOADING_SHARE_EXTENSION }));
 		store.dispatch(selectServerRequest(SERVER_URL, '7.0.0', false));

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -1,7 +1,7 @@
 import { InteractionManager } from 'react-native';
 import RNCallKeep from 'react-native-callkeep';
 import I18n from 'i18n-js';
-import { all, call, delay, put, select, take, takeLatest } from 'redux-saga/effects';
+import { all, call, delay, put, race, select, take, takeLatest } from 'redux-saga/effects';
 
 import { shareSetParams } from '../actions/share';
 import * as types from '../actions/actionsTypes';
@@ -156,11 +156,20 @@ const handleShareExtension = function* handleOpen({ params }) {
 	yield localAuthenticate(server);
 	const serverRecord = yield getServerById(server);
 	if (!serverRecord) {
+		yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 		return;
 	}
 	yield put(selectServerRequest(server, serverRecord.version));
 	if (sdk.current?.client?.host !== server) {
-		yield take(types.LOGIN.SUCCESS);
+		const { loginSuccess } = yield race({
+			loginSuccess: take(types.LOGIN.SUCCESS),
+			loginFailure: take(types.LOGIN.FAILURE),
+			selectServerFailure: take(types.SERVER.SELECT_FAILURE)
+		});
+		if (!loginSuccess) {
+			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+			return;
+		}
 	}
 	yield put(shareSetParams(params));
 	yield put(appStart({ root: RootEnum.ROOT_SHARE_EXTENSION }));

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -153,26 +153,32 @@ const handleShareExtension = function* handleOpen({ params }) {
 	}
 
 	yield put(appStart({ root: RootEnum.ROOT_LOADING_SHARE_EXTENSION }));
-	yield localAuthenticate(server);
-	const serverRecord = yield getServerById(server);
-	if (!serverRecord) {
-		yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-		return;
-	}
-	yield put(selectServerRequest(server, serverRecord.version));
-	if (sdk.current?.client?.host !== server) {
-		const { loginSuccess } = yield race({
-			loginSuccess: take(types.LOGIN.SUCCESS),
-			loginFailure: take(types.LOGIN.FAILURE),
-			selectServerFailure: take(types.SERVER.SELECT_FAILURE)
-		});
-		if (!loginSuccess) {
+	try {
+		yield localAuthenticate(server);
+		const serverRecord = yield getServerById(server);
+		if (!serverRecord) {
 			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 			return;
 		}
+		yield put(selectServerRequest(server, serverRecord.version));
+		if (sdk.current?.client?.host !== server) {
+			const { loginSuccess } = yield race({
+				loginSuccess: take(types.LOGIN.SUCCESS),
+				loginFailure: take(types.LOGIN.FAILURE),
+				selectServerFailure: take(types.SERVER.SELECT_FAILURE),
+				logout: take(types.LOGOUT)
+			});
+			if (!loginSuccess) {
+				yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+				return;
+			}
+		}
+		yield put(shareSetParams(params));
+		yield put(appStart({ root: RootEnum.ROOT_SHARE_EXTENSION }));
+	} catch (e) {
+		log(e);
+		yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 	}
-	yield put(shareSetParams(params));
-	yield put(appStart({ root: RootEnum.ROOT_SHARE_EXTENSION }));
 };
 
 const handleOpen = function* handleOpen({ params }) {

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -21,12 +21,12 @@ export const initLocalSettings = function* initLocalSettings() {
 	yield put(setAllPreferences(sortPreferences));
 };
 
-const serverToRestore = function* serverToRestore(server, userId) {
+const serverToRestore = function* serverToRestore(server) {
 	if (!server) {
 		return null;
 	}
 
-	if (!userId) {
+	if (!UserPreferences.getString(`${TOKEN_KEY}-${server}`)) {
 		const serversDB = database.servers;
 		const serversCollection = serversDB.get('servers');
 		const servers = yield serversCollection.query().fetch();
@@ -35,14 +35,13 @@ const serverToRestore = function* serverToRestore(server, userId) {
 	}
 
 	yield localAuthenticate(server);
-	return yield getServerById(server);
+	return (yield getServerById(server)) || null;
 };
 
 const restore = function* restore() {
 	try {
 		const server = UserPreferences.getString(CURRENT_SERVER);
-		const userId = UserPreferences.getString(`${TOKEN_KEY}-${server}`);
-		const restoredServer = yield* serverToRestore(server, userId);
+		const restoredServer = yield* serverToRestore(server);
 
 		if (restoredServer) {
 			yield put(selectServerRequest(restoredServer.id, restoredServer.version));

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -48,9 +48,10 @@ const restore = function* restore() {
 			yield localAuthenticate(server);
 			const serverRecord = yield getServerById(server);
 			if (!serverRecord) {
-				return;
+				yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+			} else {
+				yield put(selectServerRequest(server, serverRecord.version));
 			}
-			yield put(selectServerRequest(server, serverRecord.version));
 		}
 
 		yield put(appReady({}));

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -53,7 +53,7 @@ const restore = function* restore() {
 		yield put(appReady({}));
 		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');
 		if (pushNotification) {
-			const pushNotification = yield call(AsyncStorage.removeItem, 'pushNotification');
+			yield call(AsyncStorage.removeItem, 'pushNotification');
 			yield call(deepLinkingClickCallPush, JSON.parse(pushNotification));
 		}
 	} catch (e) {

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -21,40 +21,40 @@ export const initLocalSettings = function* initLocalSettings() {
 	yield put(setAllPreferences(sortPreferences));
 };
 
+const serverToRestore = function* serverToRestore(server, userId) {
+	if (!server) {
+		return null;
+	}
+
+	if (!userId) {
+		const serversDB = database.servers;
+		const serversCollection = serversDB.get('servers');
+		const servers = yield serversCollection.query().fetch();
+
+		return servers.find(({ id }) => UserPreferences.getString(`${TOKEN_KEY}-${id}`)) || null;
+	}
+
+	yield localAuthenticate(server);
+	return yield getServerById(server);
+};
+
 const restore = function* restore() {
 	try {
 		const server = UserPreferences.getString(CURRENT_SERVER);
 		const userId = UserPreferences.getString(`${TOKEN_KEY}-${server}`);
+		const restoredServer = yield* serverToRestore(server, userId);
 
-		if (!server) {
-			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-		} else if (!userId) {
-			const serversDB = database.servers;
-			const serversCollection = serversDB.get('servers');
-			const servers = yield serversCollection.query().fetch();
-
-			const loggedInServer = servers.find(({ id }) => UserPreferences.getString(`${TOKEN_KEY}-${id}`));
-			if (loggedInServer) {
-				yield put(selectServerRequest(loggedInServer.id, loggedInServer.version));
-			} else {
-				yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-			}
+		if (restoredServer) {
+			yield put(selectServerRequest(restoredServer.id, restoredServer.version));
 		} else {
-			yield localAuthenticate(server);
-			const serverRecord = yield getServerById(server);
-			if (!serverRecord) {
-				yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-			} else {
-				yield put(selectServerRequest(server, serverRecord.version));
-			}
+			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 		}
 
 		yield put(appReady({}));
 		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');
 		if (pushNotification) {
 			yield call(AsyncStorage.removeItem, 'pushNotification');
-			const root = yield select(state => state.app.root);
-			if (root !== RootEnum.ROOT_OUTSIDE) {
+			if (restoredServer) {
 				try {
 					yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
 				} catch (e) {

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -34,17 +34,10 @@ const restore = function* restore() {
 			const servers = yield serversCollection.query().fetch();
 
 			// Check if there're other logged in servers and picks first one
-			if (servers.length > 0) {
-				for (let i = 0; i < servers.length; i += 1) {
-					const newServer = servers[i].id;
-					userId = UserPreferences.getString(`${TOKEN_KEY}-${newServer}`);
-					if (userId) {
-						yield put(selectServerRequest(newServer, servers[i].version));
-						break;
-					}
-				}
-			}
-			if (!userId) {
+			const loggedInServer = servers.find(({ id }) => UserPreferences.getString(`${TOKEN_KEY}-${id}`));
+			if (loggedInServer) {
+				yield put(selectServerRequest(loggedInServer.id, loggedInServer.version));
+			} else {
 				yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 			}
 		} else {

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -21,17 +21,19 @@ export const initLocalSettings = function* initLocalSettings() {
 	yield put(setAllPreferences(sortPreferences));
 };
 
+const isLoggedIn = server => !!UserPreferences.getString(`${TOKEN_KEY}-${server}`);
+
 const serverToRestore = function* serverToRestore(server) {
 	if (!server) {
 		return null;
 	}
 
-	if (!UserPreferences.getString(`${TOKEN_KEY}-${server}`)) {
+	if (!isLoggedIn(server)) {
 		const serversDB = database.servers;
 		const serversCollection = serversDB.get('servers');
 		const servers = yield serversCollection.query().fetch();
 
-		return servers.find(({ id }) => UserPreferences.getString(`${TOKEN_KEY}-${id}`)) || null;
+		return servers.find(({ id }) => isLoggedIn(id)) || null;
 	}
 
 	yield localAuthenticate(server);

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -54,7 +54,11 @@ const restore = function* restore() {
 		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');
 		if (pushNotification) {
 			yield call(AsyncStorage.removeItem, 'pushNotification');
-			yield call(deepLinkingClickCallPush, JSON.parse(pushNotification));
+			try {
+				yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
+			} catch (e) {
+				log(e);
+			}
 		}
 	} catch (e) {
 		log(e);

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -24,7 +24,7 @@ export const initLocalSettings = function* initLocalSettings() {
 const restore = function* restore() {
 	try {
 		const server = UserPreferences.getString(CURRENT_SERVER);
-		let userId = UserPreferences.getString(`${TOKEN_KEY}-${server}`);
+		const userId = UserPreferences.getString(`${TOKEN_KEY}-${server}`);
 
 		if (!server) {
 			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -39,11 +39,14 @@ const restore = function* restore() {
 					const newServer = servers[i].id;
 					userId = UserPreferences.getString(`${TOKEN_KEY}-${newServer}`);
 					if (userId) {
-						return yield put(selectServerRequest(newServer, newServer.version));
+						yield put(selectServerRequest(newServer, servers[i].version));
+						break;
 					}
 				}
 			}
-			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+			if (!userId) {
+				yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+			}
 		} else {
 			yield localAuthenticate(server);
 			const serverRecord = yield getServerById(server);

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -33,7 +33,6 @@ const restore = function* restore() {
 			const serversCollection = serversDB.get('servers');
 			const servers = yield serversCollection.query().fetch();
 
-			// Check if there're other logged in servers and picks first one
 			const loggedInServer = servers.find(({ id }) => UserPreferences.getString(`${TOKEN_KEY}-${id}`));
 			if (loggedInServer) {
 				yield put(selectServerRequest(loggedInServer.id, loggedInServer.version));
@@ -54,10 +53,13 @@ const restore = function* restore() {
 		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');
 		if (pushNotification) {
 			yield call(AsyncStorage.removeItem, 'pushNotification');
-			try {
-				yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
-			} catch (e) {
-				log(e);
+			const root = yield select(state => state.app.root);
+			if (root !== RootEnum.ROOT_OUTSIDE) {
+				try {
+					yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
+				} catch (e) {
+					log(e);
+				}
 			}
 		}
 	} catch (e) {

--- a/app/sagas/selectServer.ts
+++ b/app/sagas/selectServer.ts
@@ -218,6 +218,10 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 		yield put(selectServerSuccess({ server, version: serverVersion, name: serverInfo?.name || 'Rocket.Chat' }));
 	} catch (e) {
 		yield put(selectServerFailure());
+		const currentRoot = yield* appSelector(state => state.app.root);
+		if (currentRoot === RootEnum.ROOT_LOADING || currentRoot === RootEnum.ROOT_LOADING_SHARE_EXTENSION) {
+			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+		}
 		log(e);
 	}
 };

--- a/app/sagas/selectServer.ts
+++ b/app/sagas/selectServer.ts
@@ -219,7 +219,7 @@ const handleSelectServer = function* handleSelectServer({ server, version, fetch
 	} catch (e) {
 		yield put(selectServerFailure());
 		const currentRoot = yield* appSelector(state => state.app.root);
-		if (currentRoot === RootEnum.ROOT_LOADING || currentRoot === RootEnum.ROOT_LOADING_SHARE_EXTENSION) {
+		if (currentRoot !== RootEnum.ROOT_INSIDE && currentRoot !== RootEnum.ROOT_SHARE_EXTENSION) {
 			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 		}
 		log(e);


### PR DESCRIPTION
## Proposed changes

Sibling of the promise-settlement audit on this branch's base — the same defect class, expressed in saga effects rather than hand-built promises: **a saga exits without ever reaching a user-facing root.** Every instance leaves the app pinned on a loading root with no error, no recovery, and force-quit as the only exit.

By *user-facing root* I mean a `RootEnum` value the app can rest on, where the user sees content and can act — `outside`, `inside`, `shareextension`. `loading` and `loadingshareextension` are not: they show a spinner and depend on some later `APP.START` to move the app on. If that action never comes, the spinner is permanent.

`APP.START` is the only action that hides the boot splash (`init.js`'s `start`) and the only one that moves `app.root` off a loading value. Any saga exit that skips it strands the app.

### `app/sagas/init.js` — `restore()`

**The boot splash never hides.** The stored-server branch bare-`return`ed when the server had no database record, exiting before `appReady` and before any `appStart`. The stored server and token come from `UserPreferences`, not WatermelonDB, so the two can diverge — an interrupted `removeServer`, a wiped or migration-failed database. The `return` also skipped the pending-push-notification handling below it. Both `return`s in the function are gone: the missing-record case now dispatches `ROOT_OUTSIDE` (exactly what the sibling `!server` branch already does), and the other-logged-in-server branch became a `find`, so both outcomes fall through to `appReady` and the push handling.

**The pending push notification was never delivered.** Two separate bugs in the same three lines. An inner `const pushNotification` shadowed the payload with `removeItem`'s `undefined` result, so `JSON.parse` threw, `restore()`'s catch dispatched `ROOT_OUTSIDE` **over the server it had just selected**, and the notification was dropped. With the shadow removed, the next line was still inert: `call(deepLinkingClickCallPush, …)` builds the `OPEN_VIDEO_CONF` action and discards the return value, so the `takeLatest` watcher at `app/sagas/deepLinking.js:366` never ran. It is now `put(…)`, wrapped in its own guard so a malformed stored payload logs instead of throwing into the catch and stomping a valid session.

**The push is delivered only when the boot resolved a server.** A stored payload is `OPEN_VIDEO_CONF` — a ringing call — so delivering it into `ROOT_OUTSIDE`, where there is no session to open it in, would open a dead conference. When `restore()` resolves no server the payload is now cleared from `AsyncStorage` without being dispatched.

The gate is the resolved server record, **not** `state.app.root`. Reading the root after `appReady` would be correct only by timing: the connect on the `selectServerRequest` branches is async, so the root is still `ROOT_LOADING` at that point, and `selectServer`'s new `ROOT_OUTSIDE` fallback can land afterwards — which would swallow a valid notification on exactly the failure path this PR adds. Branch selection is extracted to `serverToRestore(server)`, which returns the server record or `null`, so the gate is the branch actually taken rather than a root observed mid-flight.

### `app/sagas/deepLinking.js` — `handleShareExtension()`

**The share sheet was pinned on the loading root.** It pushes `ROOT_LOADING_SHARE_EXTENSION`, then bare-`return`ed on the same missing-record condition.

**The un-raced take.** `yield take(LOGIN.SUCCESS)` had no race against failure and no timeout, so ordinary flaky network while resuming a share hung the share extension on the loading root indefinitely. This one needs no store divergence, which makes it by far the likeliest instance. It was also the only `take(LOGIN.SUCCESS)` in the file with no surrounding guard, while `login.js` uses `race` for the same shape.

The race takes four arms, not two. `login.js`'s catch has five outcomes, and three of them emit neither `LOGIN.FAILURE` nor `SERVER.SELECT_FAILURE` — `Logged_out_by_server`, `Token_expired`, and a 401 with an existing `user.id` all dispatch `logoutAction` instead, so a two-arm race would never settle on the three failure paths most likely to hit a resumed share. `LOGOUT` is the fourth arm.

**Unexpected throws.** The body is now wrapped in `try`/`catch`, so a throw from `localAuthenticate` or `getServerById` reaches `ROOT_OUTSIDE` rather than leaving the loading root in place.

### `app/sagas/selectServer.ts` — `handleSelectServer()`

**A failed connect had no path back to a visible UI.** `SERVER.SELECT_FAILURE` is handled only by `reducers/server.ts`, which never touches `app.root`. `restore()`'s two surviving exits both end on `selectServerRequest`, so a failed switch left the app on a loading root — the same defect class, one indirection further out. The catch now falls back to `ROOT_OUTSIDE` from any root except `inside` and `shareextension`, which are left as they were. The gate is a denylist rather than a list of loading roots because the primary path has neither: `reducers/app.ts` initialises `root` to `undefined`, and nothing sets `ROOT_LOADING` during boot — it is only pushed by logout, delete-account, language change and clear-cache. A failed switch at cold boot therefore leaves a root that matches no navigator group in `AppContainer`, so the splash never hides. `getServerInfo.ts`'s `selectServerFailure` rethrows into this same catch, so that path is covered too.

`appInit()` was rejected as the share-extension exit, even though the `!user` branch a few lines above uses it. `restore()` ends at `appReady`, which does **not** set a root, so the share sheet would stay pinned on `ROOT_LOADING_SHARE_EXTENSION` — it moves the confusion rather than removing it.

**No timeout is added to the race**, deliberately. `selectServer`'s catch always emits `selectServerFailure`, so the failure modes are covered by action rather than by a clock. A bare timer here would re-introduce the regression recorded in the comment at `app/sagas/login.js` (#7333), where a 2s timeout ripped a slow-but-succeeding connect and stranded users on the login screen.

## Issue(s)

## How to test or reproduce

1. `pnpm install`
2. `TZ=UTC pnpm test` — 250 suites, 2260 tests pass.
3. `pnpm format-lint` — passes; no findings in the changed files.
4. To watch the tests catch the bugs, revert the three saga files to the base branch and re-run `TZ=UTC npx jest app/sagas`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

**Tests.** `app/sagas/init.js` had no unit coverage of `restore()`; `app/sagas/__tests__/init.test.ts` is new. The share-extension cases are appended to the existing `deepLinking.test.ts`, and the failed-switch cases to `selectServer.test.ts`. All three use the `createRecordingStore` harness this branch's base introduced, asserting on the observable `app.root`, `app.ready`, and dispatched actions rather than on effect shape — the right signal for a defect defined by "the UI never reaches a user-facing root". Every new assertion was watched red against unmodified source before the fix went in, and each failure block carries a control test that stays green throughout, so a test that passes vacuously would show up. The `SELECT_FAILURE` guard has a `ROOT_INSIDE` control proving it is not unconditional.

**Two more instances of the class, listed rather than fixed** to keep this change reviewable: `handleOpen` has un-raced `take(LOGIN.SUCCESS)` calls in three branches — same-server, known-other-server, and the `params.token` branch, which also has un-raced takes on `SERVER.SELECT_SUCCESS` and `APP.START`. Same missing guard, but none pushes a loading root first, so the failure is a silently dropped deep link rather than a pinned UI — a different severity that deserves its own change.

Based on the `new-sdk` branch rather than `develop`, so its diff includes that branch's commits until they are pushed.



