### PR TITLE
fix: server version recorded as undefined when falling back to another workspace

### DIFF
--- a/app/sagas/__tests__/init.fallbackServer.test.ts
+++ b/app/sagas/__tests__/init.fallbackServer.test.ts
@@ -33,6 +33,8 @@ describe('init saga — fallback workspace', () => {
 
 	afterEach(() => {
 		cancelSagaTasks();
+		UserPreferences.removeItem(CURRENT_SERVER);
+		UserPreferences.removeItem(`${TOKEN_KEY}-${FALLBACK_SERVER}`);
 	});
 
 	it('requests the fallback workspace with the version from its own record', async () => {

--- a/app/sagas/__tests__/init.fallbackServer.test.ts
+++ b/app/sagas/__tests__/init.fallbackServer.test.ts
@@ -1,0 +1,48 @@
+const FALLBACK_SERVER = 'https://fallback.rocket.chat';
+const FALLBACK_VERSION = '7.0.0';
+const LOGGED_OUT_SERVER = 'https://loggedout.rocket.chat';
+
+jest.mock('../../lib/database', () => ({
+	__esModule: true,
+	default: {
+		servers: {
+			get: () => ({
+				query: () => ({ fetch: () => Promise.resolve([{ id: FALLBACK_SERVER, version: FALLBACK_VERSION }]) })
+			})
+		}
+	}
+}));
+
+jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
+	localAuthenticate: jest.fn()
+}));
+
+import { appInit } from '../../actions/app';
+import { SERVER } from '../../actions/actionsTypes';
+import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
+import UserPreferences from '../../lib/methods/userPreferences';
+import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import initRoot from '../init';
+
+describe('init saga — fallback workspace', () => {
+	beforeEach(() => {
+		UserPreferences.setString(CURRENT_SERVER, LOGGED_OUT_SERVER);
+		UserPreferences.removeItem(`${TOKEN_KEY}-${LOGGED_OUT_SERVER}`);
+		UserPreferences.setString(`${TOKEN_KEY}-${FALLBACK_SERVER}`, 'userId');
+	});
+
+	afterEach(() => {
+		cancelSagaTasks();
+	});
+
+	it('requests the fallback workspace with the version from its own record', async () => {
+		const { store, dispatchedActions } = createRecordingStore(initRoot);
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(dispatchedActions.find(action => action.type === SERVER.SELECT_REQUEST)).toEqual(
+			expect.objectContaining({ server: FALLBACK_SERVER, version: FALLBACK_VERSION })
+		);
+	});
+});

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -36,10 +36,10 @@ const restore = function* restore() {
 			// Check if there're other logged in servers and picks first one
 			if (servers.length > 0) {
 				for (let i = 0; i < servers.length; i += 1) {
-					const newServer = servers[i].id;
+					const { id: newServer, version } = servers[i];
 					userId = UserPreferences.getString(`${TOKEN_KEY}-${newServer}`);
 					if (userId) {
-						return yield put(selectServerRequest(newServer, newServer.version));
+						return yield put(selectServerRequest(newServer, version));
 					}
 				}
 			}

--- a/app/sagas/login.js
+++ b/app/sagas/login.js
@@ -394,10 +394,10 @@ const handleLogout = function* handleLogout({ forcedByServer, message }) {
 				// see if there're other logged in servers and selects first one
 				if (servers.length > 0) {
 					for (let i = 0; i < servers.length; i += 1) {
-						const newServer = servers[i].id;
+						const { id: newServer, version } = servers[i];
 						const token = UserPreferences.getString(`${TOKEN_KEY}-${newServer}`);
 						if (token) {
-							yield put(selectServerRequest(newServer, newServer.version));
+							yield put(selectServerRequest(newServer, version));
 							return;
 						}
 					}
@@ -461,10 +461,10 @@ const handleDeleteAccount = function* handleDeleteAccount() {
 			// see if there're other logged in servers and selects first one
 			if (servers.length > 0) {
 				for (let i = 0; i < servers.length; i += 1) {
-					const newServer = servers[i].id;
+					const { id: newServer, version } = servers[i];
 					const token = UserPreferences.getString(`${TOKEN_KEY}-${newServer}`);
 					if (token) {
-						yield put(selectServerRequest(newServer, newServer.version));
+						yield put(selectServerRequest(newServer, version));
 						return;
 					}
 				}


### PR DESCRIPTION
## Proposed changes

The three "auto-pick another logged-in workspace" paths read the version off a string:

```js
const newServer = servers[i].id;
...
yield put(selectServerRequest(newServer, newServer.version));
```

`newServer` is the record's id, not the record, so `newServer.version` is always `undefined` and `selectServerRequest` receives no version. Fixed by destructuring the record at all three sites — `init.js` (boot restore), `login.js` (logout fallback), `login.js` (delete-account fallback). Ten lines below the first one, the non-loop path already does this correctly via `serverRecord.version`, which is what makes these a slip rather than a design choice.

Online the bug is masked: all three omit `fetchVersion`, so `handleSelectServer` re-fetches `/info` and `serverInfo?.version || version` never needs the fallback. It bites when that re-fetch cannot produce a version — `getServerInfoSaga` runs with `raiseError: false`, and if it throws (no local server record, `checkSupportedVersions` throwing, `getServerInfo` throwing) it returns `undefined`, so `selectServerSuccess` stores no version.

Downstream, a stored `undefined` is silent rather than loud: `compareServerVersion` short-circuits on a null-ish version, so every version gate takes its legacy branch with no error and no log. In `sdk.ts` that means subscribing to `${rid}/typing` instead of `/user-activity`.

Worth noting the offline window is narrower than it first looks: on a failed `/info`, `getServerInfoSaga` falls back to `getServerById(server)` and usually returns a record that does carry a version. The undefined only escapes when that saga throws outright.

## Issue(s)

## How to test or reproduce

`TZ=UTC pnpm test app/sagas`

Adds `app/sagas/__tests__/init.fallbackServer.test.ts` on the `sagaStore` harness from #7590: seeds a logged-out `currentServer` plus one other workspace holding a token, dispatches `appInit()`, and asserts the resulting `SERVER_SELECT_REQUEST` carries that workspace's recorded version. Reverting the `init.js` clause turns it red with `version: undefined` — the exact symptom.

The two `login.js` sites are fixed but untested. A seam there needs `logoutCall`, `removeServerData`, `removeServerDatabase` and `disconnect` mocked to reach a clause lexically identical to the one the init test pins, so I did not build a second harness for it.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

## Further comments

Targets `new-sdk` (#7574) rather than `develop` because it builds on the `sagaStore` test harness added there.

The real cure for this class is typing: `selectServerRequest`'s `version` parameter is already non-optional, so the type system is correct and simply is not applied — `init.js` and `login.js` are plain JS. Converting two large sagas to TypeScript is out of scope here, so any future `selectServerRequest` caller in those files can reintroduce this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server switching during startup, logout, and account deletion.
  - Preserved the correct server version when restoring or selecting a server.
  - Fixed fallback server selection to use the version recorded for that server.

- **Tests**
  - Added coverage for fallback server behavior during application initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->