### PR TITLE
refactor: narrow Socket Health's access to the SDK socket

### DIFF
--- a/app/lib/services/__tests__/socketHealth.integration.test.ts
+++ b/app/lib/services/__tests__/socketHealth.integration.test.ts
@@ -21,7 +21,7 @@ jest.mock('universal-websocket-client', () =>
 
 jest.mock('../sdk', () => ({
 	__esModule: true,
-	default: { current: undefined }
+	default: { socket: undefined }
 }));
 
 const USER_ID = 'user-id';
@@ -36,7 +36,7 @@ describe('recoverSocket against the real SDK socket', () => {
 		jest.useFakeTimers();
 		mockConnections.length = 0;
 		driver = await buildConnectedDriver(mockConnections, USER_ID);
-		(sdk as unknown as { current: { driver: ISdkDriver } }).current = { driver };
+		(sdk as unknown as { socket: ISdkDriver }).socket = driver;
 	});
 
 	afterEach(() => {

--- a/app/lib/services/__tests__/socketHealth.test.ts
+++ b/app/lib/services/__tests__/socketHealth.test.ts
@@ -1,18 +1,18 @@
 jest.mock('../sdk', () => ({
 	__esModule: true,
 	default: {
-		current: { driver: undefined }
+		socket: undefined
 	}
 }));
 
-import sdk, { type TDriver } from '../sdk';
+import sdk, { type ISocket } from '../sdk';
 import { classifySocketHealth, recoverSocket } from '../socketHealth';
 
 const now = 1_000_000;
 
-const sdkMock = sdk as unknown as { current: { driver: unknown } | undefined };
+const sdkMock = sdk as unknown as { socket: unknown };
 
-interface MockDriver {
+interface MockSocket {
 	connected: boolean;
 	lastPing: number;
 	pingInterval: number;
@@ -20,7 +20,7 @@ interface MockDriver {
 	probe: jest.Mock<Promise<boolean>, [number]>;
 }
 
-function makeDriver(overrides: Partial<MockDriver> = {}): MockDriver {
+function makeSocket(overrides: Partial<MockSocket> = {}): MockSocket {
 	return {
 		connected: true,
 		lastPing: now,
@@ -41,85 +41,80 @@ describe('classifySocketHealth', () => {
 	});
 
 	it('returns round-trip-check for a connected socket rather than trusting it outright', () => {
-		const driver = makeDriver({ connected: true });
-		expect(classifySocketHealth(driver as unknown as TDriver)).toBe('round-trip-check');
+		const socket = makeSocket({ connected: true });
+		expect(classifySocketHealth(socket as unknown as ISocket)).toBe('round-trip-check');
 	});
 
 	it('returns reopen for a closed socket even when lastPing is fresh', () => {
-		const driver = makeDriver({ connected: false, lastPing: now });
-		expect(classifySocketHealth(driver as unknown as TDriver)).toBe('reopen');
+		const socket = makeSocket({ connected: false, lastPing: now });
+		expect(classifySocketHealth(socket as unknown as ISocket)).toBe('reopen');
 	});
 });
 
 describe('recoverSocket', () => {
-	let driver: MockDriver;
+	let socket: MockSocket;
 
 	beforeEach(() => {
-		driver = makeDriver({ lastPing: Date.now() });
-		sdkMock.current = { driver };
+		socket = makeSocket({ lastPing: Date.now() });
+		sdkMock.socket = socket;
 	});
 
 	it('keeps a socket whose round trip answers', async () => {
 		await expect(recoverSocket()).resolves.toBe('confirmed-alive');
-		expect(driver.reopenNow).not.toHaveBeenCalled();
+		expect(socket.reopenNow).not.toHaveBeenCalled();
 	});
 
 	it('runs the round trip with a 2s budget', async () => {
 		await recoverSocket();
-		expect(driver.probe).toHaveBeenCalledWith(2000);
+		expect(socket.probe).toHaveBeenCalledWith(2000);
 	});
 
 	it('reopens when the round trip goes unanswered', async () => {
-		driver.probe.mockResolvedValue(false);
+		socket.probe.mockResolvedValue(false);
 		await expect(recoverSocket()).resolves.toBe('reopened');
-		expect(driver.reopenNow).toHaveBeenCalledTimes(1);
+		expect(socket.reopenNow).toHaveBeenCalledTimes(1);
 	});
 
 	it('reopens a known-dead socket without a round trip', async () => {
-		driver.connected = false;
+		socket.connected = false;
 		await expect(recoverSocket()).resolves.toBe('reopened');
-		expect(driver.probe).not.toHaveBeenCalled();
-		expect(driver.reopenNow).toHaveBeenCalledTimes(1);
+		expect(socket.probe).not.toHaveBeenCalled();
+		expect(socket.reopenNow).toHaveBeenCalledTimes(1);
 	});
 
-	it('reports no-socket when the driver handle is missing', async () => {
-		sdkMock.current = { driver: undefined };
+	it('reports no-socket when the socket handle is missing', async () => {
+		sdkMock.socket = undefined;
 		await expect(recoverSocket()).resolves.toBe('no-socket');
-		expect(driver.probe).not.toHaveBeenCalled();
-		expect(driver.reopenNow).not.toHaveBeenCalled();
-	});
-
-	it('reports no-socket when there is no sdk instance', async () => {
-		sdkMock.current = undefined;
-		await expect(recoverSocket()).resolves.toBe('no-socket');
+		expect(socket.probe).not.toHaveBeenCalled();
+		expect(socket.reopenNow).not.toHaveBeenCalled();
 	});
 
 	it('rejects when the round trip throws', async () => {
-		driver.probe.mockRejectedValue(new Error('round trip failed'));
+		socket.probe.mockRejectedValue(new Error('round trip failed'));
 		await expect(recoverSocket()).rejects.toThrow('round trip failed');
 	});
 
 	it('rejects when reopening throws', async () => {
-		driver.connected = false;
-		driver.reopenNow.mockRejectedValue(new Error('reopen failed'));
+		socket.connected = false;
+		socket.reopenNow.mockRejectedValue(new Error('reopen failed'));
 		await expect(recoverSocket()).rejects.toThrow('reopen failed');
 	});
 
 	it('shares one in-flight recovery between overlapping callers', async () => {
 		const outcomes = await Promise.all([recoverSocket(), recoverSocket()]);
 		expect(outcomes).toEqual(['confirmed-alive', 'confirmed-alive']);
-		expect(driver.probe).toHaveBeenCalledTimes(1);
+		expect(socket.probe).toHaveBeenCalledTimes(1);
 	});
 
 	it('starts a fresh recovery after the shared one settles', async () => {
 		await recoverSocket();
 		await recoverSocket();
-		expect(driver.probe).toHaveBeenCalledTimes(2);
+		expect(socket.probe).toHaveBeenCalledTimes(2);
 	});
 
 	it('abandons the aborted caller while the shared recovery runs on', async () => {
 		let answerRoundTrip: (alive: boolean) => void = () => {};
-		driver.probe.mockImplementation(() => new Promise<boolean>(resolve => (answerRoundTrip = resolve)));
+		socket.probe.mockImplementation(() => new Promise<boolean>(resolve => (answerRoundTrip = resolve)));
 
 		const controller = new AbortController();
 		const aborted = recoverSocket({ abortSignal: controller.signal });
@@ -130,7 +125,7 @@ describe('recoverSocket', () => {
 
 		answerRoundTrip(true);
 		await expect(other).resolves.toBe('confirmed-alive');
-		expect(driver.probe).toHaveBeenCalledTimes(1);
+		expect(socket.probe).toHaveBeenCalledTimes(1);
 	});
 
 	it('abandons a pre-aborted caller without touching the socket', async () => {
@@ -138,7 +133,7 @@ describe('recoverSocket', () => {
 		controller.abort();
 
 		await expect(recoverSocket({ abortSignal: controller.signal })).resolves.toBe('abandoned');
-		expect(driver.probe).not.toHaveBeenCalled();
-		expect(driver.reopenNow).not.toHaveBeenCalled();
+		expect(socket.probe).not.toHaveBeenCalled();
+		expect(socket.reopenNow).not.toHaveBeenCalled();
 	});
 });

--- a/app/lib/services/sdk.ts
+++ b/app/lib/services/sdk.ts
@@ -17,6 +17,16 @@ import { compareServerVersion, random } from '../methods/helpers';
 
 export type TDriver = Rocketchat['driver'];
 
+/**
+ * The Meteor Connect socket, narrowed to what Socket Health needs.
+ * Keeps `driver` an implementation detail of this module.
+ */
+export interface ISocket {
+	connected: boolean;
+	reopenNow: () => Promise<void>;
+	probe: (timeout: number) => Promise<boolean>;
+}
+
 export type TStreamDataCallback = (ddpMessage: any) => void;
 
 export interface IStreamDataListener {
@@ -41,6 +51,10 @@ class Sdk {
 
 	get current(): Rocketchat {
 		return this.sdk;
+	}
+
+	get socket(): ISocket | undefined {
+		return this.sdk?.driver;
 	}
 
 	/**

--- a/app/lib/services/socketHealth.ts
+++ b/app/lib/services/socketHealth.ts
@@ -1,5 +1,5 @@
 import { onAbort } from '../methods/helpers/onAbort';
-import sdk, { type TDriver } from './sdk';
+import sdk, { type ISocket } from './sdk';
 
 /**
  * The recovery plan — what classification decides.
@@ -12,9 +12,9 @@ import sdk, { type TDriver } from './sdk';
  */
 export type SocketRecoveryPlan = 'reopen' | 'round-trip-check';
 
-export function classifySocketHealth(driver: TDriver): SocketRecoveryPlan {
-	// `driver.connected` already folds in the ping-age test, so a stale ping lands here.
-	if (!driver.connected) {
+export function classifySocketHealth(socket: ISocket): SocketRecoveryPlan {
+	// `socket.connected` already folds in the ping-age test, so a stale ping lands here.
+	if (!socket.connected) {
 		return 'reopen';
 	}
 	// A connected socket is still verified by a round trip, never trusted outright:
@@ -26,7 +26,7 @@ export function classifySocketHealth(driver: TDriver): SocketRecoveryPlan {
  * What a recovery attempt reports.
  * - `'confirmed-alive'` — round trip succeeded; nothing was done.
  * - `'reopened'`        — socket reopened (stale ping, or round trip failed).
- * - `'no-socket'`       — `sdk.current?.driver` undefined; nothing to recover.
+ * - `'no-socket'`       — `sdk.socket` undefined; nothing to recover.
  * - `'abandoned'`       — caller's abort signal fired while waiting; the
  *                         underlying recovery (shared — see below) runs on.
  *
@@ -43,20 +43,20 @@ function shareRecovery(): Promise<SocketRecoveryOutcome> {
 	if (inFlightRecovery) {
 		return inFlightRecovery;
 	}
-	const driver = sdk.current?.driver;
-	if (!driver) {
+	const { socket } = sdk;
+	if (!socket) {
 		return Promise.resolve('no-socket');
 	}
 	const recovery = (async (): Promise<SocketRecoveryOutcome> => {
-		if (classifySocketHealth(driver) === 'reopen') {
-			await driver.reopenNow();
+		if (classifySocketHealth(socket) === 'reopen') {
+			await socket.reopenNow();
 			return 'reopened';
 		}
-		const alive = await driver.probe(2000);
+		const alive = await socket.probe(2000);
 		if (alive) {
 			return 'confirmed-alive';
 		}
-		await driver.reopenNow();
+		await socket.reopenNow();
 		return 'reopened';
 	})();
 	inFlightRecovery = recovery;


### PR DESCRIPTION
## Proposed changes

`socketHealth.ts` reached two levels into the SDK (`sdk.current?.driver`) and typed itself against the whole `Rocketchat['driver']` surface just to read `connected` and call `reopenNow()` / `probe()`.

`sdk.ts` now owns that knowledge and exposes the Meteor Connect socket narrowed to those three members:

```ts
export interface ISocket {
	connected: boolean;
	reopenNow: () => Promise<void>;
	probe: (timeout: number) => Promise<boolean>;
}

get socket(): ISocket | undefined {
	return this.sdk?.driver;
}
```

Socket Health no longer knows `Rocketchat` or `driver` exist — it reads `sdk.socket`. `classifySocketHealth` takes `ISocket`. The `no-socket` outcome is unchanged: the getter's optional chain covers both a missing SDK instance and a missing driver.

Behaviour is identical; this is a types-and-access change.

## Issue(s)

N/A — follow-up cleanup on #7574.

## Steps to test or reproduce

`TZ=UTC pnpm test app/lib/services/__tests__/socketHealth` — 25 tests pass, including the integration suite driving the real SDK socket over a mock WebSocket.

## Further comments

Test mocks got simpler: the unit suite now builds a 3-member socket object instead of a fake driver, and casts to `ISocket` instead of `TDriver`.

`acceptNativeCall.ts` still takes a `TDriver` for `waitForMediaSignalSubs` (it needs subscription internals, not socket health), so `TDriver` stays exported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved socket health monitoring and recovery handling.
  - Socket connectivity checks, probing, reopening, shared recovery, and abort scenarios now behave more consistently.
  - Correctly handles situations where no active socket is available.

- **Refactor**
  - Standardized access to the active socket through a clearer public interface.
  - Updated automated coverage to reflect the current socket connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->