### PR TITLE
fix: grant pull-requests write to build call sites in build-develop

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -31,6 +31,7 @@ jobs:
     if: ${{ github.repository == 'RocketChat/Rocket.Chat.ReactNative' }}
     permissions:
       contents: read
+      pull-requests: write
     uses: ./.github/workflows/build-android.yml
     needs: [run-eslint-and-test, generate-changelog]
     secrets: inherit
@@ -42,6 +43,7 @@ jobs:
     if: ${{ github.repository == 'RocketChat/Rocket.Chat.ReactNative' }}
     permissions:
       contents: read
+      pull-requests: write
     uses: ./.github/workflows/build-ios.yml
     needs: [run-eslint-and-test, generate-changelog]
     secrets: inherit


### PR DESCRIPTION
## Proposed changes
`build-develop.yml` fails workflow validation (run [32748833349](https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/32748833349)):

> The nested job 'upload-android' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

**Root cause:** regression from #7350 (least-privilege permissions pass). It added explicit `pull-requests: write` declarations to the `upload-android`/`upload-internal`/`upload-ios` jobs in the reusable workflows, and simultaneously narrowed `build-develop.yml`'s call sites to `contents: read` only. GitHub validates reusable-workflow permissions at call time regardless of job conditionals (`if: trigger == 'pr'` doesn't help), so the caller must grant every permission the called jobs declare. `build-pr.yml`'s call sites got `pull-requests: write` in that PR; `build-develop.yml`'s didn't — hence validation fails only there.

This PR mirrors `build-pr.yml` by granting `pull-requests: write` at `build-develop.yml`'s two call sites. The write capability is unused on the develop path (upload-internal is PR-gated; PR commenting only happens with `trigger: pr`), so this grants nothing new in practice.

## Issue(s)
[NATIVE-1503](https://rocketchat.atlassian.net/browse/NATIVE-1503)
Failing run: https://github.com/RocketChat/Rocket.Chat.ReactNative/actions/runs/32748833349
Regression introduced by: #7350

## How to test or reproduce
Push to develop (or re-run the failed workflow): previously the workflow failed validation immediately; with this change it should start.

## Screenshots
N/A

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
Alternative considered: drop `pull-requests: write` from the job declarations in the reusable workflows and rely on caller-provided permissions (stricter least privilege), but that changes behavior for both callers; mirroring `build-pr.yml` is the smaller, consistent fix. Worth noting for a follow-up: `actionlint` in CI would catch this class of error at PR time.

[NATIVE-1503]: https://rocketchat.atlassian.net/browse/NATIVE-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ