### PR TITLE
fix: cold start drops a restored server when reading a pending notification fails

### DIFF
--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -199,3 +199,44 @@ describe('init saga — restore user-facing roots', () => {
 		expect(store.getState().server.server).toBe(HOST);
 	});
 });
+
+describe('init saga — restore keeps a server that already restored', () => {
+	beforeEach(() => {
+		jest.mocked(UserPreferences.getString).mockReset();
+		jest.mocked(getServerById).mockReset();
+		jest.mocked(RNBootSplash.hide).mockClear();
+		jest.mocked(AsyncStorage.getItem).mockResolvedValue(null as any);
+		jest.mocked(AsyncStorage.removeItem).mockClear();
+		jest.mocked(database.servers.get).mockReset();
+		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
+	});
+
+	afterEach(() => {
+		cancelSagaTasks();
+	});
+
+	it('stays on the restored server when reading the pending push notification fails', async () => {
+		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
+		jest.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable') as any);
+		const { store } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).not.toBe(RootEnum.ROOT_OUTSIDE);
+		expect(store.getState().server.server).toBe(HOST);
+	});
+
+	it('stays on the restored server when clearing the pending push notification fails', async () => {
+		jest.mocked(getServerById).mockResolvedValue({ id: HOST, version: '6.0.0' } as any);
+		jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({ rid: 'room-1' }) as any);
+		jest.mocked(AsyncStorage.removeItem).mockRejectedValue(new Error('storage unavailable') as any);
+		const { store } = setupStore();
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).not.toBe(RootEnum.ROOT_OUTSIDE);
+		expect(store.getState().server.server).toBe(HOST);
+	});
+});

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -198,21 +198,16 @@ describe('init saga — restore user-facing roots', () => {
 		expect(store.getState().app.ready).toBe(true);
 		expect(store.getState().server.server).toBe(HOST);
 	});
-});
 
-describe('init saga — restore keeps a server that already restored', () => {
-	beforeEach(() => {
-		jest.mocked(UserPreferences.getString).mockReset();
-		jest.mocked(getServerById).mockReset();
-		jest.mocked(RNBootSplash.hide).mockClear();
-		jest.mocked(AsyncStorage.getItem).mockResolvedValue(null as any);
-		jest.mocked(AsyncStorage.removeItem).mockClear();
-		jest.mocked(database.servers.get).mockReset();
-		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
-	});
+	it('lands on ROOT_OUTSIDE when resolving the stored server throws', async () => {
+		jest.mocked(getServerById).mockRejectedValue(new Error('database unavailable'));
+		const { store } = setupStore();
 
-	afterEach(() => {
-		cancelSagaTasks();
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(store.getState().app.root).toBe(RootEnum.ROOT_OUTSIDE);
+		expect(store.getState().app.ready).toBe(true);
 	});
 
 	it('stays on the restored server when reading the pending push notification fails', async () => {

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -16,32 +16,51 @@ import { getSortPreferences } from '../lib/methods/userPreferencesMethods';
 import { deepLinkingClickCallPush } from '../actions/deepLinking';
 import { getServerById } from '../lib/database/services/Server';
 
+const PUSH_NOTIFICATION_KEY = 'pushNotification';
+
 export const initLocalSettings = function* initLocalSettings() {
 	const sortPreferences = getSortPreferences();
 	yield put(setAllPreferences(sortPreferences));
 };
 
-const serverToRestore = function* serverToRestore(server) {
-	if (!server) {
-		return null;
-	}
-
-	if (!hasStoredLoginToken(server)) {
-		return (yield* findLoggedInServer()) || null;
-	}
-
-	yield localAuthenticate(server);
-	return (yield getServerById(server)) || null;
-};
-
-const restore = function* restore() {
-	let restoredServer = null;
+const serverToRestore = function* serverToRestore() {
 	try {
 		const server = UserPreferences.getString(CURRENT_SERVER);
-		restoredServer = yield* serverToRestore(server);
+		if (!server) {
+			return null;
+		}
+
+		if (!hasStoredLoginToken(server)) {
+			return (yield* findLoggedInServer()) || null;
+		}
+
+		yield localAuthenticate(server);
+		return (yield getServerById(server)) || null;
+	} catch (e) {
+		log(e);
+		return null;
+	}
+};
+
+const deliverPendingPushNotification = function* deliverPendingPushNotification(restoredServer) {
+	try {
+		const pushNotification = yield call(AsyncStorage.getItem, PUSH_NOTIFICATION_KEY);
+		if (!pushNotification) {
+			return;
+		}
+
+		yield call(AsyncStorage.removeItem, PUSH_NOTIFICATION_KEY);
+
+		if (restoredServer) {
+			yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
+		}
 	} catch (e) {
 		log(e);
 	}
+};
+
+const restore = function* restore() {
+	const restoredServer = yield* serverToRestore();
 
 	if (restoredServer) {
 		yield put(selectServerRequest(restoredServer.id, restoredServer.version));
@@ -51,17 +70,7 @@ const restore = function* restore() {
 
 	yield put(appReady({}));
 
-	try {
-		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');
-		if (pushNotification) {
-			yield call(AsyncStorage.removeItem, 'pushNotification');
-			if (restoredServer) {
-				yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
-			}
-		}
-	} catch (e) {
-		log(e);
-	}
+	yield* deliverPendingPushNotification(restoredServer);
 };
 
 const start = function* start() {

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -35,31 +35,32 @@ const serverToRestore = function* serverToRestore(server) {
 };
 
 const restore = function* restore() {
+	let restoredServer = null;
 	try {
 		const server = UserPreferences.getString(CURRENT_SERVER);
-		const restoredServer = yield* serverToRestore(server);
+		restoredServer = yield* serverToRestore(server);
+	} catch (e) {
+		log(e);
+	}
 
-		if (restoredServer) {
-			yield put(selectServerRequest(restoredServer.id, restoredServer.version));
-		} else {
-			yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
-		}
+	if (restoredServer) {
+		yield put(selectServerRequest(restoredServer.id, restoredServer.version));
+	} else {
+		yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
+	}
 
-		yield put(appReady({}));
+	yield put(appReady({}));
+
+	try {
 		const pushNotification = yield call(AsyncStorage.getItem, 'pushNotification');
 		if (pushNotification) {
 			yield call(AsyncStorage.removeItem, 'pushNotification');
 			if (restoredServer) {
-				try {
-					yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
-				} catch (e) {
-					log(e);
-				}
+				yield put(deepLinkingClickCallPush(JSON.parse(pushNotification)));
 			}
 		}
 	} catch (e) {
 		log(e);
-		yield put(appStart({ root: RootEnum.ROOT_OUTSIDE }));
 	}
 };
 


### PR DESCRIPTION
## Proposed changes

A cold start restores the last used server, then reads the pending push notification that a tapped notification left behind. Both steps shared one `try/catch`, and that catch dispatched `ROOT_OUTSIDE`. So a failure in the push notification step — unreadable storage, a failed clear — threw away a server that had already restored successfully and dropped the user on the workspace list.

The catch is now scoped to the step that can fail:

- Resolving the server owns its own failure and returns `null`, so "resolution failed" and "no server stored" reach the same routing decision instead of one of them unwinding past it. `appReady` is now dispatched on that path too; previously a throw skipped it.
- Reading and clearing the pending push notification owns its own failure and only logs. A restored server survives it.

`restore` is left as a flat boot sequence — resolve, route, ready, deliver — with no `try` of its own.

## Issue(s)

## How to test or reproduce

Affects cold start only, no UI changes.

1. Log in to a workspace and force quit the app.
2. Make `AsyncStorage.getItem('pushNotification')` reject on the next launch.
3. Launch the app.

Before: the app lands on the workspace list, logged out of a workspace that is still valid. After: the app opens the restored workspace and the failure is logged.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Stacked on #7574 — that is the base branch, so review only the last two commits.

Three new tests in `app/sagas/__tests__/init.test.ts` cover a rejected read, a rejected clear, and the pre-existing throw-on-resolve path that was silently skipping `appReady`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup handling when server lookup, authentication, database access, or notification storage fails.
  * The app now reliably enters the correct initial state and marks startup complete after restoration errors.
  * Pending push notifications are delivered only when a server is successfully restored, preventing invalid delivery attempts.
  * Preserved the restored server selection when notification storage operations fail.

* **Tests**
  * Added coverage for database restoration failures and notification storage errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->