### PR TITLE
refactor: centralise the server lookups behind the Server service

### DIFF
--- a/app/lib/database/services/Server.ts
+++ b/app/lib/database/services/Server.ts
@@ -6,12 +6,11 @@ import { SERVERS_TABLE } from '../model';
 const getCollection = (db: TServerDatabase) => db.get(SERVERS_TABLE);
 
 export const getServerById = async (server: string): Promise<TServerModel | null> => {
-	const db = database.servers;
-	const serverCollection = getCollection(db);
 	try {
-		const result = await serverCollection.find(server);
-		return result;
+		return await getCollection(database.servers).find(server);
 	} catch {
 		return null;
 	}
 };
+
+export const getAllServers = (): Promise<TServerModel[]> => getCollection(database.servers).query().fetch();

--- a/app/lib/methods/loggedInServer.ts
+++ b/app/lib/methods/loggedInServer.ts
@@ -1,13 +1,10 @@
 import { type TServerModel } from '../../definitions';
 import { TOKEN_KEY } from '../constants/keys';
-import database from '../database';
-import { SERVERS_TABLE } from '../database/model';
+import { getAllServers } from '../database/services/Server';
 import UserPreferences from './userPreferences';
 
-export const hasStoredLoginToken = (serverId: string): boolean => !!UserPreferences.getString(`${TOKEN_KEY}-${serverId}`);
+export const isLoggedInServer = (serverId?: string | null): boolean =>
+	!!serverId && !!UserPreferences.getString(`${TOKEN_KEY}-${serverId}`);
 
-export const findLoggedInServer = function* findLoggedInServer(): Generator<any, TServerModel | undefined> {
-	const serversCollection = database.servers.get(SERVERS_TABLE);
-	const servers = (yield serversCollection.query().fetch()) as TServerModel[];
-	return servers.find(({ id }) => hasStoredLoginToken(id));
-};
+export const findLoggedInServer = async (): Promise<TServerModel | undefined> =>
+	(await getAllServers()).find(({ id }) => isLoggedInServer(id));

--- a/app/sagas/__tests__/init.fallbackServer.test.ts
+++ b/app/sagas/__tests__/init.fallbackServer.test.ts
@@ -2,15 +2,9 @@ const FALLBACK_SERVER = 'https://fallback.rocket.chat';
 const FALLBACK_VERSION = '7.0.0';
 const LOGGED_OUT_SERVER = 'https://loggedout.rocket.chat';
 
-jest.mock('../../lib/database', () => ({
-	__esModule: true,
-	default: {
-		servers: {
-			get: () => ({
-				query: () => ({ fetch: () => Promise.resolve([{ id: FALLBACK_SERVER, version: FALLBACK_VERSION }]) })
-			})
-		}
-	}
+jest.mock('../../lib/database/services/Server', () => ({
+	getServerById: jest.fn(),
+	getAllServers: jest.fn(() => Promise.resolve([{ id: FALLBACK_SERVER, version: FALLBACK_VERSION }]))
 }));
 
 jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
@@ -18,15 +12,16 @@ jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
 }));
 
 import { appInit } from '../../actions/app';
-import { APP, SERVER } from '../../actions/actionsTypes';
+import { SERVER } from '../../actions/actionsTypes';
 import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
-import { RootEnum } from '../../definitions';
+import { localAuthenticate } from '../../lib/methods/helpers/localAuthentication';
 import initRoot from '../init';
 
 describe('init saga — fallback workspace', () => {
 	beforeEach(() => {
+		jest.mocked(localAuthenticate).mockClear();
 		UserPreferences.setString(CURRENT_SERVER, LOGGED_OUT_SERVER);
 		UserPreferences.removeItem(`${TOKEN_KEY}-${LOGGED_OUT_SERVER}`);
 		UserPreferences.setString(`${TOKEN_KEY}-${FALLBACK_SERVER}`, 'userId');
@@ -47,6 +42,7 @@ describe('init saga — fallback workspace', () => {
 		expect(dispatchedActions.find(action => action.type === SERVER.SELECT_REQUEST)).toEqual(
 			expect.objectContaining({ server: FALLBACK_SERVER, version: FALLBACK_VERSION })
 		);
+		expect(jest.mocked(localAuthenticate)).toHaveBeenCalledWith(FALLBACK_SERVER);
 	});
 
 	it('requests the fallback workspace when the current server was cleared by a logout', async () => {
@@ -59,6 +55,5 @@ describe('init saga — fallback workspace', () => {
 		expect(dispatchedActions.find(action => action.type === SERVER.SELECT_REQUEST)).toEqual(
 			expect.objectContaining({ server: FALLBACK_SERVER, version: FALLBACK_VERSION })
 		);
-		expect(dispatchedActions).not.toContainEqual(expect.objectContaining({ type: APP.START, root: RootEnum.ROOT_OUTSIDE }));
 	});
 });

--- a/app/sagas/__tests__/init.fallbackServer.test.ts
+++ b/app/sagas/__tests__/init.fallbackServer.test.ts
@@ -18,10 +18,11 @@ jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
 }));
 
 import { appInit } from '../../actions/app';
-import { SERVER } from '../../actions/actionsTypes';
+import { APP, SERVER } from '../../actions/actionsTypes';
 import { CURRENT_SERVER, TOKEN_KEY } from '../../lib/constants/keys';
 import UserPreferences from '../../lib/methods/userPreferences';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
+import { RootEnum } from '../../definitions';
 import initRoot from '../init';
 
 describe('init saga — fallback workspace', () => {
@@ -46,5 +47,18 @@ describe('init saga — fallback workspace', () => {
 		expect(dispatchedActions.find(action => action.type === SERVER.SELECT_REQUEST)).toEqual(
 			expect.objectContaining({ server: FALLBACK_SERVER, version: FALLBACK_VERSION })
 		);
+	});
+
+	it('requests the fallback workspace when the current server was cleared by a logout', async () => {
+		UserPreferences.removeItem(CURRENT_SERVER);
+		const { store, dispatchedActions } = createRecordingStore(initRoot);
+
+		store.dispatch(appInit());
+		await flushSagaMicrotasks();
+
+		expect(dispatchedActions.find(action => action.type === SERVER.SELECT_REQUEST)).toEqual(
+			expect.objectContaining({ server: FALLBACK_SERVER, version: FALLBACK_VERSION })
+		);
+		expect(dispatchedActions).not.toContainEqual(expect.objectContaining({ type: APP.START, root: RootEnum.ROOT_OUTSIDE }));
 	});
 });

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -6,7 +6,8 @@ jest.mock('../../lib/methods/userPreferences', () => ({
 }));
 
 jest.mock('../../lib/database/services/Server', () => ({
-	getServerById: jest.fn()
+	getServerById: jest.fn(),
+	getAllServers: jest.fn()
 }));
 
 jest.mock('../../lib/methods/helpers/localAuthentication', () => ({
@@ -30,26 +31,16 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 	}
 }));
 
-jest.mock('../../lib/database', () => ({
-	__esModule: true,
-	default: {
-		servers: {
-			get: jest.fn()
-		}
-	}
-}));
-
 import RNBootSplash from 'react-native-bootsplash';
 
 import { appInit, appStart } from '../../actions/app';
 import { RootEnum } from '../../definitions';
 import initRoot from '../init';
 import UserPreferences from '../../lib/methods/userPreferences';
-import { getServerById } from '../../lib/database/services/Server';
+import { getAllServers, getServerById } from '../../lib/database/services/Server';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DEEP_LINKING } from '../../actions/actionsTypes';
 import { TOKEN_KEY } from '../../lib/constants/keys';
-import database from '../../lib/database';
 import { cancelSagaTasks, createRecordingStore, flushSagaMicrotasks } from '../../lib/testUtils/sagaStore';
 import type { RecordingStore } from '../../lib/testUtils/sagaStore';
 
@@ -65,7 +56,7 @@ describe('init saga — restore user-facing roots', () => {
 		jest.mocked(RNBootSplash.hide).mockClear();
 		jest.mocked(AsyncStorage.getItem).mockResolvedValue(null as any);
 		jest.mocked(AsyncStorage.removeItem).mockClear();
-		jest.mocked(database.servers.get).mockReset();
+		jest.mocked(getAllServers).mockResolvedValue([]);
 		jest.mocked(UserPreferences.getString).mockImplementation(() => HOST);
 	});
 
@@ -96,9 +87,6 @@ describe('init saga — restore user-facing roots', () => {
 
 	it('lands on ROOT_OUTSIDE when no server is stored at all', async () => {
 		jest.mocked(UserPreferences.getString).mockImplementation(() => null);
-		jest.mocked(database.servers.get).mockReturnValue({
-			query: () => ({ fetch: () => Promise.resolve([]) })
-		} as any);
 		const { store } = setupStore();
 
 		store.dispatch(appInit());
@@ -110,9 +98,7 @@ describe('init saga — restore user-facing roots', () => {
 
 	it('lands on ROOT_OUTSIDE when neither the stored server nor any other has a token', async () => {
 		jest.mocked(UserPreferences.getString).mockImplementation(key => (key.startsWith(`${TOKEN_KEY}-`) ? null : HOST));
-		jest.mocked(database.servers.get).mockReturnValue({
-			query: () => ({ fetch: () => Promise.resolve([{ id: OTHER_HOST, version: '7.0.0' }]) })
-		} as any);
+		jest.mocked(getAllServers).mockResolvedValue([{ id: OTHER_HOST, version: '7.0.0' }] as any);
 		const { store } = setupStore();
 
 		store.dispatch(appInit());
@@ -128,9 +114,7 @@ describe('init saga — restore user-facing roots', () => {
 			if (key.startsWith(`${TOKEN_KEY}-`)) return null;
 			return HOST;
 		});
-		jest.mocked(database.servers.get).mockReturnValue({
-			query: () => ({ fetch: () => Promise.resolve([{ id: OTHER_HOST, version: '7.0.0' }]) })
-		} as any);
+		jest.mocked(getAllServers).mockResolvedValue([{ id: OTHER_HOST, version: '7.0.0' }] as any);
 		const { store } = setupStore();
 
 		store.dispatch(appInit());

--- a/app/sagas/__tests__/init.test.ts
+++ b/app/sagas/__tests__/init.test.ts
@@ -96,6 +96,9 @@ describe('init saga — restore user-facing roots', () => {
 
 	it('lands on ROOT_OUTSIDE when no server is stored at all', async () => {
 		jest.mocked(UserPreferences.getString).mockImplementation(() => null);
+		jest.mocked(database.servers.get).mockReturnValue({
+			query: () => ({ fetch: () => Promise.resolve([]) })
+		} as any);
 		const { store } = setupStore();
 
 		store.dispatch(appInit());

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -22,10 +22,6 @@ export const initLocalSettings = function* initLocalSettings() {
 };
 
 const serverToRestore = function* serverToRestore(server) {
-	if (!server) {
-		return null;
-	}
-
 	if (!hasStoredLoginToken(server)) {
 		return (yield* findLoggedInServer()) || null;
 	}

--- a/app/sagas/init.js
+++ b/app/sagas/init.js
@@ -4,7 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { CURRENT_SERVER } from '../lib/constants/keys';
 import UserPreferences from '../lib/methods/userPreferences';
-import { findLoggedInServer, hasStoredLoginToken } from '../lib/methods/loggedInServer';
+import { findLoggedInServer, isLoggedInServer } from '../lib/methods/loggedInServer';
 import { selectServerRequest } from '../actions/server';
 import { setAllPreferences } from '../actions/sortPreferences';
 import { APP } from '../actions/actionsTypes';
@@ -21,19 +21,20 @@ export const initLocalSettings = function* initLocalSettings() {
 	yield put(setAllPreferences(sortPreferences));
 };
 
-const serverToRestore = function* serverToRestore(server) {
-	if (!hasStoredLoginToken(server)) {
-		return (yield* findLoggedInServer()) || null;
+const serverToRestore = async server => {
+	const restoredServer = isLoggedInServer(server) ? await getServerById(server) : await findLoggedInServer();
+
+	if (restoredServer) {
+		await localAuthenticate(restoredServer.id);
 	}
 
-	yield localAuthenticate(server);
-	return (yield getServerById(server)) || null;
+	return restoredServer;
 };
 
 const restore = function* restore() {
 	try {
 		const server = UserPreferences.getString(CURRENT_SERVER);
-		const restoredServer = yield* serverToRestore(server);
+		const restoredServer = yield call(serverToRestore, server);
 
 		if (restoredServer) {
 			yield put(selectServerRequest(restoredServer.id, restoredServer.version));


### PR DESCRIPTION
## Proposed changes

Two follow-ups on this branch's base, both about where the servers table is read from.

### `getAllServers` on the Server service

`app/lib/methods/loggedInServer.ts` reached into `lib/database` and `SERVERS_TABLE` directly to run `query().fetch()`, duplicating what `lib/database/services/Server.ts` exists to own. The query moves to a new `getAllServers` export there, next to `getServerById`, and `findLoggedInServer` becomes a plain `async` function instead of a generator — nothing delegated to it with `yield*` any more; both saga call sites already use `yield call(...)`, which accepts either.

`hasStoredLoginToken` is renamed `isLoggedInServer` and now accepts `undefined | null`, so the callers stop having to check for a missing server id before asking whether it is logged in.

The knock-on effect in tests is the point of the refactor: `init.test.ts` and `init.fallbackServer.test.ts` previously hand-built a fake `database.servers.get()` returning a nested `query().fetch()` chain to stub a lookup two modules away. Both now mock `lib/database/services/Server` — the module the code under test actually depends on.

`getAllServers` deliberately does not swallow errors the way `getServerById` does. A rejection propagates to the three call sites (`init.js`'s `restore`, `login.js`'s logout and delete-account handlers), which all already catch and fall back to `ROOT_OUTSIDE`. Returning `[]` on failure would hide a database error inside the indistinguishable "no logged-in workspace" answer.

### `serverToRestore` authenticates whichever workspace it restores

`serverToRestore` called `localAuthenticate(server)` only on the stored-server branch. When the stored server had no token and the fallback lookup picked a different logged-in workspace, that workspace was selected without ever passing local authentication — with a passcode or biometrics enabled, the fallback path skipped the prompt.

It is now a single `await localAuthenticate(restoredServer.id)` on the resolved record, so both branches authenticate the workspace they actually return. The function stops being a generator, and `restore` reaches it through `yield call(...)`.

## Issue(s)

## How to test or reproduce

1. `TZ=UTC pnpm jest app/sagas` — 10 suites, 71 tests pass.
2. `pnpm format-lint` — clean on the changed files.
3. For the authentication gap: enable the passcode, log into two workspaces, log out of the current one, force-quit, and relaunch. Before this change the fallback workspace opened without a passcode prompt.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`init.fallbackServer.test.ts` gains a `localAuthenticate` assertion on the fallback path — the test that goes red without the second change. Its `not.toContainEqual(ROOT_OUTSIDE)` assertion is dropped: the positive `SELECT_REQUEST` assertion above it already covers the outcome, and the negative one was passing for reasons unrelated to the fallback.

Targets `new-sdk` (#7574), so the diff includes that branch's commits until it merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server restoration after login and logout.
  * Ensured fallback server selection works when the previously active server is unavailable.
  * Improved authentication handling for restored and fallback servers.
  * Improved delivery and cleanup of pending push notifications, including error handling.

* **Refactor**
  * Streamlined asynchronous server lookup and loading.
  * Added support for retrieving all available servers.
  * Improved handling when no server ID is stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->