### PR TITLE
test: cover the normalized 2FA retry credentials for ldap and crowd

### DIFF
--- a/app/lib/services/connect.test.ts
+++ b/app/lib/services/connect.test.ts
@@ -92,6 +92,11 @@ jest.mock('../methods/helpers/events', () => ({
 }));
 
 const mockLog = jest.fn<void, unknown[]>();
+const mockTwoFactor = jest.fn<Promise<{ twoFactorCode: string }>, [unknown]>(() => Promise.resolve({ twoFactorCode: '123456' }));
+jest.mock('./twoFactor', () => ({
+	twoFactor: (params: unknown) => mockTwoFactor(params)
+}));
+
 jest.mock('../methods/helpers/log', () => ({
 	__esModule: true,
 	default: (...args: unknown[]) => mockLog(...args)
@@ -684,5 +689,23 @@ describe('loginTOTP', () => {
 
 	it('rejects instead of hanging when the SDK resolves login without a login result', async () => {
 		await expect(loginTOTP({ user: 'user', password: 'password' })).rejects.toThrow('Login failed: missing login result');
+	}, 2000);
+
+	it('normalizes ldap credentials to user and password on the 2FA retry', async () => {
+		mockSdkLogin.mockImplementationOnce(() => Promise.reject({ data: { error: 'totp-required', details: {} } }));
+		mockSdkCurrent.currentLogin = { result: { userId: 'userId', authToken: 'authToken', me: { username: 'username' } } };
+
+		await loginTOTP({ username: 'user', ldapPass: 'password', ldap: true, ldapOptions: {} }, true);
+
+		expect(mockSdkLogin).toHaveBeenLastCalledWith({ user: 'user', password: 'password', code: '123456' });
+	}, 2000);
+
+	it('normalizes crowd credentials to user and password on the 2FA retry', async () => {
+		mockSdkLogin.mockImplementationOnce(() => Promise.reject({ data: { error: 'totp-required', details: {} } }));
+		mockSdkCurrent.currentLogin = { result: { userId: 'userId', authToken: 'authToken', me: { username: 'username' } } };
+
+		await loginTOTP({ username: 'user', crowdPassword: 'password', crowd: true }, true);
+
+		expect(mockSdkLogin).toHaveBeenLastCalledWith({ user: 'user', password: 'password', code: '123456' });
 	}, 2000);
 });


### PR DESCRIPTION
## Proposed changes

`toPasswordLogin` flattens ldap/crowd credentials to `{ user, password }` on every 2FA retry. That dropped a `>= 3.9.0` server-version gate which previously passed the raw ldap/crowd params through on older servers.

Investigated whether that is a login regression. It is not — the gate was unreachable:

- The built-in supported-versions floor in `app-supportedversions.json` is 6.3.x, with every entry expired in 2023-12 / 2024-02 and `enforcementStartDate` 2023-10-31.
- `app/sagas/selectServer.ts` calls `disconnect()` as soon as `checkSupportedVersions` returns `expired`, and `app/sagas/login.js` blocks login unless the status is `warn`.

A pre-3.9.0 server is disconnected before the login flow can run, so the branch has been dead for around two years. For every server the app still supports, the unconditional flattening is equivalent to the previous behaviour.

No production code changed. This PR adds the regression tests that pin the surviving behaviour, so the normalization is covered rather than incidental.

## Issue(s)

Follow-up to #7574 — targets that branch.

## How to test or reproduce

`TZ=UTC npx jest app/lib/services/connect.test.ts`

Two new cases under the `loginTOTP` suite assert that an ldap login and a crowd login each reach the SDK as `{ user, password, code }` on the 2FA retry. Reverting `toPasswordLogin` to pass the raw params through turns both red.

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify that two-factor authentication login retries consistently handle LDAP and Crowd credentials.
  - Improved validation of credential normalization during authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->