### PR TITLE
fix: stale 2FA code survives a cancelled prompt in ChangePasswordView

### DIFF
--- a/app/views/ChangePasswordView/index.test.tsx
+++ b/app/views/ChangePasswordView/index.test.tsx
@@ -5,7 +5,7 @@ import ChangePasswordView from './index';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 import { saveUserProfile } from '../../lib/services/restApi';
 import { twoFactor } from '../../lib/services/twoFactor';
-import { TwoFactorCancelledError } from '../../lib/services/twoFactorCancelled';
+import { TwoFactorCancelledError } from '../../lib/services/twoFactor';
 import handleSaveUserProfileError from '../../lib/methods/helpers/handleSaveUserProfileError';
 import { TwoFactorMethods } from '../../definitions/ITotp';
 
@@ -23,7 +23,7 @@ jest.mock('../../lib/services/restApi', () => ({
 }));
 
 jest.mock('../../lib/services/twoFactor', () => ({
-	...jest.requireActual('../../lib/services/twoFactorCancelled'),
+	...jest.requireActual('../../lib/services/twoFactor'),
 	twoFactor: jest.fn()
 }));
 

--- a/app/views/ChangePasswordView/index.test.tsx
+++ b/app/views/ChangePasswordView/index.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { useDispatch } from 'react-redux';
+
+import ChangePasswordView from './index';
+import { useAppSelector } from '../../lib/hooks/useAppSelector';
+import { saveUserProfile } from '../../lib/services/restApi';
+import { twoFactor } from '../../lib/services/twoFactor';
+import { TwoFactorCancelledError } from '../../lib/services/twoFactorCancelled';
+import handleSaveUserProfileError from '../../lib/methods/helpers/handleSaveUserProfileError';
+import { TwoFactorMethods } from '../../definitions/ITotp';
+
+jest.mock('react-redux', () => ({
+	useDispatch: jest.fn()
+}));
+
+jest.mock('../../lib/hooks/useAppSelector', () => ({
+	useAppSelector: jest.fn()
+}));
+
+jest.mock('../../lib/services/restApi', () => ({
+	saveUserProfile: jest.fn(),
+	setPassword: jest.fn()
+}));
+
+jest.mock('../../lib/services/twoFactor', () => ({
+	...jest.requireActual('../../lib/services/twoFactorCancelled'),
+	twoFactor: jest.fn()
+}));
+
+jest.mock('../../lib/methods/helpers/handleSaveUserProfileError', () => jest.fn());
+
+jest.mock('../../lib/hooks/useVerifyPassword', () => () => ({ isPasswordValid: true, passwordPolicies: null }));
+
+jest.mock('react-native-keyboard-controller', () => {
+	const { View } = require('react-native');
+	return { KeyboardAvoidingView: View };
+});
+
+const user = {
+	id: 'user-id',
+	username: 'john.doe',
+	emails: [{ address: 'john@rocket.chat', verified: true }]
+};
+
+const buildState = () => ({
+	login: { user },
+	server: { server: 'https://open.rocket.chat' },
+	settings: {
+		Accounts_AllowPasswordChange: true,
+		Accounts_RequirePasswordConfirmation: true
+	}
+});
+
+const navigation = {
+	setOptions: jest.fn(),
+	goBack: jest.fn(),
+	getState: () => ({ routes: [{ name: 'ProfileView' }] })
+} as any;
+
+const totpInvalid = { error: 'totp-invalid', details: { method: TwoFactorMethods.TOTP } };
+
+const renderChangePassword = () => {
+	(useAppSelector as jest.Mock).mockImplementation((selector: (state: any) => unknown) => selector(buildState()));
+	return render(<ChangePasswordView navigation={navigation} />);
+};
+
+const fillAndSubmit = (getByTestId: (id: string) => any) => {
+	fireEvent.changeText(getByTestId('change-password-view-current-password'), 'current-password');
+	fireEvent.changeText(getByTestId('change-password-view-new-password'), 'new-password');
+	fireEvent.changeText(getByTestId('change-password-view-confirm-new-password'), 'new-password');
+	fireEvent.press(getByTestId('change-password-view-set-new-password-button'));
+};
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	(useDispatch as jest.Mock).mockReturnValue(jest.fn());
+});
+
+describe('ChangePasswordView two-factor', () => {
+	it('clears the current password and the stored code when the user cancels the 2FA prompt', async () => {
+		(saveUserProfile as jest.Mock).mockRejectedValue(totpInvalid);
+		(twoFactor as jest.Mock)
+			.mockResolvedValueOnce({ twoFactorCode: '123456', twoFactorMethod: TwoFactorMethods.TOTP })
+			.mockRejectedValue(new TwoFactorCancelledError());
+
+		const { getByTestId } = renderChangePassword();
+		fillAndSubmit(getByTestId);
+
+		await waitFor(() => expect(twoFactor).toHaveBeenCalledTimes(2));
+		expect(getByTestId('change-password-view-current-password').props.value).toBe('');
+
+		fillAndSubmit(getByTestId);
+
+		await waitFor(() => expect(twoFactor).toHaveBeenCalledTimes(3));
+		expect((twoFactor as jest.Mock).mock.calls[2][0]).toEqual(expect.objectContaining({ invalid: false }));
+		expect(handleSaveUserProfileError).not.toHaveBeenCalled();
+	});
+
+	it('reports the two-factor failure instead of the original totp-invalid error', async () => {
+		const twoFactorFailure = new Error('two-factor prompt blew up');
+		(saveUserProfile as jest.Mock).mockRejectedValue(totpInvalid);
+		(twoFactor as jest.Mock).mockRejectedValue(twoFactorFailure);
+
+		const { getByTestId } = renderChangePassword();
+		fillAndSubmit(getByTestId);
+
+		await waitFor(() => expect(handleSaveUserProfileError).toHaveBeenCalledWith(twoFactorFailure, 'saving_profile'));
+	});
+});

--- a/app/views/ChangePasswordView/index.tsx
+++ b/app/views/ChangePasswordView/index.tsx
@@ -147,9 +147,12 @@ const ChangePasswordView = ({ navigation }: IChangePasswordViewProps) => {
 					setTwoFactorCode(code as any);
 					return handleSetNewPassword();
 				} catch (twoFactorError) {
+					setValue('currentPassword', '');
+					setTwoFactorCode(null);
 					if (isTwoFactorCancelled(twoFactorError)) {
 						return;
 					}
+					return handleSaveUserProfileError(twoFactorError, 'saving_profile');
 				}
 			}
 

--- a/app/views/ChangePasswordView/index.tsx
+++ b/app/views/ChangePasswordView/index.tsx
@@ -118,6 +118,11 @@ const ChangePasswordView = ({ navigation }: IChangePasswordViewProps) => {
 		}
 	};
 
+	const resetTwoFactorState = () => {
+		setValue('currentPassword', '');
+		setTwoFactorCode(null);
+	};
+
 	const changePasswordFromProfileView = async () => {
 		const { currentPassword, newPassword, confirmNewPassword } = inputValues;
 		if (newPassword !== confirmNewPassword) {
@@ -147,8 +152,7 @@ const ChangePasswordView = ({ navigation }: IChangePasswordViewProps) => {
 					setTwoFactorCode(code as any);
 					return handleSetNewPassword();
 				} catch (twoFactorError) {
-					setValue('currentPassword', '');
-					setTwoFactorCode(null);
+					resetTwoFactorState();
 					if (isTwoFactorCancelled(twoFactorError)) {
 						return;
 					}
@@ -162,8 +166,7 @@ const ChangePasswordView = ({ navigation }: IChangePasswordViewProps) => {
 				return;
 			}
 
-			setValue('currentPassword', '');
-			setTwoFactorCode(null);
+			resetTwoFactorState();
 			handleSaveUserProfileError(e, 'saving_profile');
 		} finally {
 			setValue('saving', false);


### PR DESCRIPTION
## Proposed changes

The named `isTwoFactorCancelled` guard in `ChangePasswordView` returns early from the two-factor `catch`, which skips the `setValue('currentPassword', '')` and `setTwoFactorCode(null)` reset that the previous bare `catch` reached by falling through. A stale two-factor code therefore survived into the next submit, which then asked for a code with `invalid: true` while the current-password field kept its old value.

The same `catch` also had no non-cancel branch, so a two-factor prompt that failed for any other reason reported the outer `totp-invalid` error and lost the real one.

Both are fixed by resetting the state first, then returning on cancel and reporting the actual two-factor error otherwise.

Adds `app/views/ChangePasswordView/index.test.tsx`, which had no coverage before: one test drives a cancel and asserts the next submit starts from a clean code, the other asserts the reported error is the two-factor failure.

## Issue(s)

Follow-up on #7574.

## How to test or reproduce

1. Enable two-factor authentication on the account.
2. Open Profile → Change password, fill the form and submit.
3. Enter a wrong code, then cancel the prompt when it reappears.
4. Submit again — the current-password field is empty and the prompt no longer reports the previous code as invalid.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Targets `new-sdk` rather than `develop` so it merges with the change that introduced the guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved two-factor authentication handling during password changes.
  * Clears entered password and verification code when authentication is cancelled or fails.
  * Reports two-factor authentication errors accurately instead of showing the original password-change error.

* **Tests**
  * Added coverage for cancellation, retry, and error-reporting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->