### PR TITLE
fix: distinguish 2FA retry from cancel when saving the profile

### DIFF
--- a/app/views/ProfileView/index.test.tsx
+++ b/app/views/ProfileView/index.test.tsx
@@ -6,6 +6,7 @@ import ProfileView from './index';
 import { useAppSelector } from '../../lib/hooks/useAppSelector';
 import { saveUserProfile } from '../../lib/services/restApi';
 import { twoFactor } from '../../lib/services/twoFactor';
+import { TwoFactorCancelledError } from '../../lib/services/twoFactorCancelled';
 import handleSaveUserProfileError from '../../lib/methods/helpers/handleSaveUserProfileError';
 import EventEmitter from '../../lib/methods/helpers/events';
 import { setUser } from '../../actions/login';
@@ -28,6 +29,7 @@ jest.mock('../../lib/services/restApi', () => ({
 }));
 
 jest.mock('../../lib/services/twoFactor', () => ({
+	...jest.requireActual('../../lib/services/twoFactor'),
 	twoFactor: jest.fn()
 }));
 
@@ -132,6 +134,28 @@ describe('ProfileView submit', () => {
 		await waitFor(() => expect(twoFactor).toHaveBeenCalledWith({ method: 'totp', invalid: false }));
 		await waitFor(() => expect(saveUserProfile).toHaveBeenCalledTimes(2));
 		expect(handleSaveUserProfileError).not.toHaveBeenCalled();
+	});
+
+	it('stays silent when the user cancels the 2FA challenge', async () => {
+		(saveUserProfile as jest.Mock).mockRejectedValue({ error: 'totp-invalid', details: { method: 'totp' } });
+		(twoFactor as jest.Mock).mockRejectedValue(new TwoFactorCancelledError());
+
+		const { getByTestId } = renderProfile();
+		changeNameAndSubmit(getByTestId);
+
+		await waitFor(() => expect(twoFactor).toHaveBeenCalled());
+		expect(handleSaveUserProfileError).not.toHaveBeenCalled();
+	});
+
+	it('reports the 2FA error itself when the challenge fails for a reason other than cancelling', async () => {
+		const twoFactorError = { error: 'totp-required' };
+		(saveUserProfile as jest.Mock).mockRejectedValue({ error: 'totp-invalid', details: { method: 'totp' } });
+		(twoFactor as jest.Mock).mockRejectedValue(twoFactorError);
+
+		const { getByTestId } = renderProfile();
+		changeNameAndSubmit(getByTestId);
+
+		await waitFor(() => expect(handleSaveUserProfileError).toHaveBeenCalledWith(twoFactorError, 'saving_profile'));
 	});
 
 	it('handles the save error after a cancelled/non-2FA failure', async () => {

--- a/app/views/ProfileView/index.tsx
+++ b/app/views/ProfileView/index.tsx
@@ -50,6 +50,12 @@ const MAX_NICKNAME_LENGTH = 120;
 interface IProfileViewProps {
 	navigation: NativeStackNavigationProp<ProfileStackParamList, 'ProfileView'>;
 }
+type TwoFactorChallengeOutcome =
+	| { status: 'notChallenged' }
+	| { status: 'retried' }
+	| { status: 'cancelled' }
+	| { status: 'failed'; error: unknown };
+
 const ProfileView = ({ navigation }: IProfileViewProps): ReactElement => {
 	const validationSchema = yup.object().shape({
 		name: yup.string().required(I18n.t('Name_required')),
@@ -205,21 +211,20 @@ const ProfileView = ({ navigation }: IProfileViewProps): ReactElement => {
 		}
 	};
 
-	const handleTwoFactorChallenge = async (e: any): Promise<boolean> => {
+	const handleTwoFactorChallenge = async (e: any): Promise<TwoFactorChallengeOutcome> => {
 		if (e?.error !== 'totp-invalid' || e?.details.method === TwoFactorMethods.PASSWORD) {
-			return false;
+			return { status: 'notChallenged' };
 		}
 		try {
 			const code = await twoFactor({ method: e.details.method, invalid: e?.error === 'totp-invalid' && !!twoFactorCode });
 			setTwoFactorCode(code as any);
 			await submit();
-			return true;
+			return { status: 'retried' };
 		} catch (twoFactorError) {
 			if (isTwoFactorCancelled(twoFactorError)) {
-				resetSavingState();
-				return true;
+				return { status: 'cancelled' };
 			}
-			return false;
+			return { status: 'failed', error: twoFactorError };
 		}
 	};
 
@@ -251,12 +256,17 @@ const ProfileView = ({ navigation }: IProfileViewProps): ReactElement => {
 			const { email } = getValues();
 			setFieldErrorsFromResponse(e, email);
 
-			const handled = await handleTwoFactorChallenge(e);
-			if (handled) return;
+			const twoFactorOutcome = await handleTwoFactorChallenge(e);
+			if (twoFactorOutcome.status === 'retried') return;
+
+			if (twoFactorOutcome.status === 'cancelled') {
+				resetSavingState();
+				return;
+			}
 
 			logEvent(events.PROFILE_SAVE_CHANGES_F);
 			resetSavingState();
-			handleSaveUserProfileError(e, 'saving_profile');
+			handleSaveUserProfileError(twoFactorOutcome.status === 'failed' ? twoFactorOutcome.error : e, 'saving_profile');
 		}
 	};
 

--- a/app/views/ProfileView/index.tsx
+++ b/app/views/ProfileView/index.tsx
@@ -50,11 +50,7 @@ const MAX_NICKNAME_LENGTH = 120;
 interface IProfileViewProps {
 	navigation: NativeStackNavigationProp<ProfileStackParamList, 'ProfileView'>;
 }
-type TwoFactorChallengeOutcome =
-	| { status: 'notChallenged' }
-	| { status: 'retried' }
-	| { status: 'cancelled' }
-	| { status: 'failed'; error: unknown };
+type TwoFactorChallengeOutcome = { status: 'retried' } | { status: 'cancelled' } | { status: 'failed'; error: unknown };
 
 const ProfileView = ({ navigation }: IProfileViewProps): ReactElement => {
 	const validationSchema = yup.object().shape({
@@ -213,7 +209,7 @@ const ProfileView = ({ navigation }: IProfileViewProps): ReactElement => {
 
 	const handleTwoFactorChallenge = async (e: any): Promise<TwoFactorChallengeOutcome> => {
 		if (e?.error !== 'totp-invalid' || e?.details.method === TwoFactorMethods.PASSWORD) {
-			return { status: 'notChallenged' };
+			return { status: 'failed', error: e };
 		}
 		try {
 			const code = await twoFactor({ method: e.details.method, invalid: e?.error === 'totp-invalid' && !!twoFactorCode });
@@ -259,14 +255,11 @@ const ProfileView = ({ navigation }: IProfileViewProps): ReactElement => {
 			const twoFactorOutcome = await handleTwoFactorChallenge(e);
 			if (twoFactorOutcome.status === 'retried') return;
 
-			if (twoFactorOutcome.status === 'cancelled') {
-				resetSavingState();
-				return;
-			}
+			resetSavingState();
+			if (twoFactorOutcome.status === 'cancelled') return;
 
 			logEvent(events.PROFILE_SAVE_CHANGES_F);
-			resetSavingState();
-			handleSaveUserProfileError(twoFactorOutcome.status === 'failed' ? twoFactorOutcome.error : e, 'saving_profile');
+			handleSaveUserProfileError(twoFactorOutcome.error, 'saving_profile');
 		}
 	};
 


### PR DESCRIPTION
## Proposed changes

`ProfileView`'s `handleTwoFactorChallenge` returned a single `boolean` for three different outcomes, and the ambiguity hid a fourth. Walking the caller in `submit`:

| outcome | returned | caller did |
| --- | --- | --- |
| not a 2FA challenge | `false` | reports `e` — correct |
| retry issued | `true` | returns, nested `submit()` owns the rest — correct |
| user cancelled | `true` | returns silently — right UX, but the helper had to call `resetSavingState()` itself to compensate |
| `twoFactor` rejected for any other reason | `false` | **reports the outer `totp-invalid` instead of the real 2FA error** |

Cancel was not itself taking a wrong branch. Collapsing cancel onto `true` is what forced the *failure* case onto `false`, where it became indistinguishable from "not a 2FA challenge" — that is the branch that broke, and the only one with a user-visible symptom: a failed challenge surfaces a misleading `totp-invalid` and the real error is discarded.

`handleTwoFactorChallenge` now returns a discriminated `TwoFactorChallengeOutcome` — `notChallenged | retried | cancelled | failed { error }`. The caller yields on `retried`, resets silently on `cancelled`, and reports `outcome.error` on `failed`. `resetSavingState()` moves back to the caller, which already owned that state.

Also worth flagging for the `runUserAction` consolidation being discussed for these 2FA-cancel guards: this call site cannot be absorbed by a helper that only knows "cancel vs not", because cancel participates in a four-way protocol here rather than a two-way one. Such a helper would have to re-flatten `failed` into `notChallenged` and reintroduce exactly this bug.

## Issue(s)

Follow-up to #7574 — targets that branch. The fix briefly landed on `new-sdk` directly and was reverted in 6062025 so it could go through review here; this PR re-applies it unchanged.

## How to test or reproduce

`TZ=UTC npx jest app/views/ProfileView/index.test.tsx`

Two new cases:

- a cancelled challenge stays silent — `handleSaveUserProfileError` is never called
- a challenge that fails for a non-cancel reason reports **that** error, not the outer `totp-invalid`

The second one is red before the fix, with `handleSaveUserProfileError` receiving `{ error: 'totp-invalid', details: { method: 'totp' } }`.

Note the existing suite mocked `lib/services/twoFactor` without `isTwoFactorCancelled`, so the whole `catch` block was unreachable under test and would have thrown a `TypeError`. The mock now spreads `jest.requireActual`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelling a two-factor authentication challenge no longer displays an error.
  * Other two-factor authentication failures continue to be reported when saving profile changes.
  * Profile form state is correctly reset after cancelling two-factor authentication.
  * Error handling now preserves and displays relevant details for unsuccessful two-factor authentication attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->