### PR TITLE
docs: add coding standard against tautological tests

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,1 @@
+Tautological tests considered harmful.


### PR DESCRIPTION
## Proposed changes

Adds a `CODING_STANDARDS.md` note that tautological tests are harmful.

## Issue(s)

N/A

## How to test or reproduce

N/A, docs only.

## Screenshots

N/A

## Types of changes

- Documentation

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] My changes generate no new warnings

## Further comments

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance discouraging tautological tests in the coding standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->