### PR TITLE
fix(android): resolve channel push notification navigation failure

### DIFF
--- a/app/lib/methods/canOpenRoom.test.ts
+++ b/app/lib/methods/canOpenRoom.test.ts
@@ -210,6 +210,13 @@ describe('canOpenRoom — local subscription fast-path', () => {
 });
 
 describe('canOpenRoom — other paths', () => {
+	it('returns { rid } fallback when rid is provided but path is empty and not found locally', async () => {
+		mockFind.mockRejectedValueOnce(new Error('not found'));
+
+		const result = await canOpenRoom({ rid: 'remote-rid-123', path: '' });
+		expect(result).toEqual({ rid: 'remote-rid-123' });
+	});
+
 	it('returns false when no path and no rid', async () => {
 		const result = await canOpenRoom({ rid: '', path: '' });
 		expect(result).toBe(false);

--- a/app/lib/methods/canOpenRoom.test.ts
+++ b/app/lib/methods/canOpenRoom.test.ts
@@ -2,6 +2,26 @@ import { canOpenRoom } from './canOpenRoom';
 import sdk from '../services/sdk';
 import { getRoomByTypeAndName } from '../services/restApi';
 
+const mockFind = jest.fn();
+const mockQuery = jest.fn();
+
+jest.mock('../database', () => ({
+	__esModule: true,
+	default: {
+		active: {
+			get: jest.fn((collection: string) => {
+				if (collection === 'subscriptions') {
+					return {
+						find: mockFind,
+						query: mockQuery
+					};
+				}
+				return null;
+			})
+		}
+	}
+}));
+
 jest.mock('../services/sdk', () => ({
 	__esModule: true,
 	default: {
@@ -18,6 +38,10 @@ const mockedGetRoomByTypeAndName = getRoomByTypeAndName as jest.Mock;
 
 beforeEach(() => {
 	jest.clearAllMocks();
+	mockFind.mockRejectedValue(new Error('not found'));
+	mockQuery.mockReturnValue({
+		fetch: jest.fn().mockResolvedValue([])
+	});
 });
 
 describe('canOpenRoom — GROUP deeplink', () => {
@@ -135,6 +159,53 @@ describe('canOpenRoom — CHANNEL deeplink', () => {
 		const result = await canOpenRoom({ rid: '', path: 'channel/test-channel' });
 
 		expect(result).toBe(false);
+	});
+});
+
+describe('canOpenRoom — local subscription fast-path', () => {
+	const localSubFixture = {
+		rid: 'local-room-1',
+		t: 'c',
+		name: 'general',
+		fname: 'General Room',
+		prid: '',
+		uids: ['u1', 'u2'],
+		usernames: ['user1', 'user2']
+	};
+
+	it('returns room immediately from local DB when rid matches without calling REST API', async () => {
+		mockFind.mockResolvedValueOnce(localSubFixture);
+
+		const result = await canOpenRoom({ rid: 'local-room-1', path: '' });
+
+		expect(mockFind).toHaveBeenCalledWith('local-room-1');
+		expect(mockedGetRoomByTypeAndName).not.toHaveBeenCalled();
+		expect(mockedSdkPost).not.toHaveBeenCalled();
+		expect(result).toEqual(localSubFixture);
+	});
+
+	it('returns room immediately from local DB when path matches channel name without calling REST API', async () => {
+		mockQuery.mockReturnValueOnce({
+			fetch: jest.fn().mockResolvedValueOnce([localSubFixture])
+		});
+
+		const result = await canOpenRoom({ rid: '', path: 'channel/general' });
+
+		expect(mockedGetRoomByTypeAndName).not.toHaveBeenCalled();
+		expect(mockedSdkPost).not.toHaveBeenCalled();
+		expect(result).toEqual(localSubFixture);
+	});
+
+	it('returns room from local DB when model has asPlain() method', async () => {
+		const modelWithAsPlain = {
+			...localSubFixture,
+			asPlain: () => localSubFixture
+		};
+		mockFind.mockResolvedValueOnce(modelWithAsPlain);
+
+		const result = await canOpenRoom({ rid: 'local-room-1', path: '' });
+
+		expect(result).toEqual(localSubFixture);
 	});
 });
 

--- a/app/lib/methods/canOpenRoom.ts
+++ b/app/lib/methods/canOpenRoom.ts
@@ -87,7 +87,9 @@ async function open({ type, rid, name }: { type: ERoomTypes; rid: string; name: 
 }
 
 /**
- * Formats a subscription model or raw subscription object into a plain room representation.
+ * WatermelonDB models are lazy proxies that can't be passed across the saga/navigation
+ * boundary. Normalize to a plain object so downstream consumers (goRoom, navigate) receive
+ * serializable data.
  */
 function formatRoom(room: TSubscriptionModel | ISubscription | any, rid?: string): ICanOpenRoomResult | ISubscription {
 	return (
@@ -104,7 +106,9 @@ function formatRoom(room: TSubscriptionModel | ISubscription | any, rid?: string
 }
 
 /**
- * Queries local WatermelonDB subscriptions collection for a room by ID.
+ * Push notifications carry the room ID. Resolving by rid first avoids a network round trip
+ * and succeeds even when the socket is still reconnecting after a background-to-foreground
+ * transition.
  */
 async function findSubscriptionByRid(
 	subsCollection: Collection<TSubscriptionModel>,
@@ -119,7 +123,9 @@ async function findSubscriptionByRid(
 }
 
 /**
- * Queries local WatermelonDB subscriptions collection for a room by name or room ID.
+ * Deep-link path segments may hold either a room name or a room ID depending on how the
+ * link was generated. Querying by both with a room-type filter avoids a false-negative
+ * when the path contains an ID instead of a name.
  */
 async function findSubscriptionByName(
 	subsCollection: Collection<TSubscriptionModel>,
@@ -140,8 +146,9 @@ async function findSubscriptionByName(
 }
 
 /**
- * Determines whether a room can be opened from a deep link or push notification payload,
- * resolving from local database first and falling back to remote REST API calls.
+ * Local resolution is attempted before the REST fallback so that notification taps succeed
+ * instantly even when the network or DDP socket is temporarily unavailable (e.g. Android
+ * transitioning from a doze/background state).
  */
 export async function canOpenRoom({
 	rid,

--- a/app/lib/methods/canOpenRoom.ts
+++ b/app/lib/methods/canOpenRoom.ts
@@ -1,3 +1,5 @@
+import { Q } from '@nozbe/watermelondb';
+
 import { ERoomTypes } from '../../definitions';
 import database from '../database';
 import sdk from '../services/sdk';
@@ -72,36 +74,76 @@ async function open({ type, rid, name }: { type: ERoomTypes; rid: string; name: 
 	}
 }
 
+function formatRoom(room: any, rid?: string) {
+	return (
+		room?.asPlain?.() ?? {
+			rid: rid ?? room.rid,
+			t: room.t,
+			name: room.name,
+			fname: room.fname,
+			prid: room.prid,
+			uids: room.uids,
+			usernames: room.usernames
+		}
+	);
+}
+
+async function findSubscriptionByRid(subsCollection: any, rid: string) {
+	try {
+		const room = await subsCollection.find(rid);
+		return formatRoom(room, rid);
+	} catch {
+		return null;
+	}
+}
+
+async function findSubscriptionByName(subsCollection: any, name: string, roomType: string) {
+	try {
+		const rows = await subsCollection
+			.query(Q.or(Q.where('name', name), Q.where('rid', name)), Q.where('t', roomType), Q.take(1))
+			.fetch();
+		if (rows.length && rows[0]) {
+			return formatRoom(rows[0]);
+		}
+	} catch {
+		// Do nothing
+	}
+	return null;
+}
+
 export async function canOpenRoom({ rid, path }: { rid: string; path: string }): Promise<any> {
 	try {
 		const db = database.active;
-		const subsCollection = db.get('subscriptions');
+		const subsCollection = db?.get ? db.get('subscriptions') : null;
 
-		if (rid) {
-			try {
-				const room = await subsCollection.find(rid);
-				return {
-					rid,
-					t: room.t,
-					name: room.name,
-					fname: room.fname,
-					prid: room.prid,
-					uids: room.uids,
-					usernames: room.usernames
-				};
-			} catch (e) {
-				// Do nothing
+		if (subsCollection && rid) {
+			const room = await findSubscriptionByRid(subsCollection, rid);
+			if (room) {
+				return room;
 			}
 		}
 
-		const [type, name] = path.split('/');
-		const t = type as ERoomTypes;
-		try {
-			const result = await open({ type: t, rid, name });
-			return result;
-		} catch (e) {
-			return false;
+		if (path) {
+			const [type, name] = path.split('/');
+			const t = type as ERoomTypes;
+			const roomType = t === ERoomTypes.GROUP ? 'p' : t === ERoomTypes.DIRECT ? 'd' : (t as string) === 'channels' ? 'l' : 'c';
+
+			if (subsCollection && name) {
+				const room = await findSubscriptionByName(subsCollection, name, roomType);
+				if (room) {
+					return room;
+				}
+			}
+
+			try {
+				const result = await open({ type: t, rid, name });
+				return result;
+			} catch (e) {
+				return false;
+			}
 		}
+
+		return false;
 	} catch (e) {
 		return false;
 	}

--- a/app/lib/methods/canOpenRoom.ts
+++ b/app/lib/methods/canOpenRoom.ts
@@ -1,10 +1,22 @@
+import type { Collection } from '@nozbe/watermelondb';
 import { Q } from '@nozbe/watermelondb';
 
-import { ERoomTypes } from '../../definitions';
+import { ERoomTypes, type ISubscription, type TSubscriptionModel } from '../../definitions';
 import database from '../database';
 import sdk from '../services/sdk';
 import { createDirectMessage } from './createDirectMessage';
 import { getRoomByTypeAndName } from '../services/restApi';
+
+export interface ICanOpenRoomResult {
+	rid: string;
+	t?: string;
+	name?: string;
+	fname?: string;
+	prid?: string;
+	uids?: string[];
+	usernames?: string[];
+	[key: string]: any;
+}
 
 async function openGroup(roomId: string) {
 	try {
@@ -74,7 +86,10 @@ async function open({ type, rid, name }: { type: ERoomTypes; rid: string; name: 
 	}
 }
 
-function formatRoom(room: any, rid?: string) {
+/**
+ * Formats a subscription model or raw subscription object into a plain room representation.
+ */
+function formatRoom(room: TSubscriptionModel | ISubscription | any, rid?: string): ICanOpenRoomResult | ISubscription {
 	return (
 		room?.asPlain?.() ?? {
 			rid: rid ?? room.rid,
@@ -88,7 +103,13 @@ function formatRoom(room: any, rid?: string) {
 	);
 }
 
-async function findSubscriptionByRid(subsCollection: any, rid: string) {
+/**
+ * Queries local WatermelonDB subscriptions collection for a room by ID.
+ */
+async function findSubscriptionByRid(
+	subsCollection: Collection<TSubscriptionModel>,
+	rid: string
+): Promise<ICanOpenRoomResult | ISubscription | null> {
 	try {
 		const room = await subsCollection.find(rid);
 		return formatRoom(room, rid);
@@ -97,7 +118,14 @@ async function findSubscriptionByRid(subsCollection: any, rid: string) {
 	}
 }
 
-async function findSubscriptionByName(subsCollection: any, name: string, roomType: string) {
+/**
+ * Queries local WatermelonDB subscriptions collection for a room by name or room ID.
+ */
+async function findSubscriptionByName(
+	subsCollection: Collection<TSubscriptionModel>,
+	name: string,
+	roomType: string
+): Promise<ICanOpenRoomResult | ISubscription | null> {
 	try {
 		const rows = await subsCollection
 			.query(Q.or(Q.where('name', name), Q.where('rid', name)), Q.where('t', roomType), Q.take(1))
@@ -111,10 +139,20 @@ async function findSubscriptionByName(subsCollection: any, name: string, roomTyp
 	return null;
 }
 
-export async function canOpenRoom({ rid, path }: { rid: string; path: string }): Promise<any> {
+/**
+ * Determines whether a room can be opened from a deep link or push notification payload,
+ * resolving from local database first and falling back to remote REST API calls.
+ */
+export async function canOpenRoom({
+	rid,
+	path
+}: {
+	rid: string;
+	path: string;
+}): Promise<ICanOpenRoomResult | ISubscription | { rid: string } | boolean> {
 	try {
 		const db = database.active;
-		const subsCollection = db?.get ? db.get('subscriptions') : null;
+		const subsCollection = (db?.get ? db.get('subscriptions') : null) as Collection<TSubscriptionModel> | null;
 
 		if (subsCollection && rid) {
 			const room = await findSubscriptionByRid(subsCollection, rid);
@@ -141,6 +179,10 @@ export async function canOpenRoom({ rid, path }: { rid: string; path: string }):
 			} catch (e) {
 				return false;
 			}
+		}
+
+		if (rid) {
+			return { rid };
 		}
 
 		return false;

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -66,6 +66,10 @@ jest.mock('../../lib/services/voip/resetVoipState', () => ({
 	resetVoipState: jest.fn()
 }));
 
+jest.mock('../../lib/services/socketHealth', () => ({
+	recoverSocket: jest.fn(() => Promise.resolve('confirmed-alive'))
+}));
+
 jest.mock('../../lib/navigation/appNavigation', () => ({
 	__esModule: true,
 	default: {

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -245,7 +245,9 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		const store = setupStore();
 		const params = makeParamsWithToken();
 
-		// First call fails, second call succeeds after recoverSocket
+		// Simulate a dormant socket: the first canOpenRoom fails because the REST
+		// fallback can't reach the server; after recoverSocket restores the connection,
+		// the retry succeeds.
 		jest
 			.mocked(canOpenRoom)
 			.mockResolvedValueOnce(false as any)

--- a/app/sagas/__tests__/deepLinking.test.ts
+++ b/app/sagas/__tests__/deepLinking.test.ts
@@ -113,6 +113,7 @@ import { getServerInfo } from '../../lib/methods/getServerInfo';
 import { goRoom, navigateToRoom } from '../../lib/methods/helpers/goRoom';
 import { waitForNavigationReady } from '../../lib/navigation/appNavigation';
 import { loginOAuthOrSso } from '../../lib/services/connect';
+import { recoverSocket } from '../../lib/services/socketHealth';
 import sdk from '../../lib/services/sdk';
 import database from '../../lib/database';
 import EventEmitter from '../../lib/methods/helpers/events';
@@ -237,6 +238,36 @@ describe('deepLinking saga — Regression race (new server + token + room path)'
 		await flushSagaMicrotasks();
 		await flushSagaMicrotasks();
 
+		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
+	});
+
+	it('retries canOpenRoom after calling recoverSocket when the first canOpenRoom attempt fails', async () => {
+		const store = setupStore();
+		const params = makeParamsWithToken();
+
+		// First call fails, second call succeeds after recoverSocket
+		jest
+			.mocked(canOpenRoom)
+			.mockResolvedValueOnce(false as any)
+			.mockResolvedValueOnce({ rid: 'room-1', name: 'general', t: 'c' } as any);
+
+		store.dispatch(deepLinkingOpen(params));
+		await flushSagaMicrotasks();
+		await jest.advanceTimersByTimeAsync(1000);
+		await flushSagaMicrotasks();
+
+		store.dispatch(selectServerSuccess({ ...makeServerRecord(), name: 'open.rocket.chat', server: HOST }));
+		await flushSagaMicrotasks();
+
+		store.dispatch(loginSuccess({ id: 'user-1', token: makeStoredUser() } as any));
+		await flushSagaMicrotasks();
+
+		store.dispatch(appStart({ root: RootEnum.ROOT_INSIDE }));
+		await flushSagaMicrotasks();
+		await flushSagaMicrotasks();
+
+		expect(jest.mocked(recoverSocket)).toHaveBeenCalled();
+		expect(jest.mocked(canOpenRoom)).toHaveBeenCalledTimes(2);
 		expect(jest.mocked(goRoom)).toHaveBeenCalledTimes(1);
 	});
 

--- a/app/sagas/deepLinking.js
+++ b/app/sagas/deepLinking.js
@@ -29,6 +29,7 @@ import { notifyUser } from '../lib/services/restApi';
 import sdk from '../lib/services/sdk';
 import Navigation, { waitForNavigationReady } from '../lib/navigation/appNavigation';
 import { resetVoipState } from '../lib/services/voip/resetVoipState';
+import { recoverSocket } from '../lib/services/socketHealth';
 
 const roomTypes = {
 	channel: 'c',
@@ -58,7 +59,15 @@ const navigate = function* navigate({ params }) {
 			[type, name, , jumpToThreadId] = params.path.split('/');
 		}
 		if (type !== 'invite' || params.rid) {
-			const room = yield canOpenRoom(params);
+			let room = yield canOpenRoom(params);
+			if (!room) {
+				try {
+					yield call(recoverSocket);
+				} catch (e) {
+					log(e);
+				}
+				room = yield canOpenRoom(params);
+			}
 			if (room) {
 				const item = {
 					name,

--- a/app/sagas/state.js
+++ b/app/sagas/state.js
@@ -1,4 +1,4 @@
-import { select, takeLatest } from 'redux-saga/effects';
+import { call, select, takeLatest } from 'redux-saga/effects';
 
 import log from '../lib/methods/helpers/log';
 import { localAuthenticate, saveLastLocalAuthenticationSession } from '../lib/methods/helpers/localAuthentication';
@@ -29,12 +29,17 @@ const appHasComeBackToForeground = function* appHasComeBackToForeground() {
 		const server = yield select(state => state.server.server);
 		yield localAuthenticate(server);
 
-		recoverSocket().catch(e => log(e));
+		try {
+			yield call(recoverSocket);
+		} catch (e) {
+			log(e);
+		}
 
-		// Check for pending notification when app comes to foreground (Android - notification tap while in background)
-		checkPendingNotification().catch(e => {
+		try {
+			yield call(checkPendingNotification);
+		} catch (e) {
 			log('[state.js] Error checking pending notification:', e);
-		});
+		}
 		return yield setUserPresenceOnline();
 	} catch (e) {
 		log(e);


### PR DESCRIPTION
## Proposed changes
Resolves an issue where tapping a channel push notification or deep link on Android fails to navigate to the target room when the socket is disconnected or when transitioning from background to foreground.

- **Local-First Resolution:** Resolves room from WatermelonDB (`findSubscriptionByName`, `findSubscriptionByRid`) in `canOpenRoom` before falling back to REST calls.
- **Socket Recovery Retry:** In `deepLinking.js`, attempts `recoverSocket` and retries `canOpenRoom` if initial resolution fails on a dormant connection.
- **Foreground Lifecycle Sequencing:** In `state.js`, converted detached promises in `appHasComeBackToForeground` to sequential `yield call(...)` effects with error handling.

## Issue(s)
N/A

## How to test or reproduce
1. On Android, background the app and ensure the WebSocket connection is idle or disconnected.
2. Receive a push notification for a channel or private group the user belongs to.
3. Tap the notification from the system tray.
4. **Expected:** App foregrounds, reconnects socket, resolves room from local subscriptions, and navigates directly into the chat room.

## Screenshots
N/A

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
> **Note / AI Disclosure:** This fix was developed with AI. I did reproduce the issue beforehand, and then ran the new build for a week to verify it on my personal Android phone, with a stubbed notification relay proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room deep linking by resolving rooms through identifiers, names, or paths.
  - Added automatic connection recovery and retry when opening a room fails.
  - Improved reliability when opening rooms after temporary connection interruptions.
  - Prevented unnecessary subscription lookups when local subscription data is unavailable.
  - Improved app return-from-background handling by completing connection recovery and pending notification checks before continuing navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->