### PR TITLE
chore: bump @rocket.chat/sdk to SDK #421 head

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@rocket.chat/media-signaling": "1.0.0-rc.1",
 		"@rocket.chat/message-parser": "0.31.36",
 		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#main",
-		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#64b80bd5fdea2ae2e79413cea2c182ed0f39accb",
+		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#fd48a8b5876564bf429dee42434794e21acd3c84",
 		"@rocket.chat/ui-kit": "^0.39.0",
 		"@zoontek/react-native-navigation-bar": "^1.1.1",
 		"axios": "0.30.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@rocket.chat/media-signaling": "1.0.0-rc.1",
 		"@rocket.chat/message-parser": "0.31.36",
 		"@rocket.chat/mobile-crypto": "RocketChat/rocket.chat-mobile-crypto#main",
-		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#fd48a8b5876564bf429dee42434794e21acd3c84",
+		"@rocket.chat/sdk": "RocketChat/Rocket.Chat.js.SDK#1103487a7b0a3beec0dc2a70644a3aa5a009a549",
 		"@rocket.chat/ui-kit": "^0.39.0",
 		"@zoontek/react-native-navigation-bar": "^1.1.1",
 		"axios": "0.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: RocketChat/rocket.chat-mobile-crypto#main
         version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/69a0a250dd7c6ff0808eb659d7202be1cae7fa1c(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@7.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@rocket.chat/sdk':
-        specifier: RocketChat/Rocket.Chat.js.SDK#fd48a8b5876564bf429dee42434794e21acd3c84
-        version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84
+        specifier: RocketChat/Rocket.Chat.js.SDK#1103487a7b0a3beec0dc2a70644a3aa5a009a549
+        version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/1103487a7b0a3beec0dc2a70644a3aa5a009a549
       '@rocket.chat/ui-kit':
         specifier: ^0.39.0
         version: 0.39.0(@rocket.chat/icons@0.47.0)(@types/node@25.0.3)(typescript@7.0.2)
@@ -2633,8 +2633,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84':
-    resolution: {gitHosted: true, integrity: sha512-wEKvK5yrrOlaZLF0nEkaqOPKm8enkZPZIL/HU52U9DYyLbeJ3QtVZu/gGmA5Cy4IwG+220si7nT7LyIVOFMMYA==, tarball: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84}
+  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/1103487a7b0a3beec0dc2a70644a3aa5a009a549':
+    resolution: {gitHosted: true, integrity: sha512-Fa2arHcIsIxva8g3M0wnhsPkRxA1q9nwpnAFdcGlhmkMTG/rhY9LrIIh0rfnnKmes5aFcTmZ65FCfjWdDXEmFA==, tarball: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/1103487a7b0a3beec0dc2a70644a3aa5a009a549}
     version: 1.3.3-mobile
 
   '@rocket.chat/ui-kit@0.39.0':
@@ -10517,7 +10517,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@7.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0)
 
-  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84':
+  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/1103487a7b0a3beec0dc2a70644a3aa5a009a549':
     dependencies:
       js-sha256: 0.9.0
       tiny-events: 1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: RocketChat/rocket.chat-mobile-crypto#main
         version: https://codeload.github.com/RocketChat/rocket.chat-mobile-crypto/tar.gz/69a0a250dd7c6ff0808eb659d7202be1cae7fa1c(react-native@0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@7.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@rocket.chat/sdk':
-        specifier: RocketChat/Rocket.Chat.js.SDK#64b80bd5fdea2ae2e79413cea2c182ed0f39accb
-        version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/64b80bd5fdea2ae2e79413cea2c182ed0f39accb
+        specifier: RocketChat/Rocket.Chat.js.SDK#fd48a8b5876564bf429dee42434794e21acd3c84
+        version: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84
       '@rocket.chat/ui-kit':
         specifier: ^0.39.0
         version: 0.39.0(@rocket.chat/icons@0.47.0)(@types/node@25.0.3)(typescript@7.0.2)
@@ -2633,8 +2633,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/64b80bd5fdea2ae2e79413cea2c182ed0f39accb':
-    resolution: {gitHosted: true, integrity: sha512-zuldU9lrKi14PBkxdfP00AL1Bwpwj//YzI8+O+JCCmDRZDMKbR4wbkSSu1y1zftQFv1zzmibKpfyR5wakzP3pg==, tarball: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/64b80bd5fdea2ae2e79413cea2c182ed0f39accb}
+  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84':
+    resolution: {gitHosted: true, integrity: sha512-wEKvK5yrrOlaZLF0nEkaqOPKm8enkZPZIL/HU52U9DYyLbeJ3QtVZu/gGmA5Cy4IwG+220si7nT7LyIVOFMMYA==, tarball: https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84}
     version: 1.3.3-mobile
 
   '@rocket.chat/ui-kit@0.39.0':
@@ -10517,7 +10517,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.25.9)(@react-native-community/cli@20.0.0(typescript@7.0.2))(@react-native/metro-config@0.81.5(@babel/core@7.25.9))(@types/react@19.1.17)(react@19.1.0)
 
-  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/64b80bd5fdea2ae2e79413cea2c182ed0f39accb':
+  '@rocket.chat/sdk@https://codeload.github.com/RocketChat/Rocket.Chat.js.SDK/tar.gz/fd48a8b5876564bf429dee42434794e21acd3c84':
     dependencies:
       js-sha256: 0.9.0
       tiny-events: 1.0.1


### PR DESCRIPTION
## Proposed changes

Stacked on #7574. Moves the `@rocket.chat/sdk` pin from `64b80bd5` to `1103487a`, the current
head of the SDK `mobile` branch. That is the merge commit for
[Rocket.Chat.js.SDK#421](https://github.com/RocketChat/Rocket.Chat.js.SDK/pull/421)
("feat: allow only one active Connection Attempt"), which is now merged.

No app code changes.

## Issue(s)

https://github.com/RocketChat/Rocket.Chat.js.SDK/pull/421

## How to test or reproduce

No user-facing behaviour is expected to change. The SDK change is a latent-defect fix on the
Connection/Transport lifecycle, reachable only through `driver.logout()`, which this app never
calls.

Logout was re-measured on a physical device against this pin to check that, with every awaited
step in `app/lib/methods/logout.ts` and the `handleLogout` saga instrumented:

1. Log in on a dev build, open Settings, scroll so `settings-logout` is tappable.
2. `adb shell cmd connectivity airplane-mode enable`, wait 4s, then disable.
3. Wait until an HTTPS `GET /api/info` from the device succeeds.
4. Tap Logout, then LOGOUT, and time from the confirm tap.
5. Detect completion by screencap of the `Add workspace` screen.

Galaxy S10, Android 12, dev build, `reopen: 20000`:

| Run | Condition | Total | removePushToken | sdk.logout (REST) | removeServerData | removeServerDatabase |
|---|---|---|---|---|---|---|
| Baseline | healthy | 760ms | 446ms | 246ms | 8ms | 29ms |
| 1 | logout right after recovery | 1085ms | 691ms | 335ms | 14ms | 35ms |
| 2 | same | 1105ms | 688ms | 317ms | 19ms | 37ms |
| 3 | same | 1083ms | 642ms | 333ms | 17ms | 41ms |
| 4 | same | 1046ms | 642ms | 318ms | 10ms | 34ms |

`Socket.logout()` and `driver.logout()` entry logs fired zero times across all five runs; the
REST `POST logout` fired every time.

An earlier round of QA reported a 36-46s logout stall on this path. That was an artifact of the
measuring script: it polled `adb exec-out uiautomator dump`, which returns the 7-byte string
`Killed ` for 35-45s after the React Native root swap on this device. Screencaps show the
`Add workspace` screen already rendered 2s after the confirm tap. There is no stall.

Only one disruption shape was covered (4s airplane, logout immediately after recovery). Logout
while still offline, after a long outage, or from a wedged "Waiting for network..." state was
not measured.

## Screenshots

n/a

## Types of changes

- [x] Improvement (non-breaking change which improves a current function)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The first commit pinned SDK #421's pre-merge head (`fd48a8b5`); the second repoints to the
`mobile` merge commit now that #421 has landed. Same SDK content, but the pin now tracks a
commit on `mobile` rather than a PR head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rocket.Chat SDK dependency to a newer revision.
  * Includes the latest available SDK updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->