### PR TITLE
fix: leaked prepared subscriptions break lastOpen writes

### DIFF
--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -167,29 +167,29 @@ describe('Encryption.encryptMessage', () => {
 	});
 });
 
+// Mimics a WatermelonDB Model: prepareUpdate throws while a previous prepared
+// update has not been committed yet.
+const makeRecord = (table: string, id: string, fields: Record<string, any> = {}) => {
+	const record: any = {
+		id,
+		...fields,
+		_preparedState: null,
+		prepareUpdate(recordUpdater: (m: any) => void) {
+			if (record._preparedState) {
+				throw new Error(`Cannot update a record with pending changes (${table}#${id})`);
+			}
+			recordUpdater(record);
+			record._preparedState = 'update';
+			return record;
+		}
+	};
+	return record;
+};
+
 describe('Encryption.decryptPendingMessages', () => {
 	const rid = 'r1';
 
-	// Mimics a WatermelonDB Model: prepareUpdate throws while a previous prepared
-	// update has not been committed yet.
-	const makeMessageRecord = (id: string) => {
-		const record: any = {
-			id,
-			t: 'e2e',
-			msg: 'cipher',
-			subscription: { id: rid },
-			_preparedState: null as string | null,
-			prepareUpdate(recordUpdater: (m: any) => void) {
-				if (record._preparedState) {
-					throw new Error(`Cannot update a record with pending changes (messages#${id})`);
-				}
-				recordUpdater(record);
-				record._preparedState = 'update';
-				return record;
-			}
-		};
-		return record;
-	};
+	const makeMessageRecord = (id: string) => makeRecord('messages', id, { t: 'e2e', msg: 'cipher', subscription: { id: rid } });
 
 	const deferred = () => {
 		let resolve: () => void = () => undefined;
@@ -265,25 +265,8 @@ describe('Encryption.decryptPendingMessages', () => {
 });
 
 describe('Encryption.decryptPendingSubscriptions', () => {
-	const makeSubscriptionRecordRejectingSecondPrepareUpdate = (id: string) => {
-		const record: any = {
-			id,
-			rid: id,
-			encrypted: true,
-			e2eKeyId: 'key',
-			lastMessage: { t: 'e2e', e2e: 'pending', msg: 'cipher' },
-			_preparedState: null as string | null,
-			prepareUpdate(recordUpdater: (m: any) => void) {
-				if (record._preparedState) {
-					throw new Error(`Cannot update a record with pending changes (subscriptions#${id})`);
-				}
-				recordUpdater(record);
-				record._preparedState = 'update';
-				return record;
-			}
-		};
-		return record;
-	};
+	const makeSubscriptionRecord = (id: string) =>
+		makeRecord('subscriptions', id, { lastMessage: { t: 'e2e', e2e: 'pending', msg: 'cipher' } });
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -295,8 +278,8 @@ describe('Encryption.decryptPendingSubscriptions', () => {
 	});
 
 	it('leaves no subscription prepared-but-uncommitted when one decryption rejects', async () => {
-		const healthy = makeSubscriptionRecordRejectingSecondPrepareUpdate('s1');
-		const failing = makeSubscriptionRecordRejectingSecondPrepareUpdate('s2');
+		const healthy = makeSubscriptionRecord('s1');
+		const failing = makeSubscriptionRecord('s2');
 		mockQueryRows.subscriptions = [healthy, failing];
 		jest.spyOn(encryption, 'decryptSubscription').mockImplementation((sub: any) => {
 			if (sub.id === failing.id) {
@@ -309,5 +292,10 @@ describe('Encryption.decryptPendingSubscriptions', () => {
 
 		expect(healthy._preparedState).toBeNull();
 		expect(failing._preparedState).toBeNull();
+
+		const batched = mockDbBatch.mock.calls.flatMap(call => call.flat());
+		expect(batched).toContain(healthy);
+		expect(healthy.lastMessage).toEqual({ t: 'e2e', e2e: 'done', msg: 'plain' });
+		expect(failing.lastMessage).toEqual({ t: 'e2e', e2e: 'pending', msg: 'cipher' });
 	});
 });

--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -263,3 +263,53 @@ describe('Encryption.decryptPendingMessages', () => {
 		expect(failing.msg).toBe('cipher');
 	});
 });
+
+describe('Encryption.decryptPendingSubscriptions', () => {
+	// Mimics a WatermelonDB Model: prepareUpdate throws while a previous prepared
+	// update has not been committed yet.
+	const makeSubscriptionRecord = (id: string) => {
+		const record: any = {
+			id,
+			rid: id,
+			encrypted: true,
+			e2eKeyId: 'key',
+			lastMessage: { t: 'e2e', e2e: 'pending', msg: 'cipher' },
+			_preparedState: null as string | null,
+			prepareUpdate(recordUpdater: (m: any) => void) {
+				if (record._preparedState) {
+					throw new Error(`Cannot update a record with pending changes (subscriptions#${id})`);
+				}
+				recordUpdater(record);
+				record._preparedState = 'update';
+				return record;
+			}
+		};
+		return record;
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockQueryRows.subscriptions = [];
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('leaves no subscription prepared-but-uncommitted when one decryption rejects', async () => {
+		const healthy = makeSubscriptionRecord('s1');
+		const failing = makeSubscriptionRecord('s2');
+		mockQueryRows.subscriptions = [healthy, failing];
+		jest.spyOn(encryption, 'decryptSubscription').mockImplementation((sub: any) => {
+			if (sub.id === failing.id) {
+				return Promise.reject(new Error('decrypt failed'));
+			}
+			return Promise.resolve({ lastMessage: { t: 'e2e', e2e: 'done', msg: 'plain' } } as any);
+		});
+
+		await encryption.decryptPendingSubscriptions();
+
+		expect(healthy._preparedState).toBeNull();
+		expect(failing._preparedState).toBeNull();
+	});
+});

--- a/app/lib/encryption/encryption.test.ts
+++ b/app/lib/encryption/encryption.test.ts
@@ -265,9 +265,7 @@ describe('Encryption.decryptPendingMessages', () => {
 });
 
 describe('Encryption.decryptPendingSubscriptions', () => {
-	// Mimics a WatermelonDB Model: prepareUpdate throws while a previous prepared
-	// update has not been committed yet.
-	const makeSubscriptionRecord = (id: string) => {
+	const makeSubscriptionRecordRejectingSecondPrepareUpdate = (id: string) => {
 		const record: any = {
 			id,
 			rid: id,
@@ -297,8 +295,8 @@ describe('Encryption.decryptPendingSubscriptions', () => {
 	});
 
 	it('leaves no subscription prepared-but-uncommitted when one decryption rejects', async () => {
-		const healthy = makeSubscriptionRecord('s1');
-		const failing = makeSubscriptionRecord('s2');
+		const healthy = makeSubscriptionRecordRejectingSecondPrepareUpdate('s1');
+		const failing = makeSubscriptionRecordRejectingSecondPrepareUpdate('s2');
 		mockQueryRows.subscriptions = [healthy, failing];
 		jest.spyOn(encryption, 'decryptSubscription').mockImplementation((sub: any) => {
 			if (sub.id === failing.id) {

--- a/app/lib/encryption/encryption.ts
+++ b/app/lib/encryption/encryption.ts
@@ -1,4 +1,4 @@
-import { type Model, Q } from '@nozbe/watermelondb';
+import { Q } from '@nozbe/watermelondb';
 import EJSON from 'ejson';
 import { deleteAsync } from 'expo-file-system/legacy';
 import {
@@ -404,9 +404,12 @@ class Encryption {
 				sub => sub.lastMessage?.t === E2E_MESSAGE_TYPE && sub.lastMessage?.e2e !== E2E_STATUS.DONE
 			);
 
-			const preparedSubscriptions: (Model | null)[] = await Promise.all(
-				subsEncryptedToDecrypt.map(async (sub: TSubscriptionModel) => {
-					const newSub = await this.decryptSubscription(sub);
+			const decrypted = await Promise.all(
+				subsEncryptedToDecrypt.map(async (sub: TSubscriptionModel) => ({ sub, newSub: await this.decryptSubscription(sub) }))
+			);
+
+			await db.write(async () => {
+				const prepared = decrypted.map(({ sub, newSub }) => {
 					try {
 						return sub.prepareUpdate(
 							protectedFunction((m: TSubscriptionModel) => {
@@ -415,14 +418,12 @@ class Encryption {
 								}
 							})
 						);
-					} catch {
+					} catch (e) {
+						log(e);
 						return null;
 					}
-				})
-			);
-
-			await db.write(async () => {
-				await db.batch(preparedSubscriptions.filter((record): record is Model => record !== null));
+				});
+				await db.batch(prepared.filter((record): record is TSubscriptionModel => record !== null));
 			});
 		} catch (e) {
 			log(e);

--- a/app/lib/encryption/encryption.ts
+++ b/app/lib/encryption/encryption.ts
@@ -64,6 +64,7 @@ import {
 } from './utils';
 
 const ROOM_KEY_EXCHANGE_SIZE = 10;
+
 class Encryption {
 	ready: boolean;
 	privateKey: string | null;
@@ -379,7 +380,7 @@ class Encryption {
 						return null;
 					}
 				});
-				await db.batch(...prepared);
+				await db.batch(prepared.filter(record => record !== null));
 			});
 		} catch (e) {
 			log(e);
@@ -405,7 +406,14 @@ class Encryption {
 			);
 
 			const decrypted = await Promise.all(
-				subsEncryptedToDecrypt.map(async (sub: TSubscriptionModel) => ({ sub, newSub: await this.decryptSubscription(sub) }))
+				subsEncryptedToDecrypt.map(async (sub: TSubscriptionModel) => {
+					try {
+						return { sub, newSub: await this.decryptSubscription(sub) };
+					} catch (e) {
+						log(e);
+						return { sub, newSub: null };
+					}
+				})
 			);
 
 			if (!decrypted.length) {
@@ -427,7 +435,7 @@ class Encryption {
 						return null;
 					}
 				});
-				await db.batch(prepared.filter((record): record is TSubscriptionModel => record !== null));
+				await db.batch(prepared.filter(record => record !== null));
 			});
 		} catch (e) {
 			log(e);

--- a/app/lib/encryption/encryption.ts
+++ b/app/lib/encryption/encryption.ts
@@ -408,6 +408,10 @@ class Encryption {
 				subsEncryptedToDecrypt.map(async (sub: TSubscriptionModel) => ({ sub, newSub: await this.decryptSubscription(sub) }))
 			);
 
+			if (!decrypted.length) {
+				return;
+			}
+
 			await db.write(async () => {
 				const prepared = decrypted.map(({ sub, newSub }) => {
 					try {

--- a/app/lib/methods/subscriptions/rooms.ts
+++ b/app/lib/methods/subscriptions/rooms.ts
@@ -153,8 +153,7 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 		const sub = await getSubscriptionByRoomId(tmp.rid);
 
 		const { subscribedRoom } = store.getState().room;
-		const shouldSaveLastMessage = !!tmp.lastMessage && subscribedRoom !== tmp.rid;
-		const lastMessage = tmp.lastMessage && shouldSaveLastMessage ? buildMessage(tmp.lastMessage) : null;
+		const lastMessage = tmp.lastMessage && subscribedRoom !== tmp.rid ? buildMessage(tmp.lastMessage) : null;
 		const messageRecord = lastMessage ? await getMessageById(lastMessage._id) : null;
 
 		await db.write(async () => {
@@ -195,7 +194,7 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 				}
 			}
 
-			if (shouldSaveLastMessage) {
+			if (lastMessage) {
 				const messagesCollection = db.get('messages');
 				try {
 					if (messageRecord) {
@@ -207,11 +206,9 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 					} else {
 						batch.push(
 							messagesCollection.prepareCreate(m => {
-								if (lastMessage) {
-									m._raw = sanitizedRaw({ id: lastMessage._id }, messagesCollection.schema);
-									if (m.subscription) {
-										m.subscription.id = lastMessage.rid;
-									}
+								m._raw = sanitizedRaw({ id: lastMessage._id }, messagesCollection.schema);
+								if (m.subscription) {
+									m.subscription.id = lastMessage.rid;
 								}
 								return Object.assign(m, lastMessage);
 							})

--- a/app/lib/methods/subscriptions/rooms.ts
+++ b/app/lib/methods/subscriptions/rooms.ts
@@ -51,6 +51,7 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 		const db = database.active;
 		const subCollection = db.get('subscriptions');
 		const roomsCollection = db.get('rooms');
+		const messagesCollection = db.get('messages');
 
 		if (!subscription) {
 			try {
@@ -158,8 +159,9 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 
 		await db.write(async () => {
 			const batch: Model[] = [];
-			if (sub) {
-				try {
+
+			try {
+				if (sub) {
 					batch.push(
 						sub.prepareUpdate(s => {
 							Object.assign(s, tmp);
@@ -175,11 +177,7 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 							}
 						})
 					);
-				} catch (e) {
-					log(e);
-				}
-			} else {
-				try {
+				} else {
 					batch.push(
 						subCollection.prepareCreate(s => {
 							s._raw = sanitizedRaw({ id: tmp.rid }, subCollection.schema);
@@ -189,13 +187,12 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 							}
 						})
 					);
-				} catch (e) {
-					log(e);
 				}
+			} catch (e) {
+				log(e);
 			}
 
 			if (lastMessage) {
-				const messagesCollection = db.get('messages');
 				try {
 					if (messageRecord) {
 						batch.push(

--- a/app/lib/methods/subscriptions/rooms.ts
+++ b/app/lib/methods/subscriptions/rooms.ts
@@ -152,72 +152,76 @@ const createOrUpdateSubscription = async (subscription: ISubscription, room: ISe
 		const tmp = merge(subscription, room);
 		const sub = await getSubscriptionByRoomId(tmp.rid);
 
-		const batch: Model[] = [];
-		if (sub) {
-			try {
-				const update = sub.prepareUpdate(s => {
-					Object.assign(s, tmp);
-					if (subscription.announcement) {
-						if (subscription.announcement !== sub.announcement) {
-							s.bannerClosed = false;
-						}
-					}
-					if (sub.hideUnreadStatus && subscription.hasOwnProperty('hideUnreadStatus')) {
-						if (sub.hideUnreadStatus !== subscription.hideUnreadStatus) {
-							s.hideUnreadStatus = !!subscription.hideUnreadStatus;
-						}
-					}
-				});
-				batch.push(update);
-			} catch (e) {
-				console.log(e);
-			}
-		} else {
-			try {
-				const create = subCollection.prepareCreate(s => {
-					s._raw = sanitizedRaw({ id: tmp.rid }, subCollection.schema);
-					Object.assign(s, tmp);
-					if (s.roomUpdatedAt) {
-						s.roomUpdatedAt = new Date();
-					}
-				});
-				batch.push(create);
-			} catch (e) {
-				console.log(e);
-			}
-		}
-
 		const { subscribedRoom } = store.getState().room;
-		if (tmp.lastMessage && subscribedRoom !== tmp.rid) {
-			const lastMessage = buildMessage(tmp.lastMessage);
-			const messagesCollection = db.get('messages');
-			let messageRecord = {} as TMessageModel | null;
-			if (lastMessage) {
-				messageRecord = await getMessageById(lastMessage._id);
-			}
-
-			if (messageRecord) {
-				batch.push(
-					messageRecord.prepareUpdate(() => {
-						Object.assign(messageRecord, lastMessage);
-					})
-				);
-			} else {
-				batch.push(
-					messagesCollection.prepareCreate(m => {
-						if (lastMessage) {
-							m._raw = sanitizedRaw({ id: lastMessage._id }, messagesCollection.schema);
-							if (m.subscription) {
-								m.subscription.id = lastMessage.rid;
-							}
-						}
-						return Object.assign(m, lastMessage);
-					})
-				);
-			}
-		}
+		const shouldSaveLastMessage = !!tmp.lastMessage && subscribedRoom !== tmp.rid;
+		const lastMessage = tmp.lastMessage && shouldSaveLastMessage ? buildMessage(tmp.lastMessage) : null;
+		const messageRecord = lastMessage ? await getMessageById(lastMessage._id) : null;
 
 		await db.write(async () => {
+			const batch: Model[] = [];
+			if (sub) {
+				try {
+					batch.push(
+						sub.prepareUpdate(s => {
+							Object.assign(s, tmp);
+							if (subscription.announcement) {
+								if (subscription.announcement !== sub.announcement) {
+									s.bannerClosed = false;
+								}
+							}
+							if (sub.hideUnreadStatus && subscription.hasOwnProperty('hideUnreadStatus')) {
+								if (sub.hideUnreadStatus !== subscription.hideUnreadStatus) {
+									s.hideUnreadStatus = !!subscription.hideUnreadStatus;
+								}
+							}
+						})
+					);
+				} catch (e) {
+					log(e);
+				}
+			} else {
+				try {
+					batch.push(
+						subCollection.prepareCreate(s => {
+							s._raw = sanitizedRaw({ id: tmp.rid }, subCollection.schema);
+							Object.assign(s, tmp);
+							if (s.roomUpdatedAt) {
+								s.roomUpdatedAt = new Date();
+							}
+						})
+					);
+				} catch (e) {
+					log(e);
+				}
+			}
+
+			if (shouldSaveLastMessage) {
+				const messagesCollection = db.get('messages');
+				try {
+					if (messageRecord) {
+						batch.push(
+							messageRecord.prepareUpdate(() => {
+								Object.assign(messageRecord, lastMessage);
+							})
+						);
+					} else {
+						batch.push(
+							messagesCollection.prepareCreate(m => {
+								if (lastMessage) {
+									m._raw = sanitizedRaw({ id: lastMessage._id }, messagesCollection.schema);
+									if (m.subscription) {
+										m.subscription.id = lastMessage.rid;
+									}
+								}
+								return Object.assign(m, lastMessage);
+							})
+						);
+					}
+				} catch (e) {
+					log(e);
+				}
+			}
+
 			await db.batch(batch);
 		});
 


### PR DESCRIPTION
## Proposed changes

`Cannot update a record with pending changes (subscriptions#<id>)`, logged from `updateLastOpen`, is not a bug in `updateLastOpen`. It means the subscription record was left in `_preparedState: 'update'` by an earlier writer that called `prepareUpdate` but never reached `db.batch`. WatermelonDB then rejects every later `update()` on that cached instance for the rest of the session, so `lastOpen` silently stops being persisted for that room.

Two sites prepared a subscription outside the writer and awaited before batching, so any rejection in that window leaked the prepared state permanently:

- `Encryption.decryptPendingSubscriptions` prepared each subscription inside a `Promise.all` map. One failing decryption rejects the whole `Promise.all`, the `db.write` never runs, and every subscription already prepared by that map stays stuck.
- `createOrUpdateSubscription` (rooms stream) prepared the subscription, then awaited the last-message lookup before opening the write.

Both now resolve everything asynchronous first and prepare inside `db.write`, immediately before `db.batch`, with a per-record `try/catch` so one bad record cannot block the others. This is the same shape as the earlier `decryptPendingMessages` fix.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1589

## How to test or reproduce

Regression test added in `app/lib/encryption/encryption.test.ts`: two pending encrypted subscriptions, one whose decryption rejects. Before the fix the healthy subscription is left with `_preparedState === 'update'` (the exact state that makes the next `updateLastOpen` throw); after the fix nothing is left prepared.

```
TZ=UTC npx jest app/lib/encryption app/lib/methods/updateLastOpen.test.ts app/lib/methods/subscriptions
```

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The `createOrUpdateSubscription` half has no unit-test seam today: it is a module-private function reached only through the rooms stream listener, so the regression test covers the encryption site only. Worth noting because the same prepare-then-await pattern exists at other call sites (`app/sagas/rooms.js`, `ThreadMessagesView`) and nothing currently prevents it from being reintroduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of subscription decryption failures so healthy subscriptions continue processing.
  * Prevented incomplete message or subscription updates from being committed after processing errors.
  * Improved room and last-message synchronization when creating or updating subscriptions.
  * Avoided unnecessary processing when there are no pending items to decrypt.
  * Improved error handling during message and subscription synchronization to keep database updates consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
