### PR TITLE
fix: skip lastOpen write when subscription was deleted mid-flight

### DIFF
--- a/app/lib/methods/updateLastOpen.test.ts
+++ b/app/lib/methods/updateLastOpen.test.ts
@@ -1,5 +1,6 @@
 import { updateLastOpen } from './updateLastOpen';
 import { getSubscriptionByRoomId } from '../database/services/Subscription';
+import log from './helpers/log';
 
 jest.mock('../database', () => ({
 	__esModule: true,
@@ -11,6 +12,8 @@ jest.mock('../database/services/Subscription', () => ({
 }));
 
 jest.mock('./helpers/log', () => ({ __esModule: true, default: jest.fn() }));
+
+const mockedLog = log as jest.MockedFunction<typeof log>;
 
 const mockedGetSubscriptionByRoomId = getSubscriptionByRoomId as jest.MockedFunction<typeof getSubscriptionByRoomId>;
 
@@ -101,5 +104,21 @@ describe('updateLastOpen', () => {
 		mockedGetSubscriptionByRoomId.mockResolvedValue(null as never);
 
 		await expect(updateLastOpen(RID, [{ _updatedAt: '2024-01-01T12:00:00.000Z' }])).resolves.toBeUndefined();
+	});
+
+	it('is a silent no-op when the subscription is deleted between the read and the write', async () => {
+		const subscription = makeSubscription(null);
+		const deletedSubscription = {
+			...subscription,
+			syncStatus: 'deleted',
+			update: () => {
+				throw new Error(`Not allowed to change deleted record subscriptions#${RID}`);
+			}
+		};
+		mockedGetSubscriptionByRoomId.mockResolvedValue(deletedSubscription as never);
+
+		await updateLastOpen(RID, [{ _updatedAt: '2024-01-01T12:00:00.000Z' }]);
+
+		expect(mockedLog).not.toHaveBeenCalled();
 	});
 });

--- a/app/lib/methods/updateLastOpen.test.ts
+++ b/app/lib/methods/updateLastOpen.test.ts
@@ -22,10 +22,17 @@ const RID = 'ROOM_ID';
 const makeSubscription = (lastOpen: Date | null) => {
 	const subscription = {
 		lastOpen,
-		update: (updater: (s: { lastOpen: Date | null }) => void) => {
+		_raw: { _status: 'updated' },
+		get syncStatus() {
+			return this._raw._status;
+		},
+		update: jest.fn((updater: (s: { lastOpen: Date | null }) => void) => {
+			if (subscription.syncStatus === 'deleted') {
+				throw new Error(`Not allowed to change deleted record subscriptions#${RID}`);
+			}
 			updater(subscription);
 			return Promise.resolve();
-		}
+		})
 	};
 	return subscription;
 };
@@ -108,17 +115,13 @@ describe('updateLastOpen', () => {
 
 	it('is a silent no-op when the subscription is deleted between the read and the write', async () => {
 		const subscription = makeSubscription(null);
-		const deletedSubscription = {
-			...subscription,
-			syncStatus: 'deleted',
-			update: () => {
-				throw new Error(`Not allowed to change deleted record subscriptions#${RID}`);
-			}
-		};
-		mockedGetSubscriptionByRoomId.mockResolvedValue(deletedSubscription as never);
+		mockedGetSubscriptionByRoomId.mockResolvedValue(subscription as never);
+		subscription._raw._status = 'deleted';
 
 		await updateLastOpen(RID, [{ _updatedAt: '2024-01-01T12:00:00.000Z' }]);
 
+		expect(subscription.update).not.toHaveBeenCalled();
+		expect(subscription.lastOpen).toBeNull();
 		expect(mockedLog).not.toHaveBeenCalled();
 	});
 });

--- a/app/lib/methods/updateLastOpen.ts
+++ b/app/lib/methods/updateLastOpen.ts
@@ -28,6 +28,9 @@ export async function updateLastOpen(rid: string, payload: TServerTimestamps): P
 
 		const db = database.active;
 		await db.write(async () => {
+			if (subscription.syncStatus === 'deleted') {
+				return;
+			}
 			await subscription.update((s: TSubscriptionModel) => {
 				s.lastOpen = lastOpen;
 			});


### PR DESCRIPTION
## Proposed changes

`updateLastOpen` reads the subscription, then awaits `db.write` before mutating it. If the room row disappears in that window (user left / was removed, room deleted, or a sync destroying the subscription), WatermelonDB's `__ensureCanSetRaw` invariant fires with `Not allowed to change deleted record subscriptions#<rid>`, and the surrounding `catch` reports it through `log` as a user-visible diagnostic error.

Confirmed hypothesis: benign delete-during-write race, not a corrupted cursor.

The fix re-checks `syncStatus` inside the write, where the record state is freshest, and no-ops. Nothing is lost, the row is going away.

## Issue(s)

N/A

## How to test or reproduce

`TZ=UTC pnpm jest app/lib/methods/updateLastOpen.test.ts`

The new case mocks a subscription that models `_raw._status` behind a `syncStatus` getter, mirroring WatermelonDB's real `Model` prototype getter, and flips it to `deleted` after the read resolves. Its `update` throws the verbatim WatermelonDB invariant as a backstop, so a bypassed guard fails loudly. The case fails before the fix and passes after.

## Screenshots

N/A

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat.ReactNative/blob/develop/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

The record can also become un-writable via `_getChanges().isStopped`, which `syncStatus` does not cover. Not observed in this report, so left alone rather than widened into a blanket swallow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented deleted subscriptions from being updated with a new “last opened” timestamp.
  - Improved handling of subscriptions removed between being read and updated, avoiding unnecessary errors or log messages.

- **Tests**
  - Added coverage for deleted-subscription scenarios to verify timestamps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->