### PR TITLE
fix: sqlite UNIQUE constraint failure on permissions sync

### DIFF
--- a/app/lib/methods/getPermissions.test.ts
+++ b/app/lib/methods/getPermissions.test.ts
@@ -1,4 +1,6 @@
 import { getPermissions } from './getPermissions';
+import log from './helpers/log';
+import { createWriterLock } from '../database/__tests__/mockedWatermelonDB';
 import type { IPermission } from '../../definitions';
 
 const UNIQUE_CONSTRAINT_ERROR = 'Failed to execute db update - sqlite error 1555 (UNIQUE constraint failed: permissions.id)';
@@ -9,7 +11,7 @@ interface IPermissionRow {
 	_updatedAt: string;
 }
 
-type TPermissionDraft = { _raw: { id: string }; roles: string[]; _updatedAt: string };
+type TPermissionDraft = Omit<IPermissionRow, 'id'> & { _raw: { id: string } };
 
 type TBatchOperation =
 	| { type: 'create'; model: TPermissionDraft }
@@ -17,7 +19,6 @@ type TBatchOperation =
 	| { type: 'destroy'; row: IPermissionRow };
 
 const mockPermissionsTable = new Map<string, IPermissionRow>();
-const mockLoggedErrors: Error[] = [];
 
 const makePermissionModel = (row: IPermissionRow) => ({
 	id: row.id,
@@ -28,7 +29,6 @@ const makePermissionModel = (row: IPermissionRow) => ({
 });
 
 const mockPermissionsCollection = {
-	schema: { columns: {} },
 	query: () => ({ fetch: () => Promise.resolve([...mockPermissionsTable.values()].map(makePermissionModel)) }),
 	prepareCreate: (build: (model: TPermissionDraft) => void): TBatchOperation => {
 		const model: TPermissionDraft = { _raw: { id: '' }, roles: [], _updatedAt: '' };
@@ -37,15 +37,11 @@ const mockPermissionsCollection = {
 	}
 };
 
-let mockWriterQueue: Promise<unknown> = Promise.resolve();
+let mockWrite = createWriterLock();
 
 const mockDatabase = {
 	get: () => mockPermissionsCollection,
-	write: <T>(writer: () => Promise<T>) => {
-		const settled = mockWriterQueue.then(writer);
-		mockWriterQueue = settled.catch(() => undefined);
-		return settled as Promise<T>;
-	},
+	write: <T>(writer: () => Promise<T>) => mockWrite(writer),
 	batch: (operations: TBatchOperation[]) => {
 		operations.forEach(operation => {
 			if (operation.type === 'destroy') {
@@ -79,7 +75,7 @@ jest.mock('../database', () => ({
 jest.mock('../store/auxStore', () => ({
 	store: { getState: () => ({ server: { version: '7.0.0' } }), dispatch: jest.fn() }
 }));
-jest.mock('./helpers/log', () => ({ __esModule: true, default: (error: Error) => mockLoggedErrors.push(error) }));
+jest.mock('./helpers/log', () => ({ __esModule: true, default: jest.fn() }));
 
 let mockServerUpdate: IPermission[] = [];
 let mockServerRemove: IPermission[] = [];
@@ -94,10 +90,8 @@ jest.mock('../services/sdk', () => ({
 	}
 }));
 
-const makeServerPermission = (id: string, roles: string[], updatedAt = '2026-01-01T00:00:00.000Z') =>
+const makeServerPermission = (id: string, roles: string[] = [], updatedAt = '2026-01-01T00:00:00.000Z') =>
 	({ _id: id, roles, _updatedAt: updatedAt }) as unknown as IPermission;
-
-const makeRemovedPermission = (id: string) => ({ _id: id }) as unknown as IPermission;
 
 const storedRoles = (id: string) => mockPermissionsTable.get(id)?.roles;
 
@@ -105,16 +99,18 @@ describe('getPermissions', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockPermissionsTable.clear();
-		mockWriterQueue = Promise.resolve();
-		mockLoggedErrors.length = 0;
+		mockWrite = createWriterLock();
 		mockServerUpdate = [makeServerPermission('edit-message', ['admin']), makeServerPermission('mute-user', ['admin'])];
 		mockServerRemove = [];
+	});
+
+	afterEach(() => {
+		expect(log).not.toHaveBeenCalled();
 	});
 
 	it('does not violate the permissions unique constraint when two runs race on an empty database', async () => {
 		await Promise.all([getPermissions(), getPermissions()]);
 
-		expect(mockLoggedErrors).toHaveLength(0);
 		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message', 'mute-user']);
 	});
 
@@ -123,7 +119,6 @@ describe('getPermissions', () => {
 
 		await getPermissions();
 
-		expect(mockLoggedErrors).toHaveLength(0);
 		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message', 'mute-user']);
 		expect(storedRoles('edit-message')).toEqual(['user']);
 	});
@@ -134,7 +129,6 @@ describe('getPermissions', () => {
 
 		await getPermissions();
 
-		expect(mockLoggedErrors).toHaveLength(0);
 		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message', 'mute-user']);
 		expect(storedRoles('edit-message')).toEqual(['owner']);
 	});
@@ -142,22 +136,20 @@ describe('getPermissions', () => {
 	it('deletes permissions the server removed', async () => {
 		await getPermissions();
 		mockServerUpdate = [];
-		mockServerRemove = [makeRemovedPermission('mute-user')];
+		mockServerRemove = [makeServerPermission('mute-user')];
 
 		await getPermissions();
 
-		expect(mockLoggedErrors).toHaveLength(0);
 		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message']);
 	});
 
 	it('recreates a permission the server sends in both remove and update', async () => {
 		await getPermissions();
 		mockServerUpdate = [makeServerPermission('mute-user', ['owner'], '2026-01-02T00:00:00.000Z')];
-		mockServerRemove = [makeRemovedPermission('mute-user')];
+		mockServerRemove = [makeServerPermission('mute-user')];
 
 		await getPermissions();
 
-		expect(mockLoggedErrors).toHaveLength(0);
 		expect(storedRoles('mute-user')).toEqual(['owner']);
 	});
 });

--- a/app/lib/methods/getPermissions.test.ts
+++ b/app/lib/methods/getPermissions.test.ts
@@ -1,0 +1,163 @@
+import { getPermissions } from './getPermissions';
+import type { IPermission } from '../../definitions';
+
+const UNIQUE_CONSTRAINT_ERROR = 'Failed to execute db update - sqlite error 1555 (UNIQUE constraint failed: permissions.id)';
+
+interface IPermissionRow {
+	id: string;
+	roles: string[];
+	_updatedAt: string;
+}
+
+type TPermissionDraft = { _raw: { id: string }; roles: string[]; _updatedAt: string };
+
+type TBatchOperation =
+	| { type: 'create'; model: TPermissionDraft }
+	| { type: 'update'; row: IPermissionRow; apply: (row: IPermissionRow) => void }
+	| { type: 'destroy'; row: IPermissionRow };
+
+const mockPermissionsTable = new Map<string, IPermissionRow>();
+const mockLoggedErrors: Error[] = [];
+
+const makePermissionModel = (row: IPermissionRow) => ({
+	id: row.id,
+	roles: row.roles,
+	_updatedAt: row._updatedAt,
+	prepareUpdate: (apply: (row: IPermissionRow) => void): TBatchOperation => ({ type: 'update', row, apply }),
+	prepareDestroyPermanently: (): TBatchOperation => ({ type: 'destroy', row })
+});
+
+const mockPermissionsCollection = {
+	schema: { columns: {} },
+	query: () => ({ fetch: () => Promise.resolve([...mockPermissionsTable.values()].map(makePermissionModel)) }),
+	prepareCreate: (build: (model: TPermissionDraft) => void): TBatchOperation => {
+		const model: TPermissionDraft = { _raw: { id: '' }, roles: [], _updatedAt: '' };
+		build(model);
+		return { type: 'create', model };
+	}
+};
+
+let mockWriterQueue: Promise<unknown> = Promise.resolve();
+
+const mockDatabase = {
+	get: () => mockPermissionsCollection,
+	write: <T>(writer: () => Promise<T>) => {
+		const settled = mockWriterQueue.then(writer);
+		mockWriterQueue = settled.catch(() => undefined);
+		return settled as Promise<T>;
+	},
+	batch: (operations: TBatchOperation[]) => {
+		operations.forEach(operation => {
+			if (operation.type === 'destroy') {
+				mockPermissionsTable.delete(operation.row.id);
+				return;
+			}
+			if (operation.type === 'update') {
+				operation.apply(operation.row);
+				mockPermissionsTable.set(operation.row.id, operation.row);
+				return;
+			}
+			const { id } = operation.model._raw;
+			if (mockPermissionsTable.has(id)) {
+				throw new Error(UNIQUE_CONSTRAINT_ERROR);
+			}
+			mockPermissionsTable.set(id, { id, roles: operation.model.roles, _updatedAt: operation.model._updatedAt });
+		});
+		return Promise.resolve();
+	}
+};
+
+jest.mock('@nozbe/watermelondb/RawRecord', () => ({ sanitizedRaw: (raw: { id: string }) => raw }));
+jest.mock('../database', () => ({
+	__esModule: true,
+	default: {
+		get active() {
+			return mockDatabase;
+		}
+	}
+}));
+jest.mock('../store/auxStore', () => ({
+	store: { getState: () => ({ server: { version: '7.0.0' } }), dispatch: jest.fn() }
+}));
+jest.mock('./helpers/log', () => ({ __esModule: true, default: (error: Error) => mockLoggedErrors.push(error) }));
+
+let mockServerUpdate: IPermission[] = [];
+let mockServerRemove: IPermission[] = [];
+jest.mock('../services/sdk', () => ({
+	__esModule: true,
+	default: {
+		subscribe: jest.fn(),
+		get: jest.fn(async () => {
+			await new Promise(resolve => setTimeout(resolve, 5));
+			return { success: true, update: mockServerUpdate, remove: mockServerRemove };
+		})
+	}
+}));
+
+const makeServerPermission = (id: string, roles: string[], updatedAt = '2026-01-01T00:00:00.000Z') =>
+	({ _id: id, roles, _updatedAt: updatedAt }) as unknown as IPermission;
+
+const makeRemovedPermission = (id: string) => ({ _id: id }) as unknown as IPermission;
+
+const storedRoles = (id: string) => mockPermissionsTable.get(id)?.roles;
+
+describe('getPermissions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockPermissionsTable.clear();
+		mockWriterQueue = Promise.resolve();
+		mockLoggedErrors.length = 0;
+		mockServerUpdate = [makeServerPermission('edit-message', ['admin']), makeServerPermission('mute-user', ['admin'])];
+		mockServerRemove = [];
+	});
+
+	it('does not violate the permissions unique constraint when two runs race on an empty database', async () => {
+		await Promise.all([getPermissions(), getPermissions()]);
+
+		expect(mockLoggedErrors).toHaveLength(0);
+		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message', 'mute-user']);
+	});
+
+	it('keeps the last entry when the server repeats an _id in one payload', async () => {
+		mockServerUpdate = [...mockServerUpdate, makeServerPermission('edit-message', ['user'], '2026-01-02T00:00:00.000Z')];
+
+		await getPermissions();
+
+		expect(mockLoggedErrors).toHaveLength(0);
+		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message', 'mute-user']);
+		expect(storedRoles('edit-message')).toEqual(['user']);
+	});
+
+	it('persists updated roles across sequential runs', async () => {
+		await getPermissions();
+		mockServerUpdate = [makeServerPermission('edit-message', ['owner'], '2026-01-02T00:00:00.000Z')];
+
+		await getPermissions();
+
+		expect(mockLoggedErrors).toHaveLength(0);
+		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message', 'mute-user']);
+		expect(storedRoles('edit-message')).toEqual(['owner']);
+	});
+
+	it('deletes permissions the server removed', async () => {
+		await getPermissions();
+		mockServerUpdate = [];
+		mockServerRemove = [makeRemovedPermission('mute-user')];
+
+		await getPermissions();
+
+		expect(mockLoggedErrors).toHaveLength(0);
+		expect([...mockPermissionsTable.keys()]).toEqual(['edit-message']);
+	});
+
+	it('recreates a permission the server sends in both remove and update', async () => {
+		await getPermissions();
+		mockServerUpdate = [makeServerPermission('mute-user', ['owner'], '2026-01-02T00:00:00.000Z')];
+		mockServerRemove = [makeRemovedPermission('mute-user')];
+
+		await getPermissions();
+
+		expect(mockLoggedErrors).toHaveLength(0);
+		expect(storedRoles('mute-user')).toEqual(['owner']);
+	});
+});

--- a/app/lib/methods/getPermissions.ts
+++ b/app/lib/methods/getPermissions.ts
@@ -109,10 +109,11 @@ const updatePermissions = async ({ update = [], remove = [] }: { update?: IPermi
 	const permissionsCollection = db.get('permissions');
 
 	const uniqueUpdate = [...new Map(update.map(permission => [permission._id, permission])).values()];
+	const touchedIds = [...remove.map(permission => permission._id), ...uniqueUpdate.map(permission => permission._id)];
 
 	try {
 		await db.write(async () => {
-			const allRecords = (await permissionsCollection.query().fetch()) as TPermissionModel[];
+			const allRecords = (await permissionsCollection.query(Q.where('id', Q.oneOf(touchedIds))).fetch()) as TPermissionModel[];
 			const recordById = new Map(allRecords.map(record => [record.id, record]));
 			const batch: TPermissionModel[] = [];
 
@@ -125,24 +126,17 @@ const updatePermissions = async ({ update = [], remove = [] }: { update?: IPermi
 			});
 
 			uniqueUpdate.forEach(permission => {
+				const assign = (p: TPermissionModel) => Object.assign(p, permission);
 				const record = recordById.get(permission._id);
-				if (record) {
-					batch.push(
-						record.prepareUpdate(
-							protectedFunction((p: TPermissionModel) => {
-								Object.assign(p, permission);
-							})
-						)
-					);
-					return;
-				}
 				batch.push(
-					permissionsCollection.prepareCreate(
-						protectedFunction((p: TPermissionModel) => {
-							p._raw = sanitizedRaw({ id: permission._id }, permissionsCollection.schema);
-							Object.assign(p, permission);
-						})
-					)
+					record
+						? record.prepareUpdate(protectedFunction(assign))
+						: permissionsCollection.prepareCreate(
+								protectedFunction((p: TPermissionModel) => {
+									p._raw = sanitizedRaw({ id: permission._id }, permissionsCollection.schema);
+									assign(p);
+								})
+							)
 				);
 			});
 
@@ -158,9 +152,6 @@ export function getPermissions(): Promise<void> {
 	return new Promise(async resolve => {
 		try {
 			const serverVersion: string | null = reduxStore.getState().server.version;
-			const db = database.active;
-			const permissionsCollection = db.get('permissions');
-			const allRecords = await permissionsCollection.query().fetch();
 			sdk.subscribe('stream-notify-logged', 'permissions-changed');
 			// if server version is lower than 0.73.0, fetches from old api
 			if (serverVersion && compareServerVersion(serverVersion, 'lowerThan', '0.73.0')) {
@@ -178,6 +169,7 @@ export function getPermissions(): Promise<void> {
 			}
 
 			const params: { updatedSince?: string } = {};
+			const allRecords = (await database.active.get('permissions').query().fetch()) as TPermissionModel[];
 			const updatedSince = getUpdatedSince(allRecords);
 			if (updatedSince) {
 				params.updatedSince = updatedSince;

--- a/app/lib/methods/getPermissions.ts
+++ b/app/lib/methods/getPermissions.ts
@@ -101,56 +101,51 @@ const getUpdatedSince = (allRecords: TPermissionModel[]) => {
 	return null;
 };
 
-const updatePermissions = async ({
-	update = [],
-	remove = [],
-	allRecords
-}: {
-	update?: IPermission[];
-	remove?: IPermission[];
-	allRecords: TPermissionModel[];
-}) => {
-	if (!((update && update.length) || (remove && remove.length))) {
+const updatePermissions = async ({ update = [], remove = [] }: { update?: IPermission[]; remove?: IPermission[] }) => {
+	if (!(update.length || remove.length)) {
 		return;
 	}
 	const db = database.active;
 	const permissionsCollection = db.get('permissions');
 
-	const batch: TPermissionModel[] = [];
-
-	// Delete
-	if (remove?.length) {
-		const filteredPermissionsToDelete = allRecords.filter(i1 => remove.find(i2 => i1.id === i2._id));
-		const permissionsToDelete = filteredPermissionsToDelete.map(permission => permission.prepareDestroyPermanently());
-		batch.push(...permissionsToDelete);
-	}
-
-	// Create or update
-	if (update?.length) {
-		const filteredPermissionsToCreate = update.filter(i1 => !allRecords.find(i2 => i1._id === i2.id));
-		const filteredPermissionsToUpdate = allRecords.filter(i1 => update.find(i2 => i1.id === i2._id));
-		const permissionsToCreate = filteredPermissionsToCreate.map(permission =>
-			permissionsCollection.prepareCreate(
-				protectedFunction((p: TPermissionModel) => {
-					p._raw = sanitizedRaw({ id: permission._id }, permissionsCollection.schema);
-					Object.assign(p, permission);
-				})
-			)
-		);
-		const permissionsToUpdate = filteredPermissionsToUpdate.map(permission => {
-			const newPermission = update.find(p => p._id === permission.id);
-			return permission.prepareUpdate(
-				protectedFunction((p: TPermissionModel) => {
-					Object.assign(p, newPermission);
-				})
-			);
-		});
-
-		batch.push(...permissionsToCreate, ...permissionsToUpdate);
-	}
+	const uniqueUpdate = [...new Map(update.map(permission => [permission._id, permission])).values()];
 
 	try {
 		await db.write(async () => {
+			const allRecords = (await permissionsCollection.query().fetch()) as TPermissionModel[];
+			const recordById = new Map(allRecords.map(record => [record.id, record]));
+			const batch: TPermissionModel[] = [];
+
+			remove.forEach(permission => {
+				const record = recordById.get(permission._id);
+				if (record) {
+					batch.push(record.prepareDestroyPermanently());
+					recordById.delete(permission._id);
+				}
+			});
+
+			uniqueUpdate.forEach(permission => {
+				const record = recordById.get(permission._id);
+				if (record) {
+					batch.push(
+						record.prepareUpdate(
+							protectedFunction((p: TPermissionModel) => {
+								Object.assign(p, permission);
+							})
+						)
+					);
+					return;
+				}
+				batch.push(
+					permissionsCollection.prepareCreate(
+						protectedFunction((p: TPermissionModel) => {
+							p._raw = sanitizedRaw({ id: permission._id }, permissionsCollection.schema);
+							Object.assign(p, permission);
+						})
+					)
+				);
+			});
+
 			await db.batch(batch);
 		});
 		return true;
@@ -175,7 +170,7 @@ export function getPermissions(): Promise<void> {
 				if (!result.success) {
 					return resolve();
 				}
-				const changePermissions = await updatePermissions({ update: result.permissions, allRecords });
+				const changePermissions = await updatePermissions({ update: result.permissions });
 				if (changePermissions) {
 					setPermissions();
 				}
@@ -194,7 +189,7 @@ export function getPermissions(): Promise<void> {
 				return resolve();
 			}
 
-			const changePermissions = await updatePermissions({ update: result.update, remove: result.remove, allRecords });
+			const changePermissions = await updatePermissions({ update: result.update, remove: result.remove });
 			if (changePermissions) {
 				setPermissions();
 			}


### PR DESCRIPTION
## Proposed changes

`getPermissions` fetched the existing permission records *before* awaiting the server response, then decided outside any write transaction which ids needed `prepareCreate`. Two concurrent runs could each read an empty (or stale) set, both conclude the same id was missing, and both try to insert it, producing:

```
Failed to execute db update - sqlite error 1555 (UNIQUE constraint failed: permissions.id)
```

Two independent causes, both fixed:

1. **Read/decide/write was not atomic.** The `query().fetch()` that decides create-vs-update now runs *inside* `db.write`. WatermelonDB serializes writers through its `WorkQueue`, so a second run observes the rows the first one inserted and emits updates instead of duplicate creates.
2. **A single payload could repeat an `_id`.** `permissions.listAll` can return the same `_id` more than once in one `update` array, which produced two `prepareCreate` ops in the same batch. The update list is now deduplicated by `_id`, keeping the last entry (newest-wins, matching sync semantics).

The `allRecords` parameter was dropped from `updatePermissions` since it now reads its own snapshot inside the transaction. `getPermissions` still fetches `allRecords` for `getUpdatedSince`, which is unchanged.

The filter/`find` scans were replaced with a `Map` lookup while restructuring, turning the O(n·m) diff into O(n).

Note this is collision *tolerance*, not collision *avoidance*: two concurrent runs can still compute the same `updatedSince` and fetch overlapping payloads. The write-scoped read absorbs that harmlessly.

## Issue(s)

No tracker issue.

## How to test or reproduce

Covered by the new unit tests in `app/lib/methods/getPermissions.test.ts`:

- Two concurrent `getPermissions()` calls against an empty database
- A server payload repeating the same `_id`
- Roles persisting across sequential runs
- A permission the server removed being deleted
- An id present in both `remove` and `update` (destroy then recreate, so the update wins)

Run with `TZ=UTC npx jest app/lib/methods/getPermissions.test.ts`. The first two tests fail against the pre-fix code with the real 1555 message and pass after; the other three pass on both sides as state guards.

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The tests mock `database.active` with an in-memory double rather than using LokiJS, because the bug depends on WatermelonDB's writer serialization and on SQLite's UNIQUE constraint — the mock reproduces both (`write` chains onto a queue; `batch` throws 1555 on a duplicate id and applies operations in array order).

One consequence of the restructure worth calling out: an id appearing in both `remove` and `update` is now destroyed and recreated, rather than being prepared twice. Since `listAll` returns both arrays from the same window, the `update` entry carries current server state and should win — which is what this produces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission synchronization to prevent duplicate-record conflicts during concurrent updates.
  * Ensured repeated permission updates retain the latest roles.
  * Preserved roles across sequential synchronization runs.
  * Removed permissions that are no longer provided by the server.
  * Correctly recreates permissions when removal and update instructions arrive together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->