### PR TITLE
fix: five room screen and message module defects

### DIFF
--- a/app/containers/ThreadDetails.tsx
+++ b/app/containers/ThreadDetails.tsx
@@ -86,11 +86,13 @@ const ThreadDetails = ({ item, user, badgeColor, toggleFollowThread, style }: IT
 			</View>
 			<View style={styles.badgeContainer}>
 				{badgeColor ? <View style={[styles.badge, { backgroundColor: badgeColor }]} /> : null}
-				<Touch
-					accessibilityLabel={i18n.t(isFollowing ? 'Unfollow_thread' : 'Follow_thread')}
-					onPress={() => toggleFollowThread?.(isFollowing, item.id)}>
-					<CustomIcon size={24} name={isFollowing ? 'notification' : 'notification-disabled'} />
-				</Touch>
+				{toggleFollowThread ? (
+					<Touch
+						accessibilityLabel={i18n.t(isFollowing ? 'Unfollow_thread' : 'Follow_thread')}
+						onPress={() => toggleFollowThread(isFollowing, item.id)}>
+						<CustomIcon size={24} name={isFollowing ? 'notification' : 'notification-disabled'} />
+					</Touch>
+				) : null}
 			</View>
 		</View>
 	);

--- a/app/containers/message/components/Reactions.tsx
+++ b/app/containers/message/components/Reactions.tsx
@@ -76,16 +76,21 @@ const Reaction = ({ reaction }: IMessageReaction) => {
 
 const Reactions = () => {
 	const reactions = useReactions();
+	const onReactionPress = useOnReactionPress();
+	const reactionInit = useReactionInit();
 
 	if (!Array.isArray(reactions) || reactions.length === 0) {
 		return null;
 	}
+
+	if (!onReactionPress && !reactionInit) {
+		return null;
+	}
+
 	return (
 		<View style={styles.reactionsContainer}>
-			{reactions.map(reaction => (
-				<Reaction key={reaction.emoji} reaction={reaction} />
-			))}
-			<AddReaction />
+			{onReactionPress ? reactions.map(reaction => <Reaction key={reaction.emoji} reaction={reaction} />) : null}
+			{reactionInit ? <AddReaction /> : null}
 		</View>
 	);
 };

--- a/app/containers/message/components/RepliedThread.tsx
+++ b/app/containers/message/components/RepliedThread.tsx
@@ -20,17 +20,15 @@ const RepliedThread = ({ isHeader }: IMessageRepliedThread) => {
 	const [fetchedName, setFetchedName] = useState<string | undefined>();
 
 	useEffect(() => {
-		if (displayMsg || !tmid) {
+		if (displayMsg || !tmid || !fetchThreadName) {
 			return;
 		}
 		let ignore = false;
-		const fetch = async () => {
-			const threadName = fetchThreadName ? await fetchThreadName(tmid, id) : '';
+		fetchThreadName(tmid, id).then(threadName => {
 			if (!ignore) {
-				setFetchedName(threadName);
+				setFetchedName(threadName ?? '');
 			}
-		};
-		fetch();
+		});
 		return () => {
 			ignore = true;
 		};
@@ -40,11 +38,13 @@ const RepliedThread = ({ isHeader }: IMessageRepliedThread) => {
 		return null;
 	}
 
-	const msg = displayMsg || fetchedName;
+	const isFetchingName = !!fetchThreadName && !displayMsg && fetchedName === undefined;
 
-	if (!msg) {
+	if (isFetchingName) {
 		return null;
 	}
+
+	const msg = displayMsg || fetchedName || I18n.t('Thread');
 
 	return (
 		<View style={styles.repliedThread} testID={`message-thread-replied-on-${msg}`}>

--- a/app/containers/message/components/RepliedThread.tsx
+++ b/app/containers/message/components/RepliedThread.tsx
@@ -24,11 +24,17 @@ const RepliedThread = ({ isHeader }: IMessageRepliedThread) => {
 			return;
 		}
 		let ignore = false;
-		fetchThreadName(tmid, id).then(threadName => {
-			if (!ignore) {
-				setFetchedName(threadName ?? '');
-			}
-		});
+		fetchThreadName(tmid, id)
+			.then(threadName => {
+				if (!ignore) {
+					setFetchedName(threadName ?? '');
+				}
+			})
+			.catch(() => {
+				if (!ignore) {
+					setFetchedName('');
+				}
+			});
 		return () => {
 			ignore = true;
 		};

--- a/app/containers/message/components/RightIcons/Encrypted.tsx
+++ b/app/containers/message/components/RightIcons/Encrypted.tsx
@@ -10,12 +10,16 @@ const Encrypted = () => {
 	const onEncryptedPress = useOnEncryptedPress();
 	const type = useMessageField(item => item.t);
 
-	if (type !== E2E_MESSAGE_TYPE) {
+	if (type !== E2E_MESSAGE_TYPE || !onEncryptedPress) {
 		return null;
 	}
 
 	return (
-		<MessageActionTouchable onPress={onEncryptedPress} style={styles.rightIcons} hitSlop={BUTTON_HIT_SLOP}>
+		<MessageActionTouchable
+			onPress={onEncryptedPress}
+			testID='message-encrypted'
+			style={styles.rightIcons}
+			hitSlop={BUTTON_HIT_SLOP}>
 			<CustomIcon name='encrypted' size={16} />
 		</MessageActionTouchable>
 	);

--- a/app/containers/message/components/__tests__/Encrypted.test.tsx
+++ b/app/containers/message/components/__tests__/Encrypted.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react-native';
+
+import Encrypted from '../RightIcons/Encrypted';
+import { MessageProviders } from '../../__tests__/testHelpers';
+import { E2E_MESSAGE_TYPE, E2E_STATUS } from '../../../../lib/constants/keys';
+import { type TAnyMessageModel } from '../../../../definitions';
+
+const encryptedItem = {
+	id: 'msg1',
+	t: E2E_MESSAGE_TYPE,
+	e2e: E2E_STATUS.PENDING
+} as unknown as TAnyMessageModel;
+
+describe('Encrypted', () => {
+	test('renders the affordance when an encrypted-press handler was supplied', () => {
+		const { getByTestId } = render(
+			<MessageProviders item={encryptedItem} room={{ handlers: { onEncryptedPress: jest.fn() } }}>
+				<Encrypted />
+			</MessageProviders>
+		);
+
+		expect(getByTestId('message-encrypted')).toBeTruthy();
+	});
+
+	test('renders nothing when no encrypted-press handler was supplied', () => {
+		const { queryByTestId } = render(
+			<MessageProviders item={encryptedItem} room={{ handlers: {} }}>
+				<Encrypted />
+			</MessageProviders>
+		);
+
+		expect(queryByTestId('message-encrypted')).toBeNull();
+	});
+});

--- a/app/containers/message/components/__tests__/Reactions.test.tsx
+++ b/app/containers/message/components/__tests__/Reactions.test.tsx
@@ -112,3 +112,16 @@ it('should remove reaction', () => {
 	expect(queryByTestId('message-reaction-:thumbsup:')).toBeNull();
 	expect(getByTestId('message-add-reaction')).toBeTruthy();
 });
+
+it('renders nothing when neither a reaction handler nor a reaction initializer was supplied', () => {
+	const item = buildItem([{ _id: '1', emoji: '👍', usernames: ['john'], names: [] }]);
+
+	const { queryByTestId } = render(
+		<MessageProviders item={item} room={{ handlers: {} }}>
+			<Reactions />
+		</MessageProviders>
+	);
+
+	expect(queryByTestId('message-reaction-👍')).toBeNull();
+	expect(queryByTestId('message-add-reaction')).toBeNull();
+});

--- a/app/containers/message/components/__tests__/Reactions.test.tsx
+++ b/app/containers/message/components/__tests__/Reactions.test.tsx
@@ -125,3 +125,29 @@ it('renders nothing when neither a reaction handler nor a reaction initializer w
 	expect(queryByTestId('message-reaction-👍')).toBeNull();
 	expect(queryByTestId('message-add-reaction')).toBeNull();
 });
+
+it('renders the reaction chips but no add-reaction button when only a reaction handler was supplied', () => {
+	const item = buildItem([{ _id: '1', emoji: '👍', usernames: ['john'], names: [] }]);
+
+	const { getByTestId, queryByTestId } = render(
+		<MessageProviders item={item} room={{ handlers: { onReactionPress: jest.fn() } }}>
+			<Reactions />
+		</MessageProviders>
+	);
+
+	expect(getByTestId('message-reaction-👍')).toBeTruthy();
+	expect(queryByTestId('message-add-reaction')).toBeNull();
+});
+
+it('renders the add-reaction button but no chips when only a reaction initializer was supplied', () => {
+	const item = buildItem([{ _id: '1', emoji: '👍', usernames: ['john'], names: [] }]);
+
+	const { getByTestId, queryByTestId } = render(
+		<MessageProviders item={item} room={{ reactionInit: jest.fn(), handlers: {} }}>
+			<Reactions />
+		</MessageProviders>
+	);
+
+	expect(queryByTestId('message-reaction-👍')).toBeNull();
+	expect(getByTestId('message-add-reaction')).toBeTruthy();
+});

--- a/app/containers/message/components/__tests__/RepliedThread.test.tsx
+++ b/app/containers/message/components/__tests__/RepliedThread.test.tsx
@@ -88,4 +88,12 @@ describe('RepliedThread', () => {
 
 		expect(getByTestId('message-thread-replied-on-Thread')).toBeTruthy();
 	});
+
+	test('falls back to a generic thread header when the fetch rejects', async () => {
+		const fetchThreadName = jest.fn().mockRejectedValue(new Error('offline'));
+		const item = buildItem({ tmsg: undefined });
+		const { getByTestId } = renderRepliedThread(item, fetchThreadName);
+
+		await waitFor(() => expect(getByTestId('message-thread-replied-on-Thread')).toBeTruthy());
+	});
 });

--- a/app/containers/message/components/__tests__/RepliedThread.test.tsx
+++ b/app/containers/message/components/__tests__/RepliedThread.test.tsx
@@ -81,4 +81,11 @@ describe('RepliedThread', () => {
 
 		expect(getByTestId('message-thread-replied-on-second reply')).toBeTruthy();
 	});
+
+	test('falls back to a generic thread header when no fetchThreadName handler was supplied', () => {
+		const item = buildItem({ tmsg: undefined });
+		const { getByTestId } = renderRepliedThread(item);
+
+		expect(getByTestId('message-thread-replied-on-Thread')).toBeTruthy();
+	});
 });

--- a/app/containers/message/components/__tests__/Thread.test.tsx
+++ b/app/containers/message/components/__tests__/Thread.test.tsx
@@ -46,3 +46,28 @@ describe('Thread — tlm-only update regression', () => {
 		expect(getByTestId('message-thread-button-hello')).toBeTruthy();
 	});
 });
+
+describe('Thread — follow affordance gating', () => {
+	const renderWithHandlers = (handlers: Partial<MessageRoomState['handlers']>) =>
+		render(
+			<Provider store={mockedStore}>
+				<MessageRoomProvider handlers={handlers}>
+					<MessageProvider item={buildItem({ tlm: new Date('2024-01-01T00:00:00Z') })}>
+						<Thread />
+					</MessageProvider>
+				</MessageRoomProvider>
+			</Provider>
+		);
+
+	test('shows the follow toggle when a toggleFollowThread handler was supplied', () => {
+		const { getByLabelText } = renderWithHandlers({ toggleFollowThread: jest.fn(), onThreadPress: jest.fn() });
+
+		expect(getByLabelText('Follow thread')).toBeTruthy();
+	});
+
+	test('hides the follow toggle when no toggleFollowThread handler was supplied', () => {
+		const { queryByLabelText } = renderWithHandlers({ onThreadPress: jest.fn() });
+
+		expect(queryByLabelText('Follow thread')).toBeNull();
+	});
+});

--- a/app/containers/message/components/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/app/containers/message/components/__tests__/__snapshots__/Message.test.tsx.snap
@@ -40040,6 +40040,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -40325,6 +40326,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -40770,6 +40772,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -42122,6 +42125,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -42610,6 +42614,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -43013,6 +43018,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -43569,6 +43575,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -43884,6 +43891,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -44350,6 +44358,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -44657,6 +44666,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -45080,6 +45090,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -46432,6 +46443,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -46920,6 +46932,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -47323,6 +47336,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -47879,6 +47893,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -48216,6 +48231,7 @@ exports[`Story Snapshots: EncryptedLargeFont should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -71295,6 +71311,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -72702,6 +72719,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -73135,6 +73153,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -73709,6 +73728,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -74283,6 +74303,7 @@ exports[`Story Snapshots: LongNameUser should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -76350,6 +76371,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -77757,6 +77779,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
                             "paddingLeft": 5,
                           }
                         }
+                        testID="message-encrypted"
                       >
                         <Text
                           allowFontScaling={false}
@@ -78190,6 +78213,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -78764,6 +78788,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -79338,6 +79363,7 @@ exports[`Story Snapshots: LongNameUserLargeFont should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -112643,6 +112669,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -113696,6 +113723,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -114749,6 +114777,7 @@ exports[`Story Snapshots: Names should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -155997,6 +156026,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -157050,6 +157080,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}
@@ -158103,6 +158134,7 @@ exports[`Story Snapshots: Usernames should match snapshot 1`] = `
                       "paddingLeft": 5,
                     }
                   }
+                  testID="message-encrypted"
                 >
                   <Text
                     allowFontScaling={false}

--- a/app/containers/message/components/stories/Message.stories.tsx
+++ b/app/containers/message/components/stories/Message.stories.tsx
@@ -87,7 +87,15 @@ const containerHandlers = {
 const roomHandlers: Partial<MessageRoomState> = {
 	reactionInit: () => {},
 	jumpToMessage: () => {},
-	handlers: { navToRoomInfo: () => {}, showAttachment: undefined }
+	handlers: {
+		navToRoomInfo: () => {},
+		showAttachment: undefined,
+		onEncryptedPress: () => {},
+		onReactionPress: async () => {},
+		onReactionLongPress: () => {},
+		onThreadPress: () => {},
+		toggleFollowThread: async () => {}
+	}
 };
 
 export default {

--- a/app/containers/message/components/stories/Reactions.stories.tsx
+++ b/app/containers/message/components/stories/Reactions.stories.tsx
@@ -23,7 +23,8 @@ const item = {
 } as unknown as TAnyMessageModel;
 
 const room: Partial<MessageRoomState> = {
-	reactionInit: () => {}
+	reactionInit: () => {},
+	handlers: { onReactionPress: async () => {}, onReactionLongPress: () => {} }
 };
 
 const StoryWrapper = ({ children }: { children: ReactNode }) => (

--- a/app/containers/message/components/stories/RightIcons/Encrypted.stories.tsx
+++ b/app/containers/message/components/stories/RightIcons/Encrypted.stories.tsx
@@ -26,7 +26,9 @@ const plainItem = {
 	autoTranslate: false
 } as unknown as TAnyMessageModel;
 
-const room: Partial<MessageRoomState> = {};
+const room: Partial<MessageRoomState> = {
+	handlers: { onEncryptedPress: () => {} }
+};
 
 const StoryWrapper = ({ item, children }: { item: TAnyMessageModel; children: ReactNode }) => (
 	<Provider store={store}>

--- a/app/containers/message/components/stories/Thread.stories.tsx
+++ b/app/containers/message/components/stories/Thread.stories.tsx
@@ -22,7 +22,8 @@ const item = {
 } as unknown as TAnyMessageModel;
 
 const room: Partial<MessageRoomState> = {
-	isThreadRoom: false
+	isThreadRoom: false,
+	handlers: { onThreadPress: () => {}, toggleFollowThread: async () => {} }
 };
 
 const StoryWrapper = ({ children }: { children: ReactNode }) => (

--- a/app/containers/message/components/stories/__tests__/__snapshots__/leaves.test.tsx.snap
+++ b/app/containers/message/components/stories/__tests__/__snapshots__/leaves.test.tsx.snap
@@ -768,6 +768,7 @@ exports[`Story Snapshots: Encrypted should match snapshot 1`] = `
       "paddingLeft": 5,
     }
   }
+  testID="message-encrypted"
 >
   <Text
     allowFontScaling={false}

--- a/app/views/MessagesView/__tests__/index.test.tsx
+++ b/app/views/MessagesView/__tests__/index.test.tsx
@@ -1,0 +1,74 @@
+import { render, waitFor } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { type ReactNode } from 'react';
+import { SafeAreaFrameContext, SafeAreaInsetsContext } from 'react-native-safe-area-context';
+
+import MessagesView from '..';
+import Navigation from '../../../lib/navigation/appNavigation';
+import { getPinnedMessages } from '../../../lib/services/restApi';
+import { mockedStore } from '../../../reducers/mockedStore';
+import { type MessageRoomState } from '../../../containers/message/stores/MessageRoomStore';
+
+jest.mock('../../../lib/services/restApi', () => ({
+	getPinnedMessages: jest.fn(),
+	getMessages: jest.fn(),
+	getFiles: jest.fn(),
+	togglePinMessage: jest.fn(),
+	toggleStarMessage: jest.fn()
+}));
+
+jest.mock('../../../lib/navigation/appNavigation', () => ({
+	__esModule: true,
+	default: { popToRoom: jest.fn(), setParams: jest.fn(), push: jest.fn() }
+}));
+
+let capturedRoomState: Partial<MessageRoomState> | undefined;
+
+jest.mock('../../../containers/message/stores/MessageRoomStore', () => {
+	const actual = jest.requireActual('../../../containers/message/stores/MessageRoomStore');
+	return {
+		...actual,
+		MessageRoomProvider: ({ children, ...state }: { children: ReactNode } & Partial<MessageRoomState>) => {
+			capturedRoomState = state;
+			return <actual.MessageRoomProvider {...state}>{children}</actual.MessageRoomProvider>;
+		}
+	};
+});
+
+const renderMessagesView = () =>
+	render(
+		<Provider store={mockedStore}>
+			<SafeAreaFrameContext.Provider value={{ x: 0, y: 0, width: 390, height: 844 }}>
+				<SafeAreaInsetsContext.Provider value={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+					<MessagesView
+						navigation={{ setOptions: jest.fn(), navigate: jest.fn() } as any}
+						route={{ params: { rid: 'rid-1', t: 'c', name: 'Pinned' } } as any}
+					/>
+				</SafeAreaInsetsContext.Provider>
+			</SafeAreaFrameContext.Provider>
+		</Provider>
+	);
+
+describe('MessagesView', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		capturedRoomState = undefined;
+		(getPinnedMessages as jest.Mock).mockResolvedValue({
+			success: true,
+			messages: [{ _id: 'msg-1', msg: 'pinned', u: { _id: 'u1', username: 'john' }, ts: new Date() }],
+			total: 1
+		});
+	});
+
+	test('jumps in-app for an in-server message link instead of opening a browser', async () => {
+		renderMessagesView();
+
+		await waitFor(() => expect(capturedRoomState?.rid).toBe('rid-1'));
+
+		expect(capturedRoomState?.jumpToMessage).toBeDefined();
+
+		capturedRoomState?.jumpToMessage?.('https://open.rocket.chat/channel/general?msg=msg-1');
+
+		expect(Navigation.setParams).toHaveBeenCalledWith({ rid: 'rid-1', jumpToMessageId: 'msg-1', t: 'c' });
+	});
+});

--- a/app/views/MessagesView/__tests__/index.test.tsx
+++ b/app/views/MessagesView/__tests__/index.test.tsx
@@ -8,6 +8,7 @@ import Navigation from '../../../lib/navigation/appNavigation';
 import { getPinnedMessages } from '../../../lib/services/restApi';
 import { mockedStore } from '../../../reducers/mockedStore';
 import { type MessageRoomState } from '../../../containers/message/stores/MessageRoomStore';
+import { SubscriptionType } from '../../../definitions';
 
 jest.mock('../../../lib/services/restApi', () => ({
 	getPinnedMessages: jest.fn(),
@@ -42,7 +43,7 @@ const renderMessagesView = () =>
 				<SafeAreaInsetsContext.Provider value={{ top: 0, right: 0, bottom: 0, left: 0 }}>
 					<MessagesView
 						navigation={{ setOptions: jest.fn(), navigate: jest.fn() } as any}
-						route={{ params: { rid: 'rid-1', t: 'c', name: 'Pinned' } } as any}
+						route={{ params: { rid: 'rid-1', t: SubscriptionType.CHANNEL, name: 'Pinned' } } as any}
 					/>
 				</SafeAreaInsetsContext.Provider>
 			</SafeAreaFrameContext.Provider>

--- a/app/views/MessagesView/index.tsx
+++ b/app/views/MessagesView/index.tsx
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import { FlatList, Text, View } from 'react-native';
 import { connect } from 'react-redux';
 import { dequal } from 'dequal';
+import parse from 'url-parse';
 import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { type CompositeNavigationProp, type RouteProp } from '@react-navigation/core';
 import { type EdgeInsets, withSafeAreaInsets } from 'react-native-safe-area-context';
@@ -36,6 +37,7 @@ import { type TNavigation } from '../../stacks/stackType';
 import AudioManager from '../../lib/methods/AudioManager';
 import { Encryption } from '../../lib/encryption';
 import Navigation from '../../lib/navigation/appNavigation';
+import log from '../../lib/methods/helpers/log';
 import { withMasterDetail } from '../../lib/hooks/useMasterDetail';
 
 interface IMessagesViewProps {
@@ -152,6 +154,24 @@ class MessagesView extends Component<IMessagesViewProps, IMessagesViewState> {
 		} else {
 			Navigation.popToRoom(isMasterDetail);
 			Navigation.setParams(params);
+		}
+	};
+
+	jumpToMessageByUrl = (messageUrl: string) => {
+		try {
+			const messageId = parse(messageUrl, true).query.msg;
+			if (!messageId) {
+				return;
+			}
+			const { isMasterDetail } = this.props;
+			Navigation.popToRoom(isMasterDetail);
+			Navigation.setParams({
+				rid: this.rid,
+				jumpToMessageId: messageId,
+				t: this.t
+			});
+		} catch (e) {
+			log(e);
 		}
 	};
 
@@ -341,7 +361,12 @@ class MessagesView extends Component<IMessagesViewProps, IMessagesViewState> {
 		return (
 			<SafeAreaView style={{ backgroundColor: themes[theme].surfaceRoom }} testID={this.content.testID}>
 				<A11yGateProvider>
-					<MessageRoomProvider handlers={this.messageHandlers} rid={this.rid} isThreadRoom timeFormat={'MMM Do YYYY, h:mm:ss a'}>
+					<MessageRoomProvider
+						handlers={this.messageHandlers}
+						jumpToMessage={this.jumpToMessageByUrl}
+						rid={this.rid}
+						isThreadRoom
+						timeFormat={'MMM Do YYYY, h:mm:ss a'}>
 						<FlatList
 							data={messages}
 							renderItem={this.renderItem}

--- a/app/views/RoomView/components/RoomMessageHandlersBridge.tsx
+++ b/app/views/RoomView/components/RoomMessageHandlersBridge.tsx
@@ -1,15 +1,19 @@
 import { useContext, useEffect, type ReactElement, type ReactNode } from 'react';
 
 import { MessageRoomStoreContext } from '../../../containers/message/stores/MessageRoomStore';
+import { type IUseRoomMessageHandlersParams } from '../definitions';
 import { useRoomMessageHandlers } from '../hooks/useRoomMessageHandlers';
 
-// Produces the message handler bag once inside RoomView (below RoomStoreContext + MessageActionStore)
-// and publishes it into MessageRoomStore. Leaves read it through fine-grained selectors, so the
-// container -> views import inversion is gone. Published in the reactive tail (not FROZEN_KEYS): the
-// bag closes over rid/room/roomUserId/navigation/tmid, which shift when a thread reuses the mount.
-export const RoomMessageHandlersBridge = ({ children }: { children: ReactNode }): ReactElement => {
+// Produces the message handler bag once inside RoomView (below RoomStoreContext) and publishes it
+// into MessageRoomStore. Leaves read it through fine-grained selectors, so the container -> views
+// import inversion is gone. Published in the reactive tail (not FROZEN_KEYS): the bag closes over
+// rid/room/navigation/tmid, which shift when a thread reuses the mount.
+export const RoomMessageHandlersBridge = ({
+	children,
+	...handlerParams
+}: { children: ReactNode } & IUseRoomMessageHandlersParams): ReactElement => {
 	const store = useContext(MessageRoomStoreContext);
-	const handlers = useRoomMessageHandlers();
+	const handlers = useRoomMessageHandlers(handlerParams);
 
 	useEffect(() => {
 		store?.setState({ handlers });

--- a/app/views/RoomView/components/RoomMessageHandlersBridge.tsx
+++ b/app/views/RoomView/components/RoomMessageHandlersBridge.tsx
@@ -4,10 +4,8 @@ import { MessageRoomStoreContext } from '../../../containers/message/stores/Mess
 import { type IUseRoomMessageHandlersParams } from '../definitions';
 import { useRoomMessageHandlers } from '../hooks/useRoomMessageHandlers';
 
-// Produces the message handler bag once inside RoomView (below RoomStoreContext) and publishes it
-// into MessageRoomStore. Leaves read it through fine-grained selectors, so the container -> views
-// import inversion is gone. Published in the reactive tail (not FROZEN_KEYS): the bag closes over
-// rid/room/navigation/tmid, which shift when a thread reuses the mount.
+// Published in the reactive tail (not FROZEN_KEYS): the bag closes over rid/room/navigation/tmid,
+// which shift when a thread reuses the mount.
 export const RoomMessageHandlersBridge = ({
 	children,
 	...handlerParams

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -11,6 +11,7 @@ import {
 	type ILoggedUser,
 	type IMessage,
 	type IMessageEditAttachment,
+	type IUseRoomMessageHandlersResult,
 	type IVisitor,
 	type RoomType,
 	type TAnyMessageModel,
@@ -336,6 +337,12 @@ export interface IUseRoomNavigationParams {
 	isMasterDetail: boolean;
 	listRef: RefObject<IListContainerRef | null>;
 	roomUserIdRef: RefObject<string | null | undefined>;
+}
+
+export interface IUseRoomMessageHandlersParams {
+	onThreadPress: IUseRoomMessageHandlersResult['onThreadPress'];
+	onReactionPress: IUseRoomMessageHandlersResult['onReactionPress'];
+	onAnswerButtonPress: IUseRoomMessageHandlersResult['onAnswerButtonPress'];
 }
 
 export interface IUseRoomNavigationResult {

--- a/app/views/RoomView/hooks/__tests__/useRoomMessageHandlers.test.tsx
+++ b/app/views/RoomView/hooks/__tests__/useRoomMessageHandlers.test.tsx
@@ -1,16 +1,10 @@
 import { act, renderHook } from '@testing-library/react-native';
 import { createStore } from 'zustand';
 
-import { setReaction, toggleFollowMessage } from '../../../../lib/services/restApi';
+import { toggleFollowMessage } from '../../../../lib/services/restApi';
 import { replyBroadcast as replyBroadcastAction } from '../../../../actions/messages';
-import log from '../../../../lib/methods/helpers/log';
-import { Review } from '../../../../lib/methods/helpers/review';
-import { sendMessage } from '../../../../lib/methods/sendMessage';
-import { getUserSelector } from '../../../../selectors/login';
-import { type RoomState, type RoomStore } from '../../definitions';
+import { type RoomState, type RoomStore, type IUseRoomMessageHandlersParams } from '../../definitions';
 import { RoomStoreContext } from '../../stores/RoomStoreContext';
-import { RoomScreenContext } from '../../stores/RoomScreenContext';
-import { createMessageActionStore, MessageActionStoreContext } from '../../../../containers/message/stores/MessageActionStore';
 import { MessageRoomProvider } from '../../../../containers/message/stores/MessageRoomStore';
 import { useRoomMessageHandlers } from '../useRoomMessageHandlers';
 
@@ -23,14 +17,10 @@ jest.mock('react-redux', () => ({
 jest.mock('../../../../lib/hooks/useMasterDetail', () => ({
 	useMasterDetail: jest.fn(() => false)
 }));
-jest.mock('../../../../lib/hooks/useAppSelector', () => ({
-	useAppSelector: jest.fn()
-}));
 jest.mock('../../../../containers/ActionSheet', () => ({
 	useActionSheet: () => ({ showActionSheet: mockShowActionSheet, hideActionSheet: mockHideActionSheet })
 }));
 jest.mock('../../../../lib/services/restApi', () => ({
-	setReaction: jest.fn(),
 	toggleFollowMessage: jest.fn()
 }));
 jest.mock('../../../../actions/messages', () => ({
@@ -41,12 +31,6 @@ jest.mock('../../../../lib/methods/helpers/log', () => ({
 	...jest.requireActual('../../../../lib/methods/helpers/log'),
 	default: jest.fn(),
 	logEvent: jest.fn()
-}));
-jest.mock('../../../../lib/methods/helpers/review', () => ({
-	Review: { pushPositiveEvent: jest.fn() }
-}));
-jest.mock('../../../../lib/methods/sendMessage', () => ({
-	sendMessage: jest.fn(() => Promise.resolve())
 }));
 jest.mock('../../../../lib/database/services/Thread', () => ({
 	getThreadById: jest.fn(() => Promise.resolve(null))
@@ -61,15 +45,8 @@ const mockDispatch = jest.fn();
 const mockShowActionSheet = jest.fn();
 const mockHideActionSheet = jest.fn();
 
-const mockSetReaction = setReaction as jest.Mock;
 const mockToggleFollowMessage = toggleFollowMessage as jest.Mock;
 const mockReplyBroadcastAction = replyBroadcastAction as jest.Mock;
-const mockLog = log as jest.Mock;
-const mockSendMessage = sendMessage as jest.Mock;
-
-const mockUser = { id: 'u1', username: 'user', token: 'tok', showMessageInMainThread: false };
-
-const { useAppSelector } = jest.requireMock('../../../../lib/hooks/useAppSelector');
 
 const makeRoomStore = (overrides: Partial<RoomState> = {}): RoomStore =>
 	createStore<RoomState>(() => ({
@@ -91,68 +68,65 @@ const makeRoomStore = (overrides: Partial<RoomState> = {}): RoomStore =>
 		...overrides
 	}));
 
-const renderRoomMessageHandlers = (roomStoreOverrides: Partial<RoomState> = {}, tmid?: string) => {
-	const roomStore = makeRoomStore(roomStoreOverrides);
-	const messageActionStore = createMessageActionStore();
-	const clearLastSeen = jest.fn();
+const makeScreenHandlers = (overrides: Partial<IUseRoomMessageHandlersParams> = {}): IUseRoomMessageHandlersParams => ({
+	onThreadPress: jest.fn(),
+	onReactionPress: jest.fn(() => Promise.resolve()),
+	onAnswerButtonPress: jest.fn(),
+	...overrides
+});
 
-	const { result } = renderHook(() => useRoomMessageHandlers(), {
+const renderRoomMessageHandlers = (
+	roomStoreOverrides: Partial<RoomState> = {},
+	tmid?: string,
+	screenHandlers: IUseRoomMessageHandlersParams = makeScreenHandlers()
+) => {
+	const roomStore = makeRoomStore(roomStoreOverrides);
+
+	const { result } = renderHook(() => useRoomMessageHandlers(screenHandlers), {
 		wrapper: ({ children }) => (
 			<RoomStoreContext.Provider value={roomStore}>
-				<RoomScreenContext.Provider value={{ loading: false, lastSeen: null, clearLastSeen }}>
-					<MessageActionStoreContext.Provider value={messageActionStore}>
-						<MessageRoomProvider tmid={tmid} timeFormat='h:mm A'>
-							{children}
-						</MessageRoomProvider>
-					</MessageActionStoreContext.Provider>
-				</RoomScreenContext.Provider>
+				<MessageRoomProvider tmid={tmid} timeFormat='h:mm A'>
+					{children}
+				</MessageRoomProvider>
 			</RoomStoreContext.Provider>
 		)
 	});
 
-	return { result, roomStore, messageActionStore, clearLastSeen };
+	return { result, roomStore, screenHandlers };
 };
 
-// MessageRoomProvider stays mounted (useRoomTmid throws without it); the screen and room contexts are the ones left absent.
+// MessageRoomProvider stays mounted (useRoomTmid throws without it); the room store context is the one left absent.
 const renderWithoutStores = () =>
-	renderHook(() => useRoomMessageHandlers(), {
+	renderHook(() => useRoomMessageHandlers(makeScreenHandlers()), {
 		wrapper: ({ children }) => <MessageRoomProvider timeFormat='h:mm A'>{children}</MessageRoomProvider>
 	});
 
 describe('useRoomMessageHandlers', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-		useAppSelector.mockImplementation((selector: any) => (selector === getUserSelector ? mockUser : undefined));
-	});
+	beforeEach(() => jest.clearAllMocks());
 
-	describe('onReactionPress', () => {
-		it('sets the reaction, closes the action sheet and reports a positive review event', async () => {
-			mockSetReaction.mockResolvedValue(undefined);
-			const { result, messageActionStore } = renderRoomMessageHandlers();
-			messageActionStore.getState().actions.startReacting('msg-1');
+	describe('handlers owned by the room screen', () => {
+		it('publishes the screen onThreadPress rather than opening the thread itself', () => {
+			const screenHandlers = makeScreenHandlers();
+			const { result } = renderRoomMessageHandlers({}, undefined, screenHandlers);
+			const item = { id: 'msg-1' } as any;
 
-			await act(async () => {
-				await result.current.onReactionPress({ name: 'smile' } as any, 'msg-1');
-			});
+			act(() => result.current.onThreadPress(item));
 
-			expect(mockSetReaction).toHaveBeenCalledWith('smile', 'msg-1');
-			expect(mockHideActionSheet).toHaveBeenCalledTimes(1);
-			expect(messageActionStore.getState().action).toBeNull();
-			expect(Review.pushPositiveEvent).toHaveBeenCalledTimes(1);
+			expect(screenHandlers.onThreadPress).toHaveBeenCalledWith(item);
+			expect(mockNavigation.push).not.toHaveBeenCalled();
 		});
 
-		it('logs the error and skips the review event when setReaction rejects', async () => {
-			const error = new Error('boom');
-			mockSetReaction.mockRejectedValue(error);
-			const { result } = renderRoomMessageHandlers();
+		it('publishes the screen onReactionPress and onAnswerButtonPress', async () => {
+			const screenHandlers = makeScreenHandlers();
+			const { result } = renderRoomMessageHandlers({}, undefined, screenHandlers);
 
 			await act(async () => {
-				await result.current.onReactionPress('smile', 'msg-1');
+				await result.current.onReactionPress('smile' as any, 'msg-1');
+				result.current.onAnswerButtonPress('hello', true);
 			});
 
-			expect(mockLog).toHaveBeenCalledWith(error);
-			expect(mockHideActionSheet).not.toHaveBeenCalled();
-			expect(Review.pushPositiveEvent).not.toHaveBeenCalled();
+			expect(screenHandlers.onReactionPress).toHaveBeenCalledWith('smile', 'msg-1');
+			expect(screenHandlers.onAnswerButtonPress).toHaveBeenCalledWith('hello', true);
 		});
 	});
 
@@ -202,32 +176,6 @@ describe('useRoomMessageHandlers', () => {
 		});
 	});
 
-	describe('onAnswerButtonPress', () => {
-		it('sends the message, clears the unread divider and reports a positive review event', async () => {
-			mockSendMessage.mockResolvedValue(undefined);
-			const { result, clearLastSeen, messageActionStore } = renderRoomMessageHandlers({}, 'thread-1');
-			messageActionStore.getState().actions.startEditing('msg-1');
-
-			await act(async () => {
-				result.current.onAnswerButtonPress('hello', true);
-				await Promise.resolve();
-			});
-
-			expect(mockSendMessage).toHaveBeenCalledWith('rid-1', 'hello', 'thread-1', mockUser, true);
-			expect(clearLastSeen).toHaveBeenCalledTimes(1);
-			expect(Review.pushPositiveEvent).toHaveBeenCalledTimes(1);
-			expect(messageActionStore.getState().action).toBeNull();
-		});
-
-		it('no-ops when the message is undefined', () => {
-			const { result } = renderRoomMessageHandlers();
-
-			act(() => result.current.onAnswerButtonPress(undefined));
-
-			expect(mockSendMessage).not.toHaveBeenCalled();
-		});
-	});
-
 	describe('store contexts absent', () => {
 		let consoleErrorSpy: jest.SpyInstance;
 
@@ -239,8 +187,8 @@ describe('useRoomMessageHandlers', () => {
 			consoleErrorSpy.mockRestore();
 		});
 
-		it('throws when the screen and room contexts are absent', () => {
-			expect(() => renderWithoutStores()).toThrow(/must be used within a Room(Screen|Store)Context\.Provider/);
+		it('throws when the room store context is absent', () => {
+			expect(() => renderWithoutStores()).toThrow(/must be used within a RoomStoreContext\.Provider/);
 		});
 	});
 });

--- a/app/views/RoomView/hooks/__tests__/useThreadFollowing.test.ts
+++ b/app/views/RoomView/hooks/__tests__/useThreadFollowing.test.ts
@@ -12,20 +12,38 @@ const mockGet = database.active.get as jest.Mock;
 
 type Emit<T> = (value: T) => void;
 
-const setupObservable = () => {
+const setupObservable = ({ deferFind = false }: { deferFind?: boolean } = {}) => {
 	let emit: Emit<any> | undefined;
-	const unsubscribe = jest.fn();
+	let resolveFind: (() => void) | undefined;
+	let openSubscriptions = 0;
+	const unsubscribe = jest.fn(() => {
+		openSubscriptions -= 1;
+	});
 	const threadRecord = {
 		observe: () => ({
 			subscribe: (cb: Emit<any>) => {
 				emit = cb;
+				openSubscriptions += 1;
 				return { unsubscribe };
 			}
 		})
 	};
-	mockGet.mockImplementation(() => ({ find: jest.fn(() => Promise.resolve(threadRecord)) }));
+	mockGet.mockImplementation(() => ({
+		find: jest.fn(
+			() =>
+				new Promise(resolve => {
+					if (deferFind) {
+						resolveFind = () => resolve(threadRecord);
+						return;
+					}
+					resolve(threadRecord);
+				})
+		)
+	}));
 	return {
 		unsubscribe,
+		openSubscriptions: () => openSubscriptions,
+		resolveFind: () => resolveFind?.(),
 		emitThread: (thread: any) => act(() => emit?.(thread))
 	};
 };
@@ -62,5 +80,16 @@ describe('useThreadFollowing', () => {
 		await flush();
 		unmount();
 		expect(observable.unsubscribe).toHaveBeenCalledTimes(1);
+	});
+
+	it('leaves no observer open when the record resolves after unmount', async () => {
+		const observable = setupObservable({ deferFind: true });
+		const { unmount } = renderHook(() => useThreadFollowing('tmid-1', 'user-1'));
+
+		unmount();
+		observable.resolveFind();
+		await flush();
+
+		expect(observable.openSubscriptions()).toBe(0);
 	});
 });

--- a/app/views/RoomView/hooks/__tests__/useThreadFollowing.test.ts
+++ b/app/views/RoomView/hooks/__tests__/useThreadFollowing.test.ts
@@ -13,7 +13,7 @@ const mockGet = database.active.get as jest.Mock;
 type Emit<T> = (value: T) => void;
 
 const setupObservable = ({ deferFind = false }: { deferFind?: boolean } = {}) => {
-	let emit: Emit<any> | undefined;
+	let emit: Emit<unknown> | undefined;
 	let resolveFind: (() => void) | undefined;
 	let openSubscriptions = 0;
 	const unsubscribe = jest.fn(() => {
@@ -21,7 +21,7 @@ const setupObservable = ({ deferFind = false }: { deferFind?: boolean } = {}) =>
 	});
 	const threadRecord = {
 		observe: () => ({
-			subscribe: (cb: Emit<any>) => {
+			subscribe: (cb: Emit<unknown>) => {
 				emit = cb;
 				openSubscriptions += 1;
 				return { unsubscribe };

--- a/app/views/RoomView/hooks/useRoomMessageHandlers.tsx
+++ b/app/views/RoomView/hooks/useRoomMessageHandlers.tsx
@@ -1,4 +1,3 @@
-import { useContext } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
@@ -10,9 +9,7 @@ import { goRoom, type TGoRoomItem } from '../../../lib/methods/helpers/goRoom';
 import { showErrorAlert } from '../../../lib/methods/helpers/info';
 import { events, logEvent } from '../../../lib/methods/helpers/log';
 import { isInActiveVoipCall } from '../../../lib/services/voip/isInActiveVoipCall';
-import { useAppSelector } from '../../../lib/hooks/useAppSelector';
 import { useMasterDetail } from '../../../lib/hooks/useMasterDetail';
-import { getUserSelector } from '../../../selectors/login';
 import {
 	type IMessage,
 	type IRoomInfoParam,
@@ -22,37 +19,26 @@ import {
 } from '../../../definitions';
 import { useActionSheet } from '../../../containers/ActionSheet';
 import ReactionsList from '../../../containers/ReactionsList';
-import { MessageActionStoreContext } from '../../../containers/message/stores/MessageActionStore';
 import { useRoomTmid } from '../../../containers/message/stores/MessageRoomStore';
-import { type IRoomViewProps } from '../definitions';
+import { type IRoomViewProps, type IUseRoomMessageHandlersParams } from '../definitions';
 import { useRoomStore } from '../stores/RoomStoreContext';
-import { useRoomScreen } from '../stores/RoomScreenContext';
 import { blockAction as blockActionService } from '../services/blockAction';
 import { fetchThreadName as fetchThreadNameService } from '../services/fetchThreadName';
 import { toggleFollowThread as toggleFollowThreadService } from '../services/toggleFollowThread';
-import { pushThreadRoom } from '../services/pushThreadRoom';
-import { sendRoomMessage } from '../services/sendRoomMessage';
-import { useReactionActions } from './useReactionActions';
 
-export function useRoomMessageHandlers(): IUseRoomMessageHandlersResult {
+export function useRoomMessageHandlers({
+	onThreadPress,
+	onReactionPress,
+	onAnswerButtonPress
+}: IUseRoomMessageHandlersParams): IUseRoomMessageHandlersResult {
 	const navigation = useNavigation<IRoomViewProps['navigation']>();
 	const dispatch = useDispatch();
 	const isMasterDetail = useMasterDetail();
-	const user = useAppSelector(getUserSelector);
-	const { showActionSheet, hideActionSheet } = useActionSheet();
+	const { showActionSheet } = useActionSheet();
 
-	const messageActionStore = useContext(MessageActionStoreContext);
 	const tmid = useRoomTmid();
-	const { clearLastSeen } = useRoomScreen();
 	const rid = useRoomStore(s => s.room.rid);
 	const room = useRoomStore(s => s.room);
-	const roomUserId = useRoomStore(s => s.roomUserId);
-
-	if (!messageActionStore) {
-		throw new Error('useRoomMessageHandlers must be used within a MessageActionProvider');
-	}
-
-	const { resetAction, onReactionPress } = useReactionActions({ messageActionStore, hideActionSheet });
 
 	const onDiscussionPress = async (drid: TAnyMessageModel['drid']) => {
 		if (!drid) return;
@@ -64,9 +50,6 @@ export function useRoomMessageHandlers(): IUseRoomMessageHandlersResult {
 			});
 		}
 	};
-
-	// No orchestrator-owned cancelJumpToMessageRef to self-source here, so the loading overlay renders without a cancel button.
-	const onThreadPress = (item: TAnyMessageModel) => pushThreadRoom({ rid, item, roomUserId, navigation });
 
 	const navToRoomInfo = (navParam: IRoomInfoParam) => {
 		logEvent(events[`ROOM_GO_${navParam.t === SubscriptionType.DIRECT ? 'USER' : 'ROOM'}_INFO`]);
@@ -126,9 +109,6 @@ export function useRoomMessageHandlers(): IUseRoomMessageHandlersResult {
 		}
 		return toggleFollowThreadService(threadMessageId, isFollowingThread);
 	};
-
-	const onAnswerButtonPress = (message?: string, tshow?: boolean) =>
-		sendRoomMessage({ rid, message, tmid, user, tshow, onMessageSent: clearLastSeen, resetAction });
 
 	return {
 		blockAction: blockActionService,

--- a/app/views/RoomView/hooks/useThreadFollowing.ts
+++ b/app/views/RoomView/hooks/useThreadFollowing.ts
@@ -9,9 +9,10 @@ export function useThreadFollowing(tmid?: string, userId?: string): boolean {
 		if (!tmid) {
 			return;
 		}
+		let cancelled = false;
 		let unsubscribe: (() => void) | undefined;
 		getMessageById(tmid).then(threadRecord => {
-			if (!threadRecord) {
+			if (cancelled || !threadRecord) {
 				return;
 			}
 			const subscription = threadRecord.observe().subscribe(thread => {
@@ -20,7 +21,10 @@ export function useThreadFollowing(tmid?: string, userId?: string): boolean {
 			unsubscribe = () => subscription.unsubscribe();
 		});
 
-		return () => unsubscribe?.();
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
 	}, [tmid, userId]);
 
 	return isFollowingThread;

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -278,7 +278,10 @@ const RoomView = (props: IRoomViewProps) => {
 								Message_GroupingPeriod={Message_GroupingPeriod}
 								autoTranslateRoom={canAutoTranslate && 'id' in room && room.autoTranslate}
 								autoTranslateLanguage={'id' in room ? room.autoTranslateLanguage : undefined}>
-								<RoomMessageHandlersBridge>
+								<RoomMessageHandlersBridge
+									onThreadPress={onThreadPress}
+									onReactionPress={onReactionPress}
+									onAnswerButtonPress={handleSendMessage}>
 									<List
 										ref={listRef}
 										flatListRef={flatListRef}


### PR DESCRIPTION
## Proposed changes

Five confirmed defects in the room screen / message module, one commit each. Every fix is locked down by a test that goes red on the old code; mechanism and evidence per bug below.

### 1. Dead reaction, encrypted and follow-thread affordances outside RoomView

**Mechanism.** `Reactions` rendered a chip per reaction plus an unconditional add-reaction button whenever the message carried reactions; `Encrypted` and `ThreadDetails` rendered their touchables unconditionally. `MessagesView` and `SearchMessagesView` seed only `navToRoomInfo` and `showAttachment` into `MessageRoomProvider`, so `onReactionPress`, `onReactionLongPress`, `reactionInit`, `onEncryptedPress` and `toggleFollowThread` were all `undefined` there. REST-sourced messages do carry reactions, so Pinned/Starred/Mentions/Files/Search showed tappable controls where every tap was a silent no-op through the optional-chained call.

**Evidence.** `Reactions.test.tsx` renders a message with one reaction and an empty handler bag; the chip and the add-reaction button were both present. `Encrypted.test.tsx` and `Thread.test.tsx` do the same for the encrypted icon and the follow toggle.

**Fix.** Each affordance renders only when the handler behind it exists. Not fixed by seeding handlers into those views: the capability genuinely is absent there. The leaf and composed-Message stories now seed the handlers so they keep demonstrating the full row.

### 2. Observer leak in `useThreadFollowing`

**Mechanism.** Cleanup called `unsubscribe?.()`, but `unsubscribe` was only assigned inside the `getMessageById().then()`. A cleanup that ran before the record resolved was a no-op, and the observer opened afterwards was never torn down — it kept calling `setIsFollowingThread` for the previous thread after a `tmid`/`userId` change or an unmount.

**Evidence.** New test defers the `find()` promise, unmounts, then resolves. Subscribe/unsubscribe are counted: one observer stayed open.

**Fix.** The cancelled-flag pattern already used by `useOmnichannelPermissions`.

### 3. `onThreadPress` diverged into two implementations

**Mechanism.** `useRoomNavigation`'s `onThreadPress` is debounced 1000ms leading-edge and passes the screen's `cancelJumpToMessage` to `pushThreadRoom` as `onCancel`. `useRoomMessageHandlers` defined a second one that was neither. The bag published to `MessageRoomStore` carried the second one, so opening a thread from a message row gave an uncancellable loading overlay and no debounce, while the message-actions path gave both. `onReactionPress` (`useReactionActions`) and the `sendRoomMessage` call behind `onAnswerButtonPress` were duplicated the same way; those two copies had not diverged in behaviour, but were the same drift risk.

**Fix.** `RoomView` injects all three into `useRoomMessageHandlers` through `RoomMessageHandlersBridge`. No second definition is left to drift, and the params are required, so one cannot be reintroduced silently.

**Test seam.** Behaviour is already covered where each handler is defined (`useRoomNavigation`, `useMessageActions`, `useRoomActions`), so the duplicated cases in `useRoomMessageHandlers.test.tsx` were removed. What remains asserts forwarding plus the meaningful half: calling the published `onThreadPress` must not push navigation itself.

### 4. `jumpToMessage` seeded inconsistently

**Mechanism.** `SearchMessagesView` passed `jumpToMessage`; `MessagesView` did not. `useOnLinkPress` therefore sent an in-server message link to `openLink` (external browser) from Pinned/Starred/Mentions/Files, and to an in-app jump from Search — same content model, opposite behaviour.

**Evidence.** New `MessagesView` test renders the Pinned screen, captures the room state handed to `MessageRoomProvider`, and asserts `jumpToMessage` is seeded and routes an in-server link to `Navigation.setParams`. It was `undefined`.

**Fix.** `MessagesView` seeds the same url-based jump handler.

### 5. Missing `fetchThreadName` rendered no header instead of a fallback

**Mechanism.** `RepliedThread` stored `''` when no `fetchThreadName` was supplied, and the falsy check below then bailed, so the replied-thread header vanished entirely in Search/Pinned. The empty string stood in for both "name not available" and "name is empty".

**Evidence.** New test renders with no `fetchThreadName`: nothing rendered.

**Fix.** Absence is tracked as `undefined`. The component renders nothing only while a name is genuinely in flight, and otherwise falls back to the generic `Thread` label, which also covers a fetch that resolves empty or rejects. Previously a rejected fetch left the header blank forever, since nothing caught it.

## Issue(s)

n/a

## Steps to test or reproduce

Automated. `TZ=UTC pnpm test` — 273 suites, 2524 tests green.

Manually, on Pinned/Starred/Files/Search:
- tap a reaction chip and the add-reaction button on a message that has reactions
- tap the lock icon on an E2E message
- tap the bell on a message with thread replies
- tap an in-server message link in a message body
- open a message that replies into a thread and look for the thread header

## Further comments

- `jumpToMessageByUrl` is now near-identical in `MessagesView` and `SearchMessagesView`. Left duplicated rather than extracted, since a structural pass owns that.
- `Encrypted` gained a `testID`, which is the only change in the story snapshots besides the seeded handlers.
- The `Encrypted` absent-handler test only turns red on the old code together with its positive sibling, since the `testID` it queries did not exist before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for opening specific messages directly from in-app links.
  - Message actions, reactions, encrypted-message actions, and thread-follow controls now appear only when supported.
  - Added a generic “Thread” label when thread details are unavailable.

- **Bug Fixes**
  - Prevented stale thread subscriptions after leaving a screen.
  - Improved handling of unavailable message actions and asynchronous thread data.

- **Tests**
  - Expanded coverage for message links, reactions, encrypted messages, thread controls, and subscription cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
