### PR TITLE
refactor(RoomView): unblock compiler for ReactionPicker

### DIFF
--- a/app/views/RoomView/components/ReactionPicker.tsx
+++ b/app/views/RoomView/components/ReactionPicker.tsx
@@ -21,16 +21,16 @@ const ReactionPicker = ({ onEmojiSelected, messageId, reactionClose }: IReaction
 	const [searchedEmojis, setSearchedEmojis] = useState<IEmoji[]>([]);
 	const [searching, setSearching] = useState<boolean>(false);
 
-	const handleTextChange = useDebounce((text: string) => {
-		setSearching(text !== '');
-		handleSearchEmojis(text);
-	}, textInputDebounceTime);
-
 	const handleSearchEmojis = async (text: string) => {
 		logEvent(events.REACTION_PICKER_SEARCH_EMOJIS);
 		const emojis = await searchEmojis(text);
 		setSearchedEmojis(emojis);
 	};
+
+	const handleTextChange = useDebounce((text: string) => {
+		setSearching(text !== '');
+		handleSearchEmojis(text);
+	}, textInputDebounceTime);
 
 	const handleEmojiSelect = (_eventType: EventTypes, emoji?: IEmoji) => {
 		logEvent(events.REACTION_PICKER_EMOJI_SELECTED);

--- a/app/views/RoomView/reactCompilerContract.test.ts
+++ b/app/views/RoomView/reactCompilerContract.test.ts
@@ -17,9 +17,7 @@ const EXTRA_FILES: string[] = [
 // Files the React Compiler silently skips today. Fixing the underlying cause must remove its file from this list.
 const KNOWN_SKIPPED: string[] = [
 	// Disables a React ESLint rule, which makes the compiler bail out.
-	'app/views/RoomView/List/hooks/useMessages.ts',
-	// Reads a variable before its declaration.
-	'app/views/RoomView/components/ReactionPicker.tsx'
+	'app/views/RoomView/List/hooks/useMessages.ts'
 ];
 
 const collectSourceFiles = (dir: string): string[] => {


### PR DESCRIPTION
## Proposed changes

Moves the Emoji search function above the debounced text-change function so the React Compiler can compile ReactionPicker instead of silently skipping it.

This is a declaration-order change. Reaction search behavior is unchanged.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-34

Stacked on #7482.

## How to test or reproduce

1. Open a Room.
2. Open the Reaction picker for a Message.
3. Search for an Emoji.
4. Confirm that matching Emoji results appear.
5. Run the RoomView React Compiler contract and confirm ReactionPicker compiles.

## Screenshots

Not applicable.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (not applicable)
- [x] Any dependent changes have been merged and published in downstream modules (not applicable)

## Further comments

This draft targets the head branch of #7482 so the review contains only the ReactionPicker compiler change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered internal reaction picker declarations without changing functionality.
* **Tests**
  * Updated compiler validation coverage to include the reaction picker component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->