### PR TITLE
refactor(RoomView): make messaging callback wiring explicit

### DIFF
--- a/app/views/RoomView/RoomScreen.tsx
+++ b/app/views/RoomView/RoomScreen.tsx
@@ -38,7 +38,7 @@ const RoomScreen = ({ route, rid, t, tmid, roomStore }: IRoomScreenProps) => {
 		flatListRef,
 		messageActionsRef,
 		messageErrorActionsRef,
-		roomActions,
+		onThreadPress,
 		sendMessage,
 		jumpToMessage,
 		closeEmojiAndAction,
@@ -101,7 +101,9 @@ const RoomScreen = ({ route, rid, t, tmid, roomStore }: IRoomScreenProps) => {
 							listContainerRef={listContainerRef}
 							flatListRef={flatListRef}
 							onLongPress={onMessageLongPress}
-							roomActions={roomActions}
+							onThreadPress={onThreadPress}
+							onReactionPress={onReactionPress}
+							sendMessage={sendMessage}
 							jumpToMessage={jumpToMessage}
 							closeEmojiAndAction={closeEmojiAndAction}
 							reactionInit={onReactionInit}

--- a/app/views/RoomView/components/RoomMessageList.tsx
+++ b/app/views/RoomView/components/RoomMessageList.tsx
@@ -28,7 +28,9 @@ export const RoomMessageList = ({
 	listContainerRef,
 	flatListRef,
 	onLongPress,
-	roomActions,
+	onThreadPress,
+	onReactionPress,
+	sendMessage,
 	jumpToMessage,
 	closeEmojiAndAction,
 	reactionInit,
@@ -48,7 +50,9 @@ export const RoomMessageList = ({
 	return (
 		<A11yGateProvider>
 			<RoomMessageProvider
-				roomActions={roomActions}
+				onThreadPress={onThreadPress}
+				onReactionPress={onReactionPress}
+				sendMessage={sendMessage}
 				jumpToMessage={jumpToMessage}
 				closeEmojiAndAction={closeEmojiAndAction}
 				reactionInit={reactionInit}

--- a/app/views/RoomView/components/RoomMessageProvider.tsx
+++ b/app/views/RoomView/components/RoomMessageProvider.tsx
@@ -1,13 +1,20 @@
 import { type ReactElement, type ReactNode } from 'react';
 
 import { MessageRoomProvider, type MessageRoomState } from '../../../containers/message/stores/MessageRoomStore';
-import { type IRoomActions } from '../definitions';
+import { type IRoomMessageHandlersInput } from '../definitions';
 import { useRoomMessageHandlers } from '../hooks/useRoomMessageHandlers';
 
-type IRoomMessageProviderProps = Omit<MessageRoomState, 'handlers'> & { children: ReactNode; roomActions: IRoomActions };
+type IRoomMessageProviderProps = Omit<MessageRoomState, 'handlers'> &
+	Pick<IRoomMessageHandlersInput, 'onThreadPress' | 'onReactionPress' | 'sendMessage'> & { children: ReactNode };
 
-export const RoomMessageProvider = ({ children, roomActions, ...state }: IRoomMessageProviderProps): ReactElement => {
-	const handlers = useRoomMessageHandlers({ tmid: state.tmid, ...roomActions });
+export const RoomMessageProvider = ({
+	children,
+	onThreadPress,
+	onReactionPress,
+	sendMessage,
+	...state
+}: IRoomMessageProviderProps): ReactElement => {
+	const handlers = useRoomMessageHandlers({ tmid: state.tmid, onThreadPress, onReactionPress, sendMessage });
 
 	return (
 		<MessageRoomProvider {...state} handlers={handlers}>

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -13,7 +13,8 @@ import {
 	type IVisitor,
 	type RoomType,
 	type TAnyMessageModel,
-	type TSubscriptionModel
+	type TSubscriptionModel,
+	type IUseRoomMessageHandlersResult
 } from '../../definitions';
 import { type TActionSheetOptions } from '../../containers/ActionSheet';
 import { type IMessageComposerRef } from '../../containers/MessageComposer/interfaces';
@@ -150,11 +151,12 @@ export interface IListContainerProps {
 	serverVersion: string | null;
 }
 
-export interface IRoomActions {
-	onThreadPress: (item: TAnyMessageModel) => void;
-	onReactionPress: (emoji: IEmoji, messageId: string) => Promise<void>;
-	sendMessage: (message?: string, tshow?: boolean) => void;
-}
+export type IRoomMessageHandlersInput = {
+	tmid?: string;
+	onThreadPress: IUseRoomMessageHandlersResult['onThreadPress'];
+	onReactionPress: IUseRoomMessageHandlersResult['onReactionPress'];
+	sendMessage: IUseRoomMessageHandlersResult['onAnswerButtonPress'];
+};
 
 // The screen's own state, carried by RoomScreenContext — see that module for why it is per-screen.
 export interface IRoomScreenContextValue {
@@ -294,15 +296,14 @@ export interface IUseMessageActionsResult {
 	getText: () => string | undefined;
 }
 
-export interface IRoomMessageListProps extends Pick<
-	MessageRoomState,
-	'jumpToMessage' | 'closeEmojiAndAction' | 'reactionInit' | 'errorActionsShow'
-> {
+export interface IRoomMessageListProps
+	extends
+		Pick<MessageRoomState, 'jumpToMessage' | 'closeEmojiAndAction' | 'reactionInit' | 'errorActionsShow'>,
+		Pick<IRoomMessageHandlersInput, 'onThreadPress' | 'onReactionPress' | 'sendMessage'> {
 	tmid?: string;
 	listContainerRef: RefObject<IListContainerRef | null>;
 	flatListRef: TListRef;
 	onLongPress: IListContainerProps['onLongPress'];
-	roomActions: IRoomActions;
 }
 
 export type IRoomMessageActionsProps = Pick<
@@ -321,32 +322,6 @@ export interface IUseRoomMessagingParams {
 	roomStore: RoomStore;
 	roomUserId?: string | null;
 	quoteMessageId?: string;
-}
-
-export interface IUseRoomMessagingResult {
-	messageActionStore: TMessageActionStore;
-	roomScreen: IRoomScreenContextValue;
-	messageComposerRef: RefObject<IMessageComposerRef | null>;
-	listContainerRef: RefObject<IListContainerRef | null>;
-	flatListRef: TListRef;
-	messageActionsRef: RefObject<IMessageActions | null>;
-	messageErrorActionsRef: RefObject<IMessageErrorActions | null>;
-	roomActions: IRoomActions;
-	sendMessage: TComposerExternalState['onSendMessage'];
-	jumpToMessage: IMessageActionsProps['jumpToMessage'];
-	closeEmojiAndAction: IRoomMessageListProps['closeEmojiAndAction'];
-	errorActionsShow: IRoomMessageListProps['errorActionsShow'];
-	onMessageLongPress: IListContainerProps['onLongPress'];
-	onEditInit: IMessageActionsProps['editInit'];
-	onEditCancel: TComposerExternalState['editCancel'];
-	onEditRequest: TComposerExternalState['editRequest'];
-	onQuoteInit: IMessageActionsProps['quoteInit'];
-	onRemoveQuoteMessage: TComposerExternalState['onRemoveQuoteMessage'];
-	onReactionInit: IMessageActionsProps['reactionInit'];
-	onReactionPress: IMessageActionsProps['onReactionPress'];
-	onReplyInit: IMessageActionsProps['replyInit'];
-	setQuotesAndText: TComposerExternalState['setQuotesAndText'];
-	getText: TComposerExternalState['getText'];
 }
 
 export interface IUseSubscriptionUnreadsResult {

--- a/app/views/RoomView/hooks/useRoomMessageHandlers.tsx
+++ b/app/views/RoomView/hooks/useRoomMessageHandlers.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../definitions';
 import { useActionSheet } from '../../../containers/ActionSheet';
 import ReactionsList from '../../../containers/ReactionsList';
-import { type IRoomActions, type IRoomViewProps } from '../definitions';
+import { type IRoomMessageHandlersInput, type IRoomViewProps } from '../definitions';
 import { useRoomStore } from '../stores/RoomStoreContext';
 import { blockAction as blockActionService } from '../services/blockAction';
 import { fetchThreadName as fetchThreadNameService } from '../services/fetchThreadName';
@@ -30,7 +30,7 @@ export function useRoomMessageHandlers({
 	onThreadPress,
 	onReactionPress,
 	sendMessage
-}: IRoomActions & { tmid?: string }): IUseRoomMessageHandlersResult {
+}: IRoomMessageHandlersInput): IUseRoomMessageHandlersResult {
 	const navigation = useNavigation<IRoomViewProps['navigation']>();
 	const dispatch = useDispatch();
 	const isMasterDetail = useMasterDetail();

--- a/app/views/RoomView/hooks/useRoomMessaging.ts
+++ b/app/views/RoomView/hooks/useRoomMessaging.ts
@@ -9,25 +9,13 @@ import { useAppSelector } from '../../../lib/hooks/useAppSelector';
 import { useLiveRef } from '../../../lib/hooks/useLiveRef';
 import { useMasterDetail } from '../../../lib/hooks/useMasterDetail';
 import { getUserSelector } from '../../../selectors/login';
-import {
-	type IListContainerRef,
-	type IUseRoomMessagingParams,
-	type IUseRoomMessagingResult,
-	type TListRef
-} from '../definitions';
+import { type IListContainerRef, type IUseRoomMessagingParams, type TListRef } from '../definitions';
 import { sendRoomMessage } from '../services/sendRoomMessage';
 import { useMessageActions } from './useMessageActions';
 import { useRoomInit } from './useRoomInit';
 import { useRoomNavigation } from './useRoomNavigation';
 
-export function useRoomMessaging({
-	rid,
-	t,
-	tmid,
-	roomStore,
-	roomUserId,
-	quoteMessageId
-}: IUseRoomMessagingParams): IUseRoomMessagingResult {
+export function useRoomMessaging({ rid, t, tmid, roomStore, roomUserId, quoteMessageId }: IUseRoomMessagingParams) {
 	const isAuthenticated = useAppSelector(state => state.login.isAuthenticated);
 	const user = useAppSelector(getUserSelector);
 	const isMasterDetail = useMasterDetail();
@@ -103,7 +91,7 @@ export function useRoomMessaging({
 		flatListRef,
 		messageActionsRef,
 		messageErrorActionsRef,
-		roomActions: { onThreadPress, onReactionPress, sendMessage },
+		onThreadPress,
 		sendMessage,
 		jumpToMessage: jumpToMessageByUrl,
 		closeEmojiAndAction: handleCloseEmoji,


### PR DESCRIPTION
## Summary
- remove the runtime `roomActions` bundle and redundant orchestration result interface
- wire Thread navigation, Reaction handling, and Message sending explicitly through the Message tree
- preserve required Message handler callback signatures and existing behavior

## Validation
- `pnpm format-lint`
- focused and full Jest suites with `TZ=UTC` and Watchman disabled
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined room messaging action handling by passing message interactions more directly between components.
  * Preserved existing thread, reaction, and message-sending behavior.
  * Improved consistency in how room message interactions are managed internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->