### PR TITLE
refactor: tidy RoomView components

### DIFF
--- a/app/views/RoomView/components/Banner.tsx
+++ b/app/views/RoomView/components/Banner.tsx
@@ -15,46 +15,43 @@ interface IBannerProps {
 	closeBanner: () => void;
 }
 
-const Banner = memo(
-	({ text, title, bannerClosed, closeBanner }: IBannerProps) => {
-		const [showModal, openModal] = useState(false);
-		const { colors } = useTheme();
+const Banner = memo(({ text, title, bannerClosed, closeBanner }: IBannerProps) => {
+	const [showModal, openModal] = useState(false);
+	const { colors } = useTheme();
 
-		const toggleModal = () => openModal(prevState => !prevState);
+	const toggleModal = () => openModal(prevState => !prevState);
 
-		if (text && !bannerClosed) {
-			return (
-				<>
-					<BorderlessButton
-						style={[styles.bannerContainer, { backgroundColor: colors.surfaceNeutral }]}
-						testID='room-view-banner'
-						onPress={toggleModal}>
-						<MarkdownPreview msg={text} style={styles.bannerText} />
-						<BorderlessButton onPress={closeBanner} hitSlop={10}>
-							<CustomIcon color={colors.fontSecondaryInfo} name='close' size={20} />
-						</BorderlessButton>
+	if (text && !bannerClosed) {
+		return (
+			<>
+				<BorderlessButton
+					style={[styles.bannerContainer, { backgroundColor: colors.surfaceNeutral }]}
+					testID='room-view-banner'
+					onPress={toggleModal}>
+					<MarkdownPreview msg={text} style={styles.bannerText} />
+					<BorderlessButton onPress={closeBanner} hitSlop={10}>
+						<CustomIcon color={colors.fontSecondaryInfo} name='close' size={20} />
 					</BorderlessButton>
-					<Modal
-						onBackdropPress={toggleModal}
-						onBackButtonPress={toggleModal}
-						useNativeDriver
-						isVisible={showModal}
-						animationIn='fadeIn'
-						animationOut='fadeOut'>
-						<GestureHandlerRootView style={[styles.modalView, { backgroundColor: colors.surfaceNeutral }]}>
-							<Text style={[styles.bannerModalTitle, { color: colors.fontSecondaryInfo }]}>{title}</Text>
-							<ScrollView style={styles.modalScrollView}>
-								<Markdown msg={text} />
-							</ScrollView>
-						</GestureHandlerRootView>
-					</Modal>
-				</>
-			);
-		}
+				</BorderlessButton>
+				<Modal
+					onBackdropPress={toggleModal}
+					onBackButtonPress={toggleModal}
+					useNativeDriver
+					isVisible={showModal}
+					animationIn='fadeIn'
+					animationOut='fadeOut'>
+					<GestureHandlerRootView style={[styles.modalView, { backgroundColor: colors.surfaceNeutral }]}>
+						<Text style={[styles.bannerModalTitle, { color: colors.fontSecondaryInfo }]}>{title}</Text>
+						<ScrollView style={styles.modalScrollView}>
+							<Markdown msg={text} />
+						</ScrollView>
+					</GestureHandlerRootView>
+				</Modal>
+			</>
+		);
+	}
 
-		return null;
-	},
-	(prevProps, nextProps) => prevProps.text === nextProps.text && prevProps.bannerClosed === nextProps.bannerClosed
-);
+	return null;
+});
 
 export default Banner;

--- a/app/views/RoomView/components/InvitedRoom.tsx
+++ b/app/views/RoomView/components/InvitedRoom.tsx
@@ -11,12 +11,11 @@ type InvitedRoomProps = {
 	title: string;
 	description: string;
 	inviter: IInviteSubscription['inviter'];
-	loading?: boolean;
 	onAccept: () => Promise<void>;
 	onReject: () => Promise<void>;
 };
 
-export const InvitedRoom = ({ title, description, inviter, loading, onAccept, onReject }: InvitedRoomProps): ReactElement => {
+export const InvitedRoom = ({ title, description, inviter, onAccept, onReject }: InvitedRoomProps): ReactElement => {
 	const { colors } = useTheme();
 
 	return (
@@ -25,14 +24,8 @@ export const InvitedRoom = ({ title, description, inviter, loading, onAccept, on
 			title={title}
 			description={description}
 			detail={<Chip avatar={inviter.username} text={inviter.name || inviter.username} fullWidth />}>
-			<Button title={I18n.t('accept')} loading={loading} onPress={onAccept} />
-			<Button
-				title={I18n.t('reject')}
-				type='secondary'
-				loading={loading}
-				backgroundColor={colors.surfaceTint}
-				onPress={onReject}
-			/>
+			<Button title={I18n.t('accept')} onPress={onAccept} />
+			<Button title={I18n.t('reject')} type='secondary' backgroundColor={colors.surfaceTint} onPress={onReject} />
 		</RoomPlaceholder>
 	);
 };

--- a/app/views/RoomView/components/MessageRow.tsx
+++ b/app/views/RoomView/components/MessageRow.tsx
@@ -8,9 +8,6 @@ import { type RoomType, type TAnyMessageModel } from '../../../definitions';
 import { useThreadBadgeColor } from '../hooks/useThreadBadgeColor';
 import { type IRoomViewState, type TMessageRowProps } from '../definitions';
 
-// The room model mutates in place (same ref per emit), and the React Compiler caches derived
-// values on that stable ref. Deriving the boolean inside the selector keeps it fresh per emit
-// and only re-renders the caller when the derived value actually changes.
 const useIsIgnored = (authorId?: string): boolean =>
 	useRoomStore(s => (authorId && 'id' in s.room ? (s.room.ignored?.includes(authorId) ?? false) : false));
 
@@ -42,40 +39,31 @@ export const MessageRow = ({ item, previousItem, highlightedMessage, onLongPress
 	const { lastSeen } = useRoomScreen();
 	const { dateSeparator, showUnreadSeparator } = getMessageSeparators(item, previousItem, lastSeen);
 
-	let content = null;
 	if (item.t && MESSAGE_TYPE_ANY_LOAD.includes(item.t as MessageTypeLoad)) {
-		const runOnRender = () => {
-			if (item.t === MessageTypeLoad.MORE) {
-				if (!previousItem) return true;
-				if (previousItem?.tmid) return true;
-			}
-			return false;
-		};
-		content = (
+		const runOnRender = item.t === MessageTypeLoad.MORE && (!previousItem || !!previousItem.tmid);
+		return (
 			<LoadMore
 				rid={room.rid}
 				t={room.t as RoomType}
 				loaderId={item.id}
 				type={item.t}
-				runOnRender={runOnRender()}
-				dateSeparator={dateSeparator}
-				showUnreadSeparator={showUnreadSeparator}
-			/>
-		);
-	} else {
-		content = (
-			<Message
-				item={item}
-				isIgnored={isIgnored}
-				previousItem={previousItem}
-				onLongPress={onLongPress}
-				threadBadgeColor={threadBadgeColor}
-				highlighted={highlightedMessage === item.id}
+				runOnRender={runOnRender}
 				dateSeparator={dateSeparator}
 				showUnreadSeparator={showUnreadSeparator}
 			/>
 		);
 	}
 
-	return content;
+	return (
+		<Message
+			item={item}
+			isIgnored={isIgnored}
+			previousItem={previousItem}
+			onLongPress={onLongPress}
+			threadBadgeColor={threadBadgeColor}
+			highlighted={highlightedMessage === item.id}
+			dateSeparator={dateSeparator}
+			showUnreadSeparator={showUnreadSeparator}
+		/>
+	);
 };

--- a/app/views/RoomView/components/RightButtons.tsx
+++ b/app/views/RoomView/components/RightButtons.tsx
@@ -13,6 +13,7 @@ import { closeLivechat as closeLivechatService } from '../../../lib/methods/help
 import { events, logEvent } from '../../../lib/methods/helpers/log';
 import getRoomAccessibilityLabel from '../../../lib/helpers/getRoomAccessibilityLabel';
 import { useAppSelector } from '../../../lib/hooks/useAppSelector';
+import { useSetting } from '../../../lib/hooks/useSetting';
 import { useCanReturnQueue } from '../../../ee/omnichannel/hooks/useCanReturnQueue';
 import { useMasterDetail } from '../../../lib/hooks/useMasterDetail';
 import { usePermissions } from '../../../lib/hooks/usePermissions';
@@ -128,10 +129,8 @@ const RightButtons = ({ rid, tmid }: IRightButtonsProps): ReactElement | null =>
 	const { showActionSheet } = useActionSheet();
 
 	const userId = useAppSelector(state => getUserSelector(state).id);
-	const threadsEnabled = useAppSelector(state => state.settings.Threads_enabled as boolean);
-	const livechatRequestComment = useAppSelector(
-		state => state.settings.Livechat_request_comment_when_closing_conversation as boolean
-	);
+	const threadsEnabled = useSetting('Threads_enabled') as boolean;
+	const livechatRequestComment = useSetting('Livechat_request_comment_when_closing_conversation') as boolean;
 	const issuesWithNotifications = useAppSelector(state => state.troubleshootingNotification.issuesWithNotifications);
 
 	const room = useRoomStoreByRid(rid, s => s.room);
@@ -235,15 +234,12 @@ const RightButtons = ({ rid, tmid }: IRightButtonsProps): ReactElement | null =>
 		if (!rid) {
 			return;
 		}
-		if (isMasterDetail) {
-			// @ts-ignore TODO: find a way to make this work
-			navigation.navigate('ModalStackNavigator', {
-				screen: 'SearchMessagesView',
-				params: { rid, showCloseModal: true, encrypted }
-			});
-		} else {
-			navigation.navigate('SearchMessagesView', { rid, t, encrypted });
-		}
+		navigateToScreen({
+			navigation,
+			isMasterDetail,
+			screen: 'SearchMessagesView',
+			params: isMasterDetail ? { rid, t, encrypted, showCloseModal: true } : { rid, t, encrypted }
+		});
 	};
 
 	const goE2EEToggleRoomView = () => {

--- a/app/views/RoomView/components/RoomFooter/TakeOrJoin.tsx
+++ b/app/views/RoomView/components/RoomFooter/TakeOrJoin.tsx
@@ -9,7 +9,6 @@ export const TakeOrJoin = ({ joinCodeRef }: ITakeOrJoinProps): ReactElement => {
 	const room = useRoomWithUpdate();
 	const joinRoom = useRoomStore(s => s.joinRoom);
 
-	// The join-code modal lives on this screen, so the trigger is handed to joinRoom per call.
 	const onPressJoin = (): Promise<void> => joinRoom(() => joinCodeRef.current?.show());
 
 	return (

--- a/app/views/RoomView/components/RoomFooter/useFooterMessage.ts
+++ b/app/views/RoomView/components/RoomFooter/useFooterMessage.ts
@@ -1,5 +1,6 @@
 import I18n from '../../../../i18n';
 import { useAppSelector } from '../../../../lib/hooks/useAppSelector';
+import { useSetting } from '../../../../lib/hooks/useSetting';
 import { isBlocked } from '../../../../lib/methods/helpers/room';
 import { type IRoomFederated, isRoomFederated, isRoomNativeFederated } from '../../../../lib/methods/isRoomFederated';
 import { useReadOnly } from '../../hooks/useReadOnly';
@@ -25,9 +26,9 @@ const getFederatedFooterDescription = (
 export const useFooterMessage = (): string | null => {
 	const room = useRoomWithUpdate();
 	const readOnly = useReadOnly();
-	const isFederationEnabled = useAppSelector(
-		state => (state.settings.Federation_Matrix_enabled || state.settings.Federation_Service_Enabled) as boolean
-	);
+	const federationMatrixEnabled = useSetting('Federation_Matrix_enabled');
+	const federationServiceEnabled = useSetting('Federation_Service_Enabled');
+	const isFederationEnabled = !!(federationMatrixEnabled || federationServiceEnabled);
 	const isFederationModuleEnabled = useAppSelector(state => state.enterpriseModules.includes('federation'));
 
 	if (readOnly) {

--- a/app/views/RoomView/components/RoomFooter/useRoomFooterState.ts
+++ b/app/views/RoomView/components/RoomFooter/useRoomFooterState.ts
@@ -1,4 +1,4 @@
-import { useAppSelector } from '../../../../lib/hooks/useAppSelector';
+import { useSetting } from '../../../../lib/hooks/useSetting';
 import { useRoomStore, useRoomWithUpdate } from '../../stores/RoomStoreContext';
 import { useFooterMessage } from './useFooterMessage';
 
@@ -12,9 +12,9 @@ export type TRoomFooterState =
 export const useRoomFooterState = (): TRoomFooterState => {
 	const room = useRoomWithUpdate();
 	const joined = useRoomStore(s => s.joined);
-	const airGappedRestrictionRemainingDays = useAppSelector(
-		state => state.settings.Cloud_Workspace_AirGapped_Restrictions_Remaining_Days as number | undefined
-	);
+	const airGappedRestrictionRemainingDays = useSetting('Cloud_Workspace_AirGapped_Restrictions_Remaining_Days') as
+		| number
+		| undefined;
 	const footerMessage = useFooterMessage();
 
 	if ('onHold' in room && room.onHold) {

--- a/app/views/RoomView/components/RoomMessageProvider.tsx
+++ b/app/views/RoomView/components/RoomMessageProvider.tsx
@@ -6,11 +6,43 @@ import { useRoomMessageHandlers } from '../hooks/useRoomMessageHandlers';
 
 type IRoomMessageProviderProps = Omit<MessageRoomState, 'handlers'> & { children: ReactNode; roomActions: IRoomActions };
 
-export const RoomMessageProvider = ({ children, roomActions, ...state }: IRoomMessageProviderProps): ReactElement => {
-	const handlers = useRoomMessageHandlers({ tmid: state.tmid, ...roomActions });
+export const RoomMessageProvider = ({
+	children,
+	roomActions,
+	rid,
+	tmid,
+	isThreadRoom,
+	archived,
+	broadcast,
+	isReadReceiptEnabled,
+	Message_GroupingPeriod,
+	timeFormat,
+	autoTranslateRoom,
+	autoTranslateLanguage,
+	jumpToMessage,
+	closeEmojiAndAction,
+	reactionInit,
+	errorActionsShow
+}: IRoomMessageProviderProps): ReactElement => {
+	const handlers = useRoomMessageHandlers({ tmid, ...roomActions });
 
 	return (
-		<MessageRoomProvider {...state} handlers={handlers}>
+		<MessageRoomProvider
+			handlers={handlers}
+			rid={rid}
+			tmid={tmid}
+			isThreadRoom={isThreadRoom}
+			archived={archived}
+			broadcast={broadcast}
+			isReadReceiptEnabled={isReadReceiptEnabled}
+			Message_GroupingPeriod={Message_GroupingPeriod}
+			timeFormat={timeFormat}
+			autoTranslateRoom={autoTranslateRoom}
+			autoTranslateLanguage={autoTranslateLanguage}
+			jumpToMessage={jumpToMessage}
+			closeEmojiAndAction={closeEmojiAndAction}
+			reactionInit={reactionInit}
+			errorActionsShow={errorActionsShow}>
 			{children}
 		</MessageRoomProvider>
 	);

--- a/app/views/RoomView/components/RoomPlaceholder.tsx
+++ b/app/views/RoomView/components/RoomPlaceholder.tsx
@@ -7,6 +7,38 @@ import sharedStyles from '../../Styles';
 
 const GAP = 32;
 
+const styles = StyleSheet.create({
+	root: { flex: 1 },
+	container: {
+		flex: 1,
+		marginHorizontal: 24,
+		justifyContent: 'center'
+	},
+	textView: { alignItems: 'center' },
+	icon: {
+		width: 58,
+		height: 58,
+		borderRadius: 30,
+		marginBottom: GAP,
+		alignItems: 'center',
+		justifyContent: 'center'
+	},
+	title: {
+		...sharedStyles.textBold,
+		fontSize: 24,
+		lineHeight: 32,
+		textAlign: 'center',
+		marginBottom: GAP
+	},
+	description: {
+		...sharedStyles.textRegular,
+		fontSize: 16,
+		lineHeight: 24,
+		textAlign: 'center'
+	},
+	gapBottom: { marginBottom: GAP }
+});
+
 interface RoomPlaceholderProps {
 	icon: TIconsName;
 	title: string;
@@ -18,62 +50,20 @@ interface RoomPlaceholderProps {
 
 export const RoomPlaceholder = ({ icon, title, description, detail, testID, children }: RoomPlaceholderProps): ReactElement => {
 	const { colors } = useTheme();
-	const styles = useStyle(colors);
 
 	return (
-		<View style={styles.root} testID={testID}>
+		<View style={[styles.root, { backgroundColor: colors.surfaceRoom }]} testID={testID}>
 			<View style={styles.container}>
 				<View style={styles.textView}>
-					<View style={styles.icon}>
+					<View style={[styles.icon, { backgroundColor: colors.surfaceNeutral }]}>
 						<CustomIcon name={icon} size={42} color={colors.fontSecondaryInfo} />
 					</View>
-					<Text style={styles.title}>{title}</Text>
-					<Text style={[styles.description, !detail && styles.gapBottom]}>{description}</Text>
+					<Text style={[styles.title, { color: colors.fontTitlesLabels }]}>{title}</Text>
+					<Text style={[styles.description, { color: colors.fontDefault }, !detail && styles.gapBottom]}>{description}</Text>
 					{detail ? <View style={styles.gapBottom}>{detail}</View> : null}
 				</View>
 				{children}
 			</View>
 		</View>
 	);
-};
-
-const useStyle = (colors: ReturnType<typeof useTheme>['colors']) => {
-	const styles = StyleSheet.create({
-		root: {
-			flex: 1,
-			backgroundColor: colors.surfaceRoom
-		},
-		container: {
-			flex: 1,
-			marginHorizontal: 24,
-			justifyContent: 'center'
-		},
-		textView: { alignItems: 'center' },
-		icon: {
-			width: 58,
-			height: 58,
-			borderRadius: 30,
-			marginBottom: GAP,
-			backgroundColor: colors.surfaceNeutral,
-			alignItems: 'center',
-			justifyContent: 'center'
-		},
-		title: {
-			...sharedStyles.textBold,
-			fontSize: 24,
-			lineHeight: 32,
-			textAlign: 'center',
-			color: colors.fontTitlesLabels,
-			marginBottom: GAP
-		},
-		description: {
-			...sharedStyles.textRegular,
-			fontSize: 16,
-			lineHeight: 24,
-			textAlign: 'center',
-			color: colors.fontDefault
-		},
-		gapBottom: { marginBottom: GAP }
-	});
-	return styles;
 };

--- a/app/views/RoomView/components/RoomProviders.tsx
+++ b/app/views/RoomView/components/RoomProviders.tsx
@@ -9,12 +9,37 @@ type IRoomProvidersProps = TComposerExternalState & {
 	children: ReactElement;
 };
 
-export const RoomProviders = (props: IRoomProvidersProps): ReactElement => {
-	const { store, children, ...composer } = props;
-
-	return (
-		<MessageActionProvider store={store}>
-			<ComposerProvider {...composer}>{children}</ComposerProvider>
-		</MessageActionProvider>
-	);
-};
+export const RoomProviders = ({
+	store,
+	children,
+	rid,
+	t,
+	tmid,
+	room,
+	roomUpdate,
+	sharing,
+	editCancel,
+	editRequest,
+	onRemoveQuoteMessage,
+	onSendMessage,
+	setQuotesAndText,
+	getText
+}: IRoomProvidersProps): ReactElement => (
+	<MessageActionProvider store={store}>
+		<ComposerProvider
+			rid={rid}
+			t={t}
+			tmid={tmid}
+			room={room}
+			roomUpdate={roomUpdate}
+			sharing={sharing}
+			editCancel={editCancel}
+			editRequest={editRequest}
+			onRemoveQuoteMessage={onRemoveQuoteMessage}
+			onSendMessage={onSendMessage}
+			setQuotesAndText={setQuotesAndText}
+			getText={getText}>
+			{children}
+		</ComposerProvider>
+	</MessageActionProvider>
+);

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -24,8 +24,6 @@ import { type MessageRoomState } from '../../containers/message/stores/MessageRo
 
 export type IRoomViewProps = Pick<IBaseScreen<ChatsStackParamList, 'RoomView'>, 'navigation' | 'route'>;
 
-// The route parsed once at mount. A room screen's identity never legitimately changes, and a route
-// without one renders a failure state instead of a room.
 export interface IRoomScreenInput {
 	rid: string;
 	t: string;
@@ -55,8 +53,6 @@ export interface IFooterPreviewProps {
 
 export type TRoomUpdate = keyof TSubscriptionModel;
 
-// The shapes the room screen reads off a subscription. The screen's own flags live with their
-// owners: room-wide ones in RoomState, per-screen ones in IRoomScreenContextValue.
 export interface IRoomViewState {
 	room:
 		| TSubscriptionModel
@@ -95,8 +91,6 @@ export type ComposerState = {
 	updateAutocompleteVisible: (updatedAutocompleteVisible: boolean) => void;
 };
 
-// The externally-suppliable slice of ComposerState — `isAutocompleteVisible`/`updateAutocompleteVisible`
-// are store-owned (seeded internally by `createComposerStore`), not passed in by callers.
 export type TComposerExternalState = Omit<ComposerState, 'isAutocompleteVisible' | 'updateAutocompleteVisible'>;
 
 export interface IUseE2EEStatusResult {
@@ -124,18 +118,13 @@ export type TMessagesIdsRef = RefObject<string[]>;
 export interface IListProps extends FlatListProps<TAnyMessageModel> {
 	flatListRef: TListRef;
 	jumpToBottom: () => void;
-	// Anchored Window: loaded rows' bottom isn't the Live Tail, so the scroll-offset
-	// heuristic alone would hide the jump-to-bottom FAB. Keep it visible so "back to live" stays one tap.
 	isAnchored?: boolean;
 }
 
 export interface IListContainerRef {
-	// highTs: upper ts bound (ms) for an Anchored Window on the target's Chunk; null/undefined keeps a
-	// Live Window (contiguous / thread / local targets).
+	// highTs is in milliseconds
 	jumpToMessage: (messageId: string, highTs?: number | null) => Promise<void>;
 	cancelJumpToMessage: () => void;
-	// True when messageId is in the rendered window, so the orchestration skips re-anchoring for an
-	// already-visible target (a quoted reply nearby scrolls in place, Live Tail intact).
 	isMessageInWindow: (messageId: string) => boolean;
 }
 
@@ -156,7 +145,6 @@ export interface IRoomActions {
 	sendMessage: (message?: string, tshow?: boolean) => void;
 }
 
-// The screen's own state, carried by RoomScreenContext — see that module for why it is per-screen.
 export interface IRoomScreenContextValue {
 	loading: boolean;
 	failed: boolean;
@@ -168,15 +156,9 @@ export interface IRoomScreenContextValue {
 export interface IRoomStoreInitParams {
 	tmid?: string;
 	onThreadMessagesLoaded?: () => void;
-	// Per-run cancel token: a run whose signal aborts stops retrying and reports `skipped`, so a
-	// superseded run can never write over the run that replaced it.
 	signal?: AbortSignal;
 }
 
-// The distinct outcomes of one init() run. `skipped` means the run produced nothing the caller may
-// act on: either no work was attempted (no rid, an invite subscription) or the run was aborted and
-// abandoned, which can happen even after a successful load. Only `loaded` carries an unread divider
-// anchor; `failed` means every attempt was made and none succeeded.
 export type TRoomInitResult =
 	| { status: 'loaded'; lastSeen: IRoomViewState['lastSeen'] }
 	| { status: 'skipped' }
@@ -193,7 +175,6 @@ export interface RoomState {
 	canForwardGuest: boolean;
 	canViewCannedResponse: boolean;
 	lastMessageFromAgent: boolean;
-	// Resolves with the run's outcome; only `loaded` carries the screen's unread divider anchor.
 	init: (params?: IRoomStoreInitParams) => Promise<TRoomInitResult>;
 	join: () => void;
 	joinRoom: (requestJoinCode?: () => void) => Promise<void>;


### PR DESCRIPTION
## Proposed changes

Cleanup pass over the RoomView components, on top of the RoomView hooks migration.

- `RoomProviders` and `RoomMessageProvider` spread `{...props}` into their providers. Every field is now passed explicitly, so what each provider actually supplies is readable at the call site.
- `MessageRow` built its output into a `let content` through an if/else chain and wrapped a render-time decision in a nested `runOnRender` function. Now early returns and a plain boolean.
- `RightButtons` had a `@ts-ignore` on `goSearchView` because it navigated directly instead of through the file's own `navigateToScreen` helper. Routing it through the helper drops the suppression; the two branches keep their distinct params, and the modal branch now also passes the `t` it was required to.
- `Threads_enabled` and `Livechat_request_comment_when_closing_conversation` in `RightButtons`, plus the federation settings in `useRoomFooterState` and `useFooterMessage`, read through `useSetting` instead of a raw `useAppSelector` with a cast. The federation settings are read unconditionally: a short-circuit between two `useSetting` calls makes the hook order depend on the first value, which breaks the rules of hooks and fails `reactCompilerContract.test.ts`.
- `RoomPlaceholder` ran `StyleSheet.create` on every render. Hoisted to a module-level stylesheet with the four color values applied inline, matching `RoomFooter/styles.ts`.
- `Banner`'s hand-written `memo` comparator ignored `title` and `closeBanner`, so it could hold a stale banner on screen. Replaced with a plain `memo`.
- `InvitedRoom`'s `loading` prop had no caller passing it.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-34

## How to test or reproduce

Open a room and exercise the header buttons (search, threads, kebab), the footer states (preview, on hold, take/join, airgapped), an invited room, and the room placeholder during load. Behavior should be unchanged.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Targets `native-34-roomview-hooks` (#7482), not develop.

Three `resolveJumpAnchor` `fromServer` tests fail on this branch. They also fail on `native-34-roomview-hooks` unchanged, so they are pre-existing there and not caused by these changes.

Considered and not done, since each needs edits outside these components:

- `placeOnHoldLivechat` and `closeLivechat` are duplicated statement for statement with `RoomActionsView`; extracting to `app/lib/methods/helpers` would need that view changed too.
- `JoinCode` calls `joinRoom` from `restApi` directly rather than the store service. Routing it through the service would skip `logEvent(ROOM_JOIN)` and `log(e)`, which is a behavior change, not a cleanup.
- `AirgappedWs` could render through `Preview`, but the title colors differ, so it would be a visual change.
- The structural items: routing the `useRoomMessaging` handlers through context instead of prop threading, moving the join-code trigger into `RoomStore` state, extracting `useRightButtons`, and converting `UploadProgress` off its class component.
- The efficiency findings all land in `hooks/` and `stores/`. The sharpest: `last_message` sits in `OBSERVED_COLUMNS`, so the room observer wakes on every message in every room to compute a livechat-only value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search navigation consistency across room views.
  - Room federation and air-gapped workspace settings are now handled consistently.

- **Changes**
  - Removed loading-state indicators from invited-room accept and reject actions.
  - Updated room placeholders to apply theme colors more reliably.

- **Refactor**
  - Simplified room message rendering, provider configuration, and settings access.
  - Streamlined component prop handling and memoization without changing intended rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->