### PR TITLE
refactor: simplify RoomView hooks and List

### DIFF
--- a/app/views/RoomView/List/hooks/__tests__/useMessages.test.tsx
+++ b/app/views/RoomView/List/hooks/__tests__/useMessages.test.tsx
@@ -2,20 +2,20 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import { type ReactNode } from 'react';
 
-import { ROOM } from '../../../../actions/actionsTypes';
-import { type IRoomHistoryRequest } from '../../../../actions/room';
-import { type RoomType, type TAnyMessageModel } from '../../../../definitions';
-import database from '../../../../lib/database';
-import { getMessageById } from '../../../../lib/database/services/Message';
-import { getThreadById } from '../../../../lib/database/services/Thread';
-import { MessageTypeLoad } from '../../../../lib/constants/messageTypeLoad';
-import { readThreads } from '../../../../lib/services/restApi';
-import { mockedStore } from '../../../../reducers/mockedStore';
-import { MAX_AUTO_LOADS, QUERY_SIZE } from '../constants';
-import { buildVisibleSystemTypesClause } from '../visibleSystemMessages';
-import { useMessages } from './useMessages';
+import { ROOM } from '../../../../../actions/actionsTypes';
+import { type IRoomHistoryRequest } from '../../../../../actions/room';
+import { type RoomType, type TAnyMessageModel } from '../../../../../definitions';
+import database from '../../../../../lib/database';
+import { getMessageById } from '../../../../../lib/database/services/Message';
+import { getThreadById } from '../../../../../lib/database/services/Thread';
+import { MessageTypeLoad } from '../../../../../lib/constants/messageTypeLoad';
+import { readThreads } from '../../../../../lib/services/restApi';
+import { mockedStore } from '../../../../../reducers/mockedStore';
+import { MAX_AUTO_LOADS, QUERY_SIZE } from '../../constants';
+import { buildVisibleSystemTypesClause } from '../../visibleSystemMessages';
+import { useMessages } from '../useMessages';
 
-jest.mock('../../../../lib/database', () => ({
+jest.mock('../../../../../lib/database', () => ({
 	__esModule: true,
 	default: {
 		active: {
@@ -24,20 +24,20 @@ jest.mock('../../../../lib/database', () => ({
 	}
 }));
 
-jest.mock('../../../../lib/database/services/Message', () => ({
+jest.mock('../../../../../lib/database/services/Message', () => ({
 	getMessageById: jest.fn(() => Promise.resolve(null))
 }));
 
-jest.mock('../../../../lib/database/services/Thread', () => ({
+jest.mock('../../../../../lib/database/services/Thread', () => ({
 	getThreadById: jest.fn(() => Promise.resolve(null))
 }));
 
-jest.mock('../../../../lib/services/restApi', () => ({
+jest.mock('../../../../../lib/services/restApi', () => ({
 	readThreads: jest.fn(() => Promise.resolve())
 }));
 
-jest.mock('../../../../lib/methods/helpers', () => {
-	const actual = jest.requireActual('../../../../lib/methods/helpers');
+jest.mock('../../../../../lib/methods/helpers', () => {
+	const actual = jest.requireActual('../../../../../lib/methods/helpers');
 	return {
 		...actual,
 		useDebounce: (fn: (...args: unknown[]) => unknown) => Object.assign(fn, { cancel: jest.fn() })

--- a/app/views/RoomView/List/hooks/__tests__/useScroll.test.tsx
+++ b/app/views/RoomView/List/hooks/__tests__/useScroll.test.tsx
@@ -1,8 +1,8 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 
-import { type TAnyMessageModel } from '../../../../definitions';
-import { type TListRef, type TMessagesIdsRef } from '../../definitions';
-import { useScroll } from './useScroll';
+import { type TAnyMessageModel } from '../../../../../definitions';
+import { type TListRef, type TMessagesIdsRef } from '../../../definitions';
+import { useScroll } from '../useScroll';
 
 type Row = { id: string };
 

--- a/app/views/RoomView/hooks/useCanPlaceLivechatOnHold.ts
+++ b/app/views/RoomView/hooks/useCanPlaceLivechatOnHold.ts
@@ -1,10 +1,13 @@
+import { useShallow } from 'zustand/react/shallow';
+
 import { useSetting } from '../../../lib/hooks/useSetting';
 import { useRoomStoreByRid } from '../stores/RoomStore';
 
 export function useCanPlaceLivechatOnHold(rid?: string): boolean {
 	const livechatAllowManualOnHold = useSetting('Livechat_allow_manual_on_hold') as boolean;
-	const t = useRoomStoreByRid(rid, s => s.room.t);
-	const lastMessageFromAgent = useRoomStoreByRid(rid, s => s.lastMessageFromAgent);
-	const onHold = useRoomStoreByRid(rid, s => s.roomUpdate.onHold);
+	const { t, lastMessageFromAgent, onHold } = useRoomStoreByRid(
+		rid,
+		useShallow(s => ({ t: s.room.t, lastMessageFromAgent: s.lastMessageFromAgent, onHold: s.roomUpdate.onHold }))
+	);
 	return t === 'l' && !!livechatAllowManualOnHold && lastMessageFromAgent && !onHold;
 }

--- a/app/views/RoomView/hooks/useGoRoomActionsView.ts
+++ b/app/views/RoomView/hooks/useGoRoomActionsView.ts
@@ -1,4 +1,5 @@
 import { type NavigatorScreenParams, useNavigation } from '@react-navigation/native';
+import { useShallow } from 'zustand/react/shallow';
 
 import { events, logEvent } from '../../../lib/methods/helpers/log';
 import { useMasterDetail } from '../../../lib/hooks/useMasterDetail';
@@ -13,13 +14,17 @@ import { useCanPlaceLivechatOnHold } from './useCanPlaceLivechatOnHold';
 export const useGoRoomActionsView = (rid?: string): ((screen?: keyof ModalStackParamList) => void) => {
 	const navigation = useNavigation<IRoomViewProps['navigation']>();
 	const isMasterDetail = useMasterDetail();
-	// `t` comes from the store (seeded at mount) rather than route.params, which navigation can wipe.
-	const room = useRoomStoreByRid(rid, s => s.room);
+	const { room, member, joined, canForwardGuest, canViewCannedResponse } = useRoomStoreByRid(
+		rid,
+		useShallow(s => ({
+			room: s.room,
+			member: s.member,
+			joined: s.joined,
+			canForwardGuest: s.canForwardGuest,
+			canViewCannedResponse: s.canViewCannedResponse
+		}))
+	);
 	const t = room.t;
-	const member = useRoomStoreByRid(rid, s => s.member);
-	const joined = useRoomStoreByRid(rid, s => s.joined);
-	const canForwardGuest = useRoomStoreByRid(rid, s => s.canForwardGuest);
-	const canViewCannedResponse = useRoomStoreByRid(rid, s => s.canViewCannedResponse);
 	const canReturnQueue = useCanReturnQueue(t === 'l');
 	const canPlaceLivechatOnHold = useCanPlaceLivechatOnHold(rid);
 

--- a/app/views/RoomView/hooks/useHeader.tsx
+++ b/app/views/RoomView/hooks/useHeader.tsx
@@ -101,6 +101,26 @@ export const useHeader = ({ rid, tmid, name: roomName }: IUseHeaderParams): void
 		}
 
 		const headerProps = getRoomHeaderProps({ room, tmid, roomName, roomUserId, onPress: goRoomActionsView });
-		navigation.setOptions({ headerTitle: () => <RoomHeader {...headerProps} /> });
+		navigation.setOptions({
+			headerTitle: () => (
+				<RoomHeader
+					prid={headerProps.prid}
+					tmid={headerProps.tmid}
+					title={headerProps.title}
+					teamMain={headerProps.teamMain}
+					parentTitle={headerProps.parentTitle}
+					subtitle={headerProps.subtitle}
+					type={headerProps.type}
+					roomUserId={headerProps.roomUserId}
+					visitor={headerProps.visitor}
+					isGroupChat={headerProps.isGroupChat}
+					onPress={headerProps.onPress}
+					testID={headerProps.testID}
+					sourceType={headerProps.sourceType}
+					abacAttributes={headerProps.abacAttributes}
+					disabled={headerProps.disabled}
+				/>
+			)
+		});
 	}, [rid, tmid, roomName, room, roomUpdate, roomUserId, navigation, goRoomActionsView]);
 };

--- a/app/views/RoomView/hooks/useJumpToMessage.ts
+++ b/app/views/RoomView/hooks/useJumpToMessage.ts
@@ -88,7 +88,6 @@ export function useJumpToMessage({
 
 	// Live-mirrored (see useLiveRef) so the mount effect can key on [tmid] despite these being unstable.
 	const consumeJumpParamRef = useLiveRef(consumeJumpParam);
-	const onJumpParamChangedRef = useLiveRef(onJumpParamChanged);
 	const navToThreadRef = useLiveRef(navToThread);
 
 	useEffect(() => {
@@ -114,8 +113,8 @@ export function useJumpToMessage({
 		return () => task.cancel();
 	}, [navToThreadRef]);
 
-	useChangedParam(route.params?.jumpToMessageId, id => onJumpParamChangedRef.current(id));
-	useChangedParam(route.params?.jumpToThreadId, id => navToThreadRef.current({ tmid: id }));
+	useChangedParam(route.params?.jumpToMessageId, onJumpParamChanged);
+	useChangedParam(route.params?.jumpToThreadId, id => navToThread({ tmid: id }));
 
 	return { jumpToMessage, cancelJumpToMessage, onThreadMessagesLoaded };
 }

--- a/app/views/RoomView/hooks/useRoomMessageHandlers.tsx
+++ b/app/views/RoomView/hooks/useRoomMessageHandlers.tsx
@@ -36,8 +36,8 @@ export function useRoomMessageHandlers({
 	const isMasterDetail = useMasterDetail();
 	const { showActionSheet } = useActionSheet();
 
-	const rid = useRoomStore(s => s.room.rid);
 	const room = useRoomStore(s => s.room);
+	const rid = room.rid;
 
 	const onDiscussionPress = async (drid: TAnyMessageModel['drid']) => {
 		if (!drid) return;

--- a/app/views/RoomView/hooks/useRoomNavigation.ts
+++ b/app/views/RoomView/hooks/useRoomNavigation.ts
@@ -54,7 +54,7 @@ export function useRoomNavigation({
 
 	useEffect(() => {
 		cancelJumpToMessageRef.current = cancelJumpToMessage;
-	});
+	}, [cancelJumpToMessage]);
 
 	const onThreadPress = useDebounce((item: TAnyMessageModel) => navToThread(item), 1000, { leading: true, trailing: false });
 

--- a/app/views/RoomView/hooks/useUnreadsCount.ts
+++ b/app/views/RoomView/hooks/useUnreadsCount.ts
@@ -1,32 +1,29 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { Q } from '@nozbe/watermelondb';
 
 import database from '../../../lib/database';
 import { isIOS } from '../../../lib/methods/helpers';
+import { useObservable } from '../../../lib/hooks/useObservable';
 import { type TSubscriptionModel } from '../../../definitions';
 
 export function useUnreadsCount(rid?: string): number | null {
-	const [unreadsCount, setUnreadsCount] = useState<number | null>(null);
+	const observable = useMemo(
+		() =>
+			isIOS && rid
+				? database.active
+						.get<TSubscriptionModel>('subscriptions')
+						.query(Q.where('archived', false), Q.where('open', true), Q.where('rid', Q.notEq(rid)))
+						.observeWithColumns(['unread'])
+				: undefined,
+		[rid]
+	);
+	const rooms = useObservable(observable);
 
-	useEffect(() => {
-		if (!isIOS || !rid) {
-			return;
-		}
-		const observable = database.active
-			.get('subscriptions')
-			.query(Q.where('archived', false), Q.where('open', true), Q.where('rid', Q.notEq(rid)))
-			.observeWithColumns(['unread']);
-
-		const subscription = observable.subscribe((rooms: TSubscriptionModel[]) => {
-			const nextUnreadsCount = rooms.reduce(
-				(unreadCount, item) => (item.unread > 0 && !item.hideUnreadStatus ? unreadCount + item.unread : unreadCount),
-				0
-			);
-			setUnreadsCount(nextUnreadsCount);
-		});
-
-		return () => subscription.unsubscribe();
-	}, [rid]);
-
-	return unreadsCount;
+	if (!rooms) {
+		return null;
+	}
+	return rooms.reduce(
+		(unreadCount, item) => (item.unread > 0 && !item.hideUnreadStatus ? unreadCount + item.unread : unreadCount),
+		0
+	);
 }


### PR DESCRIPTION
## Proposed changes

Cleanup pass over `RoomView/hooks` and `RoomView/List`, on top of the RoomView hooks migration.

- `useUnreadsCount` hand-rolled an rxjs `subscribe` / `setState` / `unsubscribe` cycle. It now uses the repo's `useObservable` with the query in `useMemo` and the reduce computed during render, matching its sibling `useThreadFollowing`. Derived state belongs in render, not in an effect that writes state.
- `useCanPlaceLivechatOnHold` (3 subscriptions) and `useGoRoomActionsView` (5) each subscribed per field; both are now a single `useShallow` selector, so an unrelated field changing no longer re-renders the consumer.
- `useRoomMessageHandlers` subscribed to `rid` separately when it already had the room; `rid` is read off the room now.
- `useJumpToMessage` kept an `onJumpParamChangedRef` live-ref layer that `useChangedParam` already provides for its own `onChange`. Both call sites pass the callback directly.
- `useRoomNavigation`'s cycle-breaking mirror effect had no dependency array, so it ran on every render. It now depends on `[cancelJumpToMessage]`.
- `useHeader` spread `{...headerProps}` into `RoomHeader`; all 15 props are passed explicitly.
- The two List hook tests were the only ones outside a `__tests__` directory. Moved.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-34

## How to test or reproduce

Open a room and exercise the header, the unread badge, jump-to-message, discussion and thread navigation, and livechat on-hold. Behavior should be unchanged.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Targets `native-34-roomview-hooks` (#7482), not develop.

Walkthrough of every change, including the ones rejected: https://claude.ai/code/artifact/8292075a-18cc-48d5-bf3a-b5d0982603b8

One change was attempted and reverted, and is worth recording. Collapsing `useScroll`'s `onReObserve` ref and its two layout effects into a single `useLayoutEffect(onReObserve, [messages])` needs an `exhaustive-deps` suppression, and `reactCompilerContract.test.ts` then fails: the suppression makes React Compiler skip optimizing the entire file. That ref and ordering pattern is load-bearing for memoization on the hottest scroll hook, not lint appeasement. Note that the bail set is rule-specific, since `useScroll` already carries a `set-state-in-effect` suppression that the compiler tolerates, so the contract test is the only reliable check.

Left for follow-up:

- `useHeader` depends on the whole `roomUpdate` object, so `tunread` churn rebuilds the header on every incoming message. Narrowing it requires the exact field set read by `getRoomTitle` / `isGroupChat` / `isInviteSubscription`, and getting that wrong silently freezes the header.
- `getRoomInfo` plus `goRoom` is duplicated between `useRoomNavigation.navToRoom` and `useRoomMessageHandlers.onDiscussionPress`.
- `useDebounce`'s missing cancel-on-unmount is bolted onto two call sites here; the fix belongs in `lib/methods/helpers/debounce.ts`, where 21 other call sites have the same leak.
- `useCloseBanner` and `useReactionActions` use no React API, so they are not hooks.

Local run: 38 suites, 400 tests pass; `tsc` clean; no new lint warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization when cancelling message jumps during room navigation.
  - Improved unread-message count updates, including cases where no room or data is available.
  - Preserved existing room header, message handling, and live chat hold behavior.

- **Refactor**
  - Streamlined room state handling to reduce redundant subscriptions and improve efficiency without changing visible behavior.

- **Tests**
  - Updated test references so message and scrolling behavior continues to be validated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->