### PR TITLE
fix: fewer-hooks crash on NewServerView

### DIFF
--- a/app/lib/methods/helpers/navigation/index.ts
+++ b/app/lib/methods/helpers/navigation/index.ts
@@ -1,6 +1,6 @@
-import { createElement } from 'react';
+import { createElement, type ReactElement } from 'react';
 import { DarkTheme, DefaultTheme } from '@react-navigation/native';
-import { type NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import { type NativeStackHeaderProps, type NativeStackNavigationOptions } from '@react-navigation/native-stack';
 
 import { themes } from '../../../constants/colors';
 import { type TSupportedThemes } from '../../../../theme';
@@ -8,7 +8,7 @@ import sharedStyles from '../../../../views/Styles';
 import Header from '../../../../containers/Header';
 
 export const defaultHeader: NativeStackNavigationOptions = {
-	header: props => createElement(Header, props)
+	header: (props: NativeStackHeaderProps): ReactElement => createElement(Header, props)
 };
 
 export const drawerStyle = {

--- a/app/lib/methods/helpers/navigation/index.ts
+++ b/app/lib/methods/helpers/navigation/index.ts
@@ -1,3 +1,4 @@
+import { createElement } from 'react';
 import { DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { type NativeStackNavigationOptions } from '@react-navigation/native-stack';
 
@@ -7,7 +8,7 @@ import sharedStyles from '../../../../views/Styles';
 import Header from '../../../../containers/Header';
 
 export const defaultHeader: NativeStackNavigationOptions = {
-	header: Header
+	header: props => createElement(Header, props)
 };
 
 export const drawerStyle = {


### PR DESCRIPTION
## Proposed changes
Fixes the `Rendered fewer hooks than expected` crash on `NewServerView`. This was introduced by #7432, which wrapped `NewServerView` with `defaultHeader` for the first time. native-stack invokes `options.header` as a plain function inside `SceneView`'s render, so `Header`'s hooks were registered on `SceneView`. `NewServerView` then hides the header with `setOptions({ headerShown: false })` after mount, so the second render ran fewer hooks and React threw.

## Issue(s)
https://rocketchat.atlassian.net/browse/NATIVE-1527

## How to test or reproduce

- Fresh install / log out to land on `NewServerView` (no previous server).
- App renders the Connect to server screen with no redbox or crash.

## Screenshots

No visual change expected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and rendering behavior for the default navigation header.
  * Ensured the header correctly receives navigation properties when rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->