### PR TITLE
refactor: move message action admission rules into MessageActionStore

### DIFF
--- a/app/containers/message/stores/MessageActionStore.tsx
+++ b/app/containers/message/stores/MessageActionStore.tsx
@@ -4,9 +4,8 @@ import { createStore, useStore } from 'zustand';
 import { type TMessageActionState } from '../../../definitions';
 
 type TMessageActionActions = {
-	startEditing(messageId: string): void;
-	startQuote(messageId: string): void;
-	addQuote(messageId: string): void;
+	requestEditing(messageId: string): void;
+	requestQuote(messageId: string): void;
 	removeQuote(messageId: string): void;
 	startReacting(messageId: string): void;
 	setQuoteMessageIds(messageIds: string[]): void;
@@ -20,21 +19,26 @@ type MessageActionState = {
 };
 
 export const createMessageActionStore = (initialAction?: TMessageActionState) =>
-	createStore<MessageActionState>()(set => ({
+	createStore<MessageActionState>()((set, get) => ({
 		action: initialAction ?? null,
 		actions: {
-			startEditing: messageId => set({ action: { kind: 'edit', messageId } }),
-			startQuote: messageId => set({ action: { kind: 'quote', messageIds: [messageId] } }),
-			addQuote: messageId =>
-				set(state => {
-					if (state.action?.kind !== 'quote') {
-						return { action: { kind: 'quote', messageIds: [messageId] } };
-					}
-					if (state.action.messageIds.includes(messageId)) {
-						return {};
-					}
-					return { action: { kind: 'quote', messageIds: [...state.action.messageIds, messageId] } };
-				}),
+			requestEditing: messageId => {
+				if (get().action !== null) {
+					return;
+				}
+				set({ action: { kind: 'edit', messageId } });
+			},
+			requestQuote: messageId => {
+				const { action } = get();
+				if (action === null) {
+					set({ action: { kind: 'quote', messageIds: [messageId] } });
+					return;
+				}
+				if (action.kind !== 'quote' || action.messageIds.includes(messageId)) {
+					return;
+				}
+				set({ action: { kind: 'quote', messageIds: [...action.messageIds, messageId] } });
+			},
 			removeQuote: messageId =>
 				set(state => {
 					if (state.action?.kind !== 'quote') {

--- a/app/containers/message/stores/__tests__/MessageActionStore.test.tsx
+++ b/app/containers/message/stores/__tests__/MessageActionStore.test.tsx
@@ -247,63 +247,75 @@ describe('MessageActionStore', () => {
 		});
 	});
 
-	describe('action creators (union transitions)', () => {
-		it('startEditing sets an edit action with the given messageId', () => {
+	describe('requestEditing', () => {
+		it('admits and sets an edit action when idle', () => {
 			const store = createMessageActionStore();
-			store.getState().actions.startEditing('msg-1');
+			store.getState().actions.requestEditing('msg-1');
 			expect(store.getState().action).toEqual({ kind: 'edit', messageId: 'msg-1' });
 		});
 
-		it('startQuote starts a quote action with a single messageId', () => {
+		it('rejects when an action is already in progress', () => {
+			const store = createMessageActionStore({ kind: 'quote', messageIds: ['other-msg'] });
+			store.getState().actions.requestEditing('msg-1');
+			expect(store.getState().action).toEqual({ kind: 'quote', messageIds: ['other-msg'] });
+		});
+	});
+
+	describe('requestQuote', () => {
+		it('admits and starts a quote action with a single messageId when idle', () => {
 			const store = createMessageActionStore();
-			store.getState().actions.startQuote('msg-1');
+			store.getState().actions.requestQuote('msg-1');
 			expect(store.getState().action).toEqual({ kind: 'quote', messageIds: ['msg-1'] });
 		});
 
-		it('addQuote appends to an existing quote action', () => {
-			const store = createMessageActionStore();
-			store.getState().actions.startQuote('msg-1');
-			store.getState().actions.addQuote('msg-2');
+		it('admits and appends to an existing quote action', () => {
+			const store = createMessageActionStore({ kind: 'quote', messageIds: ['msg-1'] });
+			store.getState().actions.requestQuote('msg-2');
 			expect(store.getState().action).toEqual({ kind: 'quote', messageIds: ['msg-1', 'msg-2'] });
 		});
 
-		it('addQuote starts a new quote action when there is none', () => {
-			const store = createMessageActionStore();
-			store.getState().actions.addQuote('msg-1');
+		it('rejects a duplicate messageId', () => {
+			const store = createMessageActionStore({ kind: 'quote', messageIds: ['msg-1'] });
+			store.getState().actions.requestQuote('msg-1');
 			expect(store.getState().action).toEqual({ kind: 'quote', messageIds: ['msg-1'] });
 		});
 
-		it('addQuote does not append a duplicate messageId', () => {
-			const store = createMessageActionStore();
-			store.getState().actions.startQuote('msg-1');
-			store.getState().actions.addQuote('msg-1');
-			expect(store.getState().action).toEqual({ kind: 'quote', messageIds: ['msg-1'] });
+		it('rejects when a non-quote action is already in progress', () => {
+			const store = createMessageActionStore({ kind: 'edit', messageId: 'other-msg' });
+			store.getState().actions.requestQuote('msg-1');
+			expect(store.getState().action).toEqual({ kind: 'edit', messageId: 'other-msg' });
 		});
+	});
 
-		it('removeQuote drops a messageId and keeps the quote action if others remain', () => {
+	describe('removeQuote', () => {
+		it('drops a messageId and keeps the quote action if others remain', () => {
 			const store = createMessageActionStore({ kind: 'quote', messageIds: ['msg-1', 'msg-2'] });
 			store.getState().actions.removeQuote('msg-1');
 			expect(store.getState().action).toEqual({ kind: 'quote', messageIds: ['msg-2'] });
 		});
 
-		it('removeQuote clears the action when the last quoted message is removed', () => {
+		it('clears the action when the last quoted message is removed', () => {
 			const store = createMessageActionStore({ kind: 'quote', messageIds: ['msg-1'] });
 			store.getState().actions.removeQuote('msg-1');
 			expect(store.getState().action).toBeNull();
 		});
 
-		it('removeQuote is a no-op when the current action is not a quote', () => {
+		it('is a no-op when the current action is not a quote', () => {
 			const store = createMessageActionStore({ kind: 'edit', messageId: 'msg-1' });
 			store.getState().actions.removeQuote('msg-1');
 			expect(store.getState().action).toEqual({ kind: 'edit', messageId: 'msg-1' });
 		});
+	});
 
-		it('startReacting sets a react action with the given messageId', () => {
+	describe('startReacting', () => {
+		it('sets a react action with the given messageId', () => {
 			const store = createMessageActionStore();
 			store.getState().actions.startReacting('msg-1');
 			expect(store.getState().action).toEqual({ kind: 'react', messageId: 'msg-1' });
 		});
+	});
 
+	describe('setQuoteMessageIds and clear', () => {
 		it('setQuoteMessageIds sets a quote action with the given ids, or clears it when empty', () => {
 			const store = createMessageActionStore();
 			store.getState().actions.setQuoteMessageIds(['msg-1', 'msg-2']);
@@ -311,6 +323,12 @@ describe('MessageActionStore', () => {
 
 			store.getState().actions.setQuoteMessageIds([]);
 			expect(store.getState().action).toBeNull();
+		});
+
+		it('setQuoteMessageIds overrides an in-progress non-quote action unconditionally', () => {
+			const store = createMessageActionStore({ kind: 'edit', messageId: 'msg-1' });
+			store.getState().actions.setQuoteMessageIds(['msg-2']);
+			expect(store.getState().action).toEqual({ kind: 'quote', messageIds: ['msg-2'] });
 		});
 
 		it('clear resets a react action', () => {

--- a/app/views/RoomView/components/RoomProviders.test.tsx
+++ b/app/views/RoomView/components/RoomProviders.test.tsx
@@ -61,7 +61,7 @@ describe('RoomProviders', () => {
 		expect(actionSpy).toHaveBeenLastCalledWith(null);
 		expect(isBeingEditedSpy).toHaveBeenLastCalledWith(false);
 
-		act(() => store.getState().actions.startEditing('msg-1'));
+		act(() => store.getState().actions.requestEditing('msg-1'));
 
 		expect(actionSpy).toHaveBeenLastCalledWith({ kind: 'edit', messageId: 'msg-1' });
 		expect(isBeingEditedSpy).toHaveBeenLastCalledWith(true);

--- a/app/views/RoomView/hooks/__tests__/useMessageActions.test.tsx
+++ b/app/views/RoomView/hooks/__tests__/useMessageActions.test.tsx
@@ -91,7 +91,7 @@ describe('useMessageActions', () => {
 
 		it('onEditInit no-ops when an action is already in progress', () => {
 			const { result, messageActionStore } = renderMessageActions();
-			messageActionStore.getState().actions.startQuote('other-msg');
+			messageActionStore.getState().actions.requestQuote('other-msg');
 
 			act(() => result.current.onEditInit('msg-1'));
 
@@ -100,7 +100,7 @@ describe('useMessageActions', () => {
 
 		it('onEditCancel clears the current action', () => {
 			const { result, messageActionStore } = renderMessageActions();
-			messageActionStore.getState().actions.startEditing('msg-1');
+			messageActionStore.getState().actions.requestEditing('msg-1');
 
 			act(() => result.current.onEditCancel());
 
@@ -110,7 +110,7 @@ describe('useMessageActions', () => {
 		it('onEditRequest clears the action then calls editMessage', async () => {
 			mockEditMessage.mockResolvedValue(undefined);
 			const { result, messageActionStore } = renderMessageActions();
-			messageActionStore.getState().actions.startEditing('msg-1');
+			messageActionStore.getState().actions.requestEditing('msg-1');
 
 			await act(async () => {
 				await result.current.onEditRequest({ id: 'msg-1', msg: 'edited', rid: RID });
@@ -144,7 +144,7 @@ describe('useMessageActions', () => {
 
 		it('onQuoteInit appends to an in-progress quote', () => {
 			const { result, messageActionStore } = renderMessageActions();
-			messageActionStore.getState().actions.startQuote('msg-1');
+			messageActionStore.getState().actions.requestQuote('msg-1');
 
 			act(() => result.current.onQuoteInit('msg-2'));
 
@@ -153,8 +153,8 @@ describe('useMessageActions', () => {
 
 		it('onRemoveQuoteMessage removes a quoted message id', () => {
 			const { result, messageActionStore } = renderMessageActions();
-			messageActionStore.getState().actions.startQuote('msg-1');
-			messageActionStore.getState().actions.addQuote('msg-2');
+			messageActionStore.getState().actions.requestQuote('msg-1');
+			messageActionStore.getState().actions.requestQuote('msg-2');
 
 			act(() => result.current.onRemoveQuoteMessage('msg-1'));
 
@@ -205,7 +205,7 @@ describe('useMessageActions', () => {
 
 		it('onReactionInit no-ops when an action is already in progress', () => {
 			const { result, messageActionStore, showActionSheet } = renderMessageActions();
-			messageActionStore.getState().actions.startQuote('other-msg');
+			messageActionStore.getState().actions.requestQuote('other-msg');
 
 			act(() => result.current.onReactionInit('msg-1'));
 
@@ -243,7 +243,7 @@ describe('useMessageActions', () => {
 
 		it('no-ops when an action other than quote is already in progress', () => {
 			const { result, messageActionStore, refs } = renderMessageActions();
-			messageActionStore.getState().actions.startEditing('other-msg');
+			messageActionStore.getState().actions.requestEditing('other-msg');
 			const message = { id: 'msg-1' } as any;
 
 			act(() => result.current.onMessageLongPress(message));
@@ -253,7 +253,7 @@ describe('useMessageActions', () => {
 
 		it('allows a long-press while quoting (kind === quote)', () => {
 			const { result, messageActionStore, refs } = renderMessageActions();
-			messageActionStore.getState().actions.startQuote('other-msg');
+			messageActionStore.getState().actions.requestQuote('other-msg');
 			const message = { id: 'msg-1' } as any;
 
 			act(() => result.current.onMessageLongPress(message));

--- a/app/views/RoomView/hooks/useMessageActions.tsx
+++ b/app/views/RoomView/hooks/useMessageActions.tsx
@@ -31,11 +31,7 @@ export function useMessageActions({
 	};
 
 	const onEditInit = (messageId: string) => {
-		const { action, actions } = messageActionStore.getState();
-		if (action) {
-			return;
-		}
-		actions.startEditing(messageId);
+		messageActionStore.getState().actions.requestEditing(messageId);
 	};
 
 	const onEditCancel = () => {
@@ -56,17 +52,7 @@ export function useMessageActions({
 	};
 
 	const onQuoteInit = (messageId: string) => {
-		const { action, actions } = messageActionStore.getState();
-		if (action?.kind === 'quote') {
-			if (!action.messageIds.includes(messageId)) {
-				actions.addQuote(messageId);
-			}
-			return;
-		}
-		if (action) {
-			return;
-		}
-		actions.startQuote(messageId);
+		messageActionStore.getState().actions.requestQuote(messageId);
 	};
 
 	const onRemoveQuoteMessage = (messageId: string) => {

--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -379,8 +379,7 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 	}
 
 	onRemoveQuoteMessage = (messageId: string) => {
-		const newSelectedMessages = this.getSelectedMessageIds().filter(item => item !== messageId);
-		this.messageActionStore.getState().actions.setQuoteMessageIds(newSelectedMessages);
+		this.messageActionStore.getState().actions.removeQuote(messageId);
 	};
 
 	renderContent = () => {


### PR DESCRIPTION
## Proposed changes

`MessageActionStore` now owns the admission rules for message actions instead of its callers re-deriving them:

- `requestEditing(messageId)` sets an edit action only when no action is in progress.
- `requestQuote(messageId)` starts a quote when idle, appends to an existing quote without duplicates, and ignores the request while editing or reacting.
- `removeQuote(messageId)` drops one quoted message and clears the action when the last one goes.

`startEditing`, `startQuote` and `addQuote` are removed. `useMessageActions` delegates edit and quote initiation to the store, keeping only the react-specific ordering: admission is checked before the keyboard closes, and the react action is set inside the close callback ahead of the 300 ms picker delay. `ShareView` removes a quote through `removeQuote` instead of filtering and re-setting the quote list. Quote restoration via `setQuoteMessageIds` stays unconditional.

Behavior is unchanged. Store tests now cover each transition's admit and reject paths, including that `setQuoteMessageIds` overrides an in-progress action.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-34

## How to test or reproduce

- In a room, long press a message and choose Edit, then long press another and choose Quote or React: the first action stays active.
- Quote two messages, quote one of them again: it appears once in the composer.
- Remove quoted messages one by one: the composer leaves quote mode after the last one.
- Start reacting from the emoji keyboard: the keyboard closes before the reaction picker opens.
- Share content into a room with quoted messages, remove quotes one by one: same last-item behavior.

## Screenshots

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The transitions return nothing. React initiation keeps its own admission check in the hook because the check must run before the keyboard closes while the mutation must run after, so a single store transition cannot express it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented editing or quoting requests from overwriting an action already in progress.
  * Prevented duplicate messages from being added to a quote.
  * Improved quote removal behavior in shared views.
* **Refactor**
  * Unified editing and quoting actions under clearer request-based handling.
  * Updated related message actions and integrations to use the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->