### PR TITLE
refactor: share room contract across composer and screens

### DIFF
--- a/app/containers/MessageComposer/ComposerStore.tsx
+++ b/app/containers/MessageComposer/ComposerStore.tsx
@@ -2,37 +2,15 @@ import { createContext, useContext, useEffect, useState, type ReactElement, type
 import { createStore, useStore } from 'zustand';
 import { type StoreApi } from 'zustand';
 
-import {
-	type IMessage,
-	type IMessageEditAttachment,
-	type ILastMessage,
-	type IVisitor,
-	type TSubscriptionModel
-} from '../../definitions';
-import { useRoomWithUpdateFromStore } from '../../views/RoomView/stores/RoomStoreContext';
+import { type IMessage, type IMessageEditAttachment } from '../../definitions';
+import { type IRoomWithUpdateState, useRoomWithUpdateFromStore } from '../../lib/hooks/useRoomWithUpdateFromStore';
+import { type TRoomOrPreview } from '../../definitions/TRoom';
 
-type ComposerRoom =
-	| TSubscriptionModel
-	| {
-			rid: string;
-			t: string;
-			name?: string;
-			fname?: string;
-			prid?: string;
-			visitor?: IVisitor;
-			joinCodeRequired?: boolean;
-			status?: string;
-			lastMessage?: ILastMessage;
-			sysMes?: boolean;
-			onHold?: boolean;
-	  };
-
-export type ComposerState = {
+export type ComposerState = IRoomWithUpdateState & {
+	room: TRoomOrPreview;
 	rid?: string;
 	t?: string;
 	tmid?: string;
-	room: ComposerRoom;
-	roomUpdate?: Partial<TSubscriptionModel>;
 	sharing?: boolean;
 	isAutocompleteVisible: boolean;
 	editCancel?: () => void;

--- a/app/containers/MessageComposer/components/ComposerInput.test.tsx
+++ b/app/containers/MessageComposer/components/ComposerInput.test.tsx
@@ -1,12 +1,10 @@
 import { createRef } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import { Text } from 'react-native';
-import { createStore } from 'zustand';
 
 import { ComposerInput } from './ComposerInput';
 import { MessageComposerProvider, useAutocompleteParams } from '../context';
 import { ComposerProvider } from '../ComposerStore';
-import { RoomStoreContext } from '../../../views/RoomView/stores/RoomStoreContext';
 import { createMessageActionStore, MessageActionProvider } from '../../message/stores/MessageActionStore';
 import { type IComposerInput } from '../interfaces';
 import { loadDraftMessage } from '../../../lib/methods/draftMessage';
@@ -40,6 +38,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 jest.mock('../../../lib/hooks/useAltTextSupported', () => ({ useAltTextSupported: jest.fn(() => false) }));
 jest.mock('../../../lib/hooks/useMasterDetail', () => ({ useMasterDetail: jest.fn(() => false) }));
+jest.mock('../../../lib/methods/helpers/helpers', () => ({ getRoomTitle: jest.fn(() => 'Room') }));
 jest.mock('../../../lib/methods/helpers/externalInput', () => ({ isExternalKeyboardConnected: jest.fn(() => false) }));
 jest.mock('../hooks/useIOSBackSwipeHandler', () => ({
 	__esModule: true,
@@ -59,16 +58,10 @@ const composerState = {
 	rid: 'room-1',
 	t: 'c',
 	tmid: undefined,
-	room: undefined,
+	room: { rid: 'room-1', t: 'c' },
 	sharing: false,
 	onRemoveQuoteMessage: jest.fn()
 };
-
-const createRoomStore = () =>
-	createStore<any>()(() => ({
-		room: composerState.room,
-		roomUpdate: undefined
-	}));
 
 const renderInput = ({
 	action,
@@ -79,20 +72,17 @@ const renderInput = ({
 } = {}) => {
 	const composerRef = createRef<IComposerInput>();
 	const inputRef = createRef<any>();
-	const roomStore = createRoomStore();
 	const messageActionStore = createMessageActionStore(action);
 	const tree = (
 		<MessageActionProvider store={messageActionStore}>
-			<RoomStoreContext.Provider value={roomStore}>
-				<ComposerProvider {...(composerState as any)} sharing={sharing}>
-					<MessageComposerProvider>
-						<>
-							<ComposerInput ref={composerRef} inputRef={inputRef} />
-							<AutocompleteProbe />
-						</>
-					</MessageComposerProvider>
-				</ComposerProvider>
-			</RoomStoreContext.Provider>
+			<ComposerProvider {...(composerState as any)} sharing={sharing}>
+				<MessageComposerProvider>
+					<>
+						<ComposerInput ref={composerRef} inputRef={inputRef} />
+						<AutocompleteProbe />
+					</>
+				</MessageComposerProvider>
+			</ComposerProvider>
 		</MessageActionProvider>
 	);
 	const rendered = render(tree);

--- a/app/containers/MessageComposer/components/ComposerInput.tsx
+++ b/app/containers/MessageComposer/components/ComposerInput.tsx
@@ -67,7 +67,7 @@ export const ComposerInput = memo(
 		const isMasterDetail = useMasterDetail();
 		const altTextSupported = useAltTextSupported();
 		let placeholder = tmid ? I18n.t('Add_thread_reply') : '';
-		if (room && !tmid) {
+		if (!tmid) {
 			placeholder = I18n.t('Message_roomname', { roomName: (room.t === 'd' ? '@' : '#') + getRoomTitle(room) });
 			if (!isTablet && placeholder.length > COMPOSER_INPUT_PLACEHOLDER_MAX_LENGTH) {
 				placeholder = `${placeholder.slice(0, COMPOSER_INPUT_PLACEHOLDER_MAX_LENGTH)}...`;

--- a/app/definitions/TRoom.ts
+++ b/app/definitions/TRoom.ts
@@ -1,0 +1,20 @@
+import { type ILastMessage } from './IMessage';
+import { type IVisitor, type TSubscriptionModel } from './ISubscription';
+
+export type TPreviewRoom = {
+	rid: string;
+	t: string;
+	name?: string;
+	fname?: string;
+	prid?: string;
+	visitor?: IVisitor;
+	joinCodeRequired?: boolean;
+	status?: string;
+	lastMessage?: ILastMessage;
+	sysMes?: boolean;
+	onHold?: boolean;
+};
+
+export type TRoomOrPreview = TSubscriptionModel | TPreviewRoom;
+export type TRoomUpdate = keyof TSubscriptionModel;
+export type TRoomUpdatePatch = Partial<Pick<TSubscriptionModel, TRoomUpdate>>;

--- a/app/definitions/TRoom.ts
+++ b/app/definitions/TRoom.ts
@@ -17,7 +17,7 @@ export type TPreviewRoom = {
 
 export type TRoomOrPreview = TSubscriptionModel | TPreviewRoom;
 
-export const roomAttrsUpdate = [
+export const roomObservedFields = [
 	'f',
 	'ro',
 	'blocked',
@@ -51,5 +51,5 @@ export const roomAttrsUpdate = [
 	'inviter'
 ] as const satisfies readonly (keyof ISubscription)[];
 
-export type TRoomUpdate = (typeof roomAttrsUpdate)[number];
-export type TRoomUpdatePatch = Partial<Pick<ISubscription, TRoomUpdate>>;
+export type TRoomObservedField = (typeof roomObservedFields)[number];
+export type TRoomObservedFields = Partial<Pick<ISubscription, TRoomObservedField>>;

--- a/app/definitions/TRoom.ts
+++ b/app/definitions/TRoom.ts
@@ -1,5 +1,5 @@
 import { type ILastMessage } from './IMessage';
-import { type IVisitor, type TSubscriptionModel } from './ISubscription';
+import { type ISubscription, type IVisitor, type TSubscriptionModel } from './ISubscription';
 
 export type TPreviewRoom = {
 	rid: string;
@@ -16,5 +16,40 @@ export type TPreviewRoom = {
 };
 
 export type TRoomOrPreview = TSubscriptionModel | TPreviewRoom;
-export type TRoomUpdate = keyof TSubscriptionModel;
-export type TRoomUpdatePatch = Partial<Pick<TSubscriptionModel, TRoomUpdate>>;
+
+export const roomAttrsUpdate = [
+	'f',
+	'ro',
+	'blocked',
+	'blocker',
+	'archived',
+	'tunread',
+	'tunreadUser',
+	'tunreadGroup',
+	'muted',
+	'ignored',
+	'jitsiTimeout',
+	'announcement',
+	'sysMes',
+	'topic',
+	'name',
+	'fname',
+	'roles',
+	'bannerClosed',
+	'visitor',
+	'joinCodeRequired',
+	'teamMain',
+	'teamId',
+	'status',
+	'onHold',
+	't',
+	'autoTranslate',
+	'autoTranslateLanguage',
+	'unmuted',
+	'E2EKey',
+	'encrypted',
+	'inviter'
+] as const satisfies readonly (keyof ISubscription)[];
+
+export type TRoomUpdate = (typeof roomAttrsUpdate)[number];
+export type TRoomUpdatePatch = Partial<Pick<ISubscription, TRoomUpdate>>;

--- a/app/lib/hooks/__tests__/useRoomWithUpdateFromStore.test.tsx
+++ b/app/lib/hooks/__tests__/useRoomWithUpdateFromStore.test.tsx
@@ -1,0 +1,26 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { createStore } from 'zustand';
+
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
+import { useRoomWithUpdateFromStore, type IRoomWithUpdateState } from '../useRoomWithUpdateFromStore';
+
+describe('useRoomWithUpdateFromStore', () => {
+	it('re-renders when an observed room mutates in place and receives a new patch', () => {
+		const room: TRoomOrPreview = { rid: 'rid-1', t: 'c', name: 'old' };
+		const store = createStore<IRoomWithUpdateState>()(() => ({ room, roomUpdate: {} }));
+		let renders = 0;
+		const { result } = renderHook(() => {
+			renders += 1;
+			return useRoomWithUpdateFromStore(store);
+		});
+
+		act(() => {
+			room.name = 'new';
+			store.setState({ roomUpdate: { name: 'new' } });
+		});
+
+		expect(result.current).toBe(room);
+		expect(result.current.name).toBe('new');
+		expect(renders).toBe(2);
+	});
+});

--- a/app/lib/hooks/useRoomWithUpdateFromStore.ts
+++ b/app/lib/hooks/useRoomWithUpdateFromStore.ts
@@ -1,0 +1,14 @@
+import { useStore } from 'zustand';
+import { type StoreApi } from 'zustand';
+
+import { type TRoomOrPreview, type TRoomUpdatePatch } from '../../definitions/TRoom';
+
+export interface IRoomWithUpdateState {
+	room: TRoomOrPreview;
+	roomUpdate?: TRoomUpdatePatch;
+}
+
+export const useRoomWithUpdateFromStore = <S extends IRoomWithUpdateState>(store: StoreApi<S>): S['room'] => {
+	useStore(store, s => s.roomUpdate);
+	return useStore(store, s => s.room);
+};

--- a/app/lib/hooks/useRoomWithUpdateFromStore.ts
+++ b/app/lib/hooks/useRoomWithUpdateFromStore.ts
@@ -1,11 +1,11 @@
 import { useStore } from 'zustand';
 import { type StoreApi } from 'zustand';
 
-import { type TRoomOrPreview, type TRoomUpdatePatch } from '../../definitions/TRoom';
+import { type TRoomOrPreview, type TRoomObservedFields } from '../../definitions/TRoom';
 
 export interface IRoomWithUpdateState {
 	room: TRoomOrPreview;
-	roomUpdate?: TRoomUpdatePatch;
+	roomUpdate?: TRoomObservedFields;
 }
 
 export const useRoomWithUpdateFromStore = <S extends IRoomWithUpdateState>(store: StoreApi<S>): S['room'] => {

--- a/app/lib/methods/helpers/isReadOnly.ts
+++ b/app/lib/methods/helpers/isReadOnly.ts
@@ -2,6 +2,8 @@ import { store as reduxStore } from '../../store/auxStore';
 import { type ISubscription } from '../../../definitions';
 import { hasPermission } from './helpers';
 
+type ReadOnlyRoom = Pick<Partial<ISubscription>, 'rid' | 'archived' | 'muted' | 'ro' | 'unmuted'>;
+
 const canPostReadOnly = async (room: Partial<ISubscription>, username?: string) => {
 	// RC 6.4.0
 	const isUnmuted = !!room?.unmuted?.find(m => m === username);
@@ -27,7 +29,7 @@ const evaluateReadOnly = (room: Partial<ISubscription>, username: string | undef
 	return false;
 };
 
-export const isReadOnly = async (room: Partial<ISubscription>, username?: string): Promise<boolean> => {
+export const isReadOnly = async (room: ReadOnlyRoom, username?: string): Promise<boolean> => {
 	if (room.archived || isMuted(room, username)) {
 		return true;
 	}

--- a/app/lib/methods/helpers/room.ts
+++ b/app/lib/methods/helpers/room.ts
@@ -1,10 +1,10 @@
 import dayjs from '../../dayjs';
 import { themes } from '../../constants/colors';
 import I18n from '../../../i18n';
-import { type IAttachment, SubscriptionType, type TSubscriptionModel } from '../../../definitions';
+import { type IAttachment, SubscriptionType } from '../../../definitions';
 import { type TSupportedThemes } from '../../../theme';
 
-export const isBlocked = (room: TSubscriptionModel): boolean => {
+export const isBlocked = (room: { t?: string; blocked?: boolean; blocker?: boolean }): boolean => {
 	if (room) {
 		const { t, blocked, blocker } = room;
 		if (t === SubscriptionType.DIRECT && (blocked || blocker)) {

--- a/app/views/RoomView/__tests__/RoomGate.test.tsx
+++ b/app/views/RoomView/__tests__/RoomGate.test.tsx
@@ -4,7 +4,8 @@ import { Provider } from 'react-redux';
 import { createStore as createReduxStore } from 'redux';
 
 import RoomGate from '../index';
-import { type IRoomViewProps, type RoomState } from '../definitions';
+import { type IRoomViewProps } from '../definitions';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 import { isInviteSubscription } from '../../../lib/methods/isInviteSubscription';
 import { useE2EEStatus } from '../hooks/useE2EEStatus';
 
@@ -40,7 +41,7 @@ jest.mock('../hooks/useE2EEStatus', () => ({
 jest.mock('../../../lib/methods/isInviteSubscription', () => ({ isInviteSubscription: jest.fn(() => false) }));
 jest.mock('../../../lib/methods/helpers', () => ({ getUidDirectMessage: jest.fn(), getRoomTitle: jest.fn(() => 'Room Title') }));
 
-const room: { current: RoomState['room'] } = { current: { rid: 'rid-1', t: 'c' } };
+const room: { current: TRoomOrPreview } = { current: { rid: 'rid-1', t: 'c' } };
 
 jest.mock('../stores/RoomStore', () => {
 	const { createStore } = require('zustand');
@@ -99,7 +100,7 @@ describe('RoomGate', () => {
 	});
 
 	it('keeps the room screen unmounted while the room is an invite', () => {
-		room.current = { id: 'sub-1', rid: 'rid-1', t: 'c' } as RoomState['room'];
+		room.current = { id: 'sub-1', rid: 'rid-1', t: 'c' } as TRoomOrPreview;
 		jest.mocked(isInviteSubscription).mockReturnValue(true);
 
 		renderGate();
@@ -109,7 +110,7 @@ describe('RoomGate', () => {
 	});
 
 	it('keeps the room screen unmounted while the E2EE key is missing', () => {
-		room.current = { rid: 'rid-1', t: 'c', encrypted: true } as RoomState['room'];
+		room.current = { rid: 'rid-1', t: 'c', encrypted: true } as TRoomOrPreview;
 		jest.mocked(useE2EEStatus).mockReturnValue({ showMissingE2EEKey: true, showE2EEDisabledRoom: false });
 
 		renderGate();
@@ -119,7 +120,7 @@ describe('RoomGate', () => {
 	});
 
 	it('keeps the room screen unmounted while the session has E2EE disabled', () => {
-		room.current = { rid: 'rid-1', t: 'c', encrypted: true } as RoomState['room'];
+		room.current = { rid: 'rid-1', t: 'c', encrypted: true } as TRoomOrPreview;
 		jest.mocked(useE2EEStatus).mockReturnValue({ showMissingE2EEKey: false, showE2EEDisabledRoom: true });
 
 		renderGate();

--- a/app/views/RoomView/components/RoomMessageList.tsx
+++ b/app/views/RoomView/components/RoomMessageList.tsx
@@ -4,7 +4,8 @@ import { isRoomFederated } from '../../../lib/methods/isRoomFederated';
 import { getUserSelector } from '../../../selectors/login';
 import { type RoomType } from '../../../definitions';
 import { A11yGateProvider } from '../../../containers/message/stores/A11yGate';
-import { type IRoomMessageListProps, type IRoomViewState } from '../definitions';
+import { type IRoomMessageListProps } from '../definitions';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 import { useRoomStore, useRoomWithUpdate } from '../stores/RoomStoreContext';
 import List from '../List';
 import { RoomMessageProvider } from './RoomMessageProvider';
@@ -12,7 +13,7 @@ import { RoomMessageProvider } from './RoomMessageProvider';
 const EMPTY_HIDE_SYSTEM_MESSAGES: string[] = [];
 
 // FIXME: handle servers with version < 3.0.0
-const getHideSystemMessages = (room: IRoomViewState['room'], Hide_System_Messages?: string[]): string[] => {
+const getHideSystemMessages = (room: TRoomOrPreview, Hide_System_Messages?: string[]): string[] => {
 	const { sysMes } = room;
 	if (Array.isArray(sysMes)) {
 		return sysMes;

--- a/app/views/RoomView/constants.test.ts
+++ b/app/views/RoomView/constants.test.ts
@@ -1,4 +1,4 @@
-import { roomAttrsUpdate } from './constants';
+import { roomAttrsUpdate } from '../../definitions/TRoom';
 
 describe('roomAttrsUpdate invariant', () => {
 	// useReadOnly / useE2EEStatus derive synchronously from the observed room, so they only stay

--- a/app/views/RoomView/constants.test.ts
+++ b/app/views/RoomView/constants.test.ts
@@ -1,11 +1,11 @@
-import { roomAttrsUpdate } from '../../definitions/TRoom';
+import { roomObservedFields } from '../../definitions/TRoom';
 
-describe('roomAttrsUpdate invariant', () => {
+describe('roomObservedFields invariant', () => {
 	// useReadOnly / useE2EEStatus derive synchronously from the observed room, so they only stay
-	// reactive while these columns are observed. Dropping one of these columns from roomAttrsUpdate
+	// reactive while these columns are observed. Dropping one of these columns from roomObservedFields
 	// silently breaks that reactivity at runtime with no other failing signal — this test is the
 	// only guard.
 	it.each(['roles', 'encrypted', 'E2EKey'])('keeps %s so read-time derivations stay reactive', key => {
-		expect(roomAttrsUpdate).toContain(key);
+		expect(roomObservedFields).toContain(key);
 	});
 });

--- a/app/views/RoomView/constants.ts
+++ b/app/views/RoomView/constants.ts
@@ -1,4 +1,4 @@
-import { type TRoomUpdate } from './definitions';
+import { type TRoomUpdate } from '../../definitions/TRoom';
 
 export const roomAttrsUpdate = [
 	'f',

--- a/app/views/RoomView/constants.ts
+++ b/app/views/RoomView/constants.ts
@@ -1,6 +1,6 @@
-import { type TRoomUpdate } from '../../definitions/TRoom';
+import { type TRoomObservedField } from '../../definitions/TRoom';
 
-export const roomAttrsUpdateColumns: Record<TRoomUpdate, string> = {
+export const roomObservedColumns: Record<TRoomObservedField, string> = {
 	f: 'f',
 	ro: 'ro',
 	blocked: 'blocked',

--- a/app/views/RoomView/constants.ts
+++ b/app/views/RoomView/constants.ts
@@ -1,40 +1,6 @@
 import { type TRoomUpdate } from '../../definitions/TRoom';
 
-export const roomAttrsUpdate = [
-	'f',
-	'ro',
-	'blocked',
-	'blocker',
-	'archived',
-	'tunread',
-	'tunreadUser',
-	'tunreadGroup',
-	'muted',
-	'ignored',
-	'jitsiTimeout',
-	'announcement',
-	'sysMes',
-	'topic',
-	'name',
-	'fname',
-	'roles',
-	'bannerClosed',
-	'visitor',
-	'joinCodeRequired',
-	'teamMain',
-	'teamId',
-	'status',
-	'onHold',
-	't',
-	'autoTranslate',
-	'autoTranslateLanguage',
-	'unmuted',
-	'E2EKey',
-	'encrypted',
-	'inviter'
-] as const satisfies readonly TRoomUpdate[];
-
-export const roomAttrsUpdateColumns: Record<(typeof roomAttrsUpdate)[number], string> = {
+export const roomAttrsUpdateColumns: Record<TRoomUpdate, string> = {
 	f: 'f',
 	ro: 'ro',
 	blocked: 'blocked',

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -7,15 +7,14 @@ import { type ChatsStackParamList } from '../../stacks/types';
 import {
 	type IBaseScreen,
 	type IEmoji,
-	type ILastMessage,
 	type IMessage,
 	type IMessageEditAttachment,
-	type IVisitor,
 	type RoomType,
 	type TAnyMessageModel,
-	type TSubscriptionModel,
 	type IUseRoomMessageHandlersResult
 } from '../../definitions';
+import { type TRoomOrPreview, type TRoomUpdatePatch } from '../../definitions/TRoom';
+import { type TSubscriptionModel } from '../../definitions/ISubscription';
 import { type TActionSheetOptions } from '../../containers/ActionSheet';
 import { type IMessageComposerRef } from '../../containers/MessageComposer/interfaces';
 import { type IMessageActions, type IMessageActionsProps } from '../../containers/MessageActions';
@@ -30,7 +29,7 @@ export interface IRoomScreenInput {
 	t: string;
 	tmid?: string;
 	name?: string;
-	initialRoom: IRoomViewState['room'];
+	initialRoom: TRoomOrPreview;
 	roomUserId?: string | null;
 }
 
@@ -52,25 +51,9 @@ export interface IFooterPreviewProps {
 	message: string;
 }
 
-export type TRoomUpdate = keyof TSubscriptionModel;
-
 export interface IRoomViewState {
-	room:
-		| TSubscriptionModel
-		| {
-				rid: string;
-				t: string;
-				name?: string;
-				fname?: string;
-				prid?: string;
-				visitor?: IVisitor;
-				joinCodeRequired?: boolean;
-				status?: string;
-				lastMessage?: ILastMessage;
-				sysMes?: boolean;
-				onHold?: boolean;
-		  };
-	roomUpdate: Partial<Pick<TSubscriptionModel, TRoomUpdate>>;
+	room: TRoomOrPreview;
+	roomUpdate: TRoomUpdatePatch;
 	member: any;
 	lastSeen: Date | null;
 }
@@ -147,8 +130,8 @@ export type TRoomInitResult =
 	| { status: 'failed' };
 
 export interface RoomState {
-	room: IRoomViewState['room'];
-	roomUpdate: IRoomViewState['roomUpdate'];
+	room: TRoomOrPreview;
+	roomUpdate: TRoomUpdatePatch;
 	joined: boolean;
 	subscribed: boolean;
 	member: IRoomViewState['member'];

--- a/app/views/RoomView/definitions.ts
+++ b/app/views/RoomView/definitions.ts
@@ -13,7 +13,7 @@ import {
 	type TAnyMessageModel,
 	type IUseRoomMessageHandlersResult
 } from '../../definitions';
-import { type TRoomOrPreview, type TRoomUpdatePatch } from '../../definitions/TRoom';
+import { type TRoomOrPreview, type TRoomObservedFields } from '../../definitions/TRoom';
 import { type TSubscriptionModel } from '../../definitions/ISubscription';
 import { type TActionSheetOptions } from '../../containers/ActionSheet';
 import { type IMessageComposerRef } from '../../containers/MessageComposer/interfaces';
@@ -53,7 +53,7 @@ export interface IFooterPreviewProps {
 
 export interface IRoomViewState {
 	room: TRoomOrPreview;
-	roomUpdate: TRoomUpdatePatch;
+	roomUpdate: TRoomObservedFields;
 	member: any;
 	lastSeen: Date | null;
 }
@@ -131,7 +131,7 @@ export type TRoomInitResult =
 
 export interface RoomState {
 	room: TRoomOrPreview;
-	roomUpdate: TRoomUpdatePatch;
+	roomUpdate: TRoomObservedFields;
 	joined: boolean;
 	subscribed: boolean;
 	member: IRoomViewState['member'];

--- a/app/views/RoomView/hooks/__tests__/useCloseBanner.test.ts
+++ b/app/views/RoomView/hooks/__tests__/useCloseBanner.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 
-import { type IRoomViewState } from '../../definitions';
+import { type TRoomOrPreview } from '../../../../definitions/TRoom';
 import { useCloseBanner } from '../useCloseBanner';
 
 const mockWrite = jest.fn((fn: () => Promise<void>) => fn());
@@ -20,7 +20,7 @@ describe('useCloseBanner', () => {
 			mutator(draft);
 			return draft;
 		});
-		const room = { id: 'room-1', update } as unknown as IRoomViewState['room'];
+		const room = { id: 'room-1', update } as unknown as TRoomOrPreview;
 		const { result } = renderHook(() => useCloseBanner(room));
 
 		await result.current();
@@ -30,7 +30,7 @@ describe('useCloseBanner', () => {
 	});
 
 	it('is a no-op for a room without a database identity', async () => {
-		const room = { rid: 'rid-1', t: 'c' } as IRoomViewState['room'];
+		const room = { rid: 'rid-1', t: 'c' } as TRoomOrPreview;
 		const { result } = renderHook(() => useCloseBanner(room));
 
 		await result.current();
@@ -40,7 +40,7 @@ describe('useCloseBanner', () => {
 
 	it('swallows write errors', async () => {
 		mockWrite.mockRejectedValueOnce(new Error('boom'));
-		const room = { id: 'room-1', update: jest.fn() } as unknown as IRoomViewState['room'];
+		const room = { id: 'room-1', update: jest.fn() } as unknown as TRoomOrPreview;
 		const { result } = renderHook(() => useCloseBanner(room));
 
 		await expect(result.current()).resolves.toBeUndefined();

--- a/app/views/RoomView/hooks/__tests__/useRoomRemoved.test.ts
+++ b/app/views/RoomView/hooks/__tests__/useRoomRemoved.test.ts
@@ -5,7 +5,7 @@ import I18n from '../../../../i18n';
 import EventEmitterReal from '../../../../lib/methods/helpers/events';
 import Navigation from '../../../../lib/navigation/appNavigation';
 import { showErrorAlert } from '../../../../lib/methods/helpers/info';
-import { type IRoomViewState } from '../../definitions';
+import { type TRoomOrPreview } from '../../../../definitions/TRoom';
 import { useRoomRemoved } from '../useRoomRemoved';
 
 jest.mock('../../../../lib/methods/helpers', () => ({ getRoomTitle: jest.fn(() => 'Room') }));
@@ -15,7 +15,7 @@ jest.mock('../../../../lib/methods/helpers/info', () => ({ showErrorAlert: jest.
 const mockPopToTop = Navigation.popToTop as jest.Mock;
 const mockShowErrorAlert = showErrorAlert as jest.Mock;
 
-const renderRoomRemoved = (rid: string | undefined, isMasterDetail: boolean, room: IRoomViewState['room']) => {
+const renderRoomRemoved = (rid: string | undefined, isMasterDetail: boolean, room: TRoomOrPreview) => {
 	return renderHook(() => useRoomRemoved(rid, isMasterDetail, createStore(() => ({ room })) as any));
 };
 

--- a/app/views/RoomView/hooks/useCloseBanner.ts
+++ b/app/views/RoomView/hooks/useCloseBanner.ts
@@ -1,7 +1,7 @@
 import database from '../../../lib/database';
-import { type IRoomViewState } from '../definitions';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 
-export function useCloseBanner(room: IRoomViewState['room']): () => Promise<void> {
+export function useCloseBanner(room: TRoomOrPreview): () => Promise<void> {
 	return async () => {
 		if ('id' in room) {
 			try {

--- a/app/views/RoomView/hooks/useE2EEStatus.ts
+++ b/app/views/RoomView/hooks/useE2EEStatus.ts
@@ -2,7 +2,7 @@ import { isE2EEDisabledEncryptedRoom, isMissingRoomE2EEKey } from '../../../lib/
 import { useAppSelector } from '../../../lib/hooks/useAppSelector';
 import { type IUseE2EEStatusResult } from '../definitions';
 import { type RoomStore } from '../definitions';
-import { useRoomWithUpdateFromStore } from '../stores/RoomStoreContext';
+import { useRoomWithUpdateFromStore } from '../../../lib/hooks/useRoomWithUpdateFromStore';
 
 export const useE2EEStatus = (roomStore: RoomStore): IUseE2EEStatusResult => {
 	const encryptionEnabled = useAppSelector(state => state.encryption.enabled);

--- a/app/views/RoomView/hooks/useHeader.tsx
+++ b/app/views/RoomView/hooks/useHeader.tsx
@@ -10,7 +10,8 @@ import { isInviteSubscription } from '../../../lib/methods/isInviteSubscription'
 import { type IOmnichannelSource, type ISubscription, type IVisitor } from '../../../definitions';
 import LeftButtons from '../components/LeftButtons';
 import RightButtons from '../components/RightButtons';
-import { type IRoomViewProps, type IRoomViewState } from '../definitions';
+import { type IRoomViewProps } from '../definitions';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 import { type RoomStore } from '../definitions';
 import { useGoRoomActionsView } from './useGoRoomActionsView';
 
@@ -23,7 +24,7 @@ interface IUseHeaderParams {
 }
 
 interface IGetRoomHeaderPropsParams {
-	room: IRoomViewState['room'];
+	room: TRoomOrPreview;
 	tmid?: string;
 	roomName?: string;
 	roomUserId?: string | null;

--- a/app/views/RoomView/index.tsx
+++ b/app/views/RoomView/index.tsx
@@ -11,7 +11,7 @@ import RoomScreen from './RoomScreen';
 import { parseRoomRoute } from './services/parseRoomRoute';
 import { createRoomStore, observeRoom } from './stores/RoomStore';
 import { type RoomStore } from './definitions';
-import { useRoomWithUpdateFromStore } from './stores/RoomStoreContext';
+import { useRoomWithUpdateFromStore } from '../../lib/hooks/useRoomWithUpdateFromStore';
 import { useE2EEStatus } from './hooks/useE2EEStatus';
 import { useHeader } from './hooks/useHeader';
 

--- a/app/views/RoomView/services/__tests__/joinRoom.test.ts
+++ b/app/views/RoomView/services/__tests__/joinRoom.test.ts
@@ -1,6 +1,6 @@
 import { joinRoom as joinRoomService } from '../../../../lib/services/restApi';
 import { takeInquiry, takeResume } from '../../../../ee/omnichannel/lib';
-import { type IRoomViewState } from '../../definitions';
+import { type TRoomOrPreview } from '../../../../definitions/TRoom';
 import { createRoomStore } from '../../stores/RoomStore';
 
 jest.mock('../../../../lib/database', () => ({
@@ -45,7 +45,7 @@ const mockJoinRoomService = joinRoomService as jest.Mock;
 const mockTakeInquiry = takeInquiry as jest.Mock;
 const mockTakeResume = takeResume as jest.Mock;
 
-const makeStore = (room: IRoomViewState['room']) => {
+const makeStore = (room: TRoomOrPreview) => {
 	const store = createRoomStore({ initialRoom: room });
 	store.setState({ join: jest.fn() });
 	return store;

--- a/app/views/RoomView/services/joinRoom.ts
+++ b/app/views/RoomView/services/joinRoom.ts
@@ -1,9 +1,10 @@
 import { takeInquiry, takeResume } from '../../../ee/omnichannel/lib';
 import log, { events, logEvent } from '../../../lib/methods/helpers/log';
 import { joinRoom as joinRoomService } from '../../../lib/services/restApi';
-import { type IJoinRoomContext, type IRoomViewState } from '../definitions';
+import { type IJoinRoomContext } from '../definitions';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 
-export const joinRoom = async (room: IRoomViewState['room'], { requestJoinCode, onJoin }: IJoinRoomContext): Promise<void> => {
+export const joinRoom = async (room: TRoomOrPreview, { requestJoinCode, onJoin }: IJoinRoomContext): Promise<void> => {
 	logEvent(events.ROOM_JOIN);
 	try {
 		if (room.t === 'l') {
@@ -25,7 +26,7 @@ export const joinRoom = async (room: IRoomViewState['room'], { requestJoinCode, 
 	}
 };
 
-export const resumeRoom = async (room: IRoomViewState['room'], onJoin: () => void): Promise<void> => {
+export const resumeRoom = async (room: TRoomOrPreview, onJoin: () => void): Promise<void> => {
 	logEvent(events.ROOM_RESUME);
 	try {
 		if (room.t === 'l') {

--- a/app/views/RoomView/services/parseRoomRoute.ts
+++ b/app/views/RoomView/services/parseRoomRoute.ts
@@ -1,12 +1,13 @@
 import { getUidDirectMessage } from '../../../lib/methods/helpers';
-import { type IRoomScreenInput, type IRoomViewProps, type TRoomRouteParse } from '../definitions';
+import { type IRoomViewProps, type TRoomRouteParse } from '../definitions';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 
 export const parseRoomRoute = (params: IRoomViewProps['route']['params']): TRoomRouteParse => {
 	if (!params?.rid || !params.t) {
 		return { status: 'invalid' };
 	}
 	const { rid, t, tmid, name, fname, prid, visitor, joinCodeRequired, roomUserId } = params;
-	const initialRoom: IRoomScreenInput['initialRoom'] = { rid, t, name, fname, prid, visitor, joinCodeRequired };
+	const initialRoom: TRoomOrPreview = { rid, t, name, fname, prid, visitor, joinCodeRequired };
 	return {
 		status: 'valid',
 		input: { rid, t, tmid, name, initialRoom, roomUserId: roomUserId ?? getUidDirectMessage(initialRoom) }

--- a/app/views/RoomView/stores/RoomStore.ts
+++ b/app/views/RoomView/stores/RoomStore.ts
@@ -9,7 +9,7 @@ import { isGroupChat, getUidDirectMessage, canAutoTranslate as canAutoTranslateM
 import log from '../../../lib/methods/helpers/log';
 import { isInviteSubscription } from '../../../lib/methods/isInviteSubscription';
 import { type RoomType, type TSubscriptionModel } from '../../../definitions';
-import { roomAttrsUpdate, type TRoomOrPreview } from '../../../definitions/TRoom';
+import { roomObservedFields, type TRoomOrPreview } from '../../../definitions/TRoom';
 import {
 	type IRoomStoreInitParams,
 	type IRoomViewState,
@@ -17,11 +17,11 @@ import {
 	type RoomStore,
 	type TRoomInitResult
 } from '../definitions';
-import { roomAttrsUpdateColumns } from '../constants';
+import { roomObservedColumns } from '../constants';
 import getMessages from '../services/getMessages';
 import { joinRoom, resumeRoom } from '../services/joinRoom';
 
-const OBSERVED_COLUMNS = Object.values(roomAttrsUpdateColumns);
+const OBSERVED_COLUMNS = Object.values(roomObservedColumns);
 
 const EMPTY_ROOM: TRoomOrPreview = { rid: '', t: '' };
 const EMPTY_MEMBER: IRoomViewState['member'] = {};
@@ -188,7 +188,7 @@ export function observeRoom(rid: string | undefined, store: RoomStore, onReady?:
 			return;
 		}
 		const roomChanged =
-			next !== previous.room || roomAttrsUpdate.some(attr => previous.roomUpdate[attr] !== (next as TSubscriptionModel)[attr]);
+			next !== previous.room || roomObservedFields.some(attr => previous.roomUpdate[attr] !== (next as TSubscriptionModel)[attr]);
 		const lastMessageFromAgent = next.t === 'l' && !!(next.lastMessage && !next.lastMessage.token && next.lastMessage.u);
 		if (!roomChanged && previous.subscribed && lastMessageFromAgent === previous.lastMessageFromAgent) {
 			return;
@@ -201,7 +201,7 @@ export function observeRoom(rid: string | undefined, store: RoomStore, onReady?:
 				? {
 						room: next,
 						roomUpdate: Object.fromEntries(
-							roomAttrsUpdate.map(attr => [attr, (next as TSubscriptionModel)[attr]])
+							roomObservedFields.map(attr => [attr, (next as TSubscriptionModel)[attr]])
 						) as IRoomViewState['roomUpdate']
 					}
 				: {})

--- a/app/views/RoomView/stores/RoomStore.ts
+++ b/app/views/RoomView/stores/RoomStore.ts
@@ -9,6 +9,7 @@ import { isGroupChat, getUidDirectMessage, canAutoTranslate as canAutoTranslateM
 import log from '../../../lib/methods/helpers/log';
 import { isInviteSubscription } from '../../../lib/methods/isInviteSubscription';
 import { type RoomType, type TSubscriptionModel } from '../../../definitions';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 import {
 	type IRoomStoreInitParams,
 	type IRoomViewState,
@@ -22,7 +23,7 @@ import { joinRoom, resumeRoom } from '../services/joinRoom';
 
 const OBSERVED_COLUMNS = Object.values(roomAttrsUpdateColumns);
 
-const EMPTY_ROOM: IRoomViewState['room'] = { rid: '', t: '' };
+const EMPTY_ROOM: TRoomOrPreview = { rid: '', t: '' };
 const EMPTY_MEMBER: IRoomViewState['member'] = {};
 
 const INIT_MAX_ATTEMPTS = 3;
@@ -33,7 +34,7 @@ interface IDirectMessageMember {
 	member: IRoomViewState['member'];
 }
 
-const getRoomMember = async (room: IRoomViewState['room']): Promise<IDirectMessageMember> => {
+const getRoomMember = async (room: TRoomOrPreview): Promise<IDirectMessageMember> => {
 	if ('id' in room && room.t === 'd' && !isGroupChat(room)) {
 		const roomUserId = getUidDirectMessage(room);
 		try {
@@ -61,7 +62,7 @@ type TLoadRoomResult =
 
 const loadRoom = async (
 	rid: string,
-	room: IRoomViewState['room'],
+	room: TRoomOrPreview,
 	joined: boolean,
 	{ tmid, onThreadMessagesLoaded, signal }: IRoomStoreInitParams
 ): Promise<TLoadRoomResult> => {
@@ -117,7 +118,7 @@ const loadRoom = async (
 const createRoomState =
 	(
 		rid: string | undefined,
-		initialRoom: IRoomViewState['room'] = EMPTY_ROOM,
+		initialRoom: TRoomOrPreview = EMPTY_ROOM,
 		roomUserId: string | null | undefined = null
 	): StateCreator<RoomState> =>
 	(set, get) => ({
@@ -179,7 +180,7 @@ export function observeRoom(rid: string | undefined, store: RoomStore, onReady?:
 		.get('subscriptions')
 		.query(Q.where('rid', rid))
 		.observeWithColumns([...OBSERVED_COLUMNS, 'last_message']);
-	const subscription = observable.subscribe((rows: IRoomViewState['room'][]) => {
+	const subscription = observable.subscribe((rows: TRoomOrPreview[]) => {
 		const next = rows[0];
 		const previous = store.getState();
 		if (!next) {
@@ -216,6 +217,6 @@ export const createRoomStore = ({
 	roomUserId
 }: {
 	rid?: string;
-	initialRoom: IRoomViewState['room'];
+	initialRoom: TRoomOrPreview;
 	roomUserId?: string | null;
 }): RoomStore => createStore<RoomState>(createRoomState(rid, initialRoom, roomUserId));

--- a/app/views/RoomView/stores/RoomStore.ts
+++ b/app/views/RoomView/stores/RoomStore.ts
@@ -9,7 +9,7 @@ import { isGroupChat, getUidDirectMessage, canAutoTranslate as canAutoTranslateM
 import log from '../../../lib/methods/helpers/log';
 import { isInviteSubscription } from '../../../lib/methods/isInviteSubscription';
 import { type RoomType, type TSubscriptionModel } from '../../../definitions';
-import { type TRoomOrPreview } from '../../../definitions/TRoom';
+import { roomAttrsUpdate, type TRoomOrPreview } from '../../../definitions/TRoom';
 import {
 	type IRoomStoreInitParams,
 	type IRoomViewState,
@@ -17,7 +17,7 @@ import {
 	type RoomStore,
 	type TRoomInitResult
 } from '../definitions';
-import { roomAttrsUpdate, roomAttrsUpdateColumns } from '../constants';
+import { roomAttrsUpdateColumns } from '../constants';
 import getMessages from '../services/getMessages';
 import { joinRoom, resumeRoom } from '../services/joinRoom';
 

--- a/app/views/RoomView/stores/RoomStoreContext.tsx
+++ b/app/views/RoomView/stores/RoomStoreContext.tsx
@@ -1,7 +1,9 @@
 import { createContext, useContext } from 'react';
-import { useStore, type StoreApi } from 'zustand';
+import { useStore } from 'zustand';
 
 import { type RoomState, type RoomStore } from '../definitions';
+import { useRoomWithUpdateFromStore } from '../../../lib/hooks/useRoomWithUpdateFromStore';
+import { type TRoomOrPreview } from '../../../definitions/TRoom';
 
 export const RoomStoreContext = createContext<RoomStore | null>(null);
 
@@ -15,13 +17,4 @@ const useRoomStoreApi = (): RoomStore => {
 
 export const useRoomStore = <T,>(selector: (state: RoomState) => T): T => useStore(useRoomStoreApi(), selector);
 
-const useRerenderOnRoomMutatedInPlace = <S extends { roomUpdate?: unknown }>(store: StoreApi<S>): void => {
-	useStore(store, s => s.roomUpdate);
-};
-
-export const useRoomWithUpdateFromStore = <S extends { room: unknown; roomUpdate?: unknown }>(store: StoreApi<S>): S['room'] => {
-	useRerenderOnRoomMutatedInPlace(store);
-	return useStore(store, s => s.room);
-};
-
-export const useRoomWithUpdate = (): RoomState['room'] => useRoomWithUpdateFromStore(useRoomStoreApi());
+export const useRoomWithUpdate = (): TRoomOrPreview => useRoomWithUpdateFromStore(useRoomStoreApi());

--- a/app/views/RoomView/stores/__tests__/RoomStore.test.ts
+++ b/app/views/RoomView/stores/__tests__/RoomStore.test.ts
@@ -5,7 +5,8 @@ import { getUserInfo } from '../../../../lib/services/restApi';
 import { isGroupChat } from '../../../../lib/methods/helpers';
 import { isInviteSubscription } from '../../../../lib/methods/isInviteSubscription';
 import log from '../../../../lib/methods/helpers/log';
-import { roomAttrsUpdate, roomAttrsUpdateColumns } from '../../constants';
+import { roomAttrsUpdate } from '../../../../definitions/TRoom';
+import { roomAttrsUpdateColumns } from '../../constants';
 import getMessages from '../../services/getMessages';
 import { createRoomStore, observeRoom } from '../RoomStore';
 

--- a/app/views/RoomView/stores/__tests__/RoomStore.test.ts
+++ b/app/views/RoomView/stores/__tests__/RoomStore.test.ts
@@ -5,8 +5,8 @@ import { getUserInfo } from '../../../../lib/services/restApi';
 import { isGroupChat } from '../../../../lib/methods/helpers';
 import { isInviteSubscription } from '../../../../lib/methods/isInviteSubscription';
 import log from '../../../../lib/methods/helpers/log';
-import { roomAttrsUpdate } from '../../../../definitions/TRoom';
-import { roomAttrsUpdateColumns } from '../../constants';
+import { roomObservedFields } from '../../../../definitions/TRoom';
+import { roomObservedColumns } from '../../constants';
 import getMessages from '../../services/getMessages';
 import { createRoomStore, observeRoom } from '../RoomStore';
 
@@ -449,7 +449,7 @@ describe('RoomStore', () => {
 		expect(store.getState().joined).toBe(true);
 	});
 
-	it('roomAttrsUpdateColumns has exactly one entry per roomAttrsUpdate key', () => {
-		expect(Object.keys(roomAttrsUpdateColumns).sort()).toEqual([...roomAttrsUpdate].sort());
+	it('roomObservedColumns has exactly one entry per roomObservedFields key', () => {
+		expect(Object.keys(roomObservedColumns).sort()).toEqual([...roomObservedFields].sort());
 	});
 });

--- a/app/views/ShareView/Header.tsx
+++ b/app/views/ShareView/Header.tsx
@@ -7,7 +7,8 @@ import { themes } from '../../lib/constants/colors';
 import { useTheme } from '../../theme';
 import sharedStyles from '../Styles';
 import { makeThreadName } from '../../lib/methods/helpers/room';
-import { type ISubscription, type TThreadModel } from '../../definitions';
+import { type TThreadModel } from '../../definitions';
+import { type TRoomOrPreview } from '../../definitions/TRoom';
 import { getRoomTitle, isGroupChat, isAndroid, isTablet } from '../../lib/methods/helpers';
 import { getMessageById } from '../../lib/database/services/Message';
 
@@ -38,7 +39,7 @@ const styles = StyleSheet.create({
 });
 
 interface IHeader {
-	room: ISubscription;
+	room: TRoomOrPreview;
 	thread: TThreadModel | string;
 }
 

--- a/app/views/ShareView/index.tsx
+++ b/app/views/ShareView/index.tsx
@@ -31,9 +31,9 @@ import {
 	type IShareAttachment,
 	type IUser,
 	RootEnum,
-	type TSubscriptionModel,
 	type TThreadModel
 } from '../../definitions';
+import { type TRoomOrPreview } from '../../definitions/TRoom';
 import { sendAttachments } from '../../lib/methods/sendFileMessage/sendAttachments';
 import { sendMessage } from '../../lib/methods/sendMessage';
 import { hasPermission, isAndroid, canUploadFile, isReadOnly, isBlocked } from '../../lib/methods/helpers';
@@ -50,7 +50,7 @@ interface IShareViewState {
 	readOnly: boolean;
 	attachments: IShareAttachment[];
 	text: string;
-	room: TSubscriptionModel;
+	room: TRoomOrPreview;
 	thread: TThreadModel | string;
 	maxFileSize?: number;
 	mediaAllowList?: string;
@@ -96,7 +96,7 @@ class ShareView extends Component<IShareViewProps, IShareViewState> {
 			readOnly: false,
 			attachments: [],
 			text: props.route.params?.text ?? '',
-			room: props.route.params?.room ?? {},
+			room: props.route.params?.room ?? { rid: '', t: '' },
 			thread: props.route.params?.thread ?? {},
 			maxFileSize: this.isShareExtension ? this.serverInfo?.FileUpload_MaxFileSize : props.FileUpload_MaxFileSize,
 			mediaAllowList: this.isShareExtension ? this.serverInfo?.FileUpload_MediaTypeWhiteList : props.FileUpload_MediaTypeWhiteList


### PR DESCRIPTION
## Proposed changes

Move the room contract and the hook that observes in-place room updates into shared definitions and hooks. Composer, RoomView, and ShareView now use that contract, removing the composer’s dependency on RoomView and typing ShareView’s room honestly.

The implementation is commit `07aa0583ac` (25 files). It preserves the existing subscribed-room and preview-room shapes and adds a regression test proving a new update patch re-renders consumers of the same room instance.

## Issue(s)

Stacked on #7657 (`diegolmello/pr-7482-r3-a-composer-ownership`). Addresses its composer coupling review finding.

## How to test or reproduce

- `pnpm format-lint` passed, including typechecking.
- `TZ=UTC pnpm test --runInBand --watchman=false` passed: 304 suites, 2,731 tests, 412 snapshots. Watchman was disabled because its state directory was inaccessible in the sandbox.
- The shared-hook regression test fails when the patch subscription is removed and passes when restored.
- Luna implemented; Astra reviewed standards and spec coverage with no remaining findings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed message composer placeholders so they display correctly in non-thread conversations, including when room details are unavailable.
  - Improved reliability when room information changes while users interact with conversations.

- **Refactor**
  - Standardized room and preview handling across conversation, sharing, and message composition views.
  - Consolidated room update handling to provide more consistent behavior across related views.
  - Clarified room observation and update handling for more maintainable conversation state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->