### PR TITLE
fix: admin panel requiring a new login

### DIFF
--- a/.maestro/tests/assorted/admin-panel.yaml
+++ b/.maestro/tests/assorted/admin-panel.yaml
@@ -1,0 +1,49 @@
+appId: ${APP_ID}
+name: Admin Panel
+onFlowStart:
+  - runFlow: '../../helpers/setup.yaml'
+onFlowComplete:
+  - evalScript: ${output.utils.deleteCreatedUsers()}
+tags:
+  - test-3
+
+---
+- runFlow:
+    file: '../../helpers/login-with-deeplink.yaml'
+    env:
+      USERNAME: ${output.account.adminUser}
+      PASSWORD: ${output.account.adminPassword}
+
+# should open the admin panel from the sidebar
+- extendedWaitUntil:
+    visible:
+      id: 'rooms-list-view'
+    timeout: 60000
+- tapOn:
+    id: 'rooms-list-view-sidebar'
+- extendedWaitUntil:
+    visible:
+      id: 'sidebar-view'
+    timeout: 60000
+- extendedWaitUntil:
+    visible:
+      id: 'sidebar-admin'
+    timeout: 60000
+- tapOn:
+    id: 'sidebar-admin'
+- extendedWaitUntil:
+    visible:
+      id: 'admin-panel-view'
+    timeout: 60000
+
+# should log in to the embedded admin panel automatically
+- extendedWaitUntil:
+    visible:
+      text: '.*Deployment.*'
+    timeout: 120000
+- assertVisible:
+    text: '.*Deployment ID.*'
+
+# should not fall back to the workspace login form
+- assertNotVisible:
+    text: '.*Email or username.*'

--- a/.sniffler/test-map.json
+++ b/.sniffler/test-map.json
@@ -8,6 +8,10 @@
 		"dependsOn": ["app/views/AccessibilityAndAppearanceView/**"]
 	},
 	{
+		"test": ".maestro/tests/assorted/admin-panel.yaml",
+		"dependsOn": ["app/views/AdminPanelView/**", "app/views/SidebarView/**"]
+	},
+	{
 		"test": ".maestro/tests/assorted/broadcast.yaml",
 		"dependsOn": [
 			"app/views/NewMessageView/**",

--- a/app/views/AdminPanelView/__tests__/buildLoginScript.test.ts
+++ b/app/views/AdminPanelView/__tests__/buildLoginScript.test.ts
@@ -1,0 +1,53 @@
+import { buildLoginScript } from '../buildLoginScript';
+
+const run = (token?: string) => {
+	new Function(buildLoginScript(token))();
+};
+
+describe('buildLoginScript', () => {
+	let loginWithToken: jest.Mock;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		loginWithToken = jest.fn();
+		delete (globalThis as any).Meteor;
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		delete (globalThis as any).Meteor;
+	});
+
+	it('logs in immediately when Meteor is already available', () => {
+		(globalThis as any).Meteor = { loginWithToken };
+		run('token-abc');
+		expect(loginWithToken).toHaveBeenCalledTimes(1);
+		expect(loginWithToken.mock.calls[0][0]).toBe('token-abc');
+	});
+
+	it('waits for Meteor when the page bundle has not evaluated yet', () => {
+		run('token-abc');
+		expect(loginWithToken).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime(500);
+		expect(loginWithToken).not.toHaveBeenCalled();
+
+		(globalThis as any).Meteor = { loginWithToken };
+		jest.advanceTimersByTime(100);
+		expect(loginWithToken).toHaveBeenCalledTimes(1);
+		expect(loginWithToken.mock.calls[0][0]).toBe('token-abc');
+	});
+
+	it('stops polling instead of looping forever when Meteor never appears', () => {
+		run('token-abc');
+		jest.advanceTimersByTime(60000);
+		expect(jest.getTimerCount()).toBe(0);
+		expect(loginWithToken).not.toHaveBeenCalled();
+	});
+
+	it('escapes the token so it cannot break out of the script literal', () => {
+		(globalThis as any).Meteor = { loginWithToken };
+		run('it\'s"\n');
+		expect(loginWithToken.mock.calls[0][0]).toBe('it\'s"\n');
+	});
+});

--- a/app/views/AdminPanelView/buildLoginScript.ts
+++ b/app/views/AdminPanelView/buildLoginScript.ts
@@ -1,0 +1,20 @@
+const POLL_INTERVAL_MS = 50;
+const MAX_ATTEMPTS = 200;
+
+export const buildLoginScript = (token?: string) => `
+(function () {
+	var attempts = 0;
+	function login() {
+		if (typeof Meteor !== 'undefined' && Meteor.loginWithToken) {
+			Meteor.loginWithToken(${JSON.stringify(token ?? '')}, function () {});
+			return;
+		}
+		attempts += 1;
+		if (attempts < ${MAX_ATTEMPTS}) {
+			setTimeout(login, ${POLL_INTERVAL_MS});
+		}
+	}
+	login();
+})();
+true;
+`;

--- a/app/views/AdminPanelView/index.tsx
+++ b/app/views/AdminPanelView/index.tsx
@@ -12,6 +12,7 @@ import SafeAreaView from '../../containers/SafeAreaView';
 import { type AdminPanelStackParamList } from '../../stacks/types';
 import { type IApplicationState } from '../../definitions';
 import { useMasterDetail } from '../../lib/hooks/useMasterDetail';
+import { buildLoginScript } from './buildLoginScript';
 
 const AdminPanelView = () => {
 	const navigation = useNavigation<NativeStackNavigationProp<AdminPanelStackParamList, 'AdminPanelView'>>();
@@ -31,7 +32,7 @@ const AdminPanelView = () => {
 		return null;
 	}
 
-	const str = `Meteor.loginWithToken('${token}', function() { })`;
+	const str = buildLoginScript(token);
 
 	return (
 		<SafeAreaView>

--- a/app/views/AdminPanelView/index.tsx
+++ b/app/views/AdminPanelView/index.tsx
@@ -35,7 +35,7 @@ const AdminPanelView = () => {
 	const str = buildLoginScript(token);
 
 	return (
-		<SafeAreaView>
+		<SafeAreaView testID='admin-panel-view'>
 			<WebView
 				// https://github.com/react-native-community/react-native-webview/issues/1311
 				onMessage={() => {}}

--- a/app/views/SidebarView/components/Admin.tsx
+++ b/app/views/SidebarView/components/Admin.tsx
@@ -40,6 +40,7 @@ const Admin = ({ currentScreen }: { currentScreen: string | null }) => {
 		<>
 			<List.Item
 				title={'Admin_Panel'}
+				testID='sidebar-admin'
 				left={() => <List.Icon name='settings' />}
 				onPress={() => sidebarNavigate(routeName)}
 				backgroundColor={currentScreen === routeName ? colors.strokeLight : undefined}


### PR DESCRIPTION
## Proposed changes

The admin panel WebView injected `Meteor.loginWithToken(token)` through `injectedJavaScript`, which react-native-webview evaluates at document-end. On a workspace whose bundle is slow to evaluate, that fires while `document.readyState` is still `loading` and the Meteor client does not exist yet, so the script threw `Can't find variable: Meteor`, no login was ever attempted, and the panel rendered the login form. Instrumenting the WebView on device caught it:

```
{"at":"injected","readyState":"loading","meteor":"undefined","hasToken":true}
{"at":"threw","message":"Can't find variable: Meteor"}
{"at":"after-3s","userId":null,"status":{"status":"connected","connected":true}}
```

Three seconds later Meteor exists and is connected, and nothing retries. This is a race rather than a workspace configuration difference, which is why the report was specific to one server: faster workspaces win it.

The injected script now polls for `Meteor.loginWithToken` before calling it, capped so it cannot spin forever, and the token is serialised with `JSON.stringify` so it cannot break out of the script literal.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1530

## How to test or reproduce

1. Log in to `open.rocket.chat` with an account holding an admin role.
2. Open the sidebar and tap **Admin panel**.

Before: the WebView shows the workspace login form. After: it loads straight into the Workspace / Version screen.

## Screenshots

Before, the WebView rendered the workspace login form. After, it renders the Workspace / Version screen.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`buildLoginScript` is extracted into its own module so the generated script is unit-testable: `app/views/AdminPanelView/__tests__/buildLoginScript.test.ts` covers Meteor already present, Meteor arriving late, Meteor never arriving, and token escaping. Reverting to the previous one-liner turns three of those four red.

The e2e coverage the issue also asks for is not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Admin Panel sign-in reliability when the page application loads slowly.
  - Sign-in now waits briefly for the login service to become available and stops retrying after a limited period.
  - Login tokens are safely handled to prevent malformed scripts from disrupting sign-in.
  - Embedded Admin Panel sessions now authenticate automatically without displaying the workspace login form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->