### PR TITLE
fix: allow channel, user and emoji autocomplete after slash command

### DIFF
--- a/app/containers/MessageComposer/MessageComposer.test.tsx
+++ b/app/containers/MessageComposer/MessageComposer.test.tsx
@@ -572,6 +572,35 @@ describe('MessageComposer', () => {
 			expect(onSendMessage).toHaveBeenCalledWith('#general', false);
 		});
 
+		test('typing # after a slash command opens channel autocomplete', async () => {
+			const onSendMessage = jest.fn();
+			(searchRemote as unknown as jest.Mock).mockImplementationOnce(() => [{ rid: 'r1', name: 'general', t: 'c' }]);
+			render(<Render context={{ onSendMessage }} />);
+
+			await fireEvent(screen.getByTestId('message-composer-input'), 'focus');
+			await fireEvent.changeText(screen.getByTestId('message-composer-input'), '/hello #');
+			await fireEvent(screen.getByTestId('message-composer-input'), 'selectionChange', {
+				nativeEvent: { selection: { start: 8, end: 8 } }
+			});
+			await advanceComposerTimers();
+
+			await waitFor(() => expect(screen.getByTestId('autocomplete-item-general')).toBeOnTheScreen());
+		});
+
+		test('typing @ after a slash command opens user autocomplete', async () => {
+			const onSendMessage = jest.fn();
+			render(<Render context={{ onSendMessage }} />);
+
+			await fireEvent(screen.getByTestId('message-composer-input'), 'focus');
+			await fireEvent.changeText(screen.getByTestId('message-composer-input'), '/hello @');
+			await fireEvent(screen.getByTestId('message-composer-input'), 'selectionChange', {
+				nativeEvent: { selection: { start: 8, end: 8 } }
+			});
+			await advanceComposerTimers();
+
+			await waitFor(() => expect(screen.getByTestId('autocomplete-item-John')).toBeOnTheScreen());
+		});
+
 		test('select : emoji inserts emoji and sends, autocomplete hides', async () => {
 			const onSendMessage = jest.fn();
 			render(<Render context={{ onSendMessage }} />);

--- a/app/containers/MessageComposer/components/ComposerInput.tsx
+++ b/app/containers/MessageComposer/components/ComposerInput.tsx
@@ -325,6 +325,22 @@ export const ComposerInput = memo(
 				stopAutocomplete();
 				return;
 			}
+			if (lastWord.match(/^#/)) {
+				setAutocompleteParams({ text: autocompleteText, type: '#' });
+				return;
+			}
+			if (lastWord.match(/^@/)) {
+				setAutocompleteParams({ text: autocompleteText, type: '@' });
+				return;
+			}
+			if (lastWord.match(/^:/)) {
+				setAutocompleteParams({ text: autocompleteText, type: ':' });
+				return;
+			}
+			if (lastWord.match(/^!/) && room?.t === 'l') {
+				setAutocompleteParams({ text: autocompleteText, type: '!' });
+				return;
+			}
 			if (!sharing && text.match(/^\//)) {
 				const commandParameter = text.match(/^\/([a-z0-9._-]+) (.+)/im);
 				if (commandParameter) {
@@ -342,22 +358,6 @@ export const ComposerInput = memo(
 					}
 				}
 				setAutocompleteParams({ text: autocompleteText, type: '/' });
-				return;
-			}
-			if (lastWord.match(/^#/)) {
-				setAutocompleteParams({ text: autocompleteText, type: '#' });
-				return;
-			}
-			if (lastWord.match(/^@/)) {
-				setAutocompleteParams({ text: autocompleteText, type: '@' });
-				return;
-			}
-			if (lastWord.match(/^:/)) {
-				setAutocompleteParams({ text: autocompleteText, type: ':' });
-				return;
-			}
-			if (lastWord.match(/^!/) && room?.t === 'l') {
-				setAutocompleteParams({ text: autocompleteText, type: '!' });
 				return;
 			}
 


### PR DESCRIPTION
## Proposed changes

Typing `#`, `@`, `:` or `!` after a slash command text (e.g. `/hello #`) never opened its autocomplete, because the whole-text slash check ran before the cursor-word checks and forced slash-command autocomplete.

- Moved the `#` (channels) / `@` (users) / `:` (emojis) / `!` (canned responses, Omnichannel rooms only) checks before the `/` slash-command check, so the word at the cursor wins
- Added coverage for `/hello #` opening channel autocomplete and `/hello @` opening user autocomplete

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-466

## How to test or reproduce

1. open app and go to any channel/room
2. in the message composer type `/hello #`
3. in the message composer type `/hello @`

Expected: channel autocomplete opens for `#`, user autocomplete opens for `@`
Actual: slash-command autocomplete stayed open, no channel/user list

## Screenshots

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autocomplete now works for channel and user mentions immediately after slash commands.
  * Local room and emoji suggestions are recognized correctly while composing messages.

* **Bug Fixes**
  * Improved autocomplete trigger handling so channel, user, emoji, and command suggestions appear correctly based on the current word.
  * Prevented slash-command previews from interfering with other autocomplete suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->