### PR TITLE
perf: memoize MessageRow

### DIFF
--- a/app/containers/message/__tests__/testHelpers.tsx
+++ b/app/containers/message/__tests__/testHelpers.tsx
@@ -10,6 +10,7 @@ import { MessageRoomProvider, type MessageRoomState } from '../stores/MessageRoo
 interface IMessageProvidersOptions {
 	item?: TAnyMessageModel;
 	previousItem?: TAnyMessageModel;
+	lastSeen?: Date | null;
 	room?: Partial<MessageRoomState>;
 	withRedux?: boolean;
 }
@@ -17,6 +18,7 @@ interface IMessageProvidersOptions {
 export const MessageProviders = ({
 	item,
 	previousItem,
+	lastSeen,
 	room,
 	withRedux = true,
 	children
@@ -26,7 +28,7 @@ export const MessageProviders = ({
 	let tree: ReactNode = children;
 	if (item) {
 		tree = (
-			<MessageProvider item={item} previousItem={previousItem}>
+			<MessageProvider item={item} previousItem={previousItem} lastSeen={lastSeen}>
 				{tree}
 			</MessageProvider>
 		);

--- a/app/containers/message/index.tsx
+++ b/app/containers/message/index.tsx
@@ -3,33 +3,39 @@ import { memo } from 'react';
 import MessageTouchable from './components/Touchable/MessageTouchable';
 import { type TAnyMessageModel } from '../../definitions';
 import MessageSeparator from '../MessageSeparator';
-import { MessageProvider } from './stores/MessageStore';
+import { MessageProvider, useMessageSeparators } from './stores/MessageStore';
 
 interface IMessageContainerProps {
 	item: TAnyMessageModel;
 	previousItem?: TAnyMessageModel;
+	lastSeen?: Date | null;
+	withSeparators?: boolean;
 	isIgnored?: boolean;
 	highlighted?: boolean;
 	onLongPress?: (item: TAnyMessageModel) => void;
 	threadBadgeColor?: string;
 	onPress?: () => void;
 	isPreview?: boolean;
-	dateSeparator?: Date | string | null;
-	showUnreadSeparator?: boolean;
 }
 
+const MessageSeparators = () => {
+	const { dateSeparator, showUnreadSeparator } = useMessageSeparators();
+	return <MessageSeparator ts={dateSeparator} unread={showUnreadSeparator} />;
+};
+
 const MessageContainer = (props: IMessageContainerProps) => {
-	const { item, previousItem, dateSeparator, showUnreadSeparator } = props;
+	const { item, previousItem, lastSeen, withSeparators } = props;
 	return (
 		<MessageProvider
 			item={item}
 			previousItem={previousItem}
+			lastSeen={lastSeen}
 			onPress={props.onPress}
 			onLongPress={props.onLongPress}
 			threadBadgeColor={props.threadBadgeColor}
 			isIgnored={props.isIgnored}>
 			<MessageTouchable isPreview={props.isPreview} highlighted={props.highlighted} />
-			<MessageSeparator ts={dateSeparator} unread={showUnreadSeparator} />
+			{withSeparators ? <MessageSeparators /> : null}
 		</MessageProvider>
 	);
 };

--- a/app/containers/message/stores/MessageStore.tsx
+++ b/app/containers/message/stores/MessageStore.tsx
@@ -4,7 +4,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { Keyboard } from 'react-native';
 
 import { type IAttachment, type TAnyMessageModel } from '../../../definitions';
-import { getMessageTranslation } from '../utils';
+import { getMessageSeparators, getMessageTranslation, type TMessageSeparators } from '../utils';
 import { E2E_MESSAGE_TYPE, E2E_STATUS } from '../../../lib/constants/keys';
 import { messagesStatus } from '../../../lib/constants/messagesStatus';
 import { useDebounce } from '../../../lib/methods/helpers/debounce';
@@ -27,6 +27,7 @@ type MessageStoreState = {
 	tick: number;
 	item: TAnyMessageModel;
 	previousItem?: TAnyMessageModel;
+	lastSeen: Date | null;
 	isIgnored: boolean;
 	manualUnignored: boolean;
 	reveal: () => void;
@@ -36,7 +37,10 @@ type MessageStoreState = {
 };
 
 const createMessageStore = (
-	initial: Pick<MessageStoreState, 'item' | 'previousItem' | 'isIgnored' | 'onPress' | 'onLongPress' | 'threadBadgeColor'>
+	initial: Pick<
+		MessageStoreState,
+		'item' | 'previousItem' | 'lastSeen' | 'isIgnored' | 'onPress' | 'onLongPress' | 'threadBadgeColor'
+	>
 ) =>
 	createStore<MessageStoreState>(set => ({
 		tick: 0,
@@ -119,6 +123,7 @@ const subscribeModel = (m: TAnyMessageModel, store: MessageStore) => {
 export const MessageProvider = ({
 	item,
 	previousItem,
+	lastSeen = null,
 	onPress,
 	onLongPress,
 	threadBadgeColor,
@@ -127,6 +132,7 @@ export const MessageProvider = ({
 }: {
 	item: TAnyMessageModel;
 	previousItem?: TAnyMessageModel;
+	lastSeen?: Date | null;
 	onPress?: () => void;
 	onLongPress?: (item: TAnyMessageModel) => void;
 	threadBadgeColor?: string;
@@ -134,7 +140,7 @@ export const MessageProvider = ({
 	children: ReactNode;
 }): ReactElement => {
 	const [store] = useState(() =>
-		createMessageStore({ item, previousItem, isIgnored: isIgnored ?? false, onPress, onLongPress, threadBadgeColor })
+		createMessageStore({ item, previousItem, lastSeen, isIgnored: isIgnored ?? false, onPress, onLongPress, threadBadgeColor })
 	);
 
 	// Push item/previousItem into the store and (re)subscribe both records to the same tick.
@@ -148,6 +154,10 @@ export const MessageProvider = ({
 			unsubscribePrevious?.();
 		};
 	}, [item, previousItem, store]);
+
+	useEffect(() => {
+		store.setState({ lastSeen });
+	}, [lastSeen, store]);
 
 	// Mirror per-message row handlers so field-level selectors subscribe without churning the context value.
 	useEffect(() => {
@@ -212,6 +222,9 @@ export const useAttachments = (): TAnyMessageModel['attachments'] => useMessageF
 
 export const useMessageHeaderMeta = (): Pick<TAnyMessageModel, 'ts' | 'unread' | 'pinned' | 't'> =>
 	useMessageStore(useShallow(s => ({ ts: s.item.ts, unread: s.item.unread, pinned: s.item.pinned, t: s.item.t })));
+
+export const useMessageSeparators = (): TMessageSeparators =>
+	useMessageStore(useShallow(s => getMessageSeparators(s.previousItem, s.item, s.lastSeen)));
 
 const computeIsHeader = (
 	prev: TAnyMessageModel | undefined,

--- a/app/containers/message/stores/__tests__/MessageStore.test.tsx
+++ b/app/containers/message/stores/__tests__/MessageStore.test.tsx
@@ -26,6 +26,7 @@ import {
 	useMessageItem,
 	useMessageLongPress,
 	useMessagePress,
+	useMessageSeparators,
 	useMessageStatus,
 	useMessageText,
 	useMessageTouchable,
@@ -138,7 +139,11 @@ const MsgValueReporter = ({ spy }: { spy: jest.Mock }) => {
 const renderDerived = (
 	item: TAnyMessageModel,
 	useHook: () => unknown,
-	{ previousItem, config }: { previousItem?: TAnyMessageModel; config?: Partial<MessageRoomState> } = {}
+	{
+		previousItem,
+		lastSeen,
+		config
+	}: { previousItem?: TAnyMessageModel; lastSeen?: Date | null; config?: Partial<MessageRoomState> } = {}
 ) => {
 	const spy = jest.fn();
 	const Probe = () => {
@@ -148,7 +153,7 @@ const renderDerived = (
 	render(
 		<Provider store={mockedStore}>
 			<MessageRoomProvider {...(config ?? {})}>
-				<MessageProvider item={item} previousItem={previousItem}>
+				<MessageProvider item={item} previousItem={previousItem} lastSeen={lastSeen}>
 					<Probe />
 				</MessageProvider>
 			</MessageRoomProvider>
@@ -608,6 +613,95 @@ describe('MessageStore', () => {
 			const model = buildFakeModel({ ts, unread: true, pinned: true, t: 'room_changed_topic' });
 			const { latest } = renderDerived(model, useMessageHeaderMeta);
 			expect(latest()).toEqual({ ts: model.ts, unread: model.unread, pinned: model.pinned, t: model.t });
+		});
+
+		it('useMessageSeparators returns a date separator and no unread separator for the first message with no lastSeen', () => {
+			const ts = new Date('2024-01-01T10:00:00Z');
+			const model = buildFakeModel({ ts });
+			const { latest } = renderDerived(model, useMessageSeparators);
+			expect(latest()).toEqual({ dateSeparator: ts, showUnreadSeparator: false });
+		});
+
+		it('useMessageSeparators returns no date separator when prev is on the same day', () => {
+			const ts = new Date('2024-01-01T10:00:00Z');
+			const prevTs = new Date('2024-01-01T09:00:00Z');
+			const model = buildFakeModel({ ts });
+			const { latest } = renderDerived(model, useMessageSeparators, { previousItem: buildFakeModel({ id: 'p0', ts: prevTs }) });
+			expect(latest()).toEqual({ dateSeparator: null, showUnreadSeparator: false });
+		});
+
+		it('useMessageSeparators shows the unread separator on the first message at or after lastSeen', () => {
+			const ts = new Date('2024-01-01T10:00:00Z');
+			const prevTs = new Date('2024-01-01T09:00:00Z');
+			const lastSeen = new Date('2024-01-01T09:30:00Z');
+			const model = buildFakeModel({ ts });
+			const { latest } = renderDerived(model, useMessageSeparators, {
+				previousItem: buildFakeModel({ id: 'p0', ts: prevTs }),
+				lastSeen
+			});
+			expect(latest()).toEqual({ dateSeparator: null, showUnreadSeparator: true });
+		});
+
+		it('useMessageSeparators re-derives when lastSeen changes after the record mounts', () => {
+			const ts = new Date('2024-01-01T10:00:00Z');
+			const prevTs = new Date('2024-01-01T09:00:00Z');
+			const model = buildFakeModel({ ts });
+			const previousItem = buildFakeModel({ id: 'p0', ts: prevTs });
+			const spy = jest.fn();
+			const Probe = () => {
+				spy(useMessageSeparators());
+				return null;
+			};
+			const wrap = (lastSeen: Date | null) => (
+				<Provider store={mockedStore}>
+					<MessageRoomProvider>
+						<MessageProvider item={model} previousItem={previousItem} lastSeen={lastSeen}>
+							<Probe />
+						</MessageProvider>
+					</MessageRoomProvider>
+				</Provider>
+			);
+			const latest = () => {
+				const { calls } = spy.mock;
+				return calls[calls.length - 1]?.[0];
+			};
+
+			const { rerender } = render(wrap(null));
+			expect(latest()).toEqual({ dateSeparator: null, showUnreadSeparator: false });
+
+			act(() => rerender(wrap(new Date('2024-01-01T09:30:00Z'))));
+			expect(latest()).toEqual({ dateSeparator: null, showUnreadSeparator: true });
+		});
+
+		it('useMessageSeparators re-derives when ts is mutated in place across a day boundary', () => {
+			const previousItem = buildFakeModel({ id: 'p0', ts: new Date('2024-01-01T23:59:00Z') });
+			const model = buildFakeModel({ ts: new Date('2024-01-01T23:59:30Z') });
+			const { latest } = renderDerived(model, useMessageSeparators, { previousItem });
+
+			expect(latest()).toEqual({ dateSeparator: null, showUnreadSeparator: false });
+
+			const confirmedTs = new Date('2024-01-02T00:00:10Z');
+			act(() => {
+				(model as any).ts = confirmedTs;
+				(model as FakeModel)._emit();
+			});
+
+			expect(latest()).toEqual({ dateSeparator: confirmedTs, showUnreadSeparator: false });
+		});
+
+		it('useMessageSeparators re-derives when the previous message ts is mutated in place', () => {
+			const previousItem = buildFakeModel({ id: 'p0', ts: new Date('2024-01-01T23:59:00Z') });
+			const model = buildFakeModel({ ts: new Date('2024-01-02T00:00:10Z') });
+			const { latest } = renderDerived(model, useMessageSeparators, { previousItem });
+
+			expect(latest()).toEqual({ dateSeparator: model.ts, showUnreadSeparator: false });
+
+			act(() => {
+				(previousItem as any).ts = new Date('2024-01-02T00:00:00Z');
+				(previousItem as FakeModel)._emit();
+			});
+
+			expect(latest()).toEqual({ dateSeparator: null, showUnreadSeparator: false });
 		});
 	});
 

--- a/app/containers/message/utils.ts
+++ b/app/containers/message/utils.ts
@@ -2,7 +2,35 @@
 import { type IAttachment, type IMessageTranslations } from '../../definitions';
 import { type MessageTypesValues, type TAnyMessageModel, type TMessageModel } from '../../definitions/IMessage';
 import I18n from '../../i18n';
+import dayjs from '../../lib/dayjs';
 import { DISCUSSION } from './constants';
+
+export type TMessageSeparators = { dateSeparator: TAnyMessageModel['ts'] | null; showUnreadSeparator: boolean };
+
+export const getMessageSeparators = (
+	prev: TAnyMessageModel | undefined,
+	item: TAnyMessageModel,
+	lastSeen: Date | null
+): TMessageSeparators => {
+	let dateSeparator: TAnyMessageModel['ts'] | null = null;
+	let showUnreadSeparator = false;
+
+	const itemDate = dayjs(item.ts);
+
+	if (!prev) {
+		dateSeparator = item.ts;
+		showUnreadSeparator = lastSeen ? itemDate.isAfter(lastSeen) : false;
+	} else {
+		const prevDate = dayjs(prev.ts);
+		showUnreadSeparator =
+			(lastSeen && (itemDate.isSame(lastSeen) || itemDate.isAfter(lastSeen)) && prevDate.isBefore(lastSeen)) ?? false;
+		if (!itemDate.isSame(prev.ts, 'day')) {
+			dateSeparator = item.ts;
+		}
+	}
+
+	return { dateSeparator, showUnreadSeparator };
+};
 
 export const DEFAULT_MESSAGE_HEIGHT = 150;
 

--- a/app/views/RoomView/components/MessageRow.tsx
+++ b/app/views/RoomView/components/MessageRow.tsx
@@ -1,39 +1,18 @@
 import { memo } from 'react';
 
-import dayjs from '../../../lib/dayjs';
 import { useRoomStore } from '../stores/RoomStoreContext';
 import { useRoomScreen } from '../stores/RoomScreenContext';
 import Message from '../../../containers/message';
+import { getMessageSeparators } from '../../../containers/message/utils';
 import LoadMore from '../LoadMore';
 import { MESSAGE_TYPE_ANY_LOAD, MessageTypeLoad } from '../../../lib/constants/messageTypeLoad';
-import { type RoomType, type TAnyMessageModel } from '../../../definitions';
+import { type RoomType } from '../../../definitions';
 import { useThreadBadgeColor } from '../hooks/useThreadBadgeColor';
-import { type IRoomViewState, type TMessageRowProps } from '../definitions';
+import { type TMessageRowProps } from '../definitions';
 import { isSubscriptionModel } from '../../../definitions/TRoom';
 
 const useIsIgnored = (authorId?: string): boolean =>
 	useRoomStore(s => (authorId && isSubscriptionModel(s.room) ? (s.room.ignored?.includes(authorId) ?? false) : false));
-
-const getMessageSeparators = (item: TAnyMessageModel, previousItem: TAnyMessageModel, lastSeen: IRoomViewState['lastSeen']) => {
-	let dateSeparator: TAnyMessageModel['ts'] | null = null;
-	let showUnreadSeparator = false;
-
-	const itemDate = dayjs(item.ts);
-
-	if (!previousItem) {
-		dateSeparator = item.ts;
-		showUnreadSeparator = lastSeen ? itemDate.isAfter(lastSeen) : false;
-	} else {
-		const previousItemDate = dayjs(previousItem.ts);
-		showUnreadSeparator =
-			(lastSeen && (itemDate.isSame(lastSeen) || itemDate.isAfter(lastSeen)) && previousItemDate.isBefore(lastSeen)) ?? false;
-		if (!itemDate.isSame(previousItem.ts, 'day')) {
-			dateSeparator = item.ts;
-		}
-	}
-
-	return { dateSeparator, showUnreadSeparator };
-};
 
 export const MessageRow = memo(function MessageRow({ item, previousItem, highlightedMessage, onLongPress }: TMessageRowProps) {
 	const rid = useRoomStore(s => s.room.rid);
@@ -41,9 +20,9 @@ export const MessageRow = memo(function MessageRow({ item, previousItem, highlig
 	const isIgnored = useIsIgnored(item?.u?._id);
 	const threadBadgeColor = useThreadBadgeColor(item.id);
 	const { lastSeen } = useRoomScreen();
-	const { dateSeparator, showUnreadSeparator } = getMessageSeparators(item, previousItem, lastSeen);
 
 	if (item.t && MESSAGE_TYPE_ANY_LOAD.includes(item.t as MessageTypeLoad)) {
+		const { dateSeparator, showUnreadSeparator } = getMessageSeparators(previousItem, item, lastSeen);
 		const runOnRender = item.t === MessageTypeLoad.MORE && (!previousItem || !!previousItem.tmid);
 		return (
 			<LoadMore
@@ -63,11 +42,11 @@ export const MessageRow = memo(function MessageRow({ item, previousItem, highlig
 			item={item}
 			isIgnored={isIgnored}
 			previousItem={previousItem}
+			lastSeen={lastSeen}
+			withSeparators
 			onLongPress={onLongPress}
 			threadBadgeColor={threadBadgeColor}
 			highlighted={highlightedMessage === item.id}
-			dateSeparator={dateSeparator}
-			showUnreadSeparator={showUnreadSeparator}
 		/>
 	);
 });

--- a/app/views/RoomView/components/MessageRow.tsx
+++ b/app/views/RoomView/components/MessageRow.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 import dayjs from '../../../lib/dayjs';
 import { useRoomStore } from '../stores/RoomStoreContext';
 import { useRoomScreen } from '../stores/RoomScreenContext';
@@ -33,7 +35,7 @@ const getMessageSeparators = (item: TAnyMessageModel, previousItem: TAnyMessageM
 	return { dateSeparator, showUnreadSeparator };
 };
 
-export const MessageRow = ({ item, previousItem, highlightedMessage, onLongPress }: TMessageRowProps) => {
+export const MessageRow = memo(function MessageRow({ item, previousItem, highlightedMessage, onLongPress }: TMessageRowProps) {
 	const rid = useRoomStore(s => s.room.rid);
 	const t = useRoomStore(s => s.room.t) as RoomType;
 	const isIgnored = useIsIgnored(item?.u?._id);
@@ -68,4 +70,4 @@ export const MessageRow = ({ item, previousItem, highlightedMessage, onLongPress
 			showUnreadSeparator={showUnreadSeparator}
 		/>
 	);
-};
+});


### PR DESCRIPTION
## Proposed changes

`MessageRow` re-rendered once per visible cell on every incoming message. All of those
re-renders were no-ops: nothing on the row actually differed, the parent just re-rendered
because `renderItem` is a fresh closure each time, which invalidates `CellRenderer` one level
above the row.

Wrapping the row in `React.memo` with the default shallow comparator stops the call. The four
props are a primitive, a possibly-undefined string, and two WatermelonDB model references, all
of which compare correctly by reference, so no custom comparator is needed.

`memo` is complementary to the React Compiler rather than a substitute: the compiler caches the
body's work but cannot stop the component from being called. Content updates still reach the row
by a different route, the `MessageProvider` store tick consumed by the `useMessageField`
selectors, which is the same reasoning that has kept `memo(MessageContainer)` safe. Context and
zustand subscriptions are unaffected by `memo`, so `lastSeen` and the `useRoomStore` selectors
keep working.

The function inside `memo(...)` is named so the fiber records as `Memo(MessageRow)`. An anonymous
arrow records as `Anonymous`, indistinguishable from the other memoized anonymous components on
this screen. `RoomsListView` already uses this shape.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1537

## How to test or reproduce

Open a room with a screenful of messages and send two messages while profiling React commits.

Before: the row rendered once per visible cell on each incoming message, around 19 to 21
occurrences per send, every one of them carrying an empty change description.

After: 1 mount and 0 re-renders for the row per send, while `CellRenderer` keeps re-rendering
19 to 21 times. The cell continuing to re-render is the point, it shows the memo is absorbing
the parent render rather than the parent having stopped rendering.

Measured on an Android debug build, API 36, bridgeless, one profiler session covering an idle
arm plus two sends. Across the whole session the row fiber appeared twice, both mounts.

## Screenshots

n/a, no visual change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [x] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The existing `MessageRow` tests pass unchanged, which is the expected outcome since they render
the component directly and a memo wrapper is transparent to that.

Follow-up worth doing separately: `highlightedMessage` is passed to every row as the same string
and reduced to `highlighted={highlightedMessage === item.id}` inside the row. Any highlight
change therefore changes a prop on every row and defeats this memo for that one case. Computing
the boolean at the callsite would close it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved message rendering efficiency by preventing unnecessary updates when message properties remain unchanged.
  * Reduced unnecessary date and unread separator calculations during message rendering.

* **Bug Fixes**
  * Improved separator accuracy as messages load and the last-seen position changes.
  * Updated separator behavior when message timestamps change, including updates to existing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->