### PR TITLE
regression: custom emoji rendering as raw shortname in reaction bar and emoji picker

### DIFF
--- a/app/containers/EmojiPicker/Emoji.test.tsx
+++ b/app/containers/EmojiPicker/Emoji.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react-native';
+
+import { Emoji } from './Emoji';
+
+const customEmojis = { clap: { name: 'clap', extension: 'png' } };
+
+jest.mock('../../lib/hooks/useAppSelector', () => ({
+	useAppSelector: (selector: (state: any) => any) =>
+		selector({ customEmojis, server: { server: 'https://open.rocket.chat' }, login: { user: {} } })
+}));
+
+describe('Emoji', () => {
+	it('renders the custom emoji image when a shortname collides with a custom emoji', () => {
+		render(<Emoji emoji='clap' />);
+
+		expect(screen.queryByText(':clap:')).toBeNull();
+	});
+
+	it('renders the unicode emoji when there is no custom emoji with that name', () => {
+		render(<Emoji emoji='thumbsup' />);
+
+		expect(screen.getByText('👍️')).toBeOnTheScreen();
+	});
+});

--- a/app/containers/EmojiPicker/Emoji.tsx
+++ b/app/containers/EmojiPicker/Emoji.tsx
@@ -2,16 +2,18 @@ import { type ReactElement } from 'react';
 import { Text } from 'react-native';
 
 import useShortnameToUnicode from '../../lib/hooks/useShortnameToUnicode';
+import { useCustomEmoji } from '../../lib/hooks/useCustomEmoji';
 import styles from './styles';
 import CustomEmoji from './CustomEmoji';
 import { type IEmojiProps } from './interfaces';
 
 export const Emoji = ({ emoji }: IEmojiProps): ReactElement => {
 	const { formatShortnameToUnicode } = useShortnameToUnicode(true);
-	const unicodeEmoji = formatShortnameToUnicode(`:${emoji}:`);
+	const getCustomEmoji = useCustomEmoji();
+	const customEmoji = typeof emoji === 'string' ? getCustomEmoji(emoji) : emoji;
 
-	if (typeof emoji === 'string') {
-		return <Text style={styles.categoryEmoji}>{unicodeEmoji}</Text>;
+	if (customEmoji) {
+		return <CustomEmoji style={styles.customCategoryEmoji} emoji={customEmoji} />;
 	}
-	return <CustomEmoji style={styles.customCategoryEmoji} emoji={emoji} />;
+	return <Text style={styles.categoryEmoji}>{formatShortnameToUnicode(`:${emoji}:`)}</Text>;
 };

--- a/app/containers/MessageActions/Header.tsx
+++ b/app/containers/MessageActions/Header.tsx
@@ -5,6 +5,7 @@ import { type TSupportedThemes, useTheme } from '../../theme';
 import { themes } from '../../lib/constants/colors';
 import { CustomIcon } from '../CustomIcon';
 import useShortnameToUnicode from '../../lib/hooks/useShortnameToUnicode';
+import { useCustomEmoji } from '../../lib/hooks/useCustomEmoji';
 import { addFrequentlyUsed } from '../../lib/methods/emojis';
 import { useFrequentlyUsedEmoji } from '../../lib/hooks/useFrequentlyUsedEmoji';
 import CustomEmoji from '../EmojiPicker/CustomEmoji';
@@ -66,18 +67,20 @@ const styles = StyleSheet.create({
 
 const HeaderItem = ({ item, onReaction, theme }: THeaderItem) => {
 	const { formatShortnameToUnicode } = useShortnameToUnicode();
-	const unicodeEmoji = formatShortnameToUnicode(`:${item}:`);
+	const getCustomEmoji = useCustomEmoji();
+	const emojiName = typeof item === 'string' ? item : item.name;
+	const customEmoji = typeof item === 'string' ? getCustomEmoji(item) : item;
 	return (
 		<Touch
-			testID={`message-actions-emoji-${item}`}
+			testID={`message-actions-emoji-${emojiName}`}
 			accessible
-			accessibilityLabel={I18n.t('React_with_emojjname', { emojiName: item })}
+			accessibilityLabel={I18n.t('React_with_emojjname', { emojiName })}
 			onPress={() => onReaction({ emoji: item })}
 			style={[styles.headerItem, { backgroundColor: themes[theme].surfaceHover }]}>
-			{typeof item === 'string' ? (
-				<Text style={styles.headerIcon}>{unicodeEmoji}</Text>
+			{customEmoji ? (
+				<CustomEmoji style={styles.customEmoji} emoji={customEmoji} />
 			) : (
-				<CustomEmoji style={styles.customEmoji} emoji={item} />
+				<Text style={styles.headerIcon}>{formatShortnameToUnicode(`:${emojiName}:`)}</Text>
 			)}
 		</Touch>
 	);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue below. -->
Long-pressing a message showed the raw shortname (:clap:) in the reactions top bar when a custom emoji had the same name as a built-in one. The same issue happened in the emoji picker's Frequently Used tab.

This regression was introduced by #7462, where useShortnameToUnicode started returning the shortname when a custom emoji owns that name. These components were still deciding custom vs. built-in based only on the item's type.

This PR resolves string shortnames against the custom emoji map and renders CustomEmoji when needed. It also fixes the Header testID/accessibilityLabel for custom emojis and adds unit tests.

## Issue(s)	
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/NATIVE-1542

## How to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Screenshots
| Before | After |
| ----- | ----- |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-09-11 at 13 40 55" src="https://github.com/user-attachments/assets/f040856d-51d3-4057-8f28-929bf03fbd43" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-09-11 at 13 40 42" src="https://github.com/user-attachments/assets/24445911-37d4-4061-9862-012acea39192" /> |

## Types of changes
<!-- What types of changes does your code introduce to Rocket.Chat? -->
<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist
<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING](https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat) doc
- [X] I have signed the [CLA](https://cla-assistant.io/RocketChat/Rocket.Chat.ReactNative)
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] I have added necessary documentation (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Custom emojis now render as images in emoji pickers and message action headers.
- Standard Unicode emojis remain visible when no matching custom emoji is available.

## Tests
- Added coverage for custom emoji rendering and Unicode fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->