### PR TITLE
refactor: pass RoomMessageActions refs directly

### DIFF
--- a/app/views/RoomView/components/RoomMessageActions.tsx
+++ b/app/views/RoomView/components/RoomMessageActions.tsx
@@ -1,5 +1,5 @@
-import MessageActions, { type IMessageActions } from '../../../containers/MessageActions';
-import MessageErrorActions, { type IMessageErrorActions } from '../../../containers/MessageErrorActions';
+import MessageActions from '../../../containers/MessageActions';
+import MessageErrorActions from '../../../containers/MessageErrorActions';
 import { type IRoomMessageActionsProps } from '../definitions';
 import { type TSubscriptionModel } from '../../../definitions';
 import { isSubscriptionModel } from '../../../definitions/TRoom';
@@ -33,9 +33,7 @@ export const RoomMessageActions = ({
 	return (
 		<>
 			<MessageActions
-				ref={(ref: IMessageActions | null) => {
-					messageActionsRef.current = ref;
-				}}
+				ref={messageActionsRef}
 				tmid={tmid}
 				room={room}
 				user={user}
@@ -47,12 +45,7 @@ export const RoomMessageActions = ({
 				jumpToMessage={jumpToMessage}
 				isReadOnly={readOnly}
 			/>
-			<MessageErrorActions
-				ref={(ref: IMessageErrorActions | null) => {
-					messageErrorActionsRef.current = ref;
-				}}
-				tmid={tmid}
-			/>
+			<MessageErrorActions ref={messageErrorActionsRef} tmid={tmid} />
 		</>
 	);
 };

--- a/app/views/RoomView/components/__tests__/RoomMessageActions.test.tsx
+++ b/app/views/RoomView/components/__tests__/RoomMessageActions.test.tsx
@@ -1,0 +1,71 @@
+import { createRef, type RefObject } from 'react';
+import { render } from '@testing-library/react-native';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { createStore as createZustandStore } from 'zustand';
+
+import { ActionSheetProvider } from '../../../../containers/ActionSheet';
+import { type IMessageActions } from '../../../../containers/MessageActions';
+import { type IMessageErrorActions } from '../../../../containers/MessageErrorActions';
+import { type IRoomMessageActionsProps, type RoomStore } from '../../definitions';
+import { RoomStoreContext } from '../../stores/RoomStoreContext';
+import { RoomMessageActions } from '../RoomMessageActions';
+
+const makeReduxStore = () =>
+	createStore(() => ({
+		login: { user: { id: 'user-1', username: 'tester', roles: [] } },
+		server: { server: 'https://open.rocket.chat', version: '7.0.0' },
+		settings: {},
+		permissions: {},
+		app: { isMasterDetail: false }
+	}));
+
+const makeProps = (
+	messageActionsRef: RefObject<IMessageActions | null>,
+	messageErrorActionsRef: RefObject<IMessageErrorActions | null>
+): IRoomMessageActionsProps =>
+	({
+		tmid: undefined,
+		messageActionsRef,
+		messageErrorActionsRef,
+		editInit: jest.fn(),
+		replyInit: jest.fn(),
+		quoteInit: jest.fn(),
+		reactionInit: jest.fn(),
+		onReactionPress: jest.fn(),
+		jumpToMessage: jest.fn()
+	}) as IRoomMessageActionsProps;
+
+const renderComponent = (
+	messageActionsRef: RefObject<IMessageActions | null>,
+	messageErrorActionsRef: RefObject<IMessageErrorActions | null>
+) => {
+	const roomStore = createZustandStore(() => ({ room: { id: 'sub-1', rid: 'rid-1', t: 'c' } })) as unknown as RoomStore;
+	const reduxStore = makeReduxStore();
+	return render(
+		<Provider store={reduxStore}>
+			<ActionSheetProvider>
+				<RoomStoreContext.Provider value={roomStore}>
+					<RoomMessageActions {...makeProps(messageActionsRef, messageErrorActionsRef)} />
+				</RoomStoreContext.Provider>
+			</ActionSheetProvider>
+		</Provider>
+	);
+};
+
+describe('RoomMessageActions handle attachment', () => {
+	it('populates both sheet handles on mount and clears them on unmount', () => {
+		const messageActionsRef = createRef<IMessageActions>();
+		const messageErrorActionsRef = createRef<IMessageErrorActions>();
+
+		const screen = renderComponent(messageActionsRef, messageErrorActionsRef);
+
+		expect(messageActionsRef.current).toEqual(expect.objectContaining({ showMessageActions: expect.any(Function) }));
+		expect(messageErrorActionsRef.current).toEqual(expect.objectContaining({ showMessageErrorActions: expect.any(Function) }));
+
+		screen.unmount();
+
+		expect(messageActionsRef.current).toBeNull();
+		expect(messageErrorActionsRef.current).toBeNull();
+	});
+});

--- a/app/views/RoomView/components/__tests__/RoomMessageActions.test.tsx
+++ b/app/views/RoomView/components/__tests__/RoomMessageActions.test.tsx
@@ -1,69 +1,66 @@
-import { createRef, type RefObject } from 'react';
+import { createRef } from 'react';
 import { render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
-import { createStore as createZustandStore } from 'zustand';
+import { createStore } from 'zustand';
 
 import { ActionSheetProvider } from '../../../../containers/ActionSheet';
 import { type IMessageActions } from '../../../../containers/MessageActions';
 import { type IMessageErrorActions } from '../../../../containers/MessageErrorActions';
-import { type IRoomMessageActionsProps, type RoomStore } from '../../definitions';
+import { setUser } from '../../../../actions/login';
+import { createMockedStore } from '../../../../reducers/mockedStore';
+import { type RoomState } from '../../definitions';
 import { RoomStoreContext } from '../../stores/RoomStoreContext';
 import { RoomMessageActions } from '../RoomMessageActions';
 
-const makeReduxStore = () =>
-	createStore(() => ({
-		login: { user: { id: 'user-1', username: 'tester', roles: [] } },
-		server: { server: 'https://open.rocket.chat', version: '7.0.0' },
-		settings: {},
-		permissions: {},
-		app: { isMasterDetail: false }
+const subRoom = { id: 'sub-1', rid: 'rid-1', t: 'c' };
+
+const makeRoomStore = () =>
+	createStore<RoomState>(() => ({
+		room: subRoom,
+		membership: 'subscribed',
+		member: {},
+		roomUserId: null,
+		canAutoTranslate: false,
+		canForwardGuest: false,
+		canViewCannedResponse: false,
+		init: jest.fn(),
+		join: jest.fn(),
+		joinRoom: jest.fn(),
+		resumeRoom: jest.fn()
 	}));
 
-const makeProps = (
-	messageActionsRef: RefObject<IMessageActions | null>,
-	messageErrorActionsRef: RefObject<IMessageErrorActions | null>
-): IRoomMessageActionsProps =>
-	({
-		tmid: undefined,
-		messageActionsRef,
-		messageErrorActionsRef,
-		editInit: jest.fn(),
-		replyInit: jest.fn(),
-		quoteInit: jest.fn(),
-		reactionInit: jest.fn(),
-		onReactionPress: jest.fn(),
-		jumpToMessage: jest.fn()
-	}) as IRoomMessageActionsProps;
-
-const renderComponent = (
-	messageActionsRef: RefObject<IMessageActions | null>,
-	messageErrorActionsRef: RefObject<IMessageErrorActions | null>
-) => {
-	const roomStore = createZustandStore(() => ({ room: { id: 'sub-1', rid: 'rid-1', t: 'c' } })) as unknown as RoomStore;
-	const reduxStore = makeReduxStore();
-	return render(
-		<Provider store={reduxStore}>
-			<ActionSheetProvider>
-				<RoomStoreContext.Provider value={roomStore}>
-					<RoomMessageActions {...makeProps(messageActionsRef, messageErrorActionsRef)} />
-				</RoomStoreContext.Provider>
-			</ActionSheetProvider>
-		</Provider>
-	);
-};
-
-describe('RoomMessageActions handle attachment', () => {
+describe('RoomMessageActions', () => {
 	it('populates both sheet handles on mount and clears them on unmount', () => {
 		const messageActionsRef = createRef<IMessageActions>();
 		const messageErrorActionsRef = createRef<IMessageErrorActions>();
+		const roomStore = makeRoomStore();
+		const reduxStore = createMockedStore();
+		reduxStore.dispatch(setUser({ id: 'user-1', username: 'tester', roles: [] }));
 
-		const screen = renderComponent(messageActionsRef, messageErrorActionsRef);
+		const { unmount } = render(
+			<Provider store={reduxStore}>
+				<ActionSheetProvider>
+					<RoomStoreContext.Provider value={roomStore}>
+						<RoomMessageActions
+							tmid={undefined}
+							messageActionsRef={messageActionsRef}
+							messageErrorActionsRef={messageErrorActionsRef}
+							editInit={jest.fn()}
+							replyInit={jest.fn()}
+							quoteInit={jest.fn()}
+							reactionInit={jest.fn()}
+							onReactionPress={jest.fn()}
+							jumpToMessage={jest.fn()}
+						/>
+					</RoomStoreContext.Provider>
+				</ActionSheetProvider>
+			</Provider>
+		);
 
 		expect(messageActionsRef.current).toEqual(expect.objectContaining({ showMessageActions: expect.any(Function) }));
 		expect(messageErrorActionsRef.current).toEqual(expect.objectContaining({ showMessageErrorActions: expect.any(Function) }));
 
-		screen.unmount();
+		unmount();
 
 		expect(messageActionsRef.current).toBeNull();
 		expect(messageErrorActionsRef.current).toBeNull();


### PR DESCRIPTION
## Proposed changes

Pass the existing message-actions and error-actions ref objects directly to their sheet containers in `RoomMessageActions`. Remove the assignment callbacks and their unused handle-type imports; container forwarding, hook ownership, subscription guarding, and deferred handle reads stay intact.

The first commit adds a component test rendering the real exported containers and action-sheet provider. It proves both handles expose their sheet methods after mount and clear on unmount, and passed against the original callbacks before the second commit changed the wiring.

## Issue(s)

Follow-up to #7482. Targets `native-34-roomview-hooks`.

## How to test or reproduce

- `TZ=UTC pnpm exec jest --runInBand --watchman=false app/views/RoomView/components/__tests__/RoomMessageActions.test.tsx app/views/RoomView/hooks/__tests__/useMessageActions.test.tsx`: 24 tests passed.
- `pnpm format-lint`: passed with existing warnings.
- `pnpm exec tsc --noEmit`: passed; direct refs require no casts or HOC changes.
- Full Jest suite: 308 suites passed, 8 failed (2883 tests passed, 20 failed; 5 snapshots failed). Rerunning all 8 failing suites with the original callback wiring reproduced the same 20 failures and 5 snapshot failures. Affected suites: MessageStore, Reply, validate-test-map, formatStatusExpiry, message leaves snapshots, Markdown, RoomHeader, StatusRows.
- Simulator checks omitted at the requester's instruction.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] Added tests for handle attachment and cleanup.
- [x] Formatting, lint, TypeScript, and focused tests pass.
- [ ] Full suite passes (baseline failures described above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated coverage for message action handlers to verify refs are available while mounted and cleared when components are unmounted.
* **Refactor**
  * Simplified how message action handlers receive forwarded references, with no change to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->