### PR TITLE
refactor(RoomStore): inline the state initializer into createRoomStore

### DIFF
--- a/app/views/RoomView/stores/RoomStore.ts
+++ b/app/views/RoomView/stores/RoomStore.ts
@@ -1,6 +1,6 @@
 import { Q } from '@nozbe/watermelondb';
 import { filter, map, switchMap, take, tap } from 'rxjs/operators';
-import { createStore, type StateCreator } from 'zustand';
+import { createStore } from 'zustand';
 
 import database from '../../../lib/database';
 import { SUBSCRIPTIONS_TABLE } from '../../../lib/database/model/Subscription';
@@ -121,60 +121,6 @@ const deriveMembership = (room: TRoomOrPreview): RoomMembership => {
 	return room.t === 'd' ? 'subscribed' : 'preview';
 };
 
-const createRoomState =
-	(
-		rid: string | undefined,
-		initialRoom: TRoomOrPreview = EMPTY_ROOM,
-		roomUserId: string | null | undefined = null
-	): StateCreator<RoomState> =>
-	(set, get) => ({
-		room: initialRoom,
-		membership: deriveMembership(initialRoom),
-		member: EMPTY_MEMBER,
-		roomUserId,
-		canAutoTranslate: false,
-		canForwardGuest: false,
-		canViewCannedResponse: false,
-
-		init: async ({ tmid, onThreadMessagesLoaded, signal }: IRoomStoreInitParams = {}): Promise<TRoomInitResult> => {
-			if (!rid) {
-				return { status: 'skipped' };
-			}
-			for (let attempt = 1; attempt <= INIT_MAX_ATTEMPTS; attempt += 1) {
-				const { room, membership } = get();
-				const result = await loadRoom(rid, room, membership, { tmid, onThreadMessagesLoaded, signal });
-				if (signal?.aborted || result.status === 'skipped') {
-					return { status: 'skipped' };
-				}
-				if (result.status === 'loaded') {
-					set(result.pendingRoomState);
-					if (result.shouldMarkRead) {
-						readMessages(room.rid).catch(e => log(e));
-					}
-					return { status: 'loaded', lastSeen: result.lastSeen };
-				}
-				if (attempt < INIT_MAX_ATTEMPTS) {
-					await new Promise(resolve => {
-						setTimeout(resolve, INIT_RETRY_DELAY);
-					});
-					if (signal?.aborted) {
-						return { status: 'skipped' };
-					}
-				}
-			}
-			return { status: 'failed' };
-		},
-
-		join: () => set({ membership: 'subscribed' }),
-
-		joinRoom: (requestJoinCode?: () => void): Promise<void> =>
-			joinRoom(get().room, {
-				requestJoinCode,
-				onJoin: get().join
-			}),
-		resumeRoom: (): Promise<void> => resumeRoom(get().room, get().join)
-	});
-
 const publishRoom = (store: RoomStore, next: TSubscriptionModel): void => {
 	store.setState({ room: next, membership: deriveMembership(next) });
 };
@@ -248,10 +194,57 @@ export function observeRoom(rid: string | undefined, store: RoomStore, onReady?:
 
 export const createRoomStore = ({
 	rid,
-	initialRoom,
-	roomUserId
+	initialRoom = EMPTY_ROOM,
+	roomUserId = null
 }: {
 	rid?: string;
 	initialRoom: TRoomOrPreview;
 	roomUserId?: string | null;
-}): RoomStore => createStore<RoomState>(createRoomState(rid, initialRoom, roomUserId));
+}): RoomStore =>
+	createStore<RoomState>((set, get) => ({
+		room: initialRoom,
+		membership: deriveMembership(initialRoom),
+		member: EMPTY_MEMBER,
+		roomUserId,
+		canAutoTranslate: false,
+		canForwardGuest: false,
+		canViewCannedResponse: false,
+
+		init: async ({ tmid, onThreadMessagesLoaded, signal }: IRoomStoreInitParams = {}): Promise<TRoomInitResult> => {
+			if (!rid) {
+				return { status: 'skipped' };
+			}
+			for (let attempt = 1; attempt <= INIT_MAX_ATTEMPTS; attempt += 1) {
+				const { room, membership } = get();
+				const result = await loadRoom(rid, room, membership, { tmid, onThreadMessagesLoaded, signal });
+				if (signal?.aborted || result.status === 'skipped') {
+					return { status: 'skipped' };
+				}
+				if (result.status === 'loaded') {
+					set(result.pendingRoomState);
+					if (result.shouldMarkRead) {
+						readMessages(room.rid).catch(e => log(e));
+					}
+					return { status: 'loaded', lastSeen: result.lastSeen };
+				}
+				if (attempt < INIT_MAX_ATTEMPTS) {
+					await new Promise(resolve => {
+						setTimeout(resolve, INIT_RETRY_DELAY);
+					});
+					if (signal?.aborted) {
+						return { status: 'skipped' };
+					}
+				}
+			}
+			return { status: 'failed' };
+		},
+
+		join: () => set({ membership: 'subscribed' }),
+
+		joinRoom: (requestJoinCode?: () => void): Promise<void> =>
+			joinRoom(get().room, {
+				requestJoinCode,
+				onJoin: get().join
+			}),
+		resumeRoom: (): Promise<void> => resumeRoom(get().room, get().join)
+	}));


### PR DESCRIPTION
## Proposed changes

Inline the private curried `createRoomState` initializer into the exported `createRoomStore`. The public factory now calls `createStore` directly with the same initializer body, and the defaults (`EMPTY_ROOM` for the initial room, `null` for the room user id) move to its parameter destructuring. The unused `StateCreator` import is removed.

One file, mechanical move only. The exported signature, state shape, action closures, retry loop, cancellation and read receipt timing are unchanged.

## Issue(s)

Follow-up to #7482; targets its `native-34-roomview-hooks` branch.

## How to test or reproduce

- `pnpm oxfmt --check` and `pnpm oxlint` on the changed file pass (one pre-existing complexity warning in the untouched `loadRoom`).
- `pnpm tsc --noEmit` is clean.
- `TZ=UTC pnpm test` for the RoomStore and useRoomInit suites passes: 3 suites, 54 tests.
- No remaining references to `createRoomState` or `StateCreator` in `app/`.

## Screenshots

Not applicable; no visual changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [ ] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Existing tests are unchanged. An independent review confirmed the initializer body is identical modulo indentation and that no evaluation timing changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified room store setup while preserving existing room initialization, retry, membership, join, and resume behavior.
  - Added default handling for room and user values when creating the room store.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->