### PR TITLE
refactor: pass the message directly to resolveJumpAnchor

### DIFF
--- a/app/views/RoomView/hooks/__tests__/useRoomNavigation.composed.test.tsx
+++ b/app/views/RoomView/hooks/__tests__/useRoomNavigation.composed.test.tsx
@@ -90,7 +90,8 @@ describe('useRoomNavigation composed entry points', () => {
 	it('locates and highlights an in-window Message from a Message URL', async () => {
 		const listRef = makeListRef();
 		listRef.current.isMessageInWindow.mockReturnValue(true);
-		mockGetMessageInfo.mockResolvedValue({ id: 'message-1', rid: 'rid-1', ts: 100 });
+		const messageInfo = { id: 'message-1', rid: 'rid-1', ts: 100 };
+		mockGetMessageInfo.mockResolvedValue(messageInfo);
 		mockResolveJumpAnchor.mockResolvedValue(123);
 		const { result } = renderNavigation({ listContainerRef: listRef });
 
@@ -100,7 +101,7 @@ describe('useRoomNavigation composed entry points', () => {
 
 		expect(mockResolveJumpAnchor).toHaveBeenCalledWith(
 			'rid-1',
-			{ id: 'message-1', tmid: undefined, ts: 100, fromServer: undefined },
+			messageInfo,
 			true,
 			expect.objectContaining({ loadSurroundingMessages: expect.any(Function) })
 		);
@@ -111,7 +112,8 @@ describe('useRoomNavigation composed entry points', () => {
 	it('resolves an out-of-window anchor before requesting the List jump', async () => {
 		const listRef = makeListRef();
 		listRef.current.isMessageInWindow.mockReturnValue(false);
-		mockGetMessageInfo.mockResolvedValue({ id: 'message-2', rid: 'rid-1', ts: 200, fromServer: true });
+		const messageInfo = { id: 'message-2', rid: 'rid-1', ts: 200, fromServer: true };
+		mockGetMessageInfo.mockResolvedValue(messageInfo);
 		mockResolveJumpAnchor.mockResolvedValue(456);
 		const { result } = renderNavigation({ listContainerRef: listRef });
 
@@ -119,12 +121,7 @@ describe('useRoomNavigation composed entry points', () => {
 			await result.current.jumpToMessageByUrl('https://open.rocket.chat/room?msg=message-2');
 		});
 
-		expect(mockResolveJumpAnchor).toHaveBeenCalledWith(
-			'rid-1',
-			expect.objectContaining({ id: 'message-2', fromServer: true }),
-			false,
-			expect.any(Object)
-		);
+		expect(mockResolveJumpAnchor).toHaveBeenCalledWith('rid-1', messageInfo, false, expect.any(Object));
 		expect(listRef.current.jumpToMessage).toHaveBeenCalledWith('message-2', 456);
 	});
 

--- a/app/views/RoomView/hooks/useRoomNavigation.ts
+++ b/app/views/RoomView/hooks/useRoomNavigation.ts
@@ -145,12 +145,7 @@ export function useRoomNavigation({
 			return false;
 		}
 		const inWindow = listContainerRef.current?.isMessageInWindow(message.id) ?? false;
-		const highTsMs = await resolveJumpAnchor(
-			rid,
-			{ id: message.id, tmid: message.tmid, ts: message.ts, fromServer: message.fromServer },
-			inWindow,
-			{ loadSurroundingMessages, getLocalAnchorTs }
-		);
+		const highTsMs = await resolveJumpAnchor(rid, message, inWindow, { loadSurroundingMessages, getLocalAnchorTs });
 		if (!isCurrentJump(generation)) return false;
 		await waitForFabricCommit();
 		if (!isCurrentJump(generation)) return false;


### PR DESCRIPTION
## Proposed changes

Pass the message-info result directly to `resolveJumpAnchor` instead of rebuilding a four-field copy of it at the call site. The result already carries every `IJumpTarget` field with identical types, so the copy translated nothing. `IJumpTarget` stays as the resolver's narrow contract and the resolver itself is untouched.

Removing the copy also closes a drift hazard: a field added to `IJumpTarget` later is now checked by the type system at the call site instead of silently arriving as `undefined`.

## Issue(s)

Follow-up to #7482; targets its `native-34-roomview-hooks` branch.

## How to test or reproduce

- `pnpm format-lint` passed, including TypeScript compilation.
- `TZ=UTC pnpm test --runInBand --watchman=false` passed: 315 suites, 2,902 tests, 426 snapshots.
- Jump to a message from a reply, a mention and a search result, both inside and outside the current Message Window. Behavior is unchanged.

## Screenshots

Not applicable; no visual changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [ ] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The two composed navigation tests now bind the message fixture to a constant and assert the resolver call exactly against it. The out-of-window case previously used a partial matcher, so the assertion is stricter than before. No tests were added or removed. Standards and specification reviews reported no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message navigation so jump anchors receive complete message details, supporting more accurate in-window and out-of-window navigation.

- **Tests**
  - Strengthened navigation coverage by verifying exact message data is used when resolving jump anchors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->