### PR TITLE
test(RoomView): drop duplicated RightButtons composed cases

### DIFF
--- a/app/views/RoomView/components/RightButtons/__tests__/RightButtons.test.tsx
+++ b/app/views/RoomView/components/RightButtons/__tests__/RightButtons.test.tsx
@@ -75,20 +75,25 @@ describe('RightButtons routing', () => {
 	});
 
 	it('renders nothing without a rid', () => {
-		render(<RightButtons roomStore={createRoomStore({ rid: 'rid-1', t: 'c' })} />);
+		const { toJSON } = render(<RightButtons roomStore={createRoomStore({ rid: 'rid-1', t: 'c' })} />);
 
+		expect(toJSON()).toBeNull();
 		expectOnlyStub();
 	});
 
 	it('renders nothing for an invited room', () => {
-		render(<RightButtons rid='rid-1' roomStore={createRoomStore({ rid: 'rid-1', t: 'c' }, 'invited')} />);
+		const { toJSON } = render(<RightButtons rid='rid-1' roomStore={createRoomStore({ rid: 'rid-1', t: 'c' }, 'invited')} />);
 
+		expect(toJSON()).toBeNull();
 		expectOnlyStub();
 	});
 
 	it('renders nothing for a queued omnichannel room', () => {
-		render(<RightButtons rid='rid-1' roomStore={createRoomStore({ rid: 'rid-1', t: 'l', status: 'queued' })} />);
+		const { toJSON } = render(
+			<RightButtons rid='rid-1' roomStore={createRoomStore({ rid: 'rid-1', t: 'l', status: 'queued' })} />
+		);
 
+		expect(toJSON()).toBeNull();
 		expectOnlyStub();
 	});
 

--- a/app/views/RoomView/components/__tests__/RightButtons.test.tsx
+++ b/app/views/RoomView/components/__tests__/RightButtons.test.tsx
@@ -124,29 +124,6 @@ describe('RightButtons', () => {
 		};
 	});
 
-	it('renders nothing without a rid', () => {
-		const { queryByTestId, toJSON } = render(<RightButtons roomStore={roomStore} />);
-		expect(toJSON()).toBeNull();
-		expectOnly(queryByTestId, []);
-		expect(toJSON()).toMatchSnapshot();
-	});
-
-	it('renders nothing for an invited room', () => {
-		mockRoomState = { ...mockRoomState, room: { id: 'sub-1', rid: 'rid-1', t: 'c', name: 'general' }, membership: 'invited' };
-		const { queryByTestId, toJSON } = render(<RightButtons rid='rid-1' roomStore={roomStore} />);
-		expect(toJSON()).toBeNull();
-		expectOnly(queryByTestId, []);
-		expect(toJSON()).toMatchSnapshot();
-	});
-
-	it('renders nothing for a queued omnichannel room', () => {
-		mockRoomState = { ...mockRoomState, room: { id: 'sub-1', rid: 'rid-1', t: 'l', name: 'chat', status: 'queued' } };
-		const { queryByTestId, toJSON } = render(<RightButtons rid='rid-1' roomStore={roomStore} />);
-		expect(toJSON()).toBeNull();
-		expectOnly(queryByTestId, []);
-		expect(toJSON()).toMatchSnapshot();
-	});
-
 	it('renders only the kebab for an active omnichannel room', () => {
 		mockRoomState = { ...mockRoomState, room: { id: 'sub-1', rid: 'rid-1', t: 'l', name: 'chat' } };
 		const { queryByTestId, toJSON } = render(<RightButtons rid='rid-1' roomStore={roomStore} />);
@@ -256,24 +233,6 @@ describe('RightButtons', () => {
 		const { queryByTestId, toJSON } = render(<RightButtons rid='rid-1' roomStore={roomStore} />);
 		expectOnly(queryByTestId, ['header-call-button-stub', 'room-view-search']);
 		expect(toJSON()).toMatchSnapshot();
-	});
-
-	it('labels the threads button with the direct mention unread count', () => {
-		mockHeaderHooks = { ...mockHeaderHooks, tunread: ['tm-1'], tunreadUser: ['tm-1'] };
-		const { queryByTestId } = render(<RightButtons rid='rid-1' roomStore={roomStore} />);
-		expect(queryByTestId('room-view-header-threads')).toHaveProp('accessibilityLabel', 'Threads, 1 unread, direct mention');
-	});
-
-	it('labels the threads button with the group mention unread count', () => {
-		mockHeaderHooks = { ...mockHeaderHooks, tunread: ['tm-1'], tunreadGroup: ['tm-1'] };
-		const { queryByTestId } = render(<RightButtons rid='rid-1' roomStore={roomStore} />);
-		expect(queryByTestId('room-view-header-threads')).toHaveProp('accessibilityLabel', 'Threads, 1 unread, group mention');
-	});
-
-	it('labels the threads button with the plain unread count', () => {
-		mockHeaderHooks = { ...mockHeaderHooks, tunread: ['tm-1', 'tm-2'] };
-		const { queryByTestId } = render(<RightButtons rid='rid-1' roomStore={roomStore} />);
-		expect(queryByTestId('room-view-header-threads')).toHaveProp('accessibilityLabel', 'Threads, 2 unread');
 	});
 
 	it('hides the call button on a self DM', () => {

--- a/app/views/RoomView/components/__tests__/__snapshots__/RightButtons.test.tsx.snap
+++ b/app/views/RoomView/components/__tests__/__snapshots__/RightButtons.test.tsx.snap
@@ -128,12 +128,6 @@ exports[`RightButtons renders call, threads and search for a regular channel 1`]
 </Container>
 `;
 
-exports[`RightButtons renders nothing for a queued omnichannel room 1`] = `null`;
-
-exports[`RightButtons renders nothing for an invited room 1`] = `null`;
-
-exports[`RightButtons renders nothing without a rid 1`] = `null`;
-
 exports[`RightButtons renders only the kebab for an active omnichannel room 1`] = `
 <Container>
   <Item


### PR DESCRIPTION
## Proposed changes

The composed `RightButtons` suite at the components level repeated six cases that already lived elsewhere with the same inputs and assertions: three guard cases (missing `rid`, invited membership, queued omnichannel) covered by the routing suite, and three threads-button unread-label cases covered by the `RoomRightButtons` leaf suite. Their three `null` snapshot entries went with them, deleted by hand.

Before removing the guards, the routing suite's three matching cases gained an exact `toJSON()` null assertion, so the "renders an empty tree" proof the composed suite held is preserved rather than dropped. The stub-absence helper call stays alongside it.

The `useSubscriptionUnreads` mock in the composed suite remains because the self-DM case still reads `isSelfDm` from it.

## Issue(s)

Follow-up to #7482; targets its `native-34-roomview-hooks` branch.

## How to test or reproduce

- `pnpm format-lint` passed.
- `TZ=UTC pnpm test` passed: 315 suites, 2,896 tests, 423 snapshots, no obsolete snapshots.
- Composed, routing and leaf `RightButtons` suites: 6 suites, 70 tests, 11 snapshots.

## Screenshots

Not applicable; test-only change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves a current function)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Every other composed case and non-null snapshot is unchanged. Standards and specification reviews reported no defects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened validation for scenarios where the room action controls should render nothing.
  - Removed redundant coverage for unavailable room actions and notification-label variations.
  - No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->